### PR TITLE
docs(memory-trace): update walkthrough with delta log v0 step

### DIFF
--- a/docs/PULSE_memory_trace_v0_walkthrough.md
+++ b/docs/PULSE_memory_trace_v0_walkthrough.md
@@ -30,6 +30,7 @@ From those steps you should have these artefacts:
 - `decision_paradox_summary_v0.json`
 - `paradox_resolution_v0.json`
 - `paradox_resolution_dashboard_v0.json`
+- `delta_log_v0.jsonl` – per‑run delta log (one JSON object per line).
 
 
 ```markdown
@@ -91,3 +92,12 @@ python PULSE_safe_pack_v0/tools/build_paradox_resolution_dashboard_v0.py \
 python PULSE_safe_pack_v0/tools/build_topology_dashboard_v0.py \
   --map ./artifacts/stability_map.json \
   --output ./artifacts/topology_dashboard_v0.json
+
+# 8) Append delta log entry (optional but recommended)
+python3 PULSE_safe_pack_v0/tools/append_delta_log_v0.py \
+  --delta-log ./artifacts/delta_log_v0.jsonl \
+  --source local-demo
+
+This last step appends a single JSON line entry to `delta_log_v0.jsonl`,
+capturing a compact snapshot of the run (decision, stability, paradox and EPF
+snapshots, plus optional git metadata).


### PR DESCRIPTION
## Why

The memory/trace v0 walkthrough already covers how to build stability, decision,
history and resolution artefacts. The recent `append_delta_log_v0.py` tool adds
a per-run delta log, but the walkthrough did not yet mention this step.

## What changed

- Updated `docs/PULSE_memory_trace_v0_walkthrough.md` to:
  - list `delta_log_v0.json` among the resulting artefacts, and
  - add a new step that appends a delta-log entry (`append_delta_log_v0.py`)
    after the resolution plan is built.
- Kept the resolution and topology dashboards as clearly optional steps on top.

## Impact

Docs-only change: the memory/trace pipeline guide now shows how to produce the
delta log alongside the existing JSON artefacts. No code, gate logic or schemas
were modified.
