### PR TITLE
docs: expose EPF hook sketch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Docs & specs:
 - `docs/PULSE_topology_howto_v0.md` – demo walkthrough  
 - `docs/PULSE_topology_real_run_v0.md` – how the topology layer attaches to real CI runs  
 - `docs/PULSE_dual_view_v0.md` – Dual View v0 format
+- `docs/PULSE_topology_epf_hook.md` – EPF hook sketch (shadow‑only, v0)
 
 ---
 


### PR DESCRIPTION
This PR wires the new EPF hook sketch into the main README:

- Adds docs/PULSE_topology_epf_hook.md to the Docs & specs list,
- Keeps the Topology v0 documents grouped together (design note, methods, case study, hook),
- Does not change any tools, schemas, CI workflows or release behaviour (docs-only).

Once merged, the EPF hook concept becomes visible from the front page without
hunting for it in the docs/ folder.
