### PR TITLE
docs: add topology demo status_epf.run_002.json

### DIFF
--- a/docs/examples/topology_demo_v0/status_epf.run_002.json
+++ b/docs/examples/topology_demo_v0/status_epf.run_002.json
@@ -1,0 +1,10 @@
+{
+  "meta": {
+    "run_id": "run_002",
+    "source": "demo_epf_shadow"
+  },
+  "metrics": {
+    "epf_L": 0.94,
+    "shadow_pass": true
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds the EPF shadow metrics artefact for the topology demo:
`status_epf.run_002.json` for `run_002`.

---

## What is included?

- `docs/examples/topology_demo_v0/status_epf.run_002.json`
  - `meta.run_id = "run_002"`
  - `meta.source = "demo_epf_shadow"`
  - `metrics.epf_L = 0.94`
  - `metrics.shadow_pass = true`

This file is designed to be used together with
`status.run_002.json` to:

- provide EPF metadata to the Stability Map builder,
- demonstrate how EPF contributes to the instability components, and
- show a contractive shadow-pass case in the demo.

---

## Impact

- Example/demo EPF input only; no changes to tools or CI workflows.
- Completes the EPF side of the two-run topology demo (baseline without
  EPF → fairness-fix with EPF shadow pass).
