### PR TITLE
fix(dashboard): repair trace dashboard notebook; extract panels to _panels_v0_cells.py

### DIFF
--- a/PULSE_safe_pack_v0/examples/PULSE_trace_dashboard_v0_demo.ipynb
+++ b/PULSE_safe_pack_v0/examples/PULSE_trace_dashboard_v0_demo.ipynb
@@ -1,371 +1,40 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# PULSE trace dashboard v0 demo\n",
-    "\n",
-    "This notebook visualises the shadow-only memory / trace artefacts\n",
-    "produced by the PULSE EPF + paradox pipelines:\n",
-    "\n",
-    "- `decision_history_v0.json`\n",
-    "- `paradox_history_v0.json`\n",
-    "- `trace_dashboard_v0.json`\n"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# PULSE Trace Dashboard v0 — Demo (repaired)\\n",
+        "\\n",
+        "This notebook delegates panel logic to `_panels_v0_cells.py` to keep the JSON clean and robust.\\n",
+        "All CSV artefacts are written under `../artifacts/`.\\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from _panels_v0_cells import run_all_panels\\n",
+        "\\n",
+        "# If the notebook already defined runs_df / axes_df / trace_dashboard earlier,\\n",
+        "# run_all_panels() will use them; otherwise it will try to load them from ../artifacts.\\n",
+        "run_all_panels(globals())\\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Setup\n",
-    "\n",
-    "This assumes you have already run the shadow tools to produce the JSON\n",
-    "artefacts under `PULSE_safe_pack_v0/artifacts/`, and that this notebook\n",
-    "lives in `PULSE_safe_pack_v0/examples/`.\n",
-    "\n",
-    "If your layout is different, adjust `ARTIFACT_DIR` below.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "import json\n",
-    "from pathlib import Path\n",
-    "\n",
-    "import pandas as pd\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "# Where the JSON artefacts live relative to this notebook.\n",
-    "ARTIFACT_DIR = Path(\"../artifacts\")\n",
-    "\n",
-    "decision_history_path = ARTIFACT_DIR / \"decision_history_v0.json\"\n",
-    "paradox_history_path = ARTIFACT_DIR / \"paradox_history_v0.json\"\n",
-    "trace_dashboard_path = ARTIFACT_DIR / \"trace_dashboard_v0.json\"\n",
-    "\n",
-    "print(\"Decision history:\", decision_history_path)\n",
-    "print(\"Paradox history:\", paradox_history_path)\n",
-    "print(\"Trace dashboard:\", trace_dashboard_path)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "def _load_json(path):\n",
-    "    with open(path, \"r\", encoding=\"utf-8\") as f:\n",
-    "        return json.load(f)\n",
-    "\n",
-    "decision_history = _load_json(decision_history_path)\n",
-    "paradox_history = _load_json(paradox_history_path)\n",
-    "trace_dashboard = _load_json(trace_dashboard_path)\n",
-    "\n",
-    "print(\"Keys in trace_dashboard:\", list(trace_dashboard.keys()))\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "def _extract_runs(decision_history_obj):\n",
-    "    if isinstance(decision_history_obj, dict) and isinstance(\n",
-    "        decision_history_obj.get(\"runs\"), list\n",
-    "    ):\n",
-    "        return decision_history_obj[\"runs\"]\n",
-    "    elif isinstance(decision_history_obj, list):\n",
-    "        return decision_history_obj\n",
-    "    else:\n",
-    "        return [decision_history_obj]\n",
-    "\n",
-    "def _extract_axes(paradox_history_obj):\n",
-    "    if isinstance(paradox_history_obj, dict) and isinstance(\n",
-    "        paradox_history_obj.get(\"axes\"), list\n",
-    "    ):\n",
-    "        return paradox_history_obj[\"axes\"]\n",
-    "    elif isinstance(paradox_history_obj, list):\n",
-    "        return paradox_history_obj\n",
-    "    else:\n",
-    "        return []\n",
-    "\n",
-    "runs = _extract_runs(decision_history)\n",
-    "axes = _extract_axes(paradox_history)\n",
-    "\n",
-    "runs_df = pd.DataFrame(runs)\n",
-    "axes_df = pd.DataFrame(axes)\n",
-    "\n",
-    "runs_df.tail()\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "axes_df.head()\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "# Plot instability per run (if available)\n",
-    "plot_df = runs_df.copy()\n",
-    "\n",
-    "if \"run_id\" in plot_df.columns:\n",
-    "    plot_df = plot_df.sort_values(\"run_id\")\n",
-    "\n",
-    "instability_col = None\n",
-    "for candidate in [\"instability\", \"instability_score\"]:\n",
-    "    if candidate in plot_df.columns:\n",
-    "        instability_col = candidate\n",
-    "        break\n",
-    "\n",
-    "if instability_col is None:\n",
-    "    print(\"No instability column found in decision history.\")\n",
-    "else:\n",
-    "    plt.figure(figsize=(8, 4))\n",
-    "    plt.plot(plot_df[\"run_id\"], plot_df[instability_col], marker=\"o\")\n",
-    "    plt.xticks(rotation=45, ha=\"right\")\n",
-    "    plt.ylabel(instability_col)\n",
-    "    plt.title(\"Instability by run\")\n",
-    "    plt.tight_layout()\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "# Plot paradox axes by severity / dominance (if available)\n",
-    "if axes_df.empty:\n",
-    "    print(\"No axes found in paradox history.\")\n",
-    "else:\n",
-    "    severity_order = {\"LOW\": 1, \"MEDIUM\": 2, \"HIGH\": 3, \"CRITICAL\": 4}\n",
-    "    axes_plot_df = axes_df.copy()\n",
-    "    if \"severity\" in axes_plot_df.columns:\n",
-    "        axes_plot_df[\"severity_rank\"] = axes_plot_df[\"severity\"].map(severity_order).fillna(0)\n",
-    "    else:\n",
-    "        axes_plot_df[\"severity_rank\"] = 0\n",
-    "\n",
-    "    if \"times_dominant\" in axes_plot_df.columns:\n",
-    "        axes_plot_df = axes_plot_df.sort_values(\n",
-    "            [\"severity_rank\", \"times_dominant\"], ascending=False\n",
-    "        )\n",
-    "    else:\n",
-    "        axes_plot_df = axes_plot_df.sort_values(\"severity_rank\", ascending=False)\n",
-    "\n",
-    "    if \"axis_id\" not in axes_plot_df.columns:\n",
-    "        print(\"No axis_id column found in paradox history.\")\n",
-    "    else:\n",
-    "        plt.figure(figsize=(8, 4))\n",
-    "        plt.bar(axes_plot_df[\"axis_id\"], axes_plot_df[\"severity_rank\"])\n",
-    "        plt.xticks(rotation=45, ha=\"right\")\n",
-    "        plt.ylabel(\"severity_rank\")\n",
-    "        plt.title(\"Paradox axes \u2013 severity (ranked)\")\n",
-    "        plt.tight_layout()\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "from pprint import pprint\n",
-    "\n",
-    "print(\"Decision overview:\")\n",
-    "pprint(trace_dashboard.get(\"decision_overview\", {}))\n",
-    "\n",
-    "print(\"\")\n",
-    "print(\"Paradox overview:\")\n",
-    "pprint(trace_dashboard.get(\"paradox_overview\", {}))\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Next steps\n",
-    "\n",
-    "This notebook is intentionally minimal. It is meant as a starting point\n",
-    "for building richer dashboards on top of the trace artefacts.\n",
-    "\n",
-    "Ideas for extensions:\n",
-    "\n",
-    "- join the trace data with Stability Map states / transitions,\n",
-    "- add filters by decision type or paradox zone,\n",
-    "- plot EPF-related fields once those are logged into history.\n"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.10"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }
-
-## Worry index v0 — Top risky runs
-Rank runs by combining paradox zone (red/yellow/green) and instability. Save the top list to CSV.
-
-from pathlib import Path
-import pandas as pd
-import matplotlib.pyplot as plt
-
-ARTIFACT_DIR = Path("../artifacts")
-
-df = runs_df.copy()
-
-# Find an instability column
-instab_col = None
-for cand in ["instability_score", "instability"]:
-    if cand in df.columns:
-        instab_col = cand
-        break
-
-if instab_col is None:
-    print("No instability column found; skipping worry index.")
-else:
-    zone_rank_map = {"red": 3, "yellow": 2, "green": 1}
-    df["paradox_zone_rank"] = df["paradox_zone"].map(zone_rank_map).fillna(0)
-
-    # Simple v0 score: zone is dominant, instability refines
-    df["worry_score"] = df["paradox_zone_rank"] * 2 + df[instab_col]
-
-    top_k = 10
-    top_worry = (
-        df.sort_values(["worry_score", instab_col], ascending=False)
-          .head(top_k)
-          .loc[:, ["run_id", "decision", "type", "paradox_zone", instab_col, "worry_score"]]
-    )
-
-    display(top_worry)
-
-    # Save as artefact
-    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
-    out_csv = ARTIFACT_DIR / "runs_top_worry_v0.csv"
-    top_worry.to_csv(out_csv, index=False)
-    print("Saved:", out_csv)
-
-    # Quick bar chart
-    plt.figure(figsize=(8, 4))
-    plt.bar(top_worry["run_id"], top_worry["worry_score"])
-    plt.xticks(rotation=45, ha="right")
-    plt.ylabel("worry_score")
-    plt.title(f"Top {top_k} risky runs (zone + instability)")
-    plt.tight_layout()
-    plt.show()
-
-## Paradox zones and Decision×Zone matrix
-Show zone distributions and a simple decision×zone pivot. Save the pivot to CSV.
-
-import numpy as np
-
-df = runs_df.copy()
-
-if "paradox_zone" not in df.columns:
-    print("No 'paradox_zone' column found.")
-else:
-    # Zone distribution
-    zone_counts = df["paradox_zone"].fillna("none").value_counts()
-    display(zone_counts.rename("count").to_frame())
-
-    # Decision × zone combos
-    combo = (
-        df.assign(paradox_zone=df["paradox_zone"].fillna("none"))
-          .groupby(["decision", "paradox_zone"])
-          .size()
-          .reset_index(name="count")
-    )
-    display(combo)
-
-    # Pivot + save
-    pivot = combo.pivot(index="decision", columns="paradox_zone", values="count").fillna(0).astype(int)
-    display(pivot)
-
-    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
-    out_csv = ARTIFACT_DIR / "decision_zone_matrix_v0.csv"
-    pivot.to_csv(out_csv)
-    print("Saved:", out_csv)
-
-    # Heatmap (matplotlib imshow)
-    plt.figure(figsize=(6, 4))
-    plt.imshow(pivot.values, aspect="auto")
-    plt.colorbar(label="count")
-    plt.yticks(ticks=np.arange(len(pivot.index)), labels=pivot.index)
-    plt.xticks(ticks=np.arange(len(pivot.columns)), labels=pivot.columns, rotation=45, ha="right")
-    plt.title("Decision × Paradox zone — counts")
-    plt.tight_layout()
-    plt.show()
-
-## Top paradox axes (severity + dominance)
-Rank axes by severity and dominance. Save the top list to CSV.
-
-if axes_df.empty:
-    print("No paradox axes available.")
-else:
-    cols = [c for c in ["axis_id", "severity", "runs_seen", "times_dominant", "max_tension"] if c in axes_df.columns]
-    if not cols:
-        print("Paradox axes dataframe has no expected columns.")
-    else:
-        top_axes_df = axes_df[cols].copy()
-
-        severity_order = {"LOW": 1, "MEDIUM": 2, "HIGH": 3, "CRITICAL": 4}
-        top_axes_df["severity_rank"] = top_axes_df.get("severity", "").map(severity_order).fillna(0)
-
-        sort_cols = ["severity_rank"]
-        if "times_dominant" in top_axes_df.columns:
-            sort_cols.append("times_dominant")
-        if "runs_seen" in top_axes_df.columns:
-            sort_cols.append("runs_seen")
-
-        top_axes_df = top_axes_df.sort_values(sort_cols, ascending=False)
-
-        top10 = top_axes_df.head(10).loc[:, [c for c in ["axis_id", "severity", "runs_seen", "times_dominant", "max_tension"] if c in top_axes_df.columns]]
-        display(top10)
-
-        ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
-        out_csv = ARTIFACT_DIR / "paradox_axes_top_v0.csv"
-        top10.to_csv(out_csv, index=False)
-        print("Saved:", out_csv)
-
-        # Quick scatter (runs_seen vs times_dominant)
-        plt.figure()
-        plt.scatter(top10["runs_seen"], top10["times_dominant"])
-        for i, r in top10.iterrows():
-            plt.text(r["runs_seen"], r["times_dominant"], str(r["axis_id"]))
-        plt.xlabel("runs_seen")
-        plt.ylabel("times_dominant")
-        plt.title("Top paradox axes (severity + dominance)")
-        plt.tight_layout()
-        plt.show()
-
-## EPF overview (optional)
-Print EPF summary if present in the trace dashboard. Graceful fallback if missing.
-
-epf_ov = trace_dashboard.get("epf_overview", {})
-if not epf_ov:
-    print("No EPF overview present in trace_dashboard.")
-else:
-    from pprint import pprint
-    print("EPF overview:")
-    pprint(epf_ov)


### PR DESCRIPTION
## Why
The previous edit corrupted the .ipynb JSON. GitHub rendered "Invalid Notebook".

## What changed
- Replaced the notebook with a tiny, valid driver notebook.
- Moved all panel code into `examples/_panels_v0_cells.py`.

## Outcome
- Notebook opens again on GitHub.
- Panels remain identical; CSVs still exported to `../artifacts/`.
- Safer future edits (code lives in .py, not embedded JSON blobs).
