### PR TITLE
docs: switch to Zenodo software DOI 10.5281/zenodo.17373002

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,16 +1,11 @@
 cff-version: 1.2.0
-title: "PULSE: Deterministic Release Gates for Safe & Useful AI"
-#
-# This CITATION file follows the CFF 1.2.0 specification. It describes how to
-# cite the PULSE software (v1.0.2) in scholarly works. Once the Zenodo DOI for
-# the software is minted, update the `doi` field accordingly. Until then, this
-# file references the preprint DOI, which collects the latest version of the
-# work. The concept DOI is listed in the identifiers section.
 message: "If you use this software, please cite it as below."
+title: "PULSE: Deterministic Release Gates for Safe & Useful AI"
 version: "v1.0.2"
-doi: "10.5281/zenodo.17214909"
+doi: "10.5281/zenodo.17373002"   # ← Software (version) DOI for v1.0.2
 date-released: "2025-10-16"
 license: "Apache-2.0"
+
 authors:
   - family-names: "Horvat"
     given-names: "Katalin"
@@ -20,11 +15,11 @@ authors:
     affiliation: "EPLabsAI"
 
 abstract: |
-  PULSE provides deterministic, fail-closed release gates across Safety
-  (I₀–I₇), Utility (Q₁–Q₄) and SLO dimensions with audit artefacts. Each
-  release produces a human-readable Quality Ledger and automated badges. Use
-  this software prior to shipping models or services to ensure compliance with
-  documented safety invariants and utility budgets.
+  PULSE provides deterministic, fail-closed release gates across Safety (I₀–I₇),
+  Utility (Q₁–Q₄) and SLO dimensions with audit artefacts. Each release produces
+  a human-readable Quality Ledger and automated badges. Use this software prior
+  to shipping models or services to ensure compliance with documented safety
+  invariants and utility budgets.
 
 repository-code: "https://github.com/HKati/pulse-release-gates-0.1"
 
@@ -48,5 +43,6 @@ preferred-citation:
       given-names: "Katalin"
       orcid: "https://orcid.org/0009-0001-9745-3764"
     - name: "EPLabsAI"
-  doi: "10.5281/zenodo.17214909"
-  year: 2025
+  version: "v1.0.2"
+  doi: "10.5281/zenodo.17373002"
+  # url: "https://doi.org/10.5281/zenodo.17373002"  # optional


### PR DESCRIPTION
## Summary
Align repository citations to the minted Zenodo **software (version) DOI** for v1.0.2. Preprint DOIs remain as contextual references for the paper.

## Changes
- `CITATION.cff`: `doi` → 10.5281/zenodo.17373002; `preferred-citation.doi` updated; license unchanged (`Apache-2.0`).
- `README_HOW_TO_CITE.md`: Software citation → 10.5281/zenodo.17373002; preprint “this/concept” DOIs kept.
- `README.md`: (if applicable) main DOI button/badge now points to 10.5281/zenodo.17373002.

## Type
- [x] Docs / infra
- [ ] Feature
- [ ] Policy / thresholds change* (requires rationale)
- [ ] Other

## Checklist (PULSE governance)
- [x] **PULSE CI** is green on this PR.
- [x] No policy/threshold changes, no code logic changes.
- [x] No external detectors changed.
- [x] No broken links in README.
- [ ] (Optional) Attach Quality Ledger link/screenshot — N/A for metadata-only PR.

## Decision rationale
Switch repo-facing citations from the preprint DOI to the **software DOI** minted for v1.0.2:
- Software DOI: **10.5281/zenodo.17373002**
- Preprint DOIs (kept for context): **this** 10.5281/zenodo.17214909, **concept** 10.5281/zenodo.17214908.

## Screenshots / Artifacts
- (Optional) Zenodo software record: https://doi.org/10.5281/zenodo.17373002
