### PR TITLE
docs: add PULSE Paradox Module v0 documentation

### DIFF
--- a/docs/PULSE_paradox_module_v0.md
+++ b/docs/PULSE_paradox_module_v0.md
@@ -1,0 +1,51 @@
+# PULSE Paradox Module v0 — Detection on the Stability Map
+
+This document introduces the **PULSE Paradox Module v0**.
+
+The goal of v0 is **paradox detection**, not full paradox resolution:
+
+- identify when a `ReleaseState` is structurally contradictory,
+- label the type of paradox using simple, transparent patterns,
+- expose this as additional metadata on top of the Stability Map.
+
+Later versions may add:
+
+- paradox decomposition,
+- suggested resolution directions,
+- and dedicated paradox-aware decision rules.
+
+---
+
+## 1. Where the paradox module lives
+
+The paradox module operates on top of the Stability Map artefact:
+
+- input: `stability_map.json` (Pulse Topology v0)
+- target: each `ReleaseState` inside `stability_map.states[]`
+
+v0 does not introduce a new artefact; instead, it extends each state with:
+
+- a `paradox` field containing detection results, and
+- (optionally) updates `state.type` to `PARADOX` when appropriate.
+
+Example state fragment:
+
+```jsonc
+{
+  "id": "run_002",
+  "decision": "PROD-PASS",
+  "type": "PARADOX",
+  "instability": { "...": "..." },
+  "gate_summary": { "...": "..." },
+  "epf": { "...": "..." },
+  "paradox": {
+    "present": true,
+    "patterns": ["SAFETY_QUALITY_CONFLICT"],
+    "details": [
+      {
+        "pattern": "SAFETY_QUALITY_CONFLICT",
+        "reason": "No safety gate failures, but one or more quality gates failed."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds documentation for **PULSE Paradox Module v0**, which defines
how paradox detection is applied on top of the Stability Map.

The module marks structurally contradictory `ReleaseState`s and exposes
the result via a new `state.paradox` field.

---

## What is included?

- New doc: `docs/PULSE_paradox_module_v0.md`
  - describes where the paradox module lives:
    - input: `stability_map.json`
    - target: each `ReleaseState` in `states[]`
  - defines the `state.paradox` schema:
    - `present`
    - `patterns`
    - optional `details[]` with human-readable reasons
  - specifies three v0 paradox patterns:
    1. `SAFETY_QUALITY_CONFLICT`  
       – safety gates pass, quality gates fail
    2. `DECISION_SCORE_CONFLICT`  
       – release decision is PASS while instability score is collapse-level
    3. `EPF_DECISION_CONFLICT`  
       – release decision is PASS while EPF indicates non-contractive behaviour
  - explains interaction with `state.type`:
    - if any paradox is present and `type` is not `COLLAPSE`, set `type = "PARADOX"`
  - provides pseudocode for a `detect_paradox(state)` helper and a simple
    integration snippet for the Stability Map builder.

---

## Why?

The Stability Map already aggregates metrics into an instability score
and stability type, but some states are not just "more or less unstable"
– they are **internally contradictory**.

The Paradox Module v0:

- gives PULSE a first-class way to mark such states as `PARADOX`,
- makes the patterns explicit and explainable,
- prepares the ground for paradox-aware decision logic without changing
  any existing fail-closed gates.

---

## Impact

- Documentation only; no code or workflow changes.
- Provides a clear contract for future implementations of
  `detect_paradox(state)` and for consumers of the `state.paradox` field.
