### PR TITLE
docs: add PULSE Topology v0 documentation (Stability Map spec)

### DIFF
--- a/docs/PULSE_topology_v0.md
+++ b/docs/PULSE_topology_v0.md
@@ -1,0 +1,24 @@
+# PULSE Topology v0 — Stability Map & Decision Engine Foundation
+
+This document introduces the `stability_map.json` artefact.
+
+The goal of the Stability Map is **not** to replace or override the existing
+deterministic release gates. Instead, it sits *above* them and provides:
+
+- a topological view over one or more PULSE runs (states and transitions),
+- a scalar **instability score** per run,
+- simple **state types** (STABLE / METASTABLE / UNSTABLE / PARADOX / COLLAPSE),
+- the foundation for a stability‑based Decision Engine in later versions.
+
+---
+
+## 1. File layout
+
+The new artefact lives alongside existing PULSE outputs in the safe pack:
+
+```text
+PULSE_safe_pack_v0/
+  artifacts/
+    status.json
+    status_epf.json          # optional, EPF shadow layer
+    stability_map.json       # NEW: stability topology (this document)


### PR DESCRIPTION
## Summary

This PR adds the initial **Pulse Topology v0** documentation as
`docs/Pulse_topology_v0.md`.

The document introduces the **Stability Map** layer that sits on top of the
existing `PULSE_safe_pack_v0` release-gate pack and provides a topological view
over one or more PULSE runs.

---

## What is included?

- Definition of the new `stability_map.json` artefact
- Schema for:
  - `ReleaseState` objects (per-run nodes)
  - `ReleaseTransition` objects (edges between runs, planned for later versions)
- A simple instability / tension score in `[0, 1]`, built from:
  - safety gate failures
  - quality gate failures
  - RDSI (Release Decision Stability Index)
  - EPF contraction proxy (`epf_L`, if available)
- A first state-type taxonomy:
  - `STABLE`, `METASTABLE`, `UNSTABLE`, `PARADOX`, `COLLAPSE`
- An outline of how this layer can support a future stability-based Decision Engine

---

## Why?

The goal is to have a **shared, structured view of stability** that:

- does **not** modify or replace the existing deterministic gates,
- but explains where a run sits in a stability landscape,
- and prepares the ground for:
  - paradox detection,
  - stable/unstable transition analysis,
  - and co-thinking between humans and agents.

This PR is documentation-only and safe to merge: no code paths or CI logic change.

---

## Implementation notes

- New file: `docs/Pulse_topology_v0.md`
- No changes to:
  - `PULSE_safe_pack_v0/artifacts/status.json`
  - existing release-gate scripts or configs
- Future PRs will:
  - add a `build_stability_map.py` helper under `PULSE_safe_pack_v0/tools/`
  - generate `stability_map.json` from existing artefacts
  - optionally add visualisation and a small Decision Engine on top.
