### PR TITLE
docs: add EPF shadow signal section to topology methods

### DIFF
--- a/docs/PULSE_topology_v0_methods.md
+++ b/docs/PULSE_topology_v0_methods.md
@@ -79,3 +79,25 @@ Script:
 
 ```text
 PULSE_safe_pack_v0/tools/build_stability_map.py
+
+## EPF integration in Stability Map v0
+
+Stability Map v0 can optionally ingest an EPF shadow-only status file
+(`status_epf.json`) alongside the main `status.json` artefact.
+
+### CLI usage
+
+By default, the builder looks for:
+
+- `PULSE_safe_pack_v0/artifacts/status.json`
+- `PULSE_safe_pack_v0/artifacts/status_epf.json` (optional)
+
+Example command:
+
+```bash
+python PULSE_safe_pack_v0/tools/build_stability_map.py \
+  --status PULSE_safe_pack_v0/artifacts/status.json \
+  --status-epf PULSE_safe_pack_v0/artifacts/status_epf.json \
+  --out PULSE_safe_pack_v0/artifacts/stability_map.json
+
+


### PR DESCRIPTION
This PR updates the topology methods note to describe EPF shadow signal
support in Stability Map v0.

- Adds an “EPF integration in Stability Map v0” section to
  docs/PULSE_topology_v0_methods.md.
- Documents CLI usage of build_stability_map.py with the optional
  --status-epf argument.
- Describes the expected shape of status_epf.json and how the EPF
  block is attached to each ReleaseState in stability_map.json.

Change type:
- docs only; no changes to tools, schemas, CI workflows or release gates.
