### PR TITLE
ci: add JUnit+SARIF exporter wiring and artifact uploads (always-run)

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -172,7 +172,7 @@ jobs:
 +    PULSE_SARIF=reports/sarif.json \
 +    python PULSE_safe_pack_v0/tools/status_to_sarif.py
 +
-@@
+
 - name: Upload artifacts
 + name: Upload artifacts
    if: always()


### PR DESCRIPTION
- Export JUnit & SARIF from status.json (always-run).
- Upload reports/junit.xml and reports/sarif.json alongside existing artifacts.
- Optional: publish SARIF to Code scanning (security-events: write).
