### PR TITLE
docs: register Decision Engine EPF v0 in FUTURE_LIBRARY

### DIFF
--- a/docs/FUTURE_LIBRARY.md
+++ b/docs/FUTURE_LIBRARY.md
@@ -42,6 +42,7 @@ stability signal and richer diagnostics.
 **Docs:**
 - Main EPF description → `docs/PULSE_epf_report.txt` (A/B diff summary)
 - Topology EPF hook sketch → `docs/PULSE_topology_epf_hook.md`
+- Decision Engine EPF v0 design note → `docs/PULSE_decision_engine_epf_v0_design_note.md` (draft / experimental)
 
 **Notes:**
 - In v0, EPF metrics may appear as additional fields inside Topology v0


### PR DESCRIPTION
This PR wires the Decision Engine EPF v0 design note into the FUTURE_LIBRARY index:

- Updates the EPF signal layer section so it also lists `docs/PULSE_decision_engine_epf_v0_design_note.md` as a module doc.
- Keeps this as a docs-only change with no impact on PULSE safe pack tools or schemas.

Change type:
- docs only; no changes to tools, schemas, CI workflows or release gates.
