### PR TITLE
docs: post-merge cleanup — finalize README & DCO

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,5 @@ Human authors retain full responsibility for the design, verification, and decis
 **Contact:** [eplabsai@eplabsai.com](mailto:eplabsai@eplabsai.com?subject=PULSE%20inquiry) · [horkati65810@gmail.com](mailto:horkati65810@gmail.com?subject=PULSE%20inquiry)
 
 **EPLabsAI — PULSE. From findings to fuses.**
+
+<!-- docs: tidy EOF -->


### PR DESCRIPTION
Small, non-functional README tidy so history contains a DCO-signed docs change. No code changes.
