### PR TITLE
docs(q): add Q1- Q2 Quality Gates documentation

### DIFF
--- a/docs/METHODS_Q1_Q2.md
+++ b/docs/METHODS_Q1_Q2.md
@@ -1,0 +1,33 @@
+# Q1–Q2 Quality Gates (deterministic baselines)
+
+## Q1 Groundedness (RAG factuality)
+**Cél.** Az output (answer) mennyire támaszkodik a megadott kontextusra.
+
+**Baseline metrika (determinista).**
+- Token coverage @ context: az answer tokenjeinek hányada megtalálható bármely kontextus-dokumentumban.
+- Normalizálás: lower-case, egyszerű tokenizálás, stop‑szavak opcionálisan elhagyhatók.
+- Kimenet: `q1_groundedness` ∈ [0,1].
+
+**Döntés.** PASS, ha `q1_groundedness ≥ threshold`.
+
+**Megjegyzés.** Későbbi bővítésként opcionális NLI/entitás‑linkelés/embedding‑overlap tehető hozzá „external detector” rétegként, de a baseline gépfüggetlen és auditálható.
+
+## Q2 Consistency (answer agreement)
+**Cél.** Az output stabilitása könnyű, determinista perturbációk mellett.
+
+**Baseline metrika (determinista).**
+- Jaccard‑hasónlóság (token‑szinten) a válasz‑variánsok között (pl. parafrázisok, mező‑sorrend, szinonima‑cserék).
+- Aggregálás: átlagos páronkénti Jaccard (vagy min‑over‑pairs, ha szigorúbb kell).
+- Kimenet: `q2_consistency` ∈ [0,1].
+
+**Döntés.** PASS, ha `q2_consistency ≥ threshold`.
+
+## Döntési politika (fail‑closed)
+- Küszöb alatt → **FAIL** (quality gate).
+- Számítási hiba/hiányos input → **DEFER/FAIL** (konzervatív).
+- Minden lépés determinisztikus; CPU‑first, seedelt környezet.
+
+## Küszöb‑ajánlás (baseline)
+- Q1: `threshold = 0.85` (lexikális coverage).
+- Q2: `threshold = 0.90` (erős egyezés).
+A végső értékeket a **CALIBRATION.md** szerint finomítsd (ROC/DET, költségplafonok, szórás‑margó).


### PR DESCRIPTION
## Summary
Introduce `docs/METHODS_Q1_Q2.md` documenting deterministic, model-free baselines for Quality gates:
- **Q1 Groundedness** (token coverage proxy)
- **Q2 Consistency** (pairwise Jaccard over answer variants)

Includes the fail-closed decision policy, calibration hooks, and notes on determinism/repeatability.

## What’s included
- [x] docs/METHODS_Q1_Q2.md
- [ ] Code
- [ ] CI/workflow (no changes)

## CI usage
Docs-only PR. Our `.github/workflows/pulse_ci.yml` has `paths-ignore` for `docs/**`, so the main PULSE CI job does not run on this PR. Link-check / pages workflows may still run.

## Impact
- Additive / backwards-compatible.
- No runtime / behavior changes.

## Notes
Follow-ups:
- Add small numeric examples (toy inputs + expected outputs).
- Cross-link from README (Quality gates) and `docs/DETERMINISM.md`.
