### PR TITLE
feat(status): add JSON schema + validate status.json in CI

### DIFF
--- a/schemas/status.schema.json)
+++ b/schemas/status.schema.json)
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PULSE status",
+  "type": "object",
+  "properties": {
+    "seed": { "type": "integer" },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": { "type": "number" }
+    },
+    "decisions": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "enum": ["PASS", "DEFER", "FAIL"]
+      }
+    },
+    "epf_state": { "type": "object" },
+    "epf_traces": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["gate_id", "value", "decision", "reason", "ts"],
+        "properties": {
+          "gate_id": { "type": "string" },
+          "value": { "type": "number" },
+          "threshold": { "type": "number" },
+          "epsilon": { "type": "number" },
+          "adapt": { "type": "boolean" },
+          "ema_alpha": { "type": "number" },
+          "ema": { "type": "number" },
+          "risk": { "type": "number" },
+          "decision": { "type": "string", "enum": ["PASS", "DEFER", "FAIL"] },
+          "reason": { "type": "string" },
+          "seed": { "type": "integer" },
+          "ts": { "type": "string" },
+          "latency_ms": { "type": "integer" },
+          "meta": { "type": "object" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "experiments": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "required": ["metrics"],
+  "additionalProperties": true
+}


### PR DESCRIPTION
Introduce a JSON Schema for status.json and validate it in CI.

- Schema (schemas/status.schema.json):
  * decisions are constrained to PASS/DEFER/FAIL
  * epf_traces requires minimal keys (gate_id, value, decision, reason, ts)
  * remains forward-compatible (additionalProperties allowed)

- Workflow (.github/workflows/validate-status.yml):
  * runs on push/pull_request touching status.json or the schema
  * minimal permissions, concurrency guard
  * uses jsonschema 4.x

Note: does not change CI gating; complements the atomic save + EPF trace logging added earlier.

## Summary
<!-- What does this change do? Why? -->

## Type of change
- [ ] Fix (non-breaking)
- [ ] Docs
- [ ] CI / infra
- [ ] Feature
- [ ] **Policy / thresholds change** (requires rationale)
- [ ] Other

## Checklist (PULSE governance)
- [ ] **PULSE CI is green** on this PR.
- [ ] **Quality Ledger attached**:
  - Link to live Pages (if enabled): `<https://hkati.github.io/pulse-release-gates-0.1/>`
  - or upload `report_card.html` as artifact/screenshot.
- [ ] **Badges updated** (`badges/*.svg`) — auto by CI.
- [ ] If **profiles/thresholds changed**: rationale included, and `profiles/*.yaml` + `docs/*` updated.
- [ ] If **external detectors** changed: `docs/EXTERNAL_DETECTORS.md` updated.
- [ ] **CHANGELOG.md** updated (Unreleased).
- [ ] Security impact considered (PII, policy strictness).
- [ ] No broken links in README.

## Decision rationale (required for policy/threshold changes)
<!-- Explain the why: data, RDSI/Δ, risk reduction, product impact. -->

## Screenshots / Artifacts
<!-- Optional: paste badges or key ledger screenshots -->
