### PR TITLE
docs: add PULSE Dual View v0 documentation

### DIFF
--- a/docs/PULSE_dual_view_v0.md
+++ b/docs/PULSE_dual_view_v0.md
@@ -1,0 +1,24 @@
+# PULSE Dual View v0 — Human + Agent Interface
+
+This document introduces the **PULSE Dual View v0** format.
+
+The goal is to provide a single artefact that:
+
+- humans can read as a short narrative and risk summary,
+- agents can consume as a structured, machine-friendly JSON,
+- and both refer to the **same underlying Stability Map + Decision Engine data**.
+
+Dual View v0 is a *projection* on top of:
+
+- `stability_map.json` (single run snapshot),
+- optional `stability_history.json` (multi-run trajectory),
+- `decision_trace.json` (Decision Engine v0 output).
+
+---
+
+## 1. Dual View artefact
+
+Recommended filename:
+
+```text
+PULSE_safe_pack_v0/artifacts/dual_view_v0.json


### PR DESCRIPTION
## Summary

This PR adds documentation for **PULSE Dual View v0**, a shared
human + agent interface built on top of the Stability Map and Decision
Engine.

Dual View v0 defines a single artefact that presents the same state in:

- a human-oriented narrative (`human_view`)
- a machine-friendly JSON schema (`agent_view`)

---

## What is included?

- New doc: `docs/PULSE_dual_view_v0.md`
  - introduces the `dual_view_v0.json` artefact
  - defines:
    - `human_view`:
      - `headline`
      - `risk_summary[]`
      - `paradox_summary`
      - `timeline_highlights[]`
    - `agent_view`:
      - `action`, `risk_level`
      - `instability.score` and component breakdown
      - `paradox.present` and `paradox.patterns`
      - `decision.release_decision`, `decision.stability_type`
      - optional `history.last_transition`
  - explains how inputs are taken from:
    - `stability_map.json` (ReleaseState, instability, paradox)
    - `decision_trace.json` (Decision Engine v0)
    - optional history / transitions
  - provides mapping rules for both views so they remain consistent
  - sketches a `build_dual_view_v0.py` helper script to generate the
    artefact from existing PULSE outputs

---

## Why?

PULSE now provides several artefacts (Stability Map, Paradox metadata,
Transitions, Decision Engine), but users and agents need a simple,
shared interface to interpret them.

Dual View v0:

- gives humans a short, readable summary of risk and history,
- gives agents a compact JSON schema with the same semantics,
- makes it easier to build co-thinking tools where both sides refer to
  the same object.

---

## Impact

- Documentation only; no changes to existing tools or workflows.
- Establishes a clear contract for any future `build_dual_view_v0.py`
  implementation and for consumers of `dual_view_v0.json`.
