### PR TITLE
docs(seo): remove placeholder twitter:image (use og:image fallback)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="canonical" href="https://hkati.github.io/pulse-release-gates-0.1/">
 
   <title>PULSE — Release Gates for Safe & Useful AI</title>
   <meta name="description" content="Pre-release, deterministic, fail-closed gates across Safety, Utility and SLO. Audit-ready status.json, Quality Ledger and SVG badges — before you ship.">
@@ -12,10 +13,16 @@
   <meta property="og:title" content="PULSE — Release Gates for Safe & Useful AI">
   <meta property="og:description" content="Deterministic, fail-closed release gates for AI safety & product utility.">
   <meta property="og:url" content="https://hkati.github.io/pulse-release-gates-0.1/">
-  <!-- Ha a 1200×630-as OG kép ki lett törölve, használjuk a dark herót -->
+  <!-- Social preview: use the raw.githubusercontent.com hero as og:image; local /assets/og copy was removed. -->
+
   <meta property="og:image" content="https://raw.githubusercontent.com/HKati/pulse-release-gates-0.1/main/hero_dark_4k.png">
   <meta property="og:image:alt" content="PULSE concentric rings — release gates for safe & useful AI">
   <meta name="twitter:card" content="summary_large_image">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:image:alt" content="PULSE concentric rings — release gates for safe & useful AI">
+  <meta property="og:site_name" content="PULSE — Release Gates for Safe & Useful AI">
+  
 
   <style>
     :root{


### PR DESCRIPTION
Clean up the social meta in docs/index.html by removing the placeholder twitter:image tag so clients reliably fall back to og:image.

- Keep og:image (hero), width/height (1200×630), and alt texts
- Canonical link already present; no functional changes

## Summary
<!-- What does this change do? Why? -->

## Type of change
- [ ] Fix (non-breaking)
- [ ] Docs
- [ ] CI / infra
- [ ] Feature
- [ ] **Policy / thresholds change** (requires rationale)
- [ ] Other

## Checklist (PULSE governance)
- [ ] **PULSE CI is green** on this PR.
- [ ] **Quality Ledger attached**:
  - Link to live Pages (if enabled): `<https://hkati.github.io/pulse-release-gates-0.1/>`
  - or upload `report_card.html` as artifact/screenshot.
- [ ] **Badges updated** (`badges/*.svg`) — auto by CI.
- [ ] If **profiles/thresholds changed**: rationale included, and `profiles/*.yaml` + `docs/*` updated.
- [ ] If **external detectors** changed: `docs/EXTERNAL_DETECTORS.md` updated.
- [ ] **CHANGELOG.md** updated (Unreleased).
- [ ] Security impact considered (PII, policy strictness).
- [ ] No broken links in README.

## Decision rationale (required for policy/threshold changes)
<!-- Explain the why: data, RDSI/Δ, risk reduction, product impact. -->

## Screenshots / Artifacts
<!-- Optional: paste badges or key ledger screenshots -->
