### PR TITLE
ci: add tools-tests job (offline exporter smoke tests)

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -201,3 +201,25 @@ jobs:
           path: |
             ${{ env.PACK_DIR }}/artifacts/**
             badges/*.svg
+
+  tools-tests:
+    name: Tools smoke tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run exporter smoke tests
+        run: |
+          python - <<'PY'
+          import pathlib, subprocess, os, sys
+          root = pathlib.Path('.').resolve()
+          # ensure out dir
+          (root / 'tests' / 'out').mkdir(parents=True, exist_ok=True)
+          # run tests file directly (no external deps)
+          subprocess.check_call([sys.executable, 'tests/test_exporters.py'])
+          print('Exporter smoke tests OK')
+          PY


### PR DESCRIPTION
## Summary
Add a tiny, CI-neutral job **tools-tests** to run `tests/test_exporters.py` offline and
smoke-test the status→JUnit and status→SARIF converters.

## What changed
- `.github/workflows/pulse_ci.yml`: new job **tools-tests**
  - Python 3.11, no external deps / no network
  - creates `tests/out/` and writes `junit.xml` + `sarif.json`

## Why
Quick, deterministic verification of the exporter tools without touching gate logic.

## CI impact
- Non-blocking by design (release gates unaffected).
- `paths-ignore` for docs/** and **/*.md stays the same.

## Notes
If later you want this job to be required, mark it in branch protection rules.
