### PR TITLE
docs: add PULSE Topology Transitions v0 specification

### DIFF
--- a/docs/PULSE_topology_transitions_v0.md
+++ b/docs/PULSE_topology_transitions_v0.md
@@ -1,0 +1,35 @@
+# PULSE Topology Transitions v0 — Multi‑Run Stability Map
+
+This document extends the Pulse Topology v0 specification with **transitions**
+between multiple `ReleaseState`s.
+
+While `PULSE_topology_v0.md` focuses on a single snapshot (one state),
+this document defines:
+
+- how multiple runs can coexist in `stability_map.json`
+- how transitions between runs are represented
+- how we classify transitions as stabilising / destabilising.
+
+The goal is to enable *trajectories* on the Stability Map without changing
+the core `ReleaseState` format.
+
+---
+
+## 1. Multi‑run Stability Map
+
+In v0, `stability_map.json` may contain **one or more** states:
+
+```jsonc
+{
+  "version": "0.1",
+  "generated_at": "2025-11-16T22:30:00.000000+00:00",
+  "states": [
+    { "...": "ReleaseState run_001" },
+    { "...": "ReleaseState run_002" },
+    { "...": "ReleaseState run_003" }
+  ],
+  "transitions": [
+    { "...": "Transition run_001 → run_002" },
+    { "...": "Transition run_002 → run_003" }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the **PULSE Topology Transitions v0** specification, which
extends the existing Stability Map with multi-run support and transitions
between `ReleaseState`s.

The document focuses on how to represent trajectories in
`stability_map.json` without changing the core `ReleaseState` format.

---

## What is included?

- New doc: `docs/PULSE_topology_transitions_v0.md`
  - describes a multi-run Stability Map:
    - multiple `states[]` entries, each a full `ReleaseState`
    - a `transitions[]` array connecting them
  - defines the `ReleaseTransition` v0 schema:
    - `from`, `to`, `label`
    - `change.type` (e.g. `data`, `training`, `policy`, `infra`)
    - `change.notes`
    - `delta_instability`
    - optional `delta_rdsi`, `delta_epf_L`
    - `category`: `STABILISING`, `DESTABILISING`, `NEUTRAL`
    - optional `tags`
  - specifies how to classify transitions based on `delta_instability`
  - provides a worked example with three runs and two transitions
  - outlines a future helper tool (`append_run_to_stability_map.py`) to
    build multi-run maps programmatically

---

## Why?

The current Stability Map captures a single snapshot of a PULSE run.
However, real model development is a sequence of runs and changes.

By defining transitions:

- we can represent how instability and other metrics evolve over time,
- we can label changes as stabilising or destabilising,
- we prepare the ground for path-aware Decision Engines and
  visualisation tools.

---

## Impact

- Documentation only; no changes to existing tools or workflows.
- Establishes a clear schema for future multi-run topology tooling.
