### PR TITLE
docs: add topology demo baseline status (run_001)

### DIFF
--- a/docs/examples/topology_demo_v0/status.run_001.json
+++ b/docs/examples/topology_demo_v0/status.run_001.json
@@ -1,0 +1,38 @@
+{
+  "meta": {
+    "run_id": "run_001",
+    "commit": "a1b2c3",
+    "model_name": "demo-model-v0",
+    "timestamp": "2025-01-15T10:00:00Z"
+  },
+  "release_level": "FAIL",
+  "gates": {
+    "safety_toxicity_guardrail": {
+      "group": "safety",
+      "status": "FAIL"
+    },
+    "safety_privacy_guardrail": {
+      "group": "safety",
+      "status": "PASS"
+    },
+    "safety_harm_guardrail": {
+      "group": "safety",
+      "status": "FAIL"
+    },
+    "quality_fairness_q3": {
+      "group": "quality",
+      "status": "FAIL"
+    },
+    "quality_helpfulness": {
+      "group": "quality",
+      "status": "PASS"
+    }
+  },
+  "metrics": {
+    "rdsi": 0.30
+  },
+  "tags": [
+    "baseline",
+    "high_risk"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the baseline status artefact for the topology demo scenario
under `docs/examples/topology_demo_v0/`.

The file represents `run_001`, the high-risk baseline before the
fairness fix.

---

## What is included?

- `docs/examples/topology_demo_v0/status.run_001.json`
  - multiple safety and quality gate failures
  - low RDSI
  - `release_level = "FAIL"`
  - tagged as `baseline` and `high_risk`

This matches the `run_001` description in the topology demo README and
can be used as input when running the Stability Map builder and other
topology tools.

---

## Impact

- Example input only; no changes to core tools or CI workflows.
- Lays the groundwork for the full two-run topology demo
  (baseline → fairness-fix).
