### PR TITLE
docs: add PULSE_stability_map_v0 JSON Schema

### DIFF
--- a/schemas/schemas/PULSE_stability_map_v0.schema.json
+++ b/schemas/schemas/PULSE_stability_map_v0.schema.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.org/schemas/PULSE_stability_map_v0.schema.json",
+  "title": "PULSE Stability Map v0",
+  "type": "object",
+  "description": "Schema for stability_map.json produced by PULSE topology v0.",
+  "required": ["version", "generated_at", "states", "transitions"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Stability Map spec version.",
+      "example": "0.1"
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO8601 timestamp when the map was generated."
+    },
+    "states": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/ReleaseState" }
+    },
+    "transitions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/ReleaseTransition" }
+    }
+  },
+  "$defs": {
+    "ReleaseState": {
+      "type": "object",
+      "required": [
+        "id",
+        "label",
+        "decision",
+        "gate_summary",
+        "rdsi",
+        "epf",
+        "instability",
+        "type",
+        "tags",
+        "paradox"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Run identifier, e.g. run_001."
+        },
+        "label": {
+          "type": "string",
+          "description": "Short human-readable label for the state."
+        },
+        "commit": {
+          "type": ["string", "null"],
+          "description": "Optional commit hash associated with the run."
+        },
+        "pack": {
+          "type": ["string", "null"],
+          "description": "Name of the PULSE pack producing this state."
+        },
+        "decision": {
+          "type": "string",
+          "enum": ["FAIL", "STAGE-PASS", "PROD-PASS", "UNKNOWN"],
+          "description": "Release decision as produced by the PULSE gates."
+        },
+        "gate_summary": {
+          "type": "object",
+          "required": ["safety_total", "safety_failed", "quality_total", "quality_failed"],
+          "properties": {
+            "safety_total": { "type": "integer", "minimum": 0 },
+            "safety_failed": { "type": "integer", "minimum": 0 },
+            "quality_total": { "type": "integer", "minimum": 0 },
+            "quality_failed": { "type": "integer", "minimum": 0 }
+          },
+          "additionalProperties": true
+        },
+        "rdsi": {
+          "type": ["number", "null"],
+          "description": "Release Decision Stability Index for this run."
+        },
+        "rdsi_delta": {
+          "type": ["number", "null"],
+          "description": "Optional RDSI delta versus a reference or previous run."
+        },
+        "epf": {
+          "type": "object",
+          "required": ["available"],
+          "properties": {
+            "available": { "type": "boolean" },
+            "L": {
+              "type": ["number", "null"],
+              "description": "EPF contraction factor L (if available)."
+            },
+            "shadow_pass": {
+              "type": ["boolean", "null"],
+              "description": "Whether the EPF shadow experiment passes."
+            }
+          },
+          "additionalProperties": true
+        },
+        "instability": {
+          "type": "object",
+          "required": ["score"],
+          "properties": {
+            "score": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0,
+              "description": "Overall instability score in [0, 1]."
+            },
+            "safety_component": { "type": ["number", "null"] },
+            "quality_component": { "type": ["number", "null"] },
+            "rdsi_component": { "type": ["number", "null"] },
+            "epf_component": { "type": ["number", "null"] }
+          },
+          "additionalProperties": true
+        },
+        "type": {
+          "type": "string",
+          "enum": ["STABLE", "METASTABLE", "UNSTABLE", "PARADOX", "COLLAPSE"],
+          "description": "Stability type classification."
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "paradox": {
+          "type": "object",
+          "required": ["present", "patterns", "details"],
+          "properties": {
+            "present": { "type": "boolean" },
+            "patterns": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "details": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["pattern", "reason"],
+                "properties": {
+                  "pattern": { "type": "string" },
+                  "reason": { "type": "string" }
+                },
+                "additionalProperties": true
+              }
+            },
+            "resolution": {
+              "type": "object",
+              "required": ["severity", "primary_focus", "recommendations"],
+              "properties": {
+                "severity": {
+                  "type": "string",
+                  "enum": ["LOW", "MEDIUM", "HIGH"]
+                },
+                "primary_focus": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "recommendations": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "ReleaseTransition": {
+      "type": "object",
+      "required": ["from", "to", "label", "delta_instability", "category"],
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "Source state id."
+        },
+        "to": {
+          "type": "string",
+          "description": "Target state id."
+        },
+        "label": {
+          "type": "string",
+          "description": "Short human-readable label for the transition."
+        },
+        "change": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "notes": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": true
+        },
+        "delta_instability": {
+          "type": "number",
+          "description": "Change in instability score (target - source)."
+        },
+        "delta_rdsi": {
+          "type": ["number", "null"],
+          "description": "Optional change in RDSI."
+        },
+        "delta_epf_L": {
+          "type": ["number", "null"],
+          "description": "Optional change in EPF L."
+        },
+        "category": {
+          "type": "string",
+          "enum": ["STABILISING", "DESTABILISING", "NEUTRAL"],
+          "description": "Coarse classification of the transition."
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a JSON Schema for the PULSE Stability Map v0 artefact under
`schemas/`.

---

## What is included?

- `schemas/PULSE_stability_map_v0.schema.json`
  - describes the top-level map (version, generated_at, states,
    transitions)
  - defines `ReleaseState`:
    - decision, gate_summary, rdsi, epf metadata
    - instability score + components
    - stability type enum
    - paradox block with patterns, details and optional resolution plan
  - defines `ReleaseTransition`:
    - from/to/label, change type/notes
    - delta_instability, optional delta_rdsi and delta_epf_L
    - category enum (STABILISING / DESTABILISING / NEUTRAL)

---

## Why?

The topology layer already has documentation and examples for
`stability_map.json`, but tools and contributors benefit from a
machine-readable spec:

- validation of generated Stability Maps,
- IDE auto-completion / type hints,
- easier integration with other pipelines.

---

## Impact

- Schema only; no changes to tools, CI workflows or existing artefacts.
- Provides a formal reference for Stability Map v0.
