### PR TITLE
docs(memory): fix CLI flags in trace walkthrough

### DIFF
--- a/docs/PULSE_memory_trace_v0_walkthrough.md
+++ b/docs/PULSE_memory_trace_v0_walkthrough.md
@@ -73,7 +73,8 @@ python PULSE_safe_pack_v0/tools/summarise_decision_paradox_v0.py \
 
 # 4) Aggregate history across runs
 python PULSE_safe_pack_v0/tools/summarise_paradox_history_v0.py \
-  --input ./artifacts/decision_paradox_summary_v0*.json \
+  --dir ./artifacts \
+  --pattern "decision_paradox_summary_v0*.json" \
   --output ./artifacts/paradox_history_v0.json
 
 # 5) Build paradox resolution plan


### PR DESCRIPTION
## What changed

- Updated `docs/PULSE_memory_trace_v0_walkthrough.md` so the
  `summarise_paradox_history_v0.py` example uses the current flags:
  `--dir`, `--pattern`, and `--output` instead of the outdated
  `--input`/`--output` pair.

## Why

The script no longer accepts `--input`. With the old example, running
the full memory/trace demo from the repo root fails with an
“unrecognized arguments” error. The new snippet matches the actual CLI,
so the demo pipeline runs end-to-end.

Scope: docs-only; no gates or schemas touched.
