### PR TITLE
feat: add stability map JSON generator for Pulse Topology v0

### DIFF
--- a/stability_map.json
+++ b/stability_map.json
@@ -1,0 +1,53 @@
+{
+  "version": "0.1",
+  "generated_at": "2025-11-16T20:18:00.000000+00:00",
+  "states": [
+    {
+      "id": "run_001",
+      "label": "Run run_001",
+      "commit": "a1b2c3",
+      "pack": "PULSE_safe_pack_v0",
+
+      "decision": "STAGE-PASS",   // FAIL / STAGE-PASS / PROD-PASS / UNKNOWN
+
+      "gate_summary": {
+        "safety_total": 7,
+        "safety_failed": 1,
+        "quality_total": 4,
+        "quality_failed": 0
+      },
+
+      "rdsi": 0.81,
+      "rdsi_delta": 0.03,
+
+      "epf": {
+        "available": true,
+        "L": 0.94,
+        "shadow_pass": true
+      },
+
+      "instability": {
+        "score": 0.42,
+        "safety_component": 0.20,
+        "quality_component": 0.00,
+        "rdsi_component": 0.14,
+        "epf_component": 0.08
+      },
+
+      "type": "METASTABLE",       // STABLE / METASTABLE / UNSTABLE / PARADOX / COLLAPSE
+      "tags": ["model_v3", "new_refusal_policy"]
+    }
+  ],
+  "transitions": [
+    {
+      "from": "run_001",
+      "to": "run_002",
+      "label": "fairness fix + retrain",
+      "change": {
+        "type": ["data", "training"],
+        "notes": "balanced long-tail group; same refusal policy"
+      },
+      "delta_instability": -0.37
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the first **Stability Map JSON generator** for Pulse Topology v0.

A new helper script builds `stability_map.json` from existing PULSE artefacts
(`status.json` and optional `status_epf.json`) and produces a single-state
topological view over a run, including an instability score and a coarse
stability type.

---

## What is included?

- New tool:
  - `PULSE_safe_pack_v0/tools/build_stability_map.py`
    - reads `PULSE_safe_pack_v0/artifacts/status.json`
    - optionally reads `PULSE_safe_pack_v0/artifacts/status_epf.json`
    - summarises safety and quality gate failures
    - pulls RDSI and EPF (`epf_L`, `shadow_pass`) metrics when available
    - computes an instability score in `[0, 1]` with four components:
      - safety, quality, RDSI, EPF
    - assigns a state type:
      - `STABLE`, `METASTABLE`, `UNSTABLE`, `PARADOX`, or `COLLAPSE`
    - writes `PULSE_safe_pack_v0/artifacts/stability_map.json`
      with a **single** `ReleaseState` and an empty `transitions` list
- Optional demo artefact:
  - `PULSE_safe_pack_v0/artifacts/stability_map.demo.json`
    - example map with two runs and one transition for documentation/tests

---

## Why?

The Stability Map is a derived, optional layer on top of the existing
deterministic release gates. It does **not** change fail-closed behaviour.

It provides:

- a scalar instability/tension measure per run,
- decomposed contributions from safety/quality/RDSI/EPF,
- a coarse stability type that is easy to inspect (“where are we in the landscape?”).

This prepares the ground for later work:

- multi-run topologies with transitions,
- paradox detection,
- and a stability-based Decision Engine running on top of PULSE artefacts.

---

## Usage

Example:

```bash
python PULSE_safe_pack_v0/tools/build_stability_map.py \
  --status PULSE_safe_pack_v0/artifacts/status.json \
  --status-epf PULSE_safe_pack_v0/artifacts/status_epf.json \
  --out PULSE_safe_pack_v0/artifacts/stability_map.json
