### PR TITLE
feat(memory): add PULSE trace dashboard v0 demo notebook

### DIFF
--- a/PULSE_safe_pack_v0/examples/PULSE_trace_dashboard_v0_demo.ipynb
+++ b/PULSE_safe_pack_v0/examples/PULSE_trace_dashboard_v0_demo.ipynb
@@ -1,0 +1,225 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PULSE trace dashboard v0 demo\n",
+    "\n",
+    "This notebook visualises the shadow-only memory / trace artefacts\n",
+    "produced by the PULSE EPF + paradox pipelines:\n",
+    "\n",
+    "- `decision_history_v0.json`\n",
+    "- `paradox_history_v0.json`\n",
+    "- `trace_dashboard_v0.json`\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "This assumes you have already run the shadow tools to produce the JSON\n",
+    "artefacts under `PULSE_safe_pack_v0/artifacts/`, and that this notebook\n",
+    "lives in `PULSE_safe_pack_v0/examples/`.\n",
+    "\n",
+    "If your layout is different, adjust `ARTIFACT_DIR` below.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Where the JSON artefacts live relative to this notebook.\n",
+    "ARTIFACT_DIR = Path(\"../artifacts\")\n",
+    "\n",
+    "decision_history_path = ARTIFACT_DIR / \"decision_history_v0.json\"\n",
+    "paradox_history_path = ARTIFACT_DIR / \"paradox_history_v0.json\"\n",
+    "trace_dashboard_path = ARTIFACT_DIR / \"trace_dashboard_v0.json\"\n",
+    "\n",
+    "print(\"Decision history:\", decision_history_path)\n",
+    "print(\"Paradox history:\", paradox_history_path)\n",
+    "print(\"Trace dashboard:\", trace_dashboard_path)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def _load_json(path):\n",
+    "    with open(path, \"r\", encoding=\"utf-8\") as f:\n",
+    "        return json.load(f)\n",
+    "\n",
+    "decision_history = _load_json(decision_history_path)\n",
+    "paradox_history = _load_json(paradox_history_path)\n",
+    "trace_dashboard = _load_json(trace_dashboard_path)\n",
+    "\n",
+    "print(\"Keys in trace_dashboard:\", list(trace_dashboard.keys()))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def _extract_runs(decision_history_obj):\n",
+    "    if isinstance(decision_history_obj, dict) and isinstance(\n",
+    "        decision_history_obj.get(\"runs\"), list\n",
+    "    ):\n",
+    "        return decision_history_obj[\"runs\"]\n",
+    "    elif isinstance(decision_history_obj, list):\n",
+    "        return decision_history_obj\n",
+    "    else:\n",
+    "        return [decision_history_obj]\n",
+    "\n",
+    "def _extract_axes(paradox_history_obj):\n",
+    "    if isinstance(paradox_history_obj, dict) and isinstance(\n",
+    "        paradox_history_obj.get(\"axes\"), list\n",
+    "    ):\n",
+    "        return paradox_history_obj[\"axes\"]\n",
+    "    elif isinstance(paradox_history_obj, list):\n",
+    "        return paradox_history_obj\n",
+    "    else:\n",
+    "        return []\n",
+    "\n",
+    "runs = _extract_runs(decision_history)\n",
+    "axes = _extract_axes(paradox_history)\n",
+    "\n",
+    "runs_df = pd.DataFrame(runs)\n",
+    "axes_df = pd.DataFrame(axes)\n",
+    "\n",
+    "runs_df.tail()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "axes_df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Plot instability per run (if available)\n",
+    "plot_df = runs_df.copy()\n",
+    "\n",
+    "if \"run_id\" in plot_df.columns:\n",
+    "    plot_df = plot_df.sort_values(\"run_id\")\n",
+    "\n",
+    "instability_col = None\n",
+    "for candidate in [\"instability\", \"instability_score\"]:\n",
+    "    if candidate in plot_df.columns:\n",
+    "        instability_col = candidate\n",
+    "        break\n",
+    "\n",
+    "if instability_col is None:\n",
+    "    print(\"No instability column found in decision history.\")\n",
+    "else:\n",
+    "    plt.figure(figsize=(8, 4))\n",
+    "    plt.plot(plot_df[\"run_id\"], plot_df[instability_col], marker=\"o\")\n",
+    "    plt.xticks(rotation=45, ha=\"right\")\n",
+    "    plt.ylabel(instability_col)\n",
+    "    plt.title(\"Instability by run\")\n",
+    "    plt.tight_layout()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Plot paradox axes by severity / dominance (if available)\n",
+    "if axes_df.empty:\n",
+    "    print(\"No axes found in paradox history.\")\n",
+    "else:\n",
+    "    severity_order = {\"LOW\": 1, \"MEDIUM\": 2, \"HIGH\": 3, \"CRITICAL\": 4}\n",
+    "    axes_plot_df = axes_df.copy()\n",
+    "    if \"severity\" in axes_plot_df.columns:\n",
+    "        axes_plot_df[\"severity_rank\"] = axes_plot_df[\"severity\"].map(severity_order).fillna(0)\n",
+    "    else:\n",
+    "        axes_plot_df[\"severity_rank\"] = 0\n",
+    "\n",
+    "    if \"times_dominant\" in axes_plot_df.columns:\n",
+    "        axes_plot_df = axes_plot_df.sort_values(\n",
+    "            [\"severity_rank\", \"times_dominant\"], ascending=False\n",
+    "        )\n",
+    "    else:\n",
+    "        axes_plot_df = axes_plot_df.sort_values(\"severity_rank\", ascending=False)\n",
+    "\n",
+    "    if \"axis_id\" not in axes_plot_df.columns:\n",
+    "        print(\"No axis_id column found in paradox history.\")\n",
+    "    else:\n",
+    "        plt.figure(figsize=(8, 4))\n",
+    "        plt.bar(axes_plot_df[\"axis_id\"], axes_plot_df[\"severity_rank\"])\n",
+    "        plt.xticks(rotation=45, ha=\"right\")\n",
+    "        plt.ylabel(\"severity_rank\")\n",
+    "        plt.title(\"Paradox axes \u2013 severity (ranked)\")\n",
+    "        plt.tight_layout()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from pprint import pprint\n",
+    "\n",
+    "print(\"Decision overview:\")\n",
+    "pprint(trace_dashboard.get(\"decision_overview\", {}))\n",
+    "\n",
+    "print(\"\")\n",
+    "print(\"Paradox overview:\")\n",
+    "pprint(trace_dashboard.get(\"paradox_overview\", {}))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "This notebook is intentionally minimal. It is meant as a starting point\n",
+    "for building richer dashboards on top of the trace artefacts.\n",
+    "\n",
+    "Ideas for extensions:\n",
+    "\n",
+    "- join the trace data with Stability Map states / transitions,\n",
+    "- add filters by decision type or paradox zone,\n",
+    "- plot EPF-related fields once those are logged into history.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Add a demo notebook for the memory / trace artefacts:

- `PULSE_safe_pack_v0/examples/PULSE_trace_dashboard_v0_demo.ipynb`

The notebook expects the following artefacts under
`PULSE_safe_pack_v0/artifacts/`:

- `decision_history_v0.json`
- `paradox_history_v0.json`
- `trace_dashboard_v0.json`

and provides:

- pandas table views over decision and paradox history,
- a simple line plot of instability by run,
- a bar plot of paradox axes ranked by severity.

## Notes

- Shadow-only, demo notebook; no gate logic, tools or schemas are
  modified.
- Can be used locally or on Kaggle by pointing `ARTIFACT_DIR` to the
  appropriate dataset location.
