### PR TITLE
ci(report): SARIF exporter for status.json (under PULSE_safe_pack_v0/tools)

### DIFF
--- a/PULSE_safe_pack_v0/tools/status_to_sarif.py
+++ b/PULSE_safe_pack_v0/tools/status_to_sarif.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import json, os, time
+
+STATUS = os.environ.get("PULSE_STATUS", "status.json")
+OUT = os.environ.get("PULSE_SARIF", "reports/sarif.json")
+
+with open(STATUS, "r", encoding="utf-8") as f:
+    s = json.load(f)
+
+results, rules, seen = [], [], set()
+
+def push(rule_id, level, payload):
+    global results, rules, seen
+    results.append({
+        "ruleId": rule_id,
+        "level": level,
+        "message": {"text": json.dumps(payload, ensure_ascii=False)}
+    })
+    if rule_id not in seen:
+        rules.append({
+            "id": rule_id,
+            "shortDescription": {"text": rule_id},
+            "defaultConfiguration": {"level": level}
+        })
+        seen.add(rule_id)
+
+for k, v in (s.get("invariants") or {}).items():
+    push(k, "error" if not v.get("passed", False) else "none", v)
+
+for k, v in (s.get("quality") or {}).items():
+    push(k, "warning" if not v.get("passed", False) else "none", v)
+
+sarif = {
+  "version": "2.1.0",
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [{
+    "tool": { "driver": { "name": "PULSE", "rules": rules }},
+    "results": results,
+    "invocations": [{
+      "executionSuccessful": True,
+      "startTimeUtc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    }]
+  }]
+}
+
+os.makedirs(os.path.dirname(OUT), exist_ok=True)
+with open(OUT, "w", encoding="utf-8") as f:
+    json.dump(sarif, f, ensure_ascii=False, indent=2)
+print(f"Wrote {OUT}")


### PR DESCRIPTION
## Summary
Add a stdlib-only SARIF exporter colocated with the pack's tools. This lets
PULSE gate outcomes surface in **Security → Code scanning alerts**.

## What’s included
- `PULSE_safe_pack_v0/tools/status_to_sarif.py`
  - Input: `PULSE_STATUS` (default `status.json`)
  - Output: `PULSE_SARIF` (default `reports/sarif.json`)
  - Invariants → error, Quality → warning (passed → none)

## CI usage
```yaml
- name: Export SARIF
  run: |
    PULSE_STATUS=PULSE_safe_pack_v0/artifacts/status.json \
    PULSE_SARIF=reports/sarif.json \
    python PULSE_safe_pack_v0/tools/status_to_sarif.py
- name: Upload SARIF (artifact)
  uses: actions/upload-artifact@v4
  with:
    name: pulse-sarif
    path: reports/sarif.json
# Optional: publish to Code scanning (public repos, or private + GHAS)
- name: Upload SARIF to Code scanning
  uses: github/codeql-action/upload-sarif@v2
  with:
    sarif_file: reports/sarif.json
