### PR TITLE
fix(dashboard): make trace demo notebook valid and robust; run panels via shared driver

### DIFF
--- a/PULSE_safe_pack_v0/examples/PULSE_trace_dashboard_v0_demo.ipynb
+++ b/PULSE_safe_pack_v0/examples/PULSE_trace_dashboard_v0_demo.ipynb
@@ -4,10 +4,11 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "# PULSE Trace Dashboard v0 — Demo (repaired)\\n",
-        "\\n",
-        "This notebook delegates panel logic to `_panels_v0_cells.py` to keep the JSON clean and robust.\\n",
-        "All CSV artefacts are written under `../artifacts/`.\\n"
+        "## Driver — run all panels\n",
+        "\n",
+        "This notebook delegates all plotting and aggregation to `_panels_v0_cells.py`.\n",
+        "Inputs are auto-loaded from `../artifacts/*.json` if present (decision/paradox/trace);\n",
+        "otherwise safe defaults are created so panels degrade gracefully.\n"
       ]
     },
     {
@@ -16,11 +17,11 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from _panels_v0_cells import run_all_panels\\n",
-        "\\n",
-        "# If the notebook already defined runs_df / axes_df / trace_dashboard earlier,\\n",
-        "# run_all_panels() will use them; otherwise it will try to load them from ../artifacts.\\n",
-        "run_all_panels(globals())\\n"
+        "# Driver: load env (../artifacts or safe defaults) and render all panels\n",
+        "from _panels_v0_cells import maybe_load_env, run_all_panels\n",
+        "\n",
+        "maybe_load_env(globals())  # ensures runs_df / axes_df / trace_dashboard exist\n",
+        "run_all_panels(globals())   # render all dashboard panels\n"
       ]
     }
   ],


### PR DESCRIPTION
… panels module

Replace the corrupted .ipynb (duplicate top-level JSON objects) with a valid nbformat v4 file. Add a two-cell driver that imports `maybe_load_env` and `run_all_panels` from `_panels_v0_cells.py` and calls them with `globals()`, so artifacts are auto-loaded or safe defaults are created. Scope: examples-only. No gates or schemas changed.

<!-- PULSE PR Template v1.0 — keep sections; fill what applies. -->

## Summary
<!-- Short: what changes and why? -->

## What’s included
- [ ] Code
- [ ] Docs
- [ ] CI / workflow
- Paths / files touched:

## CI usage
```yaml
# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json
```

## Impact
- Additive / backwards-compatible
- Breaking change — details:
- Performance / SLO impact:
- Security considerations:

## Notes
- Follow-ups:
- Risks / mitigations:

## PULSE checklist (governance)
- [ ] PULSE CI is green on this PR
- [ ] Quality Ledger link (if enabled)
- [ ] Badges updated (PASS / RDSI / Q‑Ledger)
