### PR TITLE
docs(readme): link memory/trace v0 walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ It consists of:
     - Paradox Resolution v0
     - Topology dashboards v0
     - Memory / trace summariser v0
+    - `docs/PULSE_memory_trace_v0_walkthrough.md` – Memory / trace v0 walkthrough and demo panels.
 
 ---
 


### PR DESCRIPTION
Expose the existing docs/PULSE_memory_trace_v0_walkthrough.md from the main
README so the memory/trace layer is easier to discover.

Scope: docs-only; no code or schemas changed.
