### PR TITLE
docs: expand RUNBOOK (Windows quickstart, outputs, mini CI exporters)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,7 +1,15 @@
-# PULSE Runbook (5-minute quickstart)
+# PULSE Runbook — 5‑minute quickstart
+
+This page shows the minimal, copy‑pasteable way to run PULSE locally and where to find the outputs.
+No external runners are required.
+
+---
 
 ## Local (Linux/macOS, Python 3.11)
+
 ```bash
 python PULSE_safe_pack_v0/tools/run_all.py
-# artifacts: PULSE_safe_pack_v0/artifacts/status.json
-# exports (if wired): reports/junit.xml, reports/sarif.json
+
+# Outputs:
+#   Artifacts: PULSE_safe_pack_v0/artifacts/status.json
+#   (If exporters are wired) JUnit → reports/junit.xml, SARIF → reports/sarif.json


### PR DESCRIPTION
## Summary
Expand the **RUNBOOK** with:
- a Windows (PowerShell) quickstart,
- explicit output locations (status.json, JUnit/SARIF),
- a minimal CI exporters snippet (JUnit/SARIF + artifact upload).

## What's included
- Update: `docs/RUNBOOK.md`
- New sections: Windows quickstart; “In CI — minimal exporters snippet”
- Outputs: `PULSE_safe_pack_v0/artifacts/status.json`, `reports/junit.xml`, `reports/sarif.json`

## How to verify
- Render the page on GitHub and eyeball the code fences.
- (Optional) Run locally: `python PULSE_safe_pack_v0/tools/run_all.py` → check the listed paths exist.

## Impact
Documentation-only; no changes to code or workflow behavior.
CI pipelines remain intact.

## Notes
- Exporter snippet is deliberately minimal and guarded by `if: ${{ always() }}`.
- If exporters are already wired in your workflow, the snippet can be skipped.
