### PR TITLE
docs: add Decision Engine EPF v0 design note

### DIFF
--- a/docs/PULSE_decision_engine_epf_v0_design_note.md
+++ b/docs/PULSE_decision_engine_epf_v0_design_note.md
@@ -1,22 +1,26 @@
 # PULSE Decision Engine EPF v0 – Design Note
 
 > Status: draft – design note only.  
-> Scope: how the Decision Engine v0 and Dual View v0 can surface the EPF
+> Scope: how Decision Engine v0 and Dual View v0 can surface the EPF
 > shadow signal already present in Stability Map v0.
 
 This note describes how the experimental EPF shadow signal, already
 embedded in Stability Map v0, can be surfaced in:
 
 - the Decision Engine v0 (`decision_trace.json`), and
-- Dual View v0 (human + agent combined view),
+- Dual View v0 (combined human + agent view),
 
-without changing any deterministic release‑gate logic.
+without changing any deterministic release-gate logic.
+
+We treat EPF as an **optional diagnostic layer**: it can highlight
+concerning regions (non-contractive behaviour), but it must not change
+`status.json` or CI pass/fail behaviour.
 
 ---
 
 ## 1. Inputs
 
-The Decision Engine already consumes Stability Map v0 artefacts, which
+Decision Engine v0 already consumes Stability Map v0 artefacts, which
 include, for each `ReleaseState`, an `epf` block of the form:
 
 ```json


### PR DESCRIPTION
This PR adds a draft design note for the "Decision Engine EPF v0" module.

- Describes how Decision Engine v0 can surface the EPF shadow signal from Stability Map v0.
- Shows how the same EPF information appears in Dual View v0 (human + agent view).
- Keeps EPF strictly shadow-only: no changes to deterministic release-gate logic.

Change type:
- docs only; no changes to tools, schemas or CI workflows.
