### PR TITLE
docs: add PULSE Topology v0 overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,10 +244,6 @@ Docs & specs:
 - `docs/PULSE_topology_real_run_v0.md` – how the topology layer attaches to real CI runs  
 - `docs/PULSE_dual_view_v0.md` – Dual View v0 format
 
-
-## How to cite
-... (meglévő tartalom) ...
-
 ---
 
 ## How to cite


### PR DESCRIPTION
This PR adds a short overview of the PULSE Topology v0 layer to the main README.

Changes:
- Introduce a new section `## PULSE Topology v0 – Stability Map + Decision Engine + Dual View`.
- Summarise how the topology layer sits *on top* of the existing deterministic release gates.
- Link out to the detailed specs:
  - `docs/PULSE_topology_v0.md`
  - `docs/PULSE_decision_engine_v0.md`
  - `docs/PULSE_dual_view_v0.md`
  - `docs/PULSE_paradox_module_v0.md`
  - `docs/PULSE_paradox_resolution_v0.md`
  - `docs/PULSE_topology_howto_v0.md`
  - `docs/examples/topology_demo_v0/README.md`
- Mention the optional demo workflow: `.github/workflows/pulse_topology_demo.yml`.

Placement:
- The new section is added after the **EPF (experimental, shadow-only)** section,
- and before **Repository layout**.

Behaviour:
- Docs-only change; no impact on PULSE safe pack tools, CI workflows, or release-gate behaviour.
