### PR TITLE
docs(readme): add EPF (shadow-only); fix GFM breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,23 +124,24 @@ It will:
 
 > Tip: after making the repo **public**, add a **Branch protection rule** (Settings → Branches) and mark **PULSE CI** as a **required status check**.
 
----
-### EPF (experimental, shadow‑only)
 
-**TL;DR**: Deterministic, fail‑closed gates remain the **source of truth** for releases.  
-EPF runs **as a shadow evaluation** only; it never changes CI outcomes.
+## EPF (experimental, shadow‑only)
 
-**What is EPF?** An optional, **seeded and auditable** adaptive layer that operates
-*only* within the `[threshold − ε, threshold]` band to study potential false‑fail reduction.
+**TL;DR:** Deterministic, fail‑closed gates remain the source of truth for releases.  
+EPF runs as a **shadow evaluation only**; it never changes CI outcomes.
+
+**What is EPF?** An optional, seeded and auditable adaptive layer that operates only within the `[threshold - ε, threshold]` band to study potential false‑fail reduction.  
 Outside the band → **FAIL**; insufficient evidence → **DEFER/FAIL**; risk above `max_risk` → **FAIL**.
 
-**Status here:** *Experimental, CI‑neutral (shadow run)* via `.github/workflows/epf_experiment.yml`.  
-Artifacts:  
-- `status_baseline.json` – deterministic decisions  
-- `status_epf.json` – EPF shadow traces & decisions  
-- `epf_report.txt` – A/B diff summary
+**Status:** Experimental, CI‑neutral (shadow run) via `.github/workflows/epf_experiment.yml`.
 
-**Optional config keys (per gate):**
+### Artifacts
+- `status_baseline.json` — deterministic decisions
+- `status_epf.json` — EPF shadow traces & decisions
+- `epf_report.txt` — A/B diff summary
+
+### Optional config keys (per gate)
+
 ```yaml
 gates:
   - id: q1_groundedness
@@ -150,6 +151,9 @@ gates:
     max_risk: 0.20
     ema_alpha: 0.20
     min_samples: 5
+```
+
+---
 
 ## Repository layout
 ```


### PR DESCRIPTION
Place the EPF section after “CI — already wired” and above the hr (---). Use Markdown-only (no <details>, no <p>) to avoid GFM HTML/MD mixing. Add blank lines around code fences and before/after the hr. Normalize headings: "Artifacts" and "Optional config keys (per gate)".

Docs-only; no CI/runtime impact.

## Summary
<!-- What does this change do? Why? -->

## Type of change
- [ ] Fix (non-breaking)
- [ ] Docs
- [ ] CI / infra
- [ ] Feature
- [ ] **Policy / thresholds change** (requires rationale)
- [ ] Other

## Checklist (PULSE governance)
- [ ] **PULSE CI is green** on this PR.
- [ ] **Quality Ledger attached**:
  - Link to live Pages (if enabled): `<https://hkati.github.io/pulse-release-gates-0.1/>`
  - or upload `report_card.html` as artifact/screenshot.
- [ ] **Badges updated** (`badges/*.svg`) — auto by CI.
- [ ] If **profiles/thresholds changed**: rationale included, and `profiles/*.yaml` + `docs/*` updated.
- [ ] If **external detectors** changed: `docs/EXTERNAL_DETECTORS.md` updated.
- [ ] **CHANGELOG.md** updated (Unreleased).
- [ ] Security impact considered (PII, policy strictness).
- [ ] No broken links in README.

## Decision rationale (required for policy/threshold changes)
<!-- Explain the why: data, RDSI/Δ, risk reduction, product impact. -->

## Screenshots / Artifacts
<!-- Optional: paste badges or key ledger screenshots -->
