### PR TITLE
docs(paradox-resolution): add paradox_resolution_v0 walkthrough

### DIFF
--- a/docs/PULSE_paradox_resolution_v0_walkthrough.md
+++ b/docs/PULSE_paradox_resolution_v0_walkthrough.md
@@ -1,0 +1,12 @@
+# PULSE Paradox Resolution v0 – walkthrough
+
+Status: v0, shadow-only  
+Scope: paradox_history_v0.json → paradox_resolution_v0.json
+
+This document explains how to read the `paradox_resolution_v0.json`
+artefact produced by:
+
+```bash
+python PULSE_safe_pack_v0/tools/build_paradox_resolution_v0.py \
+  --history paradox_history_v0.json \
+  --out paradox_resolution_v0.json


### PR DESCRIPTION
## Context
We introduced `PULSE_safe_pack_v0/tools/build_paradox_resolution_v0.py`,
which generates `paradox_resolution_v0.json` from `paradox_history_v0.json`.
There was no dedicated doc explaining how to read this artefact.

## What changed
**New doc**
- `docs/PULSE_paradox_resolution_v0_walkthrough.md`
  - Where it sits in the pipeline (Topology v0 → paradox/EPF field → decision output → summary → history → resolution).
  - Structure of `paradox_resolution_v0.json`:
    - per-axis: axis_id, runs_seen, times_dominant, max/avg tension, severity, priority, recommended_focus[]
    - summary: num_axes, severity_counts
  - Notes on intent and invariants (shadow-only, human triage, gate logic unchanged).

## Usage
```bash
python PULSE_safe_pack_v0/tools/build_paradox_resolution_v0.py \
  --history paradox_history_v0.json \
  --out paradox_resolution_v0.json
