### PR TITLE
ci(report): JUnit exporter for status.json (under PULSE_safe_pack_v0/tools)

### DIFF
--- a/PULSE_safe_pack_v0/tools/status_to_junit.py
+++ b/PULSE_safe_pack_v0/tools/status_to_junit.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+import json, os, xml.etree.ElementTree as ET
+from datetime import datetime
+
+STATUS = os.environ.get("PULSE_STATUS", "status.json")
+OUT = os.environ.get("PULSE_JUNIT", "reports/junit.xml")
+
+with open(STATUS, "r", encoding="utf-8") as f:
+    s = json.load(f)
+
+tests = []
+def row(k, v, kind):
+    name = f"{k} - {kind}"
+    passed = bool(v.get("passed", False))
+    msg = json.dumps(v, ensure_ascii=False)
+    tests.append((name, passed, msg))
+
+for k, v in (s.get("invariants") or {}).items():
+    row(k, v, "invariant")
+for k, v in (s.get("quality") or {}).items():
+    row(k, v, "quality")
+
+ts = ET.Element("testsuite", {
+    "name": "PULSE Gates",
+    "timestamp": datetime.utcnow().isoformat() + "Z",
+    "tests": str(len(tests)),
+    "failures": str(sum(0 if p else 1 for _, p, _ in tests))
+})
+for name, passed, msg in tests:
+    tc = ET.SubElement(ts, "testcase", {"classname": "pulse", "name": name})
+    if not passed:
+        fail = ET.SubElement(tc, "failure", {"message": "FAIL"})
+        fail.text = msg
+
+os.makedirs(os.path.dirname(OUT), exist_ok=True)
+ET.ElementTree(ts).write(OUT, encoding="utf-8", xml_declaration=True)
+print(f"Wrote {OUT}")


### PR DESCRIPTION
## Summary
Add a stdlib-only JUnit exporter colocated with the pack's tools to prevent
top-level path conflicts and simplify CI wiring.

## What’s included
- `PULSE_safe_pack_v0/tools/status_to_junit.py`
  - Input: `PULSE_STATUS` (default `status.json`)
  - Output: `PULSE_JUNIT` (default `reports/junit.xml`)
  - Invariants/quality → JUnit testcases; failures contain the JSON payload.

## CI usage (Linux/macOS)
```yaml
- name: Export JUnit
  run: |
    PULSE_STATUS=PULSE_safe_pack_v0/artifacts/status.json \
    PULSE_JUNIT=reports/junit.xml \
    python PULSE_safe_pack_v0/tools/status_to_junit.py
- name: Upload JUnit
  uses: actions/upload-artifact@v4
  with:
    name: pulse-junit
    path: reports/junit.xml
