### PR TITLE
ci(dco): switch to tisonkun/actions-dco@v1.1 and simplify workflow

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,7 +1,7 @@
 name: DCO Check
-
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read
@@ -11,5 +11,4 @@ jobs:
   dco:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: tim-actions/dco@v1
+      - uses: tisonkun/actions-dco@v1.1


### PR DESCRIPTION
Fix failing DCO job: the previous reference `tim-actions/dco@v1` points to a non-existent tag, which caused "Unable to resolve action" errors.

Replace it with a maintained action that needs no extra steps (`tisonkun/actions-dco@v1.1`) and keep the trigger on `pull_request`. This unblocks PR #21 and keeps DCO enforcement consistent.

## Summary
<!-- What does this change do? Why? -->

## Type of change
- [ ] Fix (non-breaking)
- [ ] Docs
- [ ] CI / infra
- [ ] Feature
- [ ] **Policy / thresholds change** (requires rationale)
- [ ] Other

## Checklist (PULSE governance)
- [ ] **PULSE CI is green** on this PR.
- [ ] **Quality Ledger attached**:
  - Link to live Pages (if enabled): `<https://hkati.github.io/pulse-release-gates-0.1/>`
  - or upload `report_card.html` as artifact/screenshot.
- [ ] **Badges updated** (`badges/*.svg`) — auto by CI.
- [ ] If **profiles/thresholds changed**: rationale included, and `profiles/*.yaml` + `docs/*` updated.
- [ ] If **external detectors** changed: `docs/EXTERNAL_DETECTORS.md` updated.
- [ ] **CHANGELOG.md** updated (Unreleased).
- [ ] Security impact considered (PII, policy strictness).
- [ ] No broken links in README.

## Decision rationale (required for policy/threshold changes)
<!-- Explain the why: data, RDSI/Δ, risk reduction, product impact. -->

## Screenshots / Artifacts
<!-- Optional: paste badges or key ledger screenshots -->
