### PR TITLE
ci(paradox-gate): enable PR triage comment from gate summary

### DIFF
--- a/.github/workflows/pulse-paradox-gate.yml
+++ b/.github/workflows/pulse-paradox-gate.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: paradox-gate-${{ github.ref }}
@@ -66,3 +67,52 @@ jobs:
         with:
           name: pulse-paradox-gate-summary
           path: artifacts/pulse_paradox_gate_summary.json
+       
+        - name: Debug list artifacts dir
+  if: ${{ always() && github.event_name == 'pull_request' }}
+  run: ls -la artifacts || true
+ 
+        - name: Generate PR triage comment (Why it failed / What to try)
+  if: ${{ always() && github.event_name == 'pull_request' }}
+  continue-on-error: true           
+  run: |
+    python tools/gh_pr_comment_triage.py \
+      --summary artifacts/pulse_paradox_gate_summary.json \
+      --out triage_comment.md
+
+
+    
+ - name: Post or update PR comment
+      if: ${{ always() && github.event_name == 'pull_request' }}
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const path = 'triage_comment.md';
+          if (!fs.existsSync(path)) {
+            console.log('No triage_comment.md found — skipping PR comment.');
+          } else {
+            const body = fs.readFileSync(path, 'utf8');
+            const marker = '<!-- pulse-triage -->';
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            }
+          }


### PR DESCRIPTION
Adds PR-only triage steps that transform the gate summary into a concise
"Why it failed / What to try" comment. Grants issues: write. Advisory-only;
no change to gate logic.
