### PR TITLE
docs(memory-trace): simplify tools path formatting

### DIFF
--- a/docs/PULSE_memory_trace_v0_walkthrough.md
+++ b/docs/PULSE_memory_trace_v0_walkthrough.md
@@ -31,12 +31,26 @@ From those steps you should have these artefacts:
 - `paradox_resolution_v0.json`
 - `paradox_resolution_dashboard_v0.json`
 
-All tools mentioned below live under:
 
-```text
-PULSE_safe_pack_v0/tools/
+```markdown
+All tools mentioned below live under: `PULSE_safe_pack_v0/tools/`
+
+## Running the full memory / trace demo
+
+Once you have `stability_map.json` and the EPF/paradox fields in place, you can
+run the full memory / trace pipeline from the repo root:
+
+```bash
+# 1) Enrich stability map with EPF + paradox fields
+python PULSE_safe_pack_v0/tools/build_paradox_epf_fields_v0.py \
+  --map ./artifacts/stability_map.json
+
+# 2) Build Decision Engine v0 view
+python PULSE_safe_pack_v0/tools/build_decision_output_v0.py \
+  --map ./artifacts/stability_map.json
 
 ...
+
 
 ## Running the full memory / trace demo
 


### PR DESCRIPTION
- Replace the fenced text block for 'PULSE_safe_pack_v0/tools/' with inline code in docs/PULSE_memory_trace_v0_walkthrough.md.
- Prevent the memory/trace demo section from being captured by the previous code fence.

Docs-only; no code or schemas changed.

<!-- PULSE PR Template v1.0 — keep sections; fill what applies. -->

## Summary
<!-- Short: what changes and why? -->

## What’s included
- [ ] Code
- [ ] Docs
- [ ] CI / workflow
- Paths / files touched:

## CI usage
```yaml
# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json
```

## Impact
- Additive / backwards-compatible
- Breaking change — details:
- Performance / SLO impact:
- Security considerations:

## Notes
- Follow-ups:
- Risks / mitigations:

## PULSE checklist (governance)
- [ ] PULSE CI is green on this PR
- [ ] Quality Ledger link (if enabled)
- [ ] Badges updated (PASS / RDSI / Q‑Ledger)
