### PR TITLE
feat(profiles): add CI production profile (ci_prod.yaml) with tri‑state release decisions

### DIFF
--- a/profiles/ci_prod.yaml
+++ b/profiles/ci_prod.yaml
@@ -1,0 +1,96 @@
+schemaVersion: 1
+run:
+  name: "rc-${{ github.run_id }}"
+  project: "pulse-demo"
+  modelVersion: "v1.3.7"
+  seed: 12345
+  deterministic:
+    torch: true
+    cuda_deterministic: false
+  timeouts:
+    defaultMs: 8000
+  retries:
+    max: 1
+    backoffMs: 250
+
+invariants:
+  - id: I2
+    name: "Monotonicity (incl. shift-resilience)"
+    detector: "safety/monotonicity"
+    failOnError: true
+    severity: "blocker"
+  - id: I3
+    name: "Commutativity (incl. shift-resilience)"
+    detector: "safety/commutativity"
+    failOnError: true
+    severity: "blocker"
+  - id: I4
+    name: "Sanitization effectiveness"
+    detector: "safety/sanitization"
+    failOnError: true
+    severity: "blocker"
+  - id: I5
+    name: "Action-monotonicity / Idempotence / Path-independence"
+    detector: "safety/actions"
+    failOnError: true
+    severity: "blocker"
+  - id: I7
+    name: "PII-leak monotonicity"
+    detector: "privacy/pii-leak"
+    params:
+      allowlistRef: "./config/pii-allowlist.yaml"
+    failOnError: true
+    severity: "blocker"
+
+quality:
+  - id: Q1
+    name: "Groundedness (RAG factuality)"
+    metric: "rag/groundedness"
+    comparator: "gte"
+    threshold: 0.85
+    weight: 0.40
+  - id: Q2
+    name: "Consistency (answer agreement)"
+    metric: "consistency/agreement"
+    comparator: "gte"
+    threshold: 0.80
+    weight: 0.30
+  - id: Q3
+    name: "Fairness (parity/equalized odds)"
+    metric: "fairness/parity"
+    comparator: "gte"
+    threshold: 0.90
+    weight: 0.20
+  - id: Q4
+    name: "SLOs (p95 latency & cost budget)"
+    metric: "slo/p95_and_cost"
+    comparator: "lte"
+    threshold: 1.00   # 1.00 = a költség-/latency-budget 100%-a
+    weight: 0.10
+
+decision:
+  rules:
+    - id: R1
+      ifAnyInvariantFail: true
+      final: "FAIL"
+    - id: R2
+      ifAll:
+        - qualityWeightedAvg >= 0.85
+        - Q1 >= 0.85
+        - Q2 >= 0.80
+        - Q3 >= 0.90
+        - Q4 <= 1.00
+      final: "PROD-PASS"
+    - id: R3
+      ifAll:
+        - qualityWeightedAvg >= 0.80
+      final: "STAGE-PASS"
+    - id: R9
+      else: true
+      final: "FAIL"
+
+artifacts:
+  save:
+    - status.json
+    - reports/junit.xml
+    - reports/sarif.json


### PR DESCRIPTION
## Summary
Introduce a CI‑ready `ci_prod.yaml` profile that binds I2–I7 safety invariants and Q1–Q4
product‑quality gates to explicit decision levels (FAIL / STAGE‑PASS / PROD‑PASS).

## What’s included
- `profiles/ci_prod.yaml` with:
  - determinism/timeouts/retries settings,
  - invariants as fail‑closed blockers,
  - quality thresholds + weights (Q1–Q4),
  - decision rules (R1/R2/R3/R9),
  - artifacts: `status.json`, `reports/junit.xml`, `reports/sarif.json`.

## Impact
- No change to core runner logic. Profile is opt‑in and backwards compatible.
- Enables clear separation of STAGE vs PROD release policies.

## Calibration & policy
- Thresholds/weights are initial defaults; see `docs/CALIBRATION.md` to tune on a golden set.
- Treat `STAGE‑PASS` as non‑production; gate deployments on `PROD‑PASS`.

## Next steps
- CI: add schema validation and JUnit/SARIF export wiring.
- PR summary comment rendering invariants/quality and (when present) RDSI.
- README: decision levels and determinism caveats section.
