### PR TITLE
docs(readme): add EPF Kaggle dataset DOI + repro notebook link (mirrors)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,18 @@
 
 ### Project links (mirrors)
 
-- **Repo (GitHub):** https://github.com/HKati/pulse-release-gates-0.1
+- **Repo:** https://github.com/hkati/pulse-release-gates-0.1
 - **Live Quality Ledger:** https://hkati.github.io/pulse-release-gates-0.1/
-- **Kaggle Dataset:** https://www.kaggle.com/datasets/horvathkatalin/pulse-deterministic-fail-closed-release-gates
-- **Kaggle Notebook (offline quick start):** https://www.kaggle.com/code/horvathkatalin/pulse-demo-offline-quick-start-q3-q4-ledger
-- **DOI (versioned):** https://doi.org/10.5281/zenodo.17373002
-- **DOI (concept / all versions):** https://doi.org/10.5281/zenodo.17214908
+
+- **Kaggle Dataset (EPF A/B artifacts, seeded) — DOI:** https://doi.org/10.34740/kaggle/dsv/13571702
+- **Kaggle Dataset (baseline demo; deterministic, fail‑closed):** https://www.kaggle.com/datasets/horvathkatalin/pulse-deterministic-fail-closed-release-gates
+
+- **Kaggle Notebook (repro figures — EPF A/B, seeded):** <PASTE_NOTEBOOK_URL>
+- **Kaggle Notebook (offline quick start — Ledger & Q3+Q4):** https://www.kaggle.com/code/horvathkatalin/pulse-demo--offline-quick-start-q3-q4-ledger
+
+- **DOI (versioned, Zenodo):** https://doi.org/10.5281/zenodo.17373002
+- **DOI (concept / all versions, Zenodo):** https://doi.org/10.5281/zenodo.17214908
+
 
 # PULSE — Release Gates for Safe & Useful AI
 


### PR DESCRIPTION
- Add Kaggle Dataset (EPF A/B artifacts, seeded) via DOI
- Add Kaggle Notebook (repro figures — EPF A/B, seeded)
- Keep baseline demo dataset link (deterministic, fail-closed) separately
- Order mirrors: repo, ledger, Kaggle (EPF + baseline), notebooks, DOIs

## Summary
<!-- What does this change do? Why? -->

## Type of change
- [ ] Fix (non-breaking)
- [ ] Docs
- [ ] CI / infra
- [ ] Feature
- [ ] **Policy / thresholds change** (requires rationale)
- [ ] Other

## Checklist (PULSE governance)
- [ ] **PULSE CI is green** on this PR.
- [ ] **Quality Ledger attached**:
  - Link to live Pages (if enabled): `<https://hkati.github.io/pulse-release-gates-0.1/>`
  - or upload `report_card.html` as artifact/screenshot.
- [ ] **Badges updated** (`badges/*.svg`) — auto by CI.
- [ ] If **profiles/thresholds changed**: rationale included, and `profiles/*.yaml` + `docs/*` updated.
- [ ] If **external detectors** changed: `docs/EXTERNAL_DETECTORS.md` updated.
- [ ] **CHANGELOG.md** updated (Unreleased).
- [ ] Security impact considered (PII, policy strictness).
- [ ] No broken links in README.

## Decision rationale (required for policy/threshold changes)
<!-- Explain the why: data, RDSI/Δ, risk reduction, product impact. -->

## Screenshots / Artifacts
<!-- Optional: paste badges or key ledger screenshots -->
