### PR TITLE
docs: add RUNBOOK quickstart (local run & outputs)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,7 @@
+# PULSE Runbook (5-minute quickstart)
+
+## Local (Linux/macOS, Python 3.11)
+```bash
+python PULSE_safe_pack_v0/tools/run_all.py
+# artifacts: PULSE_safe_pack_v0/artifacts/status.json
+# exports (if wired): reports/junit.xml, reports/sarif.json


### PR DESCRIPTION
## Summary
Add a minimal **RUNBOOK** (5‑minute quickstart) so users can run PULSE locally
and find the generated outputs quickly.

## What’s included
- New file: `docs/RUNBOOK.md`
- Local run snippet (Linux/macOS, Python 3.11)
- Where artifacts land: `PULSE_safe_pack_v0/artifacts/status.json`
- Where exporters write (if wired): `reports/junit.xml`, `reports/sarif.json`

## Why
Provide a copy‑pasteable starting point and consistent pointers to outputs.

## CI impact
Documentation‑only; no logic changes. Existing CI behavior remains the same.

## Notes / next
Consider adding a short Windows (PowerShell) block and a tiny “How to view in CI”
note in a follow‑up, but keeping this page intentionally terse is good.
