### PR TITLE
docs: add PULSE Paradox Resolution v0 documentation

### DIFF
--- a/docs/PULSE_paradox_resolution_v0.md
+++ b/docs/PULSE_paradox_resolution_v0.md
@@ -1,0 +1,37 @@
+# PULSE Paradox Resolution v0 — Triage & Resolution Plans
+
+This document extends the **PULSE Paradox Module v0** from *detection* to
+a first version of *resolution planning*.
+
+The goal of v0 is:
+
+- not to fully “solve” paradoxes automatically,
+- but to attach a small, structured **resolution plan** to each paradox,
+- so that humans and agents have a clear starting point for action.
+
+Resolution v0 lives **inside** the existing `state.paradox` block.
+
+---
+
+## 1. Where resolution attaches
+
+We extend the `paradox` field on each `ReleaseState` (see
+`PULSE_paradox_module_v0.md`) with an optional `resolution` block:
+
+```jsonc
+"paradox": {
+  "present": true,
+  "patterns": ["SAFETY_QUALITY_CONFLICT", "EPF_DECISION_CONFLICT"],
+  "details": [
+    { "pattern": "...", "reason": "..." }
+  ],
+  "resolution": {
+    "severity": "HIGH",
+    "primary_focus": ["quality", "policy", "epf"],
+    "recommendations": [
+      "Review failing quality gates and clarify acceptance thresholds.",
+      "Check if refusal / policy changes are aligned with quality metrics.",
+      "Inspect EPF L > 1.0 behaviour and consider tightening adaptation rules."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds **PULSE Paradox Resolution v0** documentation, extending
the existing Paradox Module from detection to a first version of
resolution planning.

The new spec describes how to attach triage and recommendations to
paradoxical `ReleaseState`s.

---

## What is included?

- New doc: `docs/PULSE_paradox_resolution_v0.md`
  - introduces the `paradox.resolution` block inside each `ReleaseState`:
    - `severity` (LOW / MEDIUM / HIGH)
    - `primary_focus[]` (e.g. safety, quality, data, training, policy, epf)
    - `recommendations[]` (short, ordered action suggestions)
  - defines v0 resolution heuristics for each paradox pattern:
    - `SAFETY_QUALITY_CONFLICT`
    - `DECISION_SCORE_CONFLICT`
    - `EPF_DECISION_CONFLICT`
  - explains how multiple patterns are merged into a single resolution plan:
    - max severity across all patterns
    - union of focus tags (de-duplicated)
    - combined recommendations (3–6 bullets)
  - describes the interaction with the Decision Engine:
    - resolution plans guide *what to review first* when the engine
      emits `REVIEW` or `BLOCK`
  - provides pseudocode for a `build_paradox_resolution(state)` helper
    and an example of how to attach it under `state.paradox.resolution`

---

## Why?

Paradox detection tells us *that* a state is contradictory, but does not
indicate *how to respond*.

Paradox Resolution v0:

- adds a small triage layer (severity + focus),
- provides concrete first-step recommendations,
- gives both humans and agents a structured starting point for handling
  paradoxical states, while keeping the logic simple and transparent.

---

## Impact

- Documentation only; no changes to existing tools, gates or CI flows.
- Establishes a clear contract for future implementations of
  `build_paradox_resolution(state)` and for consumers of
  `paradox.resolution`.
