### PR TITLE
docs: update FUTURE_LIBRARY for Paradox Resolution v0

### DIFF
--- a/docs/FUTURE_LIBRARY.md
+++ b/docs/FUTURE_LIBRARY.md
@@ -61,7 +61,8 @@ get its own design note and be linked above.
 
 - **Paradox Resolution v0**  
   - Scope: richer handling of conflicting guardrails / objectives.  
-  - Status: planned idea.
+  - Status: draft / experimental (design note).  
+  - Docs: `docs/PULSE_paradox_resolution_v0_design_note.md`.
 
 - **Topology dashboards**  
   - Scope: visual comparison of topology runs across releases (stability,


### PR DESCRIPTION
This PR updates docs/FUTURE_LIBRARY.md to include the new
"Paradox Resolution v0" module.

Changes:
- Add a dedicated entry for Paradox Resolution v0 under the Future Library index.
- Record its scope (richer handling of conflicting guardrails/objectives).
- Mark its status as draft/experimental, and link to the design note at
  docs/PULSE_paradox_resolution_v0_design_note.md.
- Keep this as a docs-only change with no impact on tools, schemas, or CI workflows.

Change type:
- docs only; no changes to PULSE safe pack tools, schemas, or CI.
