### PR TITLE
docs: add topology demo dual_view_v0.run_002 JSON

### DIFF
--- a/docs/examples/topology_demo_v0/dual_view_v0.run_002.demo.json
+++ b/docs/examples/topology_demo_v0/dual_view_v0.run_002.demo.json
@@ -1,0 +1,47 @@
+{
+  "version": "0.1",
+  "generated_at": "2025-01-18T11:05:00Z",
+  "state_id": "run_002",
+  "human_view": {
+    "headline": "STAGE-only, metastable state with low instability after fairness fix.",
+    "risk_summary": [
+      "Overall instability: 0.004 (LOW).",
+      "Decision Engine action: STAGE_ONLY, PULSE decision: STAGE-PASS.",
+      "All safety and quality gates pass; residual risk is dominated by RDSI."
+    ],
+    "paradox_summary": "No paradox detected.",
+    "timeline_highlights": [
+      "run_001 \u2192 run_002: STABILISING change (delta_instability = -0.496)."
+    ]
+  },
+  "agent_view": {
+    "action": "STAGE_ONLY",
+    "risk_level": "LOW",
+    "instability": {
+      "score": 0.004,
+      "components": {
+        "safety": 0.0,
+        "quality": 0.0,
+        "rdsi": 0.004,
+        "epf": 0.0
+      }
+    },
+    "paradox": {
+      "present": false,
+      "patterns": []
+    },
+    "decision": {
+      "release_decision": "STAGE-PASS",
+      "stability_type": "METASTABLE"
+    },
+    "history": {
+      "has_history": true,
+      "last_transition": {
+        "from": "run_001",
+        "to": "run_002",
+        "delta_instability": -0.496,
+        "category": "STABILISING"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a synthetic **Dual View v0** artefact for the topology demo:
`dual_view_v0.run_002.demo.json` for `run_002`.

It shows how the human and agent views can be combined into a single
JSON on top of the Stability Map and Decision Engine outputs.

---

## What is included?

- `docs/examples/topology_demo_v0/dual_view_v0.run_002.demo.json`
  - `human_view`:
    - `headline` describing a STAGE-only, metastable state with low
      instability after a fairness fix
    - `risk_summary[]` with short bullet points
    - `paradox_summary` indicating that no paradox is present
    - `timeline_highlights[]` with the STABILISING transition
      `run_001 → run_002`
  - `agent_view`:
    - `action = "STAGE_ONLY"`, `risk_level = "LOW"`
    - `instability.score` and per-component breakdown
    - `paradox.present = false`, empty `patterns[]`
    - `decision.release_decision = "STAGE-PASS"`
      and `stability_type = "METASTABLE"`
    - `history` with `last_transition` summarising the stabilising change

The structure matches the `PULSE_dual_view_v0.md` spec and corresponds
to the rest of the topology demo artefacts
(`stability_map.demo.json`, `decision_trace.run_002.demo.json`, etc.).

---

## Why?

Having a concrete Dual View example makes the final layer of the
topology stack tangible:

- shows what humans would see (`headline`, `risk_summary`,
  `timeline_highlights`),
- shows what agents can consume (`action`, `risk_level`, instability,
  history),
- demonstrates the "shared interface" idea on a simple two-run story.

---

## Impact

- Example/demo artefact only; no changes to existing tools or CI
  workflows.
- Completes the end-to-end topology demo (status → Stability Map →
  Decision Engine → Dual View).
