### PR TITLE
feat(gates): add normative gates schema (v1) — schemas/gates.schema.json

### DIFF
--- a/schemas/gates.schema.json
+++ b/schemas/gates.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hkatilab.github.io/pulse-release-gates-0.1/schemas/gates.schema.json",
+  "title": "PULSE gates.yaml schema (v1)",
+  "type": "object",
+  "required": ["schemaVersion", "run", "invariants", "quality", "decision"],
+  "properties": {
+    "schemaVersion": { "type": "integer", "enum": [1] },
+    "run": {
+      "type": "object",
+      "required": ["name", "project"],
+      "properties": {
+        "name": { "type": "string" },
+        "project": { "type": "string" },
+        "modelVersion": { "type": "string" },
+        "seed": { "type": "integer" },
+        "deterministic": {
+          "type": "object",
+          "properties": {
+            "torch": { "type": "boolean" },
+            "cuda_deterministic": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        },
+        "timeouts": {
+          "type": "object",
+          "properties": {
+            "defaultMs": { "type": "integer", "minimum": 100 },
+            "perRule": { "type": "object", "additionalProperties": { "type": "integer", "minimum": 100 } }
+          },
+          "additionalProperties": false
+        },
+        "retries": {
+          "type": "object",
+          "properties": {
+            "max": { "type": "integer", "minimum": 0, "maximum": 3 },
+            "backoffMs": { "type": "integer", "minimum": 0 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "invariants": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "detector", "failOnError", "severity"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^I[2-7]$" },
+          "name": { "type": "string" },
+          "detector": { "type": "string" },
+          "params": { "type": "object", "additionalProperties": true },
+          "evidence": { "type": "boolean" },
+          "failOnError": { "type": "boolean" },
+          "severity": { "type": "string", "enum": ["blocker", "critical", "major"] }
+        },
+        "additionalProperties": false
+      }
+    },
+    "quality": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "metric", "comparator", "threshold"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^Q[1-4]$" },
+          "name": { "type": "string" },
+          "metric": { "type": "string" },
+          "comparator": { "type": "string", "enum": ["gte", "lte"] },
+          "threshold": { "type": "number" },
+          "weight": { "type": "number", "minimum": 0, "maximum": 1 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "decision": {
+      "type": "object",
+      "required": ["rules"],
+      "properties": {
+        "rules": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["id", "final"],
+            "properties": {
+              "id": { "type": "string" },
+              "ifAnyInvariantFail": { "type": "boolean" },
+              "ifAll": { "type": "array", "items": { "type": "string" } },
+              "final": { "type": "string", "enum": ["FAIL", "STAGE-PASS", "PROD-PASS"] }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "artifacts": {
+      "type": "object",
+      "properties": {
+        "save": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Adds a versioned JSON Schema for gates.yaml to make release gates declarative, reviewable, and machine-validated.

Highlights
- IDs validated: I2–I7 (invariants) and Q1–Q4 (quality gates).
- Required sections: schemaVersion, run, invariants, quality, decision.
- Determinism knobs: seed, deterministic.{torch,cuda_deterministic}.
- Ops policy: timeouts (default/perRule) and retries (max/backoffMs).
- Decision rules: supports tri‑state finals {FAIL, STAGE-PASS, PROD-PASS}.
- Artifacts: optional `artifacts.save` list for reports.

Compatibility
- Purely additive; no change to core gate logic or existing packs.
- Consumers may start validating gates.yaml against this schema; CI wiring will follow in the next PR.

Next
- Add `profiles/ci_prod.yaml` example and CI schema validation.
- Export status.json to JUnit/SARIF and post a structured PR summary.

## Summary
<!-- What does this change do? Why? -->

## Type of change
- [ ] Fix (non-breaking)
- [ ] Docs
- [ ] CI / infra
- [ ] Feature
- [ ] **Policy / thresholds change** (requires rationale)
- [ ] Other

## Checklist (PULSE governance)
- [ ] **PULSE CI is green** on this PR.
- [ ] **Quality Ledger attached**:
  - Link to live Pages (if enabled): `<https://hkati.github.io/pulse-release-gates-0.1/>`
  - or upload `report_card.html` as artifact/screenshot.
- [ ] **Badges updated** (`badges/*.svg`) — auto by CI.
- [ ] If **profiles/thresholds changed**: rationale included, and `profiles/*.yaml` + `docs/*` updated.
- [ ] If **external detectors** changed: `docs/EXTERNAL_DETECTORS.md` updated.
- [ ] **CHANGELOG.md** updated (Unreleased).
- [ ] Security impact considered (PII, policy strictness).
- [ ] No broken links in README.

## Decision rationale (required for policy/threshold changes)
<!-- Explain the why: data, RDSI/Δ, risk reduction, product impact. -->

## Screenshots / Artifacts
<!-- Optional: paste badges or key ledger screenshots -->
