### PR TITLE
feat(memory-trace): ship memory/trace dashboard demo notebook

### DIFF
--- a/PULSE_safe_pack_v0/examples/PULSE_memory_trace_dashboard_v0_demo.ipynb
+++ b/PULSE_safe_pack_v0/examples/PULSE_memory_trace_dashboard_v0_demo.ipynb
@@ -1,5 +1,35 @@
-# PULSE Memory / Trace Dashboard v0 – Demo
-
-from _memory_trace_panels_v0_cells import run_all_panels
-
-run_all_panels(globals())
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# PULSE Memory / Trace Dashboard v0 – Demo\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from _memory_trace_panels_v0_cells import run_all_panels\n",
+        "\n",
+        "run_all_panels(globals())\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## What

Add a minimal demo notebook:

- `PULSE_safe_pack_v0/examples/PULSE_memory_trace_dashboard_v0_demo.ipynb`

The notebook:

- imports `run_all_panels` from `_memory_trace_panels_v0_cells`,
- calls `run_all_panels(globals())` from a single driver cell,
- relies on the helper module to load artefacts from `../artifacts` and
  report dataset sizes.

## Why

We want a parallel demo to the trace dashboard, but for the memory/trace
artefacts. Keeping the logic in the helper module ensures the notebook
stays small and robust.

## Impact

Examples-only change. No gates, schemas, or CI flows are modified.
