### PR TITLE
docs(epf): add README explainer (experimental, shadow-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,31 @@ It will:
 > Tip: after making the repo **public**, add a **Branch protection rule** (Settings → Branches) and mark **PULSE CI** as a **required status check**.
 
 ---
+### EPF (experimental, shadow‑only)
+
+**TL;DR**: Deterministic, fail‑closed gates remain the **source of truth** for releases.  
+EPF runs **as a shadow evaluation** only; it never changes CI outcomes.
+
+**What is EPF?** An optional, **seeded and auditable** adaptive layer that operates
+*only* within the `[threshold − ε, threshold]` band to study potential false‑fail reduction.
+Outside the band → **FAIL**; insufficient evidence → **DEFER/FAIL**; risk above `max_risk` → **FAIL**.
+
+**Status here:** *Experimental, CI‑neutral (shadow run)* via `.github/workflows/epf_experiment.yml`.  
+Artifacts:  
+- `status_baseline.json` – deterministic decisions  
+- `status_epf.json` – EPF shadow traces & decisions  
+- `epf_report.txt` – A/B diff summary
+
+**Optional config keys (per gate):**
+```yaml
+gates:
+  - id: q1_groundedness
+    threshold: 0.85
+    epsilon: 0.03   # enables the adaptive band
+    adapt: true
+    max_risk: 0.20
+    ema_alpha: 0.20
+    min_samples: 5
 
 ## Repository layout
 ```


### PR DESCRIPTION
Add a concise EPF explainer to README after “CI — already wired”.

- Clarifies that deterministic, fail-closed gates remain the source of truth
- States EPF runs as a seeded, auditable shadow evaluation (does not change CI outcomes)
- Lists optional config keys (epsilon, adapt, max_risk, ema_alpha, min_samples)
- Points to the shadow workflow: .github/workflows/epf_experiment.yml
- Mentions optional EPF artifacts: status_epf.json, epf_report.txt
- Adds script paths to Repository layout: scripts/epf_adaptive.py, scripts/check_gates.py
- No code behavior changes

## Summary
<!-- What does this change do? Why? -->

## Type of change
- [ ] Fix (non-breaking)
- [ ] Docs
- [ ] CI / infra
- [ ] Feature
- [ ] **Policy / thresholds change** (requires rationale)
- [ ] Other

## Checklist (PULSE governance)
- [ ] **PULSE CI is green** on this PR.
- [ ] **Quality Ledger attached**:
  - Link to live Pages (if enabled): `<https://hkati.github.io/pulse-release-gates-0.1/>`
  - or upload `report_card.html` as artifact/screenshot.
- [ ] **Badges updated** (`badges/*.svg`) — auto by CI.
- [ ] If **profiles/thresholds changed**: rationale included, and `profiles/*.yaml` + `docs/*` updated.
- [ ] If **external detectors** changed: `docs/EXTERNAL_DETECTORS.md` updated.
- [ ] **CHANGELOG.md** updated (Unreleased).
- [ ] Security impact considered (PII, policy strictness).
- [ ] No broken links in README.

## Decision rationale (required for policy/threshold changes)
<!-- Explain the why: data, RDSI/Δ, risk reduction, product impact. -->

## Screenshots / Artifacts
<!-- Optional: paste badges or key ledger screenshots -->
