### PR TITLE
docs: add topology demo status_run_002 JSON

### DIFF
--- a/docs/examples/topology_demo_v0/docs/examples/topology_demo_v0/status.run_002.json
+++ b/docs/examples/topology_demo_v0/docs/examples/topology_demo_v0/status.run_002.json
@@ -1,0 +1,38 @@
+{
+  "meta": {
+    "run_id": "run_002",
+    "commit": "d4e5f6",
+    "model_name": "demo-model-v0",
+    "timestamp": "2025-01-18T10:00:00Z"
+  },
+  "release_level": "STAGE-PASS",
+  "gates": {
+    "safety_toxicity_guardrail": {
+      "group": "safety",
+      "status": "PASS"
+    },
+    "safety_privacy_guardrail": {
+      "group": "safety",
+      "status": "PASS"
+    },
+    "safety_harm_guardrail": {
+      "group": "safety",
+      "status": "PASS"
+    },
+    "quality_fairness_q3": {
+      "group": "quality",
+      "status": "PASS"
+    },
+    "quality_helpfulness": {
+      "group": "quality",
+      "status": "PASS"
+    }
+  },
+  "metrics": {
+    "rdsi": 0.88
+  },
+  "tags": [
+    "fairness_fix",
+    "candidate_release"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the second status JSON for the topology demo: the
fairness-fix run with all gates passing and improved RDSI.

---

## What is included?

- `docs/examples/topology_demo_v0/status_run_002.json`
  - `run_id = "run_002"`
  - `release_level = "STAGE-PASS"`
  - all safety and quality gates PASS
  - `rdsi = 0.88`
  - tags: `["fairness_fix", "candidate_release"]`

This file follows the PULSE `status.json` shape and complements the
baseline `status_run_001.json` to form a two-run demo trajectory.

---

## Why?

Together with `status_run_001.json`, this artefact provides a simple
story for the topology layer:

> baseline FAIL with fairness issues → fairness fix → STAGE-PASS
> candidate release with improved RDSI.

It can be used to demonstrate how Stability Map, transitions, the
Decision Engine and Dual View behave across runs.

---

## Impact

- Example/demo input only; no changes to tools or CI workflows.
- Completes the pair of status inputs needed for the topology demo
  (baseline + fairness-fix).
