### PR TITLE
docs(paradox-field): add paradox_field_v0 + epf_field_v0 case study

### DIFF
--- a/docs/PULSE_paradox_field_v0_case_study.md
+++ b/docs/PULSE_paradox_field_v0_case_study.md
@@ -1,0 +1,26 @@
+# PULSE paradox_field_v0 + epf_field_v0 – v0 case study
+
+Status: v0, shadow-only  
+Scope: how to **read** the paradox / EPF field layer in practice
+
+This case study shows how `paradox_field_v0` and `epf_field_v0` appear in
+PULSE artefacts, and how to interpret them as **fields**, not just flags.
+
+We’ll walk through:
+
+1. A single `ReleaseState` in `stability_map.json`  
+2. How the same field shows up in `decision_output_v0.json`  
+3. How it is compressed into `decision_paradox_summary_v0.json`  
+4. How it appears in `paradox_history_v0.json`
+
+All examples are synthetic, but consistent with the current v0 tools.
+
+---
+
+## 1. Example ReleaseState in `stability_map.json`
+
+After running:
+
+```bash
+python PULSE_safe_pack_v0/tools/build_paradox_epf_fields_v0.py \
+  --map stability_map.json


### PR DESCRIPTION
## Context

The EPF shadow pipeline v0 is implemented and documented, and we now have
paradox/EPF fields exposed in multiple artefacts:

- stability_map.json (paradox_field_v0, epf_field_v0)
- decision_output_v0.json (paradox_stamp + dual_view.paradox_panel_v0)
- decision_paradox_summary_v0.json
- paradox_history_v0.json

This PR adds a dedicated case study to show how to read these fields in a
concrete, end-to-end example.

## What changed

**New doc**

- `docs/PULSE_paradox_field_v0_case_study.md`

  - Shows a synthetic but realistic ReleaseState with:
    - `paradox_field_v0` atoms on:
      - `rdsi_vs_gate_decision`
      - `paradox_pattern:epf_field_vs_policy_field`
    - `paradox_field_v0.summary` (max_tension, num_atoms, num_red_zones,
      dominant_axes[])
    - `epf_field_v0` (phi_potential, theta_distortion, energy_delta, anchors).

  - Traces the same field through:
    - `decision_output_v0.json` (paradox_stamp + dual_view.paradox_panel_v0)
    - `decision_paradox_summary_v0.json` (paradox_overview + epf_overview)
    - `paradox_history_v0.json` (zone_counts, per-axis stats, EPF history).

  - Provides narrative interpretation of the paradox and EPF fields in each
    artefact.

## Notes

- Documentation-only change; no code or schema updates.
- Intended as a human-facing entry point for the paradox/EPF field layer and
  a complement to the EPF shadow pipeline walkthrough.
