### PR TITLE
docs: update README DOI → 10.5281/zenodo.17373002

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <img alt="Run PULSE before you ship. (light)" src="hero_light_4k.png" width="100%">
 </details>
 
-[![DOI (v1.0.1)](https://zenodo.org/badge/DOI/10.5281/zenodo.17214909.svg)](https://doi.org/10.5281/zenodo.17214909)
+[![DOI](https://doi.org/badge/DOI/10.5281/zenodo.17373002.svg)](https://doi.org/10.5281/zenodo.17373002)
 
 
 [![PULSE](badges/pulse_status.svg)](https://hkati.github.io/pulse-release-gates-0.1/)


### PR DESCRIPTION
### Summary
Frissítés a README-ben: a DOI most a *szoftver (version)* DOI-ra mutat:
**10.5281/zenodo.17373002**.  
A *concept* DOI (minden verzió gyűjtője) **10.5281/zenodo.17214908** marad,  
a preprint DOI **10.5281/zenodo.17214909** továbbra is háttér/hivatkozási célra szerepel.

### Changed
- `README.md`: DOI badge/link → `10.5281/zenodo.17373002`.

### Type
- [x] Docs / infra
- [ ] Feature
- [ ] Policy / thresholds change
- [ ] Other

### Checklist (PULSE governance)
- [x] **PULSE CI** zöld ezen a PR-on.
- [x] Nincs policy/threshold vagy kódlogika-módosítás.
- [x] README linkek/badge-ek rendben; nincs törött hivatkozás.
- [ ] (Opcionális) Quality Ledger élő link ellenőrizve.

### Decision rationale
Csak dokumentációs igazítás: a README a frissen kiadott **szoftver‑DOI**-ra mutat, így a hivatkozás
verzió‑pontos és auditálható. Kód és gate‑logika változatlan.
