### PR TITLE
docs: link Decision Engine EPF v0 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ Docs & specs:
 - `docs/PULSE_topology_real_run_v0.md` – how the topology layer attaches to real CI runs  
 - `docs/PULSE_dual_view_v0.md` – Dual View v0 format
 - `docs/PULSE_topology_epf_hook.md` – EPF hook sketch (shadow‑only, v0)
+- `docs/PULSE_decision_engine_epf_v0_design_note.md` – Decision Engine EPF v0 design note (shadow signal).
+- `docs/FUTURE_LIBRARY.md` – index of experimental modules (Future Library).
 
 ---
 


### PR DESCRIPTION
This PR wires the new Decision Engine EPF v0 design note and the Future Library index
into the Topology v0 section of the README:

- adds `docs/PULSE_decision_engine_epf_v0_design_note.md` under "Docs & specs",
- adds `docs/FUTURE_LIBRARY.md` as the index of experimental / future modules.

Change type:
- docs only; no changes to tools, schemas, CI workflows or release gates.
