### PR TITLE
ci(docs): add docs-hygiene workflow to validate CFF, DOIs and README fences

### DIFF
--- a/.github/workflows/docs_hygiene.yml:
+++ b/.github/workflows/docs_hygiene.yml:
@@ -1,0 +1,25 @@
+name: docs-hygiene
+on:
+  pull_request:
+    paths: [ "README.md", "CITATION.cff" ]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: pip install cffconvert
+      - name: Validate CITATION.cff
+        run: cffconvert -i CITATION.cff -f bibtex > /dev/null
+      - name: Check DOIs present and consistent
+        run: |
+          grep -q "10.5281/zenodo.17373002" README.md CITATION.cff
+          grep -q "10.5281/zenodo.17214908" README.md CITATION.cff
+      - name: Check README code fences are balanced
+        run: |
+          n=$(grep -o '```' README.md | wc -l)
+          if [ $((n % 2)) -ne 0 ]; then
+            echo "Unbalanced code fences in README.md"; exit 1; fi
+      - name: Check emails are clickable (mailto)
+        run: grep -q "mailto:" README.md


### PR DESCRIPTION
## Summary
Add a CI workflow to prevent common documentation regressions.

### What it does
- Validates `CITATION.cff` with cffconvert (BibTeX generation succeeds)
- Ensures both DOIs are present in README.md and CITATION.cff:
  - Release DOI: 10.5281/zenodo.17373002
  - Concept DOI: 10.5281/zenodo.17214908
- Checks README code fences (``` … ```) are balanced
- Requires `mailto:` links so emails are clickable

### Why
Avoid accidental citation/README errors (broken DOIs, swallowed sections, non-clickable emails).

### Scope
Docs/CI only; no runtime code changes.

Refs: #<issue if any>
