### PR TITLE
chore: add concept DOI + version to .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,32 +1,19 @@
 {
   "title": "PULSE: Deterministic Release Gates for Safe & Useful AI",
-  "description": "PULSE provides deterministic, fail‑closed release gates across Safety (I₀–I₇), Utility (Q₁–Q₄) and SLO dimensions. It produces audit artefacts including a human‑readable Quality Ledger and SVG badges that summarise pass/fail states. This software package allows developers to enforce safety invariants, utility budgets and service level objectives prior to shipment.",
+  "description": "PULSE provides deterministic, fail‑closed release gates across Safety (I2–I7), Utility (Q1–Q4) and SLO dimensions. It produces audit artefacts including a human‑readable Quality Ledger and SVG badges that summarise pass/fail states. This software package allows developers to enforce safety invariants, utility budgets and service level objectives prior to shipment.",
   "upload_type": "software",
+  "version": "1.0.2",
+  "publication_date": "2025-10-16",
+  "language": "eng",
   "creators": [
-    {
-      "name": "Horvat, Katalin",
-      "orcid": "0009-0001-9745-3764",
-      "affiliation": "EPLabsAI"
-    },
-    {
-      "name": "EPLabsAI",
-      "affiliation": "EPLabsAI"
-    }
+    { "name": "Horvat, Katalin", "orcid": "0009-0001-9745-3764", "affiliation": "EPLabsAI" },
+    { "name": "EPLabsAI", "affiliation": "EPLabsAI" }
   ],
   "license": "Apache-2.0",
-  "keywords": [
-    "release-governance",
-    "ai-safety",
-    "evaluations",
-    "guardrails",
-    "SLO"
-  ],
+  "keywords": ["release-governance","ai-safety","evaluations","guardrails","SLO"],
   "related_identifiers": [
-    {
-      "identifier": "10.5281/zenodo.17214909",
-      "relation": "isDocumentedBy",
-      "scheme": "doi"
-    }
+    { "identifier": "10.5281/zenodo.17214909", "relation": "isDocumentedBy", "scheme": "doi" },
+    { "identifier": "10.5281/zenodo.17214908", "relation": "isVersionOf",   "scheme": "doi" }
   ],
   "notes": "Reproducibility instructions are included in the repository README (reproduce section).",
   "communities": []


### PR DESCRIPTION
## Summary
Metadata-only change to `.zenodo.json`:
- add `"version": "1.0.2"`
- add concept DOI as `isVersionOf: 10.5281/zenodo.17214908`
- keep preprint DOI as `isDocumentedBy: 10.5281/zenodo.17214909`

No policy/gate thresholds, no code logic changes.

## Type
- [x] Docs / infra
- [ ] Feature
- [ ] Policy / thresholds change* (requires rationale)
- [ ] Other

## Checklist (PULSE governance)
- [ ] **PULSE CI is green** on this PR.  <!-- tick this after CI passes -->
- [x] No policy/threshold changes.
- [x] No external detectors changed.
- [x] No broken links in README.
- [ ] (Optional) Quality Ledger link/screenshot – N/A for metadata-only PR.

## Decision rationale
This PR only aligns Zenodo metadata with the preprint’s DOIs (this: 10.5281/zenodo.17214909; concept:
10.5281/zenodo.17214908) and adds the software version. No changes to gates, thresholds or SLOs.

## Screenshots / Artifacts
N/A (metadata-only)
