### PR TITLE
docs: link paradox field and memory metrics v0 doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,12 @@ It consists of:
 - `schemas/PULSE_stability_map_v0.schema.json`  
   – Stability Map v0 JSON schema (includes `paradox_field_v0` and `epf_field_v0`).
 
+**Paradox field & memory metrics v0**
+
+- [PULSE memory / trace v0 walkthrough](docs/PULSE_memory_trace_v0_walkthrough.md) – end-to-end pipeline from EPF/paradox fields to history and dashboards.
+- [PULSE paradox field and memory metrics v0](docs/PULSE_paradox_field_v0.md) – mathematical semantics for the paradox layer, tension/severity/priority and the memory fields.
+
+
 **EPF shadow layer & paradox field**
 
 - `docs/PULSE_topology_epf_hook.md`  


### PR DESCRIPTION
## Summary

This PR wires the new paradox field specification into the main docs:

- Adds a link to `docs/PULSE_paradox_field_v0.md` in the README "Docs & specs" section.
- Adds a reference to the same doc from `docs/FUTURE_LIBRARY.md` under the Paradox Resolution pillar.

## Why?

The paradox layer now has its own v0 spec, but it was not referenced from
the top-level docs. Linking it from the README and Future Library makes
it easier to discover how the paradox field, EPF field and memory/trace
metrics fit into the overall architecture.

## Implementation

- Documentation-only changes.
- No code, schemas or CLI flags were touched.
- No runtime behaviour changes.
