### PR TITLE
ci: add pulse topology demo workflow

### DIFF
--- a/.github/workflows/pulse_topology_demo.yml
+++ b/.github/workflows/pulse_topology_demo.yml
@@ -1,0 +1,79 @@
+name: pulse-topology-demo
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "PULSE_safe_pack_v0/tools/**"
+      - "docs/**"
+      - "schemas/**"
+
+jobs:
+  topology-demo:
+    name: Run topology demo (Stability Map + Decision + Dual View)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Prepare demo artefacts
+        run: |
+          mkdir -p PULSE_safe_pack_v0/artifacts
+          cp docs/examples/topology_demo_v0/status.run_002.json \
+             PULSE_safe_pack_v0/artifacts/status.json
+          cp docs/examples/topology_demo_v0/status_epf.run_002.json \
+             PULSE_safe_pack_v0/artifacts/status_epf.json
+
+      - name: Build Stability Map (demo)
+        run: |
+          python PULSE_safe_pack_v0/tools/build_stability_map.py \
+            --status PULSE_safe_pack_v0/artifacts/status.json \
+            --status-epf PULSE_safe_pack_v0/artifacts/status_epf.json \
+            --out PULSE_safe_pack_v0/artifacts/stability_map.demo.ci.json
+
+      - name: Run Decision Engine (demo)
+        run: |
+          python PULSE_safe_pack_v0/tools/run_decision_engine.py \
+            --stability-map PULSE_safe_pack_v0/artifacts/stability_map.demo.ci.json \
+            --out PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json
+
+      - name: Build Dual View v0 (demo)
+        run: |
+          python PULSE_safe_pack_v0/tools/build_dual_view_v0.py \
+            --stability-map PULSE_safe_pack_v0/artifacts/stability_map.demo.ci.json \
+            --decision-trace PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json \
+            --out PULSE_safe_pack_v0/artifacts/dual_view_v0.demo.ci.json
+
+      - name: Install jsonschema for validation
+        run: |
+          python -m pip install --upgrade pip
+          pip install jsonschema
+
+      - name: Validate demo artefacts against schemas
+        run: |
+          python -m jsonschema \
+            -i PULSE_safe_pack_v0/artifacts/stability_map.demo.ci.json \
+            schemas/PULSE_stability_map_v0.schema.json
+
+          python -m jsonschema \
+            -i PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json \
+            schemas/PULSE_decision_trace_v0.schema.json
+
+          python -m jsonschema \
+            -i PULSE_safe_pack_v0/artifacts/dual_view_v0.demo.ci.json \
+            schemas/PULSE_dual_view_v0.schema.json
+
+      - name: Upload topology demo artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pulse-topology-demo
+          path: |
+            PULSE_safe_pack_v0/artifacts/stability_map.demo.ci.json
+            PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json
+            PULSE_safe_pack_v0/artifacts/dual_view_v0.demo.ci.json


### PR DESCRIPTION
## Summary

This PR adds a non-blocking GitHub Actions workflow that exercises the
PULSE topology layer on the bundled demo inputs.

---

## What is included?

- `.github/workflows/pulse_topology_demo.yml`
  - triggers:
    - `workflow_dispatch`
    - `pull_request` on changes to `PULSE_safe_pack_v0/tools/**`,
      `docs/**`, `schemas/**`
  - steps:
    - copy demo status and EPF files from
      `docs/examples/topology_demo_v0/` into `PULSE_safe_pack_v0/artifacts/`
    - run topology tools to generate:
      - `stability_map.demo.ci.json`
      - `decision_trace.demo.ci.json`
      - `dual_view_v0.demo.ci.json`
    - install `jsonschema` and validate artefacts against:
      - `PULSE_stability_map_v0.schema.json`
      - `PULSE_decision_trace_v0.schema.json`
      - `PULSE_dual_view_v0.schema.json`
    - upload the generated demo artefacts as a `pulse-topology-demo`
      workflow artifact

---

## Why?

The topology layer now has:

- specs,
- examples,
- JSON Schemas.

This workflow connects them:

- checks that the topology tools still run on the demo inputs,
- verifies that the generated artefacts conform to the schemas,
- makes it easy to download a fresh set of demo outputs from the CI
  artefacts.

It is non-blocking and intended for diagnostics and experimentation,
not for release gating.

---

## Impact

- CI-only change; does not modify the PULSE safe pack or release gate
  behaviour.
- Provides a convenient way to sanity-check the topology layer on every
  relevant PR and via manual runs.
