### PR TITLE
docs(paradox-field): add paradox_field_v0 walkthrough

### DIFF
--- a/docs/PULSE_paradox_field_v0_walkthrough.md
+++ b/docs/PULSE_paradox_field_v0_walkthrough.md
@@ -1,0 +1,46 @@
+# PULSE paradox field v0 – walkthrough
+
+Status: **v0, shadow-only**  
+Scope: Stability Map v0 + Decision Engine v0 + dashboards + history
+
+This document explains how to **read** the new paradox field in PULSE:
+
+- `ReleaseState.paradox_field_v0` in `stability_map.json`
+- `paradox_zone` and related fields in `topology_dashboard_v0.json`
+- `paradox_overview` and `axes[]` in `decision_paradox_summary_v0.json`
+- `paradox_history` in `paradox_history_v0.json`
+
+The paradox field v0 is a **field representation** of tensions such as:
+
+- `rdsi` vs gate decision,
+- explicit paradox patterns,
+- (later) other axes: fairness vs safety, external vs internal thresholds, etc.
+
+The goal is not to introduce new gates, but to make paradox **visible as a field**.
+
+---
+
+## 1. What is a paradox atom?
+
+At the core of `paradox_field_v0` are **paradox atoms**. In the schema:
+
+```jsonc
+{
+  "axis_id": "rdsi_vs_gate_decision",
+  "A": "gate_decision_consistent_with_rdsi",
+  "notA": "gate_decision_in_tension_with_rdsi",
+  "direction": "towards_A",
+  "tension_score": 0.18,
+  "zone": "green",
+  "context": {
+    "run_id": "run_001",
+    "scope": "stability_map",
+    "segment": "rdsi_vs_gate_decision"
+  },
+  "anchors": [
+    {
+      "topology_node": "decision_engine/gate",
+      "role": "decision_point"
+    }
+  ]
+}


### PR DESCRIPTION
## Context

We now have:
- `paradox_field_v0` attached to each ReleaseState in `stability_map.json`
- topology dashboards with `paradox_zone` / `paradox_max_tension`
- per-run summaries (`decision_paradox_summary_v0.json`)
- multi-run history (`paradox_history_v0.json`)

However, there was no dedicated "how to read this" document for the
paradox field layer.

## What changed

**New doc**

- `docs/PULSE_paradox_field_v0_walkthrough.md`

  - Defines "paradox atoms" (axis_id, A, notA, direction, tension_score,
    zone, context, anchors).
  - Explains how `paradox_field_v0.summary` (max_tension, num_atoms,
    num_red_zones, dominant_axes[]) should be interpreted.
  - Shows how this surfaces in:
    - `topology_dashboard_v0.json` (paradox_zone, paradox_max_tension,
      paradox_dominant_axes)
    - `decision_paradox_summary_v0.json` (paradox_overview.axes[])
    - `paradox_history_v0.json` (zone_counts, per-axis stats).

  - Describes the relationship between paradox_field_v0 and epf_field_v0:
    EPF as one of the paradox axes (e.g. epf_field_vs_policy_field).

  - States invariants:
    - gate logic unchanged
    - existing fields keep their semantics
    - paradox_field_v0 is an additive, schema-backed field

## Notes

- Documentation-only addition on top of the existing EPF shadow /
  dashboard / history tooling.
