### PR TITLE
ci: skip PULSE CI on docs-only changes

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1,8 +1,16 @@
 name: PULSE CI
 
 on:
-  push: {}
-  pull_request: {}
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION

Adds paths-ignore to pulse_ci.yml so docs/** and *.md edits do not trigger the
fail-closed pipeline. Reduces noise; functional/config changes still run gates.
