### PR TITLE
fix(dashboard): make trace demo notebook valid; run panels via shared module

### DIFF
--- a/PULSE_safe_pack_v0/examples/PULSE_trace_dashboard_v0_demo.ipynb
+++ b/PULSE_safe_pack_v0/examples/PULSE_trace_dashboard_v0_demo.ipynb
@@ -7,8 +7,7 @@
         "## Driver — run all panels\n",
         "\n",
         "This notebook delegates all plotting and aggregation to `_panels_v0_cells.py`.\n",
-        "Inputs are auto-loaded from `../artifacts/*.json` if present (decision/paradox/trace);\n",
-        "otherwise safe defaults are created so panels degrade gracefully.\n"
+        "Inputs are auto‑loaded from `../artifacts/*.json` if present; otherwise safe defaults are created so panels degrade gracefully.\n"
       ]
     },
     {
@@ -17,28 +16,16 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# Driver: load env (../artifacts or safe defaults) and render all panels\n",
         "from _panels_v0_cells import maybe_load_env, run_all_panels\n",
-        "\n",
-        "maybe_load_env(globals())  # ensures runs_df / axes_df / trace_dashboard exist\n",
-        "run_all_panels(globals())   # render all dashboard panels\n"
+        "maybe_load_env(globals())\n",
+        "run_all_panels(globals())\n"
       ]
     }
   ],
   "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3"
-    }
+    "kernelspec": { "display_name": "Python 3", "language": "python", "name": "python3" },
+    "language_info": { "name": "python", "version": "3" }
   },
   "nbformat": 4,
   "nbformat_minor": 5
 }
-# Driver — render all panels
-from _panels_v0_cells import run_all_panels
-run_all_panels(globals())


### PR DESCRIPTION
Why: Previous edit appended driver code after the JSON, breaking the notebook.
What: Driver cells live inside `cells`; JSON is valid again; single entry point runs all panels.
Impact: Demo opens and runs end-to-end; Codex P1 resolved.
