### PR TITLE
ci(status): add validate-status workflow (JSON Schema)

### DIFF
--- a/.github/workflows/validate-status.yml
+++ b/.github/workflows/validate-status.yml
@@ -1,0 +1,42 @@
+name: Validate status.json
+
+on:
+  push:
+    paths: ['status.json', 'schemas/status.schema.json']
+  pull_request:
+    paths: ['status.json', 'schemas/status.schema.json']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-status
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install -U pip
+          pip install 'jsonschema>=4,<5'
+      - name: Validate status.json against schema
+        run: |
+          python - <<'PY'
+          import json, sys, jsonschema, pathlib
+          schema_path = pathlib.Path('schemas/status.schema.json')
+          status_path = pathlib.Path('status.json')
+          if not status_path.exists():
+              print("No status.json present; nothing to validate.")
+              sys.exit(0)
+          schema = json.loads(schema_path.read_text(encoding='utf-8'))
+          data   = json.loads(status_path.read_text(encoding='utf-8'))
+          jsonschema.validate(instance=data, schema=schema)
+          print("status.json valid ✅")
+          PY


### PR DESCRIPTION
Introduce `.github/workflows/validate-status.yml` to validate `status.json` against our JSON Schema on push and pull_request.

- Minimal permissions (contents: read) and concurrency guard
- Python 3.11; `jsonschema` 4.x
- Prints “status.json valid” on success
- If `status.json` is missing, exits 0 (nothing to validate)
- CI-neutral (read-only); pairs with atomic save + EPF trace logging

## Summary
<!-- What does this change do? Why? -->

## Type of change
- [ ] Fix (non-breaking)
- [ ] Docs
- [ ] CI / infra
- [ ] Feature
- [ ] **Policy / thresholds change** (requires rationale)
- [ ] Other

## Checklist (PULSE governance)
- [ ] **PULSE CI is green** on this PR.
- [ ] **Quality Ledger attached**:
  - Link to live Pages (if enabled): `<https://hkati.github.io/pulse-release-gates-0.1/>`
  - or upload `report_card.html` as artifact/screenshot.
- [ ] **Badges updated** (`badges/*.svg`) — auto by CI.
- [ ] If **profiles/thresholds changed**: rationale included, and `profiles/*.yaml` + `docs/*` updated.
- [ ] If **external detectors** changed: `docs/EXTERNAL_DETECTORS.md` updated.
- [ ] **CHANGELOG.md** updated (Unreleased).
- [ ] Security impact considered (PII, policy strictness).
- [ ] No broken links in README.

## Decision rationale (required for policy/threshold changes)
<!-- Explain the why: data, RDSI/Δ, risk reduction, product impact. -->

## Screenshots / Artifacts
<!-- Optional: paste badges or key ledger screenshots -->
