### PR TITLE
chore(citation): append Kaggle dataset references (EPF A/B DOI + base…

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -47,3 +47,25 @@ preferred-citation:
   version: "v1.0.2"
   doi: "10.5281/zenodo.17373002"
   url: "https://doi.org/10.5281/zenodo.17373002"
+
+references:
+  - type: dataset
+    title: "PULSE EPF Shadow A/B artifacts (seeded)"
+    authors:
+      - family-names: "Horvat"
+        given-names: "Katalin"
+        orcid: "https://orcid.org/0000-0001-9745-3764"
+        affiliation: "EPLabsAI"
+    year: 2025
+    doi: "10.34740/KAGGLE/DSV/13571702"
+    url: "https://www.kaggle.com/dsv/13571702"
+
+  - type: dataset
+    title: "PULSE: deterministic, fail-closed release gates (offline demo pack)"
+    authors:
+      - family-names: "Horvat"
+        given-names: "Katalin"
+        orcid: "https://orcid.org/0000-0001-9745-3764"
+        affiliation: "EPLabsAI"
+    year: 2025
+    url: "https://www.kaggle.com/datasets/horvathkatalin/pulse-deterministic-fail-closed-release-gates"


### PR DESCRIPTION
…line demo)

- Add dataset references at end of CITATION.cff:
  * PULSE EPF Shadow A/B artifacts (seeded) — DOI 10.34740/KAGGLE/DSV/13571702
  * PULSE deterministic, fail-closed release gates (offline demo pack)
- Keep preferred-citation pointing to the software (Zenodo DOI).

## Summary
<!-- What does this change do? Why? -->

## Type of change
- [ ] Fix (non-breaking)
- [ ] Docs
- [ ] CI / infra
- [ ] Feature
- [ ] **Policy / thresholds change** (requires rationale)
- [ ] Other

## Checklist (PULSE governance)
- [ ] **PULSE CI is green** on this PR.
- [ ] **Quality Ledger attached**:
  - Link to live Pages (if enabled): `<https://hkati.github.io/pulse-release-gates-0.1/>`
  - or upload `report_card.html` as artifact/screenshot.
- [ ] **Badges updated** (`badges/*.svg`) — auto by CI.
- [ ] If **profiles/thresholds changed**: rationale included, and `profiles/*.yaml` + `docs/*` updated.
- [ ] If **external detectors** changed: `docs/EXTERNAL_DETECTORS.md` updated.
- [ ] **CHANGELOG.md** updated (Unreleased).
- [ ] Security impact considered (PII, policy strictness).
- [ ] No broken links in README.

## Decision rationale (required for policy/threshold changes)
<!-- Explain the why: data, RDSI/Δ, risk reduction, product impact. -->

## Screenshots / Artifacts
<!-- Optional: paste badges or key ledger screenshots -->
