### PR TITLE
docs: add PULSE Topology v0 design note

### DIFF
--- a/docs/examples/topology_demo_v0/status.run_002.json
+++ b/docs/examples/topology_demo_v0/status.run_002.json
@@ -1,0 +1,38 @@
+{
+  "meta": {
+    "run_id": "run_002",
+    "commit": "d4e5f6",
+    "model_name": "demo-model-v0",
+    "timestamp": "2025-01-18T10:00:00Z"
+  },
+  "release_level": "STAGE-PASS",
+  "gates": {
+    "safety_toxicity_guardrail": {
+      "group": "safety",
+      "status": "PASS"
+    },
+    "safety_privacy_guardrail": {
+      "group": "safety",
+      "status": "PASS"
+    },
+    "safety_harm_guardrail": {
+      "group": "safety",
+      "status": "PASS"
+    },
+    "quality_fairness_q3": {
+      "group": "quality",
+      "status": "PASS"
+    },
+    "quality_helpfulness": {
+      "group": "quality",
+      "status": "PASS"
+    }
+  },
+  "metrics": {
+    "rds1": 0.88
+  },
+  "tags": [
+    "fairness_fix",
+    "candidate_release"
+  ]
+}


### PR DESCRIPTION
This PR:

- Adds docs/PULSE_topology_v0_design_note.md as a short design note for PULSE Topology v0.
- Introduces the topology layer on top of deterministic PULSE release gates.
- Connects Stability Map v0, Decision Engine v0 and Dual View v0 to the existing demo inputs.
- Adds docs/examples/topology_demo_v0/status.run_002.json so that the pulse-topology-demo workflow
  can copy both demo status artefacts (status.run_002.json and status_epf.run_002.json) correctly.

Change type:
- docs only; no changes to core PULSE tools, schemas, or release-gate behaviour.
