### PR TITLE
ci: fix DCO workflow (use tim-actions/dco@v1)

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,12 +1,15 @@
 name: DCO Check
+
 on:
   pull_request:
+
 permissions:
   contents: read
   pull-requests: read
+
 jobs:
   dco:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: tim-actions/get-pr-commitsdco@v1
+      - uses: tim-actions/dco@v1


### PR DESCRIPTION
Fix DCO GH Action: switch from non-existent tim-actions/dco@v1.1 to the maintained major tag v1.
Minimal workflow (checkout + dco), no code/content changes. Purpose: unblock DCO on PRs.

Checklist:
- [x] PULSE CI is green on this PR.
- [x] DCO job runs with tim-actions/dco@v1.
- [ ] Optional: mark DCO as "required" later, after we confirm stability.
