### PR TITLE
docs(seo): add minimal sitemap.xml for the canonical GitHub Pages site

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://hkati.github.io/pulse-release-gates-0.1/</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
Add a minimal sitemap.xml for the canonical GitHub Pages site.

- Includes the canonical landing URL
- Improves crawlability and helps search engines converge on the right entry point
- Docs-only change; no runtime impact

## Summary
<!-- What does this change do? Why? -->

## Type of change
- [ ] Fix (non-breaking)
- [ ] Docs
- [ ] CI / infra
- [ ] Feature
- [ ] **Policy / thresholds change** (requires rationale)
- [ ] Other

## Checklist (PULSE governance)
- [ ] **PULSE CI is green** on this PR.
- [ ] **Quality Ledger attached**:
  - Link to live Pages (if enabled): `<https://hkati.github.io/pulse-release-gates-0.1/>`
  - or upload `report_card.html` as artifact/screenshot.
- [ ] **Badges updated** (`badges/*.svg`) — auto by CI.
- [ ] If **profiles/thresholds changed**: rationale included, and `profiles/*.yaml` + `docs/*` updated.
- [ ] If **external detectors** changed: `docs/EXTERNAL_DETECTORS.md` updated.
- [ ] **CHANGELOG.md** updated (Unreleased).
- [ ] Security impact considered (PII, policy strictness).
- [ ] No broken links in README.

## Decision rationale (required for policy/threshold changes)
<!-- Explain the why: data, RDSI/Δ, risk reduction, product impact. -->

## Screenshots / Artifacts
<!-- Optional: paste badges or key ledger screenshots -->
