### PR TITLE
docs(readme): update EPF shadow layer docs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,12 +253,15 @@ It consists of:
 
 - `docs/PULSE_topology_epf_hook.md`  
   – How EPF hooks into the topology conceptually.
+- `docs/PULSE_epf_shadow_quickstart_v0.md`  
+  – Short command-level guide to run the EPF shadow pipeline v0.
 - `docs/PULSE_epf_shadow_pipeline_v0_walkthrough.md`  
-  – End‑to‑end EPF shadow pipeline v0 (Stability Map → Decision Engine → summary → history).
+  – Detailed walkthrough of the EPF shadow pipeline v0.
 - `docs/PULSE_paradox_field_v0_walkthrough.md`  
-  – How to read `paradox_field_v0` across Stability Map / dashboards / history.
+  – How to read `paradox_field_v0` across artefacts.
 - `docs/PULSE_paradox_field_v0_case_study.md`  
-  – Concrete example of paradox + EPF field for a single run.
+  – Concrete example for a single run.
+
 
 **Paradox Resolution v0**
 


### PR DESCRIPTION
## Context

We have added several EPF shadow / paradox docs (quickstart, walkthroughs,
case studies), but the README "EPF shadow layer & paradox field" section
was not fully aligned with the current documentation set.

## What changed

- Updated the "EPF shadow layer & paradox field" block in `README.md` to:

  - reference the EPF topology hook doc
  - link the EPF shadow quickstart doc
  - link the detailed EPF shadow pipeline walkthrough
  - link the paradox_field_v0 walkthrough and case study docs

This keeps the top-level Docs & specs index in sync with the current
EPF/paradox documentation on main.

## Notes

Docs-only change; no code or schema changes.
