### PR TITLE
test(fixtures): add minimal status.json fixture

### DIFF
--- a/tests/fixtures/status_min.json
+++ b/tests/fixtures/status_min.json
@@ -1,0 +1,9 @@
+{
+  "schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PULSE status (minimal)",
+  "seed": 12345,
+  "metrics": {},
+  "decisions": {
+    "final": "PASS"
+  }
+}


### PR DESCRIPTION
## Summary
Add a tiny, schema-aligned `status_min.json` fixture (seed=12345, `decisions.final: PASS`) for offline exporter smoke tests.

## What's included
- `tests/fixtures/status_min.json`

## Impact
Test-only; no gate logic or CI changes.
