### PR TITLE
docs(epf-shadow): add EPF shadow pipeline v0 walkthrough

### DIFF
--- a/docs/docs/PULSE_epf_shadow_pipeline_v0_walkthrough.md
+++ b/docs/docs/PULSE_epf_shadow_pipeline_v0_walkthrough.md
@@ -1,0 +1,71 @@
+# PULSE EPF shadow pipeline v0 – walkthrough
+
+Status: **v0, shadow-only**  
+Scope: Stability Map v0 + Decision Engine v0 + paradox / EPF field
+
+This document explains how the EPF signal is integrated into PULSE as an
+_external sensor_ and how it appears in the Topology / Stability Map /
+Decision Engine outputs, without changing any gate logic.
+
+The goal is to make the EPF field visible as a **paradox / tension field**,
+not as an extra hard-coded gate.
+
+---
+
+## 1. High-level picture
+
+The EPF shadow integration in v0 is a 3-step pipeline:
+
+1. **Topology / Stability Map v0**
+
+   - `stability_map.json` is generated as before (Topology v0).
+   - Then we enrich each `ReleaseState` with:
+     - `paradox_field_v0`
+     - `epf_field_v0`
+
+2. **Decision Engine v0 (shadow-only view)**
+
+   - We build `decision_output_v0.json` on top of the Stability Map.
+   - It exposes:
+     - the selected `ReleaseState`,
+     - the paradox/EPF field,
+     - a minimal `decision_trace[]` with a `paradox_stamp`,
+     - a `dual_view` with a `paradox_panel_v0`.
+
+3. **Summary / dashboard view**
+
+   - We build a compact summary JSON:
+     - `decision_output_v0_summary.json`
+   - It is a "headline" view: decision + stability + paradox/EPF field.
+
+At no point do we modify the release gate decision tree. The EPF field is
+a **shadow layer** on top of the existing logic.
+
+---
+
+## 2. Inputs and prerequisites
+
+The pipeline assumes the existing PULSE topology / gate machinery already
+produces:
+
+- `status.json`
+- (optionally) `status_epf.json`
+- `stability_map.json` via `build_stability_map_v0.py`
+
+Additionally, the Stability Map schema was extended:
+
+- `schemas/PULSE_stability_map_v0.schema.json` now allows, per `ReleaseState`:
+  - `paradox_field_v0`
+  - `epf_field_v0`
+
+Existing fields (`rdsi`, `epf`, `instability`, `paradox`, etc.) and their
+semantics are unchanged.
+
+---
+
+## 3. Step 1 – Enrich Stability Map with paradox/EPF field
+
+**Tool:**
+
+```text
+PULSE_safe_pack_v0/tools/build_paradox_epf_fields_v0.py


### PR DESCRIPTION
## Context

We introduced several EPF shadow tools:

- `build_paradox_epf_fields_v0.py`
- `build_decision_output_v0.py`
- `summarise_decision_paradox_v0.py`

and extended the Stability Map schema with:

- `ReleaseState.paradox_field_v0`
- `ReleaseState.epf_field_v0`

This PR adds a dedicated walkthrough document that explains how these pieces
fit together into a coherent EPF shadow pipeline in PULSE.

## What changed

**New doc**

- `docs/PULSE_epf_shadow_pipeline_v0_walkthrough.md`

  - Explains the 3-step EPF shadow pipeline:

    1. Enrich `stability_map.json` with `paradox_field_v0` and `epf_field_v0`
       using `build_paradox_epf_fields_v0.py`.
    2. Build `decision_output_v0.json` as a shadow-only Decision Engine v0
       artefact using `build_decision_output_v0.py`, exposing:
       - the selected `ReleaseState`
       - `paradox_field_v0` and `epf_field_v0`
       - `decision_trace[]` with a `paradox_stamp`
       - `dual_view.paradox_panel_v0`
    3. Build a compact summary JSON (e.g. `decision_paradox_summary_v0.json`)
       using `summarise_decision_paradox_v0.py`.

  - Documents the JSON shapes for:
    - `ReleaseState.paradox_field_v0`
    - `ReleaseState.epf_field_v0`
    - `decision_output_v0.json`
    - the summary JSON

  - States the invariants:
    - gate logic is not modified,
    - existing fields keep their semantics,
    - EPF is treated as an external sensor, projected into PULSE's paradox /
      field view rather than redefining the gates.

## Notes

- This is a documentation-only change on top of the existing EPF shadow
  implementation.
- It is intended to be the reference entry point for anyone trying to
  understand the EPF shadow integration in Topology v0 / Stability Map v0 /
  Decision Engine v0.
