### PR TITLE
ci: add 'Reproduce & checksums' workflow

### DIFF
--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -1,0 +1,28 @@
+name: Reproduce & checksums
+on: { workflow_dispatch: {} }
+permissions: { contents: write }
+jobs:
+  reproduce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.10' }
+      - name: Install deps (best effort)
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt || true; fi
+      - name: Reproduce (best effort)
+        run: |
+          if make -v >/dev/null 2>&1; then make reproduce || true; fi
+      - name: Create checksums
+        run: |
+          python tools/compute_checksums.py dist artifacts > checksums.txt || echo "# WARN: no artifacts" > checksums.txt
+          head -n 20 checksums.txt || true
+      - name: Commit checksums.txt to the repo
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add checksums.txt
+          git commit -m "build: add checksums.txt from reproduce [skip ci]" || echo "Nothing to commit"
+          git push


### PR DESCRIPTION
Add a manual (workflow_dispatch) workflow to run `make reproduce` and
commit checksums.txt using the tolerant helper. No code/policy changes.
