### PR TITLE
feat(memory): richer trace dashboard v0 (worry index, matrices, CSV exports)

### DIFF
--- a/PULSE_safe_pack_v0/examples/PULSE_trace_dashboard_v0_demo.ipynb
+++ b/PULSE_safe_pack_v0/examples/PULSE_trace_dashboard_v0_demo.ipynb
@@ -223,3 +223,149 @@
  "nbformat": 4,
  "nbformat_minor": 5
 }
+
+## Worry index v0 — Top risky runs
+Rank runs by combining paradox zone (red/yellow/green) and instability. Save the top list to CSV.
+
+from pathlib import Path
+import pandas as pd
+import matplotlib.pyplot as plt
+
+ARTIFACT_DIR = Path("../artifacts")
+
+df = runs_df.copy()
+
+# Find an instability column
+instab_col = None
+for cand in ["instability_score", "instability"]:
+    if cand in df.columns:
+        instab_col = cand
+        break
+
+if instab_col is None:
+    print("No instability column found; skipping worry index.")
+else:
+    zone_rank_map = {"red": 3, "yellow": 2, "green": 1}
+    df["paradox_zone_rank"] = df["paradox_zone"].map(zone_rank_map).fillna(0)
+
+    # Simple v0 score: zone is dominant, instability refines
+    df["worry_score"] = df["paradox_zone_rank"] * 2 + df[instab_col]
+
+    top_k = 10
+    top_worry = (
+        df.sort_values(["worry_score", instab_col], ascending=False)
+          .head(top_k)
+          .loc[:, ["run_id", "decision", "type", "paradox_zone", instab_col, "worry_score"]]
+    )
+
+    display(top_worry)
+
+    # Save as artefact
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    out_csv = ARTIFACT_DIR / "runs_top_worry_v0.csv"
+    top_worry.to_csv(out_csv, index=False)
+    print("Saved:", out_csv)
+
+    # Quick bar chart
+    plt.figure(figsize=(8, 4))
+    plt.bar(top_worry["run_id"], top_worry["worry_score"])
+    plt.xticks(rotation=45, ha="right")
+    plt.ylabel("worry_score")
+    plt.title(f"Top {top_k} risky runs (zone + instability)")
+    plt.tight_layout()
+    plt.show()
+
+## Paradox zones and Decision×Zone matrix
+Show zone distributions and a simple decision×zone pivot. Save the pivot to CSV.
+
+import numpy as np
+
+df = runs_df.copy()
+
+if "paradox_zone" not in df.columns:
+    print("No 'paradox_zone' column found.")
+else:
+    # Zone distribution
+    zone_counts = df["paradox_zone"].fillna("none").value_counts()
+    display(zone_counts.rename("count").to_frame())
+
+    # Decision × zone combos
+    combo = (
+        df.assign(paradox_zone=df["paradox_zone"].fillna("none"))
+          .groupby(["decision", "paradox_zone"])
+          .size()
+          .reset_index(name="count")
+    )
+    display(combo)
+
+    # Pivot + save
+    pivot = combo.pivot(index="decision", columns="paradox_zone", values="count").fillna(0).astype(int)
+    display(pivot)
+
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    out_csv = ARTIFACT_DIR / "decision_zone_matrix_v0.csv"
+    pivot.to_csv(out_csv)
+    print("Saved:", out_csv)
+
+    # Heatmap (matplotlib imshow)
+    plt.figure(figsize=(6, 4))
+    plt.imshow(pivot.values, aspect="auto")
+    plt.colorbar(label="count")
+    plt.yticks(ticks=np.arange(len(pivot.index)), labels=pivot.index)
+    plt.xticks(ticks=np.arange(len(pivot.columns)), labels=pivot.columns, rotation=45, ha="right")
+    plt.title("Decision × Paradox zone — counts")
+    plt.tight_layout()
+    plt.show()
+
+## Top paradox axes (severity + dominance)
+Rank axes by severity and dominance. Save the top list to CSV.
+
+if axes_df.empty:
+    print("No paradox axes available.")
+else:
+    cols = [c for c in ["axis_id", "severity", "runs_seen", "times_dominant", "max_tension"] if c in axes_df.columns]
+    if not cols:
+        print("Paradox axes dataframe has no expected columns.")
+    else:
+        top_axes_df = axes_df[cols].copy()
+
+        severity_order = {"LOW": 1, "MEDIUM": 2, "HIGH": 3, "CRITICAL": 4}
+        top_axes_df["severity_rank"] = top_axes_df.get("severity", "").map(severity_order).fillna(0)
+
+        sort_cols = ["severity_rank"]
+        if "times_dominant" in top_axes_df.columns:
+            sort_cols.append("times_dominant")
+        if "runs_seen" in top_axes_df.columns:
+            sort_cols.append("runs_seen")
+
+        top_axes_df = top_axes_df.sort_values(sort_cols, ascending=False)
+
+        top10 = top_axes_df.head(10).loc[:, [c for c in ["axis_id", "severity", "runs_seen", "times_dominant", "max_tension"] if c in top_axes_df.columns]]
+        display(top10)
+
+        ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+        out_csv = ARTIFACT_DIR / "paradox_axes_top_v0.csv"
+        top10.to_csv(out_csv, index=False)
+        print("Saved:", out_csv)
+
+        # Quick scatter (runs_seen vs times_dominant)
+        plt.figure()
+        plt.scatter(top10["runs_seen"], top10["times_dominant"])
+        for i, r in top10.iterrows():
+            plt.text(r["runs_seen"], r["times_dominant"], str(r["axis_id"]))
+        plt.xlabel("runs_seen")
+        plt.ylabel("times_dominant")
+        plt.title("Top paradox axes (severity + dominance)")
+        plt.tight_layout()
+        plt.show()
+
+## EPF overview (optional)
+Print EPF summary if present in the trace dashboard. Graceful fallback if missing.
+
+epf_ov = trace_dashboard.get("epf_overview", {})
+if not epf_ov:
+    print("No EPF overview present in trace_dashboard.")
+else:
+    from pprint import pprint
+    print("EPF overview:")
+    pprint(epf_ov)


### PR DESCRIPTION
## Summary
Add several compact sections to the trace dashboard v0 demo to make the
memory/trace exploration more actionable.

## What’s included
- **Worry index v0**: rank runs using paradox zone + instability; export CSV.
- **Paradox zones**: distribution and Decision×Zone pivot; export CSV.
- **Top paradox axes**: severity + dominance ranking; export CSV.
- **EPF overview**: prints EPF summary if available.

## Notes
- Purely a notebook extension (examples); no gate logic or tools changed.
- CSVs are written to `PULSE_safe_pack_v0/artifacts/` for reuse in docs/dashboards.
