### PR TITLE
chore(zenodo): link Guard under Pulse in metadata (hasPart)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -14,6 +14,13 @@
   "related_identifiers": [
     { "identifier": "10.5281/zenodo.17214909", "relation": "isDocumentedBy", "scheme": "doi" },
     { "identifier": "10.5281/zenodo.17214908", "relation": "isVersionOf",   "scheme": "doi" }
+  {
+  "identifier": "https://github.com/HKati/pulse-guard-pack",
+  "relation": "hasPart",
+  "resource_type": "software",
+  "scheme": "url"
+}
+
   ],
   "notes": "Reproducibility instructions are included in the repository README (reproduce section).",
   "communities": []


### PR DESCRIPTION

### What
- Add Guard repository as `hasPart` in `.zenodo.json` → `related_identifiers`.

### Why
- Guard is a Pulse module. We want it to appear under the Pulse Zenodo record as a subcomponent (no separate DOI for Guard yet).

### Notes
- No code changes, metadata only.
- The link uses the GitHub URL (scheme: url). We can switch to Guard concept DOI later if we mint one.

### Checklist
- [x] `.zenodo.json` is valid JSON (no duplicate keys, no trailing commas).
- [x] Only one `related_identifiers` array remains.
- [x] Guard object appended at the end of the array.
