### PR TITLE
docs: add PULSE topology demo inputs v0

### DIFF
--- a/docs/examples/topology_demo_v0/README.md
+++ b/docs/examples/topology_demo_v0/README.md
@@ -1,0 +1,59 @@
+# PULSE Topology demo run v0
+
+This folder contains a small, synthetic example of the PULSE topology
+layer:
+
+- a baseline run with failing gates (`run_001`)
+- a fairness-fix run that passes gates (`run_002`)
+- the corresponding derived artefacts:
+  - Stability Map with two states and one transition
+  - Decision Engine output for `run_002`
+  - Dual View v0 for `run_002`
+
+The files are:
+
+- `status.run_001.json` — baseline PULSE `status.json` (FAIL)
+- `status.run_002.json` — fairness-fix PULSE `status.json` (STAGE-PASS)
+- `status_epf.run_002.json` — EPF shadow metrics for `run_002`
+- `stability_map.demo.json` — Stability Map with both runs and a transition
+- `decision_trace.run_002.demo.json` — Decision Engine v0 output for `run_002`
+- `dual_view_v0.run_002.demo.json` — Dual View v0 on top of `run_002`
+
+The shape matches the specs in:
+
+- `PULSE_topology_v0.md`
+- `PULSE_paradox_module_v0.md`
+- `PULSE_paradox_resolution_v0.md`
+- `PULSE_decision_engine_v0.md`
+- `PULSE_topology_transitions_v0.md`
+- `PULSE_dual_view_v0.md`
+
+## Scenario
+
+- `run_001`
+  - baseline model (`commit a1b2c3`)
+  - several safety and quality gates FAIL
+  - RDSI is low
+  - no EPF metrics
+  - Stability Map type: `UNSTABLE`
+
+- `run_002`
+  - fairness-data fix and retrain (`commit d4e5f6`)
+  - all safety and quality gates PASS
+  - RDSI improves
+  - EPF shadow experiment is contractive (`epf_L < 1.0`, `shadow_pass = true`)
+  - Stability Map type: `METASTABLE`
+  - Decision Engine action: `STAGE_ONLY` with `LOW` risk
+
+The transition `run_001 → run_002` is classified as `STABILISING` based
+on the drop in instability score.
+
+## How to experiment locally
+
+If you want to run the topology tools on these examples:
+
+1. Copy one of the example statuses into the artefact location, e.g.:
+
+   ```bash
+   cp docs/examples/topology_demo_v0/status.run_001.json \
+      PULSE_safe_pack_v0/artifacts/status.json


### PR DESCRIPTION
## Summary

This PR adds a small **PULSE topology demo** under `docs/examples/`
which provides minimal status and EPF artefacts for exercising the
topology layer without running the full PULSE pipelines.

---

## What is included?

- New demo inputs:
  - `docs/examples/PULSE_topology_demo_status_run_001.json`
  - `docs/examples/PULSE_topology_demo_status_run_002.json`
  - `docs/examples/PULSE_topology_demo_status_epf_run_002.json`
- New README:
  - `docs/examples/PULSE_topology_demo_README_v0.md`

The README describes a simple story:

- `demo_run_001`: baseline with fairness and monotonicity gate failures
  and `release_level = "FAIL"`.
- `demo_run_002`: fixed run with all gates passing, improved RDSI and an
  EPF shadow pass (`epf_L = 0.94`).

It also shows how to:

- build a Stability Map for the baseline run,
- append the fixed run and create a transition,
- run the Decision Engine on the demo map,
- generate a Dual View artefact for the latest run.

---

## Why?

The topology layer is easier to understand and test with a small,
self-contained example. These demo artefacts:

- provide a concrete baseline/fix trajectory,
- demonstrate paradox detection (safety OK, quality failing),
- show how instability, transitions and EPF interact,
- allow users to experiment with the tools locally without touching
  production artefacts.

---

## Impact

- Documentation and example inputs only; no changes to core tools or CI.
- Offers a ready-made demo scenario for tutorials, workshops or local
  experimentation.
