### PR TITLE
docs: add PULSE Paradox Resolution v0 design note

### DIFF
--- a/docs/docs/PULSE_paradox_resolution_v0_design_note.md
+++ b/docs/docs/PULSE_paradox_resolution_v0_design_note.md
@@ -1,0 +1,125 @@
+# PULSE Paradox Resolution v0 — Design Note
+
+> Status: draft / experimental — not implemented yet.  
+> Scope: optional, diagnostic overlay on top of the deterministic PULSE gates and Topology v0.
+
+This note proposes a possible **"Paradox Resolution v0"** module for PULSE.
+
+The module would help reviewers reason about **conflicting guardrails / objectives** across safety and quality, and make the resolution of those tensions explicit and reusable.
+
+It is an **optional diagnostic layer** only. It does *not* change any release decisions.
+
+---
+
+## 0. Summary
+
+In many real reviews, we see situations like:
+
+- safety gates are PASS, but some metrics are close to the threshold,  
+- quality / fairness gates are PASS, but there is a residual concern,  
+- latency / cost SLOs are tight, even when all gates are green.
+
+Today, these tensions are often resolved in meetings and emails, and the reasoning is hard to reconstruct later.
+
+**Paradox Resolution v0** aims to:
+
+- capture a **small number of competing concerns** per run,  
+- record **how the paradox was resolved** (decision + justification),  
+- link that story back to concrete artefacts:
+  - Quality Ledger rows,
+  - Topology v0 views (Stability Map v0, Decision Engine v0, Dual View v0),
+  - optional external reports.
+
+---
+
+## 1. Non‑goals
+
+Paradox Resolution v0 is explicitly **not**:
+
+- a replacement for the deterministic PASS / FAIL gates,  
+- a policy engine,  
+- an automated optimiser over trade‑offs.
+
+It is a **human‑centric documentation and navigation layer**:
+
+- read‑only with respect to `status.json`,  
+- no effect on CI PASS / FAIL,  
+- safe to drop if a project decides not to use it.
+
+---
+
+## 2. Inputs and context
+
+### 2.1 Existing PULSE artefacts
+
+The module assumes the following already exist for a run:
+
+- `status.json` — main PULSE status artefact (deterministic gates),  
+- Quality Ledger rows for that run,  
+- Topology v0 artefacts (optional but recommended):
+  - `stability_map_v0.json`
+  - `decision_trace_v0.json`
+  - `dual_view_v0.json`,
+- optional external sources:
+  - eval dashboards,  
+  - red‑team reports,  
+  - incident / ticket references.
+
+### 2.2 New artefact (conceptual)
+
+Paradox Resolution v0 would introduce a **small sidecar artefact**, for example:
+
+- one JSON document per run, or  
+- a row in a structured table.
+
+For v0 we assume **one JSON per run**.
+
+---
+
+## 3. Proposed data model (sketch)
+
+A minimal JSON sketch could look like:
+
+```json
+{
+  "run_id": "run_002",
+  "source": "paradox_resolution_v0",
+  "concerns": [
+    {
+      "id": "safety",
+      "status": "strong",
+      "notes": "All safety gates PASS, no open issues."
+    },
+    {
+      "id": "fairness",
+      "status": "weak",
+      "notes": "Parity metrics borderline, see external eval report X."
+    },
+    {
+      "id": "latency",
+      "status": "tight",
+      "notes": "p95 close to SLO; cost impact acceptable."
+    }
+  ],
+  "resolution": {
+    "summary": "Proceed with STAGE_PASS only; monitor fairness and latency for two weeks.",
+    "decision_owner": "release-review-2025-XX",
+    "timestamp": "2025-01-01T12:34:56Z",
+    "links": {
+      "quality_ledger": [
+        "docs/QUALITY_LEDGER/ledger_v1_0_2.md#run_002"
+      ],
+      "topology_views": [
+        "docs/TOPOLOGY_RUNS/run_002/dual_view_v0.json"
+      ],
+      "external_reports": [
+        "https://…/fairness_eval_run_002",
+        "https://…/latency_dashboard_run_002"
+      ]
+    }
+  },
+  "notes": [
+    "Team agreed that safety margin is sufficient.",
+    "Fairness issue to be revisited before PROD_PASS."
+  ]
+}


### PR DESCRIPTION
This PR adds a draft design note for the PULSE Paradox Resolution v0 module.

Highlights:
- Defines the scope and objectives for paradox resolution as an optional,
  diagnostic layer on top of the deterministic release gates.
- Describes the inputs (status.json, status_epf.json, Stability Map v0,
  Decision Engine v0, Dual View v0).
- Proposes a JSON artefact shape for paradox_resolution_v0.json, including
  summary fields and per-event details.
- Sketches simple heuristics for hard, soft and shadow paradoxes.
- Outlines integration points with the Topology v0 family, EPF signal layer
  and the Future Library index.

Change type:
- docs only; no changes to tools, schemas, CI workflows or release behaviour.
