### PR TITLE
docs(memory): add PULSE memory/trace v0 walkthrough

### DIFF
--- a/docs/PULSE_memory_trace_v0_walkthrough.md
+++ b/docs/PULSE_memory_trace_v0_walkthrough.md
@@ -1,0 +1,40 @@
+# PULSE Memory / Trace v0 – Walkthrough
+
+Status: working draft (v0)  
+Scope: experimental / shadow-only trace views on top of PULSE Topology v0.
+
+This document explains how to build **trace-style artefacts** from the
+existing PULSE pipelines:
+
+- decision-level trace (how release decisions evolve over runs), and
+- paradox-level trace (how paradox axes and resolution plans change).
+
+It is meant as a **human-facing guide** for reading the JSON files,
+not as a formal spec. For the high-level design, see:
+
+- `docs/PULSE_memory_trace_summariser_v0_design_note.md`
+- `docs/FUTURE_LIBRARY.md` (Memory / trace summariser v0 section)
+
+---
+
+## 1. Prerequisites
+
+Before using the memory / trace tools, you should have already run the
+EPF shadow + paradox pipelines, as described in:
+
+- `docs/PULSE_epf_shadow_pipeline_v0_walkthrough.md`
+- `docs/PULSE_paradox_field_v0_walkthrough.md`
+- `docs/PULSE_paradox_resolution_v0_walkthrough.md`
+
+From those steps you should have these artefacts:
+
+- `stability_map.json`
+- `decision_output_v0.json`
+- `decision_paradox_summary_v0.json`
+- `paradox_resolution_v0.json`
+- `paradox_resolution_dashboard_v0.json`
+
+All tools mentioned below live under:
+
+```text
+PULSE_safe_pack_v0/tools/


### PR DESCRIPTION
## Summary

Introduce a new walkthrough document:

- `docs/PULSE_memory_trace_v0_walkthrough.md`

covering the memory / trace artefacts built on top of the EPF shadow
and paradox pipelines.

## What is documented

- How to obtain `decision_history_v0.json` from the Decision Engine v0
  shadow output using `summarise_decision_history_v0.py`.

- How to obtain `paradox_history_v0.json` from the paradox resolution
  artefacts using `summarise_paradox_history_v0.py`.

- Conceptual structure and intended use of these trace JSONs
  (dashboard-friendly, longitudinal views over runs / paradox axes).

## Notes

- Docs-only change; no tool logic, schemas, or gate behaviour is
  modified.
- CLI examples are illustrative; the tools' `--help` output remains the
  single source of truth.
