### PR TITLE
feat(memory): add summarise_paradox_history_v0 tool

### DIFF
--- a/PULSE_safe_pack_v0/tools/summarise_paradox_history_v0.py
+++ b/PULSE_safe_pack_v0/tools/summarise_paradox_history_v0.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python
+"""
+summarise_paradox_history_v0.py
+
+Aggregate multiple decision_paradox_summary_v0.json files into a single
+history view of paradox and EPF fields across runs.
+
+Input:
+    - a directory with one or more decision_paradox_summary_v0*.json files
+      (produced by summarise_decision_paradox_v0.py)
+
+Output:
+    - paradox_history_v0.json (by default), containing:
+        - per-run records (decision, instability, paradox zone, EPF snapshot)
+        - aggregated paradox stats per axis
+        - aggregated EPF stats (min/max/avg)
+"""
+
+import argparse
+import glob
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+
+Summary = Dict[str, Any]
+History = Dict[str, Any]
+
+
+def _safe_float(x: Any) -> Optional[float]:
+    if x is None:
+        return None
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return None
+
+
+def _zone_from_tension(t: Optional[float]) -> str:
+    if t is None:
+        return "unknown"
+    if t >= 0.66:
+        return "red"
+    if t >= 0.33:
+        return "yellow"
+    return "green"
+
+
+def _avg(vals: List[float]) -> Optional[float]:
+    if not vals:
+        return None
+    return sum(vals) / len(vals)
+
+
+def load_summaries(dir_path: str, pattern: str) -> List[Summary]:
+    glob_pattern = os.path.join(dir_path, pattern)
+    paths = sorted(glob.glob(glob_pattern))
+    summaries: List[Summary] = []
+
+    for path in paths:
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                summaries.append(json.load(f))
+        except (OSError, json.JSONDecodeError):
+            # v0: csendben kihagyjuk a hibás fájlokat
+            continue
+
+    return summaries
+
+
+def build_paradox_history_v0(summaries: List[Summary]) -> History:
+    runs: List[Dict[str, Any]] = []
+    zone_counts: Dict[str, int] = {"green": 0, "yellow": 0, "red": 0, "unknown": 0}
+    max_tension_overall: float = 0.0
+
+    axis_stats: Dict[str, Dict[str, Any]] = {}
+
+    phi_vals: List[float] = []
+    theta_vals: List[float] = []
+
+    for s in summaries:
+        if not isinstance(s, dict):
+            continue
+
+        run_id = s.get("run_id")
+        decision = s.get("decision")
+        type_ = s.get("type")
+
+        stability = s.get("stability") or {}
+        instab = _safe_float(stability.get("instability_score"))
+
+        paradox = s.get("paradox_overview") or {}
+        max_tension = _safe_float(paradox.get("max_tension"))
+        zone = _zone_from_tension(max_tension)
+
+        axes_list = paradox.get("axes") or []
+        dominant_axes = paradox.get("dominant_axes") or []
+
+        epf = s.get("epf_overview") or {}
+        phi = _safe_float(epf.get("phi_potential"))
+        theta = _safe_float(epf.get("theta_distortion"))
+
+        runs.append(
+            {
+                "run_id": run_id,
+                "decision": decision,
+                "type": type_,
+                "instability_score": instab,
+                "paradox_zone": zone,
+                "paradox_max_tension": max_tension,
+                "epf_phi_potential": phi,
+                "epf_theta_distortion": theta,
+                "dominant_axes": dominant_axes,
+            }
+        )
+
+        zone_counts[zone] = zone_counts.get(zone, 0) + 1
+
+        if max_tension is not None and max_tension > max_tension_overall:
+            max_tension_overall = max_tension
+
+        # tengely szintű aggregáció
+        for ax in axes_list:
+            if not isinstance(ax, dict):
+                continue
+            axis_id = ax.get("axis_id")
+            if not axis_id:
+                continue
+
+            t = _safe_float(ax.get("max_tension")) or 0.0
+
+            stat = axis_stats.setdefault(
+                axis_id,
+                {
+                    "axis_id": axis_id,
+                    "runs_seen": 0,
+                    "times_dominant": 0,
+                    "max_tension": 0.0,
+                    "sum_tension": 0.0,
+                },
+            )
+
+            stat["runs_seen"] += 1
+            stat["sum_tension"] += t
+            if t > stat["max_tension"]:
+                stat["max_tension"] = t
+            if axis_id in dominant_axes:
+                stat["times_dominant"] += 1
+
+        if phi is not None:
+            phi_vals.append(phi)
+        if theta is not None:
+            theta_vals.append(theta)
+
+    # tengely statusz lista
+    axes_out: List[Dict[str, Any]] = []
+    for axis_id, stat in axis_stats.items():
+        runs_seen = stat["runs_seen"]
+        avg_tension = (
+            stat["sum_tension"] / runs_seen if runs_seen > 0 else None
+        )
+        axes_out.append(
+            {
+                "axis_id": axis_id,
+                "runs_seen": runs_seen,
+                "times_dominant": stat["times_dominant"],
+                "max_tension": stat["max_tension"],
+                "avg_tension": avg_tension,
+            }
+        )
+
+    axes_out.sort(key=lambda a: a["max_tension"], reverse=True)
+
+    epf_history = {
+        "phi_potential": {
+            "min": min(phi_vals) if phi_vals else None,
+            "max": max(phi_vals) if phi_vals else None,
+            "avg": _avg(phi_vals),
+        },
+        "theta_distortion": {
+            "min": min(theta_vals) if theta_vals else None,
+            "max": max(theta_vals) if theta_vals else None,
+            "avg": _avg(theta_vals),
+        },
+    }
+
+    history: History = {
+        "version": "0.1",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "num_runs": len(runs),
+        "runs": runs,
+        "paradox_history": {
+            "max_tension_overall": max_tension_overall,
+            "zone_counts": zone_counts,
+            "axes": axes_out,
+        },
+        "epf_history": epf_history,
+    }
+
+    return history
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Aggregate multiple decision_paradox_summary_v0*.json files "
+            "into paradox_history_v0.json"
+        )
+    )
+    parser.add_argument(
+        "--dir",
+        dest="dir_path",
+        default=".",
+        help="Directory containing decision_paradox_summary_v0*.json files (default: .)",
+    )
+    parser.add_argument(
+        "--pattern",
+        dest="pattern",
+        default="decision_paradox_summary_v0*.json",
+        help="Glob pattern for summary files (default: decision_paradox_summary_v0*.json)",
+    )
+    parser.add_argument(
+        "--out",
+        dest="out_path",
+        default="paradox_history_v0.json",
+        help="Output JSON path (default: paradox_history_v0.json)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    summaries = load_summaries(args.dir_path, args.pattern)
+    history = build_paradox_history_v0(summaries)
+
+    with open(args.out_path, "w", encoding="utf-8") as f:
+        json.dump(history, f, indent=2, ensure_ascii=False)
+
+    print(
+        f"[paradox_history_v0] aggregated {history['num_runs']} runs "
+        f"into {args.out_path}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Context

We already have per-run artefacts for the EPF shadow pipeline:

1. stability_map.json + paradox_field_v0 + epf_field_v0
2. decision_output_v0.json (Decision Engine v0 shadow view)
3. decision_paradox_summary_v0.json (dashboard-style summary)

This PR adds a first "memory / trace summariser v0" tool that aggregates
multiple per-run summaries into a single paradox/EPF history view.

## What changed

**New tool**

- `PULSE_safe_pack_v0/tools/summarise_paradox_history_v0.py`

  - Input:
    - directory with `decision_paradox_summary_v0*.json` files

  - Behaviour:
    - load all matching summary files
    - build per-run records:
      - `run_id`, `decision`, `type`
      - `instability_score`
      - `paradox_zone` (derived from `max_tension`)
      - `paradox_max_tension`
      - `epf_phi_potential`, `epf_theta_distortion`
      - `dominant_axes[]`
    - aggregate across runs:
      - `paradox_history`:
        - `max_tension_overall`
        - `zone_counts` (green/yellow/red/unknown)
        - `axes[]` with:
          - `axis_id`
          - `runs_seen`
          - `times_dominant`
          - `max_tension`
          - `avg_tension`
      - `epf_history`:
        - min/max/avg for `phi_potential`
        - min/max/avg for `theta_distortion`

  - Output:
    - `paradox_history_v0.json` (by default)

## Usage

```bash
python PULSE_safe_pack_v0/tools/summarise_paradox_history_v0.py \
  --dir . \
  --pattern "decision_paradox_summary_v0*.json" \
  --out paradox_history_v0.json
