### PR TITLE
ci: fix pulse topology demo workflow

### DIFF
--- a/.github/workflows/pulse_topology_demo.yml
+++ b/.github/workflows/pulse_topology_demo.yml
@@ -23,13 +23,12 @@ jobs:
           python-version: "3.11"
 
       - name: Prepare demo artefacts
-  run: |
-    mkdir -p PULSE_safe_pack_v0/artifacts
-    cp docs/examples/topology_demo_v0/status.run_002.json \
-      PULSE_safe_pack_v0/artifacts/status.json
-    cp docs/examples/topology_demo_v0/status_epf.run_002.json \
-      PULSE_safe_pack_v0/artifacts/status_epf.json
-
+        run: |
+          mkdir -p PULSE_safe_pack_v0/artifacts
+          cp docs/examples/topology_demo_v0/status.run_002.json \
+            PULSE_safe_pack_v0/artifacts/status.json
+          cp docs/examples/topology_demo_v0/status_epf.run_002.json \
+            PULSE_safe_pack_v0/artifacts/status_epf.json
 
       - name: Build Stability Map (demo)
         run: |


### PR DESCRIPTION
## Summary

This PR fixes the `pulse_topology_demo` GitHub Actions workflow, which
was previously invalid and failed to load.

## Changes

- `.github/workflows/pulse_topology_demo.yml`
  - Attach the "Prepare demo artefacts" commands to a proper `run: |`
    block under the step.
  - Keep the demo pipeline as three explicit steps:
    - build Stability Map (demo),
    - run Decision Engine (demo),
    - build Dual View v0 (demo).
  - Leave the jsonschema installation, schema validation and artifact
    upload steps unchanged.

## Why?

The workflow used a mis-indented `run` block, which caused GitHub
Actions to report:

> Invalid workflow file: missing required keys and unexpected value
> 'mkdir -p PULSE_safe_pack_v0/artifacts cp ...'

With this change, the workflow parses correctly and the topology demo
job can be executed in CI.

## Testing

- Pushed the updated workflow and confirmed that GitHub Actions no
  longer reports "Invalid workflow file" for
  `.github/workflows/pulse_topology_demo.yml`.
