### PR TITLE
docs: add PULSE topology EPF hook note

### DIFF
--- a/docs/PULSE_topology_epf_hook_v0.md
+++ b/docs/PULSE_topology_epf_hook_v0.md
@@ -1,0 +1,33 @@
+# PULSE Topology v0 – EPF hook sketch
+
+> Status: draft – internal notes for now.
+
+This note sketches how to wire the EPF (experimental, shadow‑only) layer into **PULSE Topology v0**:
+Stability Map v0, Decision Engine v0 and Dual View v0.
+
+The goal is *not* to change any release decisions yet. We only describe where EPF metrics for a
+single run could attach to the existing topology artefacts.
+
+---
+
+## 1. Inputs
+
+For one release decision (one run), we assume three JSON inputs:
+
+- `status.json` – main PULSE status artefact for this run (deterministic release gates),
+- (optional) `status_epf.json` – EPF metrics for the same run (shadow‑only),
+- (optional) a topology config, if the caller wants to override defaults.
+
+A minimal `status_epf.json` could look like:
+
+```json
+{
+  "meta": {
+    "run_id": "run_002",
+    "source": "demo_epf_shadow"
+  },
+  "metrics": {
+    "epf_L": 0.94,
+    "shadow_pass": true
+  }
+}


### PR DESCRIPTION
This PR adds a draft EPF hook note for PULSE Topology v0.

The note:
- explains how EPF status_epf.json metrics for a single run can attach to the existing
  topology artefacts,
- sketches an optional `epf` block in Stability Map v0,
- shows how Decision Engine v0 and Dual View v0 could surface EPF signals as diagnostic
  context only (no change to deterministic release decisions),
- outlines a possible implementation roadmap for a future iteration.

Change type:
- docs only; no changes to tools, schemas, CI workflows or release gates.
