### PR TITLE
docs(readme): add decision levels, determinism caveats, and native CI…

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ PULSE enforces fail‑closed PASS/FAIL gates across Safety (I₂–I₇), Qualit
 - **RDSI** (Release Decision Stability Index) + Δ with CIs
 - **Badges** (PASS/FAIL, RDSI, Q-Ledger) in `/badges/`
 
+## Decision levels
+
+**FAIL** (pipeline blocked) • **STAGE-PASS** (staging release) • **PROD-PASS** (production deploy allowed).  
+Break‑glass overrides require justification; the justification is recorded in the Quality Ledger.
+
+## Determinism (caveats)
+
+PULSE is deterministic if the runner image + seeds + CPU/GPU mode are pinned. External detectors and GPU kernel variance can introduce flakiness; EPF (shadow) + RDSI quantify stability without ever changing CI outcomes.
+
+## Native CI outputs
+
+From `status.json`, PULSE exports **JUnit** (Tests tab) and **SARIF** (Security → Code scanning alerts) into `reports/` and uploads them as CI artifacts.
+
 ---
 
 ## CI — already wired


### PR DESCRIPTION
… outputs

Adds three concise README blocks clarifying decision levels (FAIL/STAGE-PASS/PROD-PASS), determinism caveats (GPU/external detector variance; EPF+RDSI diagnostics), and native exports (JUnit/SARIF). Doc-only.

<!-- PULSE PR Template v1.0 — keep sections; fill what applies. -->

## Summary
<!-- Short: what changes and why? -->

## What’s included
- [ ] Code
- [ ] Docs
- [ ] CI / workflow
- Paths / files touched:

## CI usage
```yaml
# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json
```

## Impact
- Additive / backwards-compatible
- Breaking change — details:
- Performance / SLO impact:
- Security considerations:

## Notes
- Follow-ups:
- Risks / mitigations:

## PULSE checklist (governance)
- [ ] PULSE CI is green on this PR
- [ ] Quality Ledger link (if enabled)
- [ ] Badges updated (PASS / RDSI / Q‑Ledger)
