### PR TITLE
docs(memory-trace): document memory/trace dashboard demo

### DIFF
--- a/docs/PULSE_memory_trace_dashboard_v0_demo.md
+++ b/docs/PULSE_memory_trace_dashboard_v0_demo.md
@@ -1,0 +1,41 @@
+# PULSE Memory / Trace Dashboard v0 – Demo
+
+Status: working draft (v0)  
+Scope: example-only notebook for exploring the memory / trace artefacts.
+
+This demo notebook shows a compact “dashboard” view on top of the memory / trace
+pipeline, driven entirely from a shared module:
+
+- panels live in `_memory_trace_panels_v0_cells.py`
+- the notebook only has a tiny driver cell
+
+---
+
+## 1. Prerequisites
+
+Before running this demo, you should already have created the memory / trace
+artefacts as described in:
+
+- `docs/PULSE_memory_trace_v0_walkthrough.md`
+
+From those steps you should have these files under `./artifacts/`:
+
+- `stability_map.json`
+- `decision_output_v0.json`
+- `decision_paradox_summary_v0.json`
+- `paradox_history_v0.json`
+- `paradox_resolution_v0.json`
+- `paradox_resolution_dashboard_v0.json` (optional)
+- `delta_log_v0.jsonl` (optional per-run delta log)
+
+The dashboard will run even if some of the optional artefacts are missing; it
+will simply skip panels that cannot find their inputs.
+
+---
+
+## 2. Where to find the notebook
+
+The demo lives here:
+
+```text
+PULSE_safe_pack_v0/examples/PULSE_memory_trace_dashboard_v0_demo.ipynb


### PR DESCRIPTION
## Why

The memory/trace pipeline now has a dedicated demo notebook
`PULSE_memory_trace_dashboard_v0_demo.ipynb`, but there was no public guide
explaining how to run it or what artefacts it expects.

## What changed

- Added `docs/PULSE_memory_trace_dashboard_v0_demo.md`:
  - lists the required artefacts under `./artifacts/`,
  - points to the notebook location under `PULSE_safe_pack_v0/examples/`,
  - describes the single driver cell that calls `run_all_panels(globals())`,
  - outlines the main panels rendered by the demo.

## Impact

Docs-only change. No gates, schemas, or JSON formats were touched. The demo
dashboard is now easier to discover and run from the docs.
