### PR TITLE
fix(memory): align trace dashboard with paradox_history_v0 format

### DIFF
--- a/PULSE_safe_pack_v0/tools/PULSE_safe_pack_v0/tools/build_trace_dashboard_v0.py
+++ b/PULSE_safe_pack_v0/tools/PULSE_safe_pack_v0/tools/build_trace_dashboard_v0.py
@@ -95,27 +95,31 @@ def _build_paradox_overview(
     """
     Build a compact paradox overview section.
 
-    Expects either:
+    Accepts either:
 
-    - {"axes": [...]}  or
-    - a bare list  of axis entries.
-
-    Each axis entry may contain:
-
-    - axis_id
-    - runs_seen
-    - times_dominant
-    - severity
-    - recommended_focus_latest (or recommended_focus)
+    - {"axes": [...]}  (top-level axes), or
+    - {"paradox_history": {"axes": [...]}}  (nested history format), or
+    - a bare list of axis entries.
     """
-    if isinstance(paradox_history, dict) and isinstance(
-        paradox_history.get("axes"), list
-    ):
-        axes = paradox_history["axes"]
+    # Normalise to a list of axis dicts
+    axes: List[Any]
+
+    if isinstance(paradox_history, dict):
+        # v0: axes directly at top level
+        if isinstance(paradox_history.get("axes"), list):
+            axes = paradox_history["axes"]
+        # canonical history format: nested under "paradox_history"
+        elif isinstance(paradox_history.get("paradox_history"), dict) and isinstance(
+            paradox_history["paradox_history"].get("axes"), list
+        ):
+            axes = paradox_history["paradox_history"]["axes"]
+        else:
+            axes = []
     elif isinstance(paradox_history, list):
         axes = paradox_history
     else:
         axes = []
+
 
     norm_axes: List[Json] = [a for a in axes if isinstance(a, dict)]
 


### PR DESCRIPTION
## Summary

Align the trace dashboard builder with the canonical
`paradox_history_v0.json` format.

## Details

The tool:

- `PULSE_safe_pack_v0/tools/build_trace_dashboard_v0.py`

previously expected paradox axes to be provided as:

- `{"axes": [...]}` (top-level),

and ignored the nested format produced by
`summarise_paradox_history_v0.py`, where axes live under:

- `{"paradox_history": {"axes": [...]}}`.

This change updates `_build_paradox_overview` to:

- first look for `paradox_history["axes"]`,
- then, if not found, look for `paradox_history["paradox_history"]["axes"]`,
- only then fall back to an empty list.

As a result, `trace_dashboard_v0.json` will correctly reflect the
paradox axes for canonical `paradox_history_v0.json` inputs.

## Notes

- No gate logic, schemas or other tools are changed.
- Behaviour for already-working inputs (top-level `axes`) remains
  compatible.
