### PR TITLE
chore(git): add .gitignore for CI reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# CI reports
+reports/


### PR DESCRIPTION
## Summary
Add a root `.gitignore` entry so CI-generated reports don’t get committed.

## What’s included
- Ignore `reports/` (JUnit `reports/junit.xml`, SARIF `reports/sarif.json`)
- Optional (not enabled): if needed later, we can also ignore pack artifacts

## Impact
- Keeps the repo clean; reports remain accessible as GitHub Actions artifacts.
- No changes to gates or workflow logic.

## Notes
- If a `.gitignore` already existed, we would append lines rather than replace it.
