### PR TITLE
docs: add topology demo decision_trace.run_002 JSON

### DIFF
--- a/docs/examples/topology_demo_v0/decision_trace.run_002.demo.json
+++ b/docs/examples/topology_demo_v0/decision_trace.run_002.demo.json
@@ -1,0 +1,28 @@
+{
+  "version": "0.1",
+  "state_id": "run_002",
+  "action": "STAGE_ONLY",
+  "risk_level": "LOW",
+  "summary": "STAGE-only: metastable state with low instability and all safety/quality gates passing.",
+  "details": {
+    "release_decision": "STAGE-PASS",
+    "stability_type": "METASTABLE",
+    "instability_score": 0.004,
+    "instability_components": {
+      "safety": 0.0,
+      "quality": 0.0,
+      "rdsi": 0.004,
+      "epf": 0.0
+    },
+    "gates": {
+      "safety_failed": 0,
+      "quality_failed": 0
+    },
+    "paradox_present": false,
+    "epf": {
+      "available": true,
+      "L": 0.94,
+      "shadow_pass": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a synthetic **Decision Engine output** JSON for the
topology demo: `decision_trace.run_002.demo.json` for `run_002`.

---

## What is included?

- `docs/examples/topology_demo_v0/decision_trace.run_002.demo.json`
  - `version = "0.1"`
  - `state_id = "run_002"`
  - `action = "STAGE_ONLY"`
  - `risk_level = "LOW"`
  - `summary` describing a metastable state with low instability and all
    safety/quality gates passing
  - `details`:
    - `release_decision = "STAGE-PASS"`
    - `stability_type = "METASTABLE"`
    - `instability_score = 0.004` with components for safety, quality,
      RDSI and EPF
    - gate failure counts (0 safety, 0 quality)
    - EPF metadata: `available = true`, `L = 0.94`, `shadow_pass = true`

The JSON matches the shape described in `PULSE_decision_engine_v0.md`
and corresponds to the `run_002` state in
`stability_map.demo.json`.

---

## Why?

Together with the demo Stability Map and Dual View, this file makes the
Decision Engine layer concrete:

- shows how actions and risk levels are reported,
- exposes the reasoning signals (instability components, gate summary,
  EPF) in a machine-readable form,
- provides a ready-made example of `decision_trace.json` for
  documentation and experimentation.

---

## Impact

- Example artefact only; no changes to tools or CI workflows.
- Completes the Decision Engine part of the topology demo.
