### PR TITLE
feat: Add paradox_field_v0 and epf_field_v0 to stability map schema

### DIFF
--- a/schemas/schemas/PULSE_stability_map_v0.schema.json
+++ b/schemas/schemas/PULSE_stability_map_v0.schema.json
@@ -4,7 +4,12 @@
   "title": "PULSE Stability Map v0",
   "type": "object",
   "description": "Schema for stability_map.json produced by PULSE topology v0.",
-  "required": ["version", "generated_at", "states", "transitions"],
+  "required": [
+    "version",
+    "generated_at",
+    "states",
+    "transitions"
+  ],
   "properties": {
     "version": {
       "type": "string",
@@ -19,11 +24,15 @@
     "states": {
       "type": "array",
       "minItems": 1,
-      "items": { "$ref": "#/$defs/ReleaseState" }
+      "items": {
+        "$ref": "#/$defs/ReleaseState"
+      }
     },
     "transitions": {
       "type": "array",
-      "items": { "$ref": "#/$defs/ReleaseTransition" }
+      "items": {
+        "$ref": "#/$defs/ReleaseTransition"
+      }
     }
   },
   "$defs": {
@@ -51,48 +60,92 @@
           "description": "Short human-readable label for the state."
         },
         "commit": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Optional commit hash associated with the run."
         },
         "pack": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Name of the PULSE pack producing this state."
         },
         "decision": {
           "type": "string",
-          "enum": ["FAIL", "STAGE-PASS", "PROD-PASS", "UNKNOWN"],
+          "enum": [
+            "FAIL",
+            "STAGE-PASS",
+            "PROD-PASS",
+            "UNKNOWN"
+          ],
           "description": "Release decision as produced by the PULSE gates."
         },
         "gate_summary": {
           "type": "object",
-          "required": ["safety_total", "safety_failed", "quality_total", "quality_failed"],
+          "required": [
+            "safety_total",
+            "safety_failed",
+            "quality_total",
+            "quality_failed"
+          ],
           "properties": {
-            "safety_total": { "type": "integer", "minimum": 0 },
-            "safety_failed": { "type": "integer", "minimum": 0 },
-            "quality_total": { "type": "integer", "minimum": 0 },
-            "quality_failed": { "type": "integer", "minimum": 0 }
+            "safety_total": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "safety_failed": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "quality_total": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "quality_failed": {
+              "type": "integer",
+              "minimum": 0
+            }
           },
           "additionalProperties": true
         },
         "rdsi": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "description": "Release Decision Stability Index for this run."
         },
         "rdsi_delta": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "description": "Optional RDSI delta versus a reference or previous run."
         },
         "epf": {
           "type": "object",
-          "required": ["available"],
+          "required": [
+            "available"
+          ],
           "properties": {
-            "available": { "type": "boolean" },
+            "available": {
+              "type": "boolean"
+            },
             "L": {
-              "type": ["number", "null"],
+              "type": [
+                "number",
+                "null"
+              ],
               "description": "EPF contraction factor L (if available)."
             },
             "shadow_pass": {
-              "type": ["boolean", "null"],
+              "type": [
+                "boolean",
+                "null"
+              ],
               "description": "Whether the EPF shadow experiment passes."
             }
           },
@@ -100,7 +153,9 @@
         },
         "instability": {
           "type": "object",
-          "required": ["score"],
+          "required": [
+            "score"
+          ],
           "properties": {
             "score": {
               "type": "number",
@@ -108,61 +163,198 @@
               "maximum": 1.0,
               "description": "Overall instability score in [0, 1]."
             },
-            "safety_component": { "type": ["number", "null"] },
-            "quality_component": { "type": ["number", "null"] },
-            "rdsi_component": { "type": ["number", "null"] },
-            "epf_component": { "type": ["number", "null"] }
+            "safety_component": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "quality_component": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "rdsi_component": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "epf_component": {
+              "type": [
+                "number",
+                "null"
+              ]
+            }
           },
           "additionalProperties": true
         },
         "type": {
           "type": "string",
-          "enum": ["STABLE", "METASTABLE", "UNSTABLE", "PARADOX", "COLLAPSE"],
+          "enum": [
+            "STABLE",
+            "METASTABLE",
+            "UNSTABLE",
+            "PARADOX",
+            "COLLAPSE"
+          ],
           "description": "Stability type classification."
         },
         "tags": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "paradox": {
           "type": "object",
-          "required": ["present", "patterns", "details"],
+          "required": [
+            "present",
+            "patterns",
+            "details"
+          ],
           "properties": {
-            "present": { "type": "boolean" },
+            "present": {
+              "type": "boolean"
+            },
             "patterns": {
               "type": "array",
-              "items": { "type": "string" }
+              "items": {
+                "type": "string"
+              }
             },
             "details": {
               "type": "array",
               "items": {
                 "type": "object",
-                "required": ["pattern", "reason"],
+                "required": [
+                  "pattern",
+                  "reason"
+                ],
                 "properties": {
-                  "pattern": { "type": "string" },
-                  "reason": { "type": "string" }
+                  "pattern": {
+                    "type": "string"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
                 },
                 "additionalProperties": true
               }
             },
             "resolution": {
               "type": "object",
-              "required": ["severity", "primary_focus", "recommendations"],
+              "required": [
+                "severity",
+                "primary_focus",
+                "recommendations"
+              ],
               "properties": {
                 "severity": {
                   "type": "string",
-                  "enum": ["LOW", "MEDIUM", "HIGH"]
+                  "enum": [
+                    "LOW",
+                    "MEDIUM",
+                    "HIGH"
+                  ]
                 },
                 "primary_focus": {
                   "type": "array",
-                  "items": { "type": "string" }
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "recommendations": {
                   "type": "array",
-                  "items": { "type": "string" }
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        },
+        "paradox_field_v0": {
+          "type": "object",
+          "description": "Paradoxon-mező v0 ehhez az állapothoz (paradox atomok + összefoglaló).",
+          "properties": {
+            "atoms": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ParadoxAtom"
+              }
+            },
+            "summary": {
+              "$ref": "#/$defs/ParadoxFieldSummary"
+            }
+          },
+          "additionalProperties": true
+        },
+        "epf_field_v0": {
+          "type": "object",
+          "description": "EPF fizikai mező v0 ehhez az állapothoz (phi/theta/energy + horgonyok).",
+          "properties": {
+            "phi_potential": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "EPF potenciál – mennyire \"tol\" az EPF jel."
+            },
+            "theta_distortion": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Torzulás az alap policy-térhez képest."
+            },
+            "energy_delta": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "description": "Energiatér-változás a döntés alatt."
+            },
+            "anchors": {
+              "type": "array",
+              "description": "Hol jelenik meg az EPF mező a topológiában.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "topology_node"
+                ],
+                "properties": {
+                  "topology_node": {
+                    "type": "string",
+                    "description": "Topológiai node azonosító (pl. decision_engine/gate)."
+                  },
+                  "potential": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "description": "Lokális phi potenciál ezen a node-on."
+                  },
+                  "deflection": {
+                    "type": [
+                      "number",
+                      "null"
+                    ],
+                    "description": "Lokális torzulás ezen a node-on."
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "linked_paradoxes": {
+              "type": "array",
+              "description": "Paradox-atom ID-k, amelyekhez ez az EPF mező kapcsolódik.",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "additionalProperties": true
@@ -172,7 +364,13 @@
     },
     "ReleaseTransition": {
       "type": "object",
-      "required": ["from", "to", "label", "delta_instability", "category"],
+      "required": [
+        "from",
+        "to",
+        "label",
+        "delta_instability",
+        "category"
+      ],
       "properties": {
         "from": {
           "type": "string",
@@ -191,7 +389,9 @@
           "properties": {
             "type": {
               "type": "array",
-              "items": { "type": "string" }
+              "items": {
+                "type": "string"
+              }
             },
             "notes": {
               "type": "string"
@@ -204,21 +404,149 @@
           "description": "Change in instability score (target - source)."
         },
         "delta_rdsi": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "description": "Optional change in RDSI."
         },
         "delta_epf_L": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "description": "Optional change in EPF L."
         },
         "category": {
           "type": "string",
-          "enum": ["STABILISING", "DESTABILISING", "NEUTRAL"],
+          "enum": [
+            "STABILISING",
+            "DESTABILISING",
+            "NEUTRAL"
+          ],
           "description": "Coarse classification of the transition."
         },
         "tags": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "ParadoxAtom": {
+      "type": "object",
+      "description": "Egyetlen paradoxon-atom v0: tengely + A/¬A + irány + feszültség.",
+      "required": [
+        "axis_id",
+        "A",
+        "notA",
+        "direction",
+        "tension_score"
+      ],
+      "properties": {
+        "axis_id": {
+          "type": "string",
+          "description": "Melyik paradox-tengelyhez tartozik (pl. epf_field_vs_policy_field)."
+        },
+        "A": {
+          "type": "string",
+          "description": "Első állítás / elv (forrás 1)."
+        },
+        "notA": {
+          "type": "string",
+          "description": "Ellentétes állítás / elv (forrás 2)."
+        },
+        "direction": {
+          "type": "string",
+          "enum": [
+            "towards_A",
+            "towards_notA",
+            "towards_stability",
+            "unresolved"
+          ],
+          "description": "Merre mozdult a rendszer a két elv között."
+        },
+        "tension_score": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0,
+          "description": "Feszültség mértéke [0,1] skálán."
+        },
+        "zone": {
+          "type": "string",
+          "enum": [
+            "green",
+            "yellow",
+            "red"
+          ],
+          "description": "Zóna: mennyire kritikus ez a paradoxon."
+        },
+        "context": {
+          "type": "object",
+          "description": "Kontekstus: hol jelent meg ez a paradoxon a Pulse-térben.",
+          "properties": {
+            "run_id": {
+              "type": "string"
+            },
+            "scope": {
+              "type": "string"
+            },
+            "segment": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": true
+        },
+        "anchors": {
+          "type": "array",
+          "description": "Topológiai horgonyok – mely node-okon fut át a paradoxon.",
+          "items": {
+            "type": "object",
+            "required": [
+              "topology_node"
+            ],
+            "properties": {
+              "topology_node": {
+                "type": "string"
+              },
+              "role": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "ParadoxFieldSummary": {
+      "type": "object",
+      "description": "Paradoxon-mező v0 összefoglaló, egyetlen ReleaseState-re.",
+      "properties": {
+        "max_tension": {
+          "type": "number",
+          "description": "A legnagyobb feszültségű paradoxon-atom score-ja."
+        },
+        "num_atoms": {
+          "type": "integer",
+          "description": "Paradoxon-atomok száma ebben az állapotban."
+        },
+        "num_red_zones": {
+          "type": "integer",
+          "description": "Hány atom van piros zónában."
+        },
+        "num_yellow_zones": {
+          "type": "integer",
+          "description": "Hány atom van sárga zónában."
+        },
+        "dominant_axes": {
+          "type": "array",
+          "description": "Azok a tengelyek, ahol a legnagyobb feszültség jelent meg.",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": true


### PR DESCRIPTION
## Context

We are extending PULSE Topology v0 / Stability Map v0 with a paradox field and an EPF physical field,
so that the Decision Engine v0 and Dual View v0 can expose paradox/EPF signals as a proper "field"
instead of ad-hoc flags.

This PR is the schema-side change only.

## What changed

**File touched**

- `schemas/PULSE_stability_map_v0.schema.json`

**New fields on `ReleaseState`**

- `paradox_field_v0` (optional)
  - `atoms[]`: paradox atoms with:
    - `axis_id`, `A`, `notA`, `direction`, `tension_score`, `zone`
    - `context` (run_id / scope / segment)
    - `anchors[]` (topology_node + role)
  - `summary`:
    - `max_tension`, `num_atoms`, `num_red_zones`, `num_yellow_zones`, `dominant_axes[]`

- `epf_field_v0` (optional)
  - `phi_potential`, `theta_distortion`, `energy_delta`
  - `anchors[]`:
    - `topology_node`, `potential`, `deflection`
  - `linked_paradoxes[]`: IDs of paradox atoms this EPF field projects onto

## Compatibility

- Existing required fields on `ReleaseState` are unchanged.
- `paradox_field_v0` and `epf_field_v0` are **not** required.
- Existing `stability_map.json` files remain valid.
- This schema change is a prerequisite for:
  - `build_stability_map_v0.py` to start emitting the paradox/EPF fields, and
  - Decision Engine v0 / Dual View v0 to expose the paradox field as a shadow-only layer.

## Notes

- This PR is schema-only (no code changes).
- Follow-up PRs will:
  - build `paradox_field_v0` from existing instability / paradox / EPF signals,
  - build `epf_field_v0` as the physical EPF field (phi/theta/energy + anchors),
  - wire these into the Decision Engine v0 output and Dual View v0 paradox panel.
