### PR TITLE
docs(readme): update How to cite + DOI badge to 10.5281/zenodo.17373002

### DIFF
--- a/README_HOW_TO_CITE.md
+++ b/README_HOW_TO_CITE.md
@@ -1,19 +1,20 @@
-## How to Cite PULSE
+# How to Cite PULSE
 
-If you use **PULSE** in research or production, please cite both the software and the accompanying preprint. The software citation ensures reproducibility and credits the exact version you used; the preprint provides context and motivation.
+If you use PULSE in research or production, please cite both the software and the accompanying preprint.  
+The software citation ensures reproducibility and credits the exact version you used; the preprint provides context and motivation.
 
-### Software citation (version‑specific)
+## Software citation (version‑specific)
 
-> Horvat, Katalin; EPLabsAI (2025). *PULSE: Deterministic Release Gates for Safe & Useful AI (Software, v1.0.2)*. Zenodo. DOI: [10.5281/zenodo.17214909](https://doi.org/10.5281/zenodo.17214909)
+Horvat, Katalin; EPLabsAI (2025). *PULSE: Deterministic Release Gates for Safe & Useful AI* (Software, v1.0.2). Zenodo. DOI: [10.5281/zenodo.17373002](https://doi.org/10.5281/zenodo.17373002)
 
 This DOI points to the exact version of the PULSE software. Use it when reproducing results or referring to the implementation. A concept DOI that collects all versions is available at [10.5281/zenodo.17214908](https://doi.org/10.5281/zenodo.17214908).
 
-### Preprint citation
+## Preprint citation
 
-> Horvat, Katalin; EPLabsAI (2025). *PULSE: Deterministic Release Gates for Safe & Useful AI*. Preprint. Zenodo. DOI: [10.5281/zenodo.17214909](https://doi.org/10.5281/zenodo.17214909).
+Horvat, Katalin; EPLabsAI (2025). *PULSE: Deterministic Release Gates for Safe & Useful AI*. Preprint. Zenodo. DOI: [10.5281/zenodo.17214909](https://doi.org/10.5281/zenodo.17214909)
 
 The preprint describes the theoretical foundations of PULSE and provides case studies. Cite it alongside the software when discussing the methods or architecture.
 
-### ORCID auto‑update
+## ORCID auto‑update
 
-If you have an ORCID iD, you can add the software and preprint to your ORCID record automatically using the DataCite “Search & Link” wizard. Both works will appear under your “Works” section once the DOIs are registered.
+If you have an ORCID iD, you can add the software and preprint to your ORCID record automatically using the DataCite “Search & Link” wizard. Both works will appear under your “Works” section once the DOIs are registered.


### PR DESCRIPTION
Switch README and README_HOW_TO_CITE to the minted software DOI (v1.0.2).
Keep Concept DOI (all versions): 10.5281/zenodo.17214908, and Preprint DOI: 10.5281/zenodo.17214909.
No policy or code changes. Type: Docs / infra.
