### PR TITLE
fix(dashboard): wire the trace demo to shared panels via run_all_panels(globals())

### DIFF
--- a/PULSE_safe_pack_v0/examples/PULSE_trace_dashboard_v0_demo.ipynb
+++ b/PULSE_safe_pack_v0/examples/PULSE_trace_dashboard_v0_demo.ipynb
@@ -38,3 +38,6 @@
   "nbformat": 4,
   "nbformat_minor": 5
 }
+# Driver — render all panels
+from _panels_v0_cells import run_all_panels
+run_all_panels(globals())


### PR DESCRIPTION
## Why
The demo notebook lacked a stable entry point to render all panels consistently with the Pulse examples.

## What changed
- Add a final code cell that imports `_panels_v0_cells` and calls `run_all_panels(globals())`.
- This uses the safe env loader (artifacts or default frames), so the demo degrades gracefully.

## Scope
Examples / visualization only. Gate logic and schemas remain unchanged.
