### PR TITLE
ci(gate): add pulse-paradox-gate.yml (shadow runner for Paradox Gate …

### DIFF
--- a/.github/workflows/pulse-paradox-gate.yml
+++ b/.github/workflows/pulse-paradox-gate.yml
@@ -1,0 +1,69 @@
+name: Pulse • Paradox Gate (shadow)
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: paradox-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  paradox_gate:
+    name: Run Paradox Gate (shadow)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout Pulse repo
+        uses: actions/checkout@v4
+
+      # Pull the gate ZIP from the public gate repo (current working branch)
+      - name: Checkout gate repo (ZIP seed)
+        uses: actions/checkout@v4
+        with:
+          repository: HKati/pulse-release-gates-0.1
+          ref: HKati-patch-61      # ← use this now; switch to a tag (e.g., gate-v0-zip) after merge
+          path: ./.gates
+
+      - name: Unpack Paradox Gate kit
+        run: unzip -q ./.gates/pulse_paradox_gate_ci_v1.zip -d ./.gates/_ex
+
+      - name: Decide metrics source (Decision Log vs. fallbacks)
+        id: metrics_src
+        shell: bash
+        run: |
+          if [ -f "logs/decision_log.ndjson" ]; then
+            echo "src=log" >> $GITHUB_OUTPUT
+            echo "Using Decision Log at logs/decision_log.ndjson"
+          else
+            echo "src=env" >> $GITHUB_OUTPUT
+            echo "Decision Log not found → using ENV fallbacks"
+            # Fallback metrics so the gate can run in shadow even with zero logs
+            echo "PF_PARADOX_DENSITY=0.0" >> $GITHUB_ENV
+            echo "PF_SETTLE_P95_MS=0" >> $GITHUB_ENV
+            echo "PF_DOWNSTREAM_ERROR_RATE=0.0" >> $GITHUB_ENV
+          fi
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run Paradox Gate (shadow, non-blocking)
+        shell: bash
+        run: |
+          G=".gates/_ex/pulse_paradox_gate_ci_v1/pulse/gates/paradox"
+          # The gate prefers ENV metrics if present; otherwise it will parse the log.
+          python "$G/gate.py" --mode shadow --policy "$G/policy.yaml"
+
+      - name: Upload Paradox Gate summary (artifact)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pulse-paradox-gate-summary
+          path: artifacts/pulse_paradox_gate_summary.json


### PR DESCRIPTION
## Summary
Introduce a minimal **Paradox Gate workflow** that runs from the public ZIP kit.
This enables the Pulse pipeline to `checkout → unzip → run` the gate in **shadow** mode.

## What’s included
- New workflow: `.github/workflows/pulse-paradox-gate.yml`
- It checks out `HKati/pulse-release-gates-0.1@HKati-patch-61`, unpacks
  `pulse_paradox_gate_ci_v1.zip`, and runs `gate.py --mode shadow`.
- Outputs `artifacts/pulse_paradox_gate_summary.json` (uploaded as a CI artifact).

## Why this change
- Fastest administrative path to start collecting live signals from the gate.
- Keeps release decisions non-blocking while we validate thresholds and telemetry.

## Usage notes
- **Temporary ref:** the workflow points to `HKati-patch-61`.  
  After merging the gate ZIP into `main`, create a tag (e.g., `gate-v0-zip`)
  and update `GATE_REF` accordingly.
- **Active mode:** later switch `PF_MODE: active` and make this workflow a **required** check
  to enforce fail-closed releases.

## Security & licensing
- No secrets or proprietary data; offline execution; audit-friendly.
- Repository content remains **English-only**.

## Test plan
1. Open a PR → workflow runs in **shadow** mode (non-blocking).
2. Confirm CI artifact `pulse-paradox-gate-summary` is present and contains
   `pulse_paradox_gate_summary.json` with `decision` and `metrics`.

## Rollout
- Phase 1: Shadow (non-blocking), collect signals.
- Phase 2: Tag the gate repo (e.g., `gate-v0-zip`), pin the workflow to the tag.
- Phase 3: Optional — switch to **active** (blocking) mode and mark the check as **required**.

## Acceptance criteria
- Workflow runs on PRs and pushes and produces the summary artifact.
- No regressions in CI time or reliability.
- All content is English-only.
