### PR TITLE
docs: add PULSE Topology HOWTO v0

### DIFF
--- a/docs/PULSE_topology_howto_v0.md
+++ b/docs/PULSE_topology_howto_v0.md
@@ -1,0 +1,33 @@
+# PULSE Topology HOWTO v0
+
+This HOWTO shows how to run the **PULSE topology layer** on top of an
+existing PULSE safe pack run.
+
+The goal is to go from:
+
+> `status.json` → `stability_map.json` → `decision_trace.json` →
+> `dual_view_v0.json`
+
+in a few simple commands.
+
+For full details of the topology specs, see:
+
+- `PULSE_topology_overview_v0.md`
+- `PULSE_topology_v0.md`
+- `PULSE_paradox_module_v0.md`
+- `PULSE_paradox_resolution_v0.md`
+- `PULSE_decision_engine_v0.md`
+- `PULSE_topology_transitions_v0.md`
+- `PULSE_dual_view_v0.md`
+
+---
+
+## 0. Prerequisites
+
+You need:
+
+- a working PULSE safe pack run that produces:
+
+  ```text
+  PULSE_safe_pack_v0/artifacts/status.json
+  PULSE_safe_pack_v0/artifacts/status_epf.json   # optional, EPF metrics


### PR DESCRIPTION
## Summary

This PR adds a **PULSE Topology HOWTO v0** guide that explains how to
run the topology tooling on top of an existing PULSE safe pack run.

The HOWTO focuses on the practical command-line steps needed to obtain
Stability Map, Decision Engine output and Dual View artefacts.

---

## What is included?

- New doc: `docs/PULSE_topology_howto_v0.md`
  - prerequisites:
    - `PULSE_safe_pack_v0/artifacts/status.json`
    - optional `status_epf.json`
  - step-by-step instructions to:
    - build `stability_map.json` via `build_stability_map.py`
    - optionally append runs and transitions with
      `append_run_to_stability_map.py`
    - run `run_decision_engine.py` to produce `decision_trace.json`
    - generate `dual_view_v0.json` via `build_dual_view_v0.py`
  - summary of all artefacts and their roles
  - troubleshooting notes for missing EPF metrics and multi-run usage

---

## Why?

The topology layer now consists of several tools and specs
(Stability Map, Paradox Module/Resolution, Decision Engine, Transitions,
Dual View), but users need a simple, concrete entry point describing:

> "Which commands do I run, in which order, and what files do I get?"

This HOWTO provides that entry point without repeating the full spec
documents.

---

## Impact

- Documentation only; no changes to existing code or CI workflows.
- Makes the topology layer easier to adopt for new users and for local
  experimentation.
