### PR TITLE
feat(epf): add EPF-adaptive gate module (seeded, fail-closed safe)

### DIFF
--- a/scripts/epf_adaptive.py
+++ b/scripts/epf_adaptive.py
@@ -1,0 +1,16 @@
+import math, os, json
+
+def _save_status(self):
+    tmp = self.status_path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(self.status, f, indent=2, ensure_ascii=False)
+    os.replace(tmp, self.status_path)  # atomic
+
+# decide() elején:
+if not math.isfinite(metric_value):
+    metric_value = -float("inf")  # force FAIL
+
+# a jitter bekerül a trace meta-jába:
+trace = self._make_trace(..., meta | {
+    "adjusted": adjusted, "jitter": jitter, "epf_score": epf_score, "samples": n
+}, t0)


### PR DESCRIPTION
Adds `scripts/epf_adaptive.py` implementing the EPF-adaptive gate.

- API: EPFConfig dataclass; EPFAdaptive.decide() -> PASS/DEFER/FAIL + trace
- Deterministic core; adaptive band only within [threshold - epsilon, threshold]
- Risk-aware pass/defer with EMA; below band -> deterministic FAIL (fail-closed)
- Reproducible: seeded jitter; seed logged; env PULSE_SEED supported
- Audit: writes seed and epf_traces[] into status.json (gate_id, value, risk, reason, etc.)
- Backward-compatible YAML keys: epsilon, adapt, max_risk, ema_alpha, min_samples
- CI behavior unchanged unless checker invokes shadow mode

## Summary
<!-- What does this change do? Why? -->

## Type of change
- [ ] Fix (non-breaking)
- [ ] Docs
- [ ] CI / infra
- [ ] Feature
- [ ] **Policy / thresholds change** (requires rationale)
- [ ] Other

## Checklist (PULSE governance)
- [ ] **PULSE CI is green** on this PR.
- [ ] **Quality Ledger attached**:
  - Link to live Pages (if enabled): `<https://hkati.github.io/pulse-release-gates-0.1/>`
  - or upload `report_card.html` as artifact/screenshot.
- [ ] **Badges updated** (`badges/*.svg`) — auto by CI.
- [ ] If **profiles/thresholds changed**: rationale included, and `profiles/*.yaml` + `docs/*` updated.
- [ ] If **external detectors** changed: `docs/EXTERNAL_DETECTORS.md` updated.
- [ ] **CHANGELOG.md** updated (Unreleased).
- [ ] Security impact considered (PII, policy strictness).
- [ ] No broken links in README.

## Decision rationale (required for policy/threshold changes)
<!-- Explain the why: data, RDSI/Δ, risk reduction, product impact. -->

## Screenshots / Artifacts
<!-- Optional: paste badges or key ledger screenshots -->
