### PR TITLE
docs(epf-shadow): add EPF shadow quickstart v0

### DIFF
--- a/docs/PULSE_epf_shadow_quickstart_v0.md
+++ b/docs/PULSE_epf_shadow_quickstart_v0.md
@@ -1,0 +1,38 @@
+# PULSE EPF shadow pipeline v0 – quickstart
+
+Status: v0, shadow-only  
+Audience: developers who already run the PULSE Topology v0 pipeline and want
+to try the EPF + paradox field layer without changing gate logic.
+
+This is a minimal, command-level quickstart. For full details, see:
+
+- `docs/PULSE_epf_shadow_pipeline_v0_walkthrough.md`
+- `docs/PULSE_paradox_field_v0_walkthrough.md`
+- `docs/PULSE_paradox_field_v0_case_study.md`
+
+---
+
+## 1. Prerequisites
+
+You should already have a working PULSE topology pipeline that produces:
+
+- `stability_map.json` (Topology v0 + Stability Map v0), and
+- optionally EPF-related fields (`epf.available`, `epf.L`, `epf.shadow_pass`).
+
+How you obtain `stability_map.json` is out of scope for this quickstart;
+see `docs/PULSE_topology_v0_methods.md` for the topology pipeline.
+
+All commands below are intended to be run from the repo root.
+
+---
+
+## 2. Single-run EPF shadow pipeline
+
+This section shows the minimal set of commands to project the EPF signal and
+paradox field onto a single run, and produce a decision-level summary.
+
+### Step 1 – Enrich Stability Map with paradox / EPF field
+
+```bash
+python PULSE_safe_pack_v0/tools/build_paradox_epf_fields_v0.py \
+  --map stability_map.json


### PR DESCRIPTION
## Context

We have the EPF shadow pipeline implemented and documented, but there is
no short "how do I actually run this?" entrypoint yet.

## What changed

- Added `docs/PULSE_epf_shadow_quickstart_v0.md`:
  - minimal command-level quickstart for the EPF shadow pipeline v0,
    starting from an existing `stability_map.json`:
    - enrich with paradox/EPF fields
    - build Decision Engine v0 shadow output
    - build per-run summary, multi-run history, resolution plan, and
      resolution dashboard
    - optional topology dashboard.

- Updated README Docs & specs section to link the quickstart under the
  "EPF shadow layer & paradox field" group.

## Notes

Documentation-only change; pipeline and gate logic remain unchanged.
