### PR TITLE
ci: fix pulse paradox gate workflow syntax

### DIFF
--- a/.github/workflows/pulse-paradox-gate.yml
+++ b/.github/workflows/pulse-paradox-gate.yml
@@ -42,40 +42,40 @@ jobs:
         shell: bash
         run: |
           if [ -f "logs/decision_log.ndjson" ]; then
-            echo "src=log" >> $GITHUB_OUTPUT
+            echo "src=log" >> "$GITHUB_OUTPUT"
             echo "Using Decision Log at logs/decision_log.ndjson"
           else
-            echo "src=env" >> $GITHUB_OUTPUT
-            echo "PF_PARADOX_DENSITY=0.0" >> $GITHUB_ENV
-            echo "PF_SETTLE_P95_MS=0" >> $GITHUB_ENV
-            echo "PF_DOWNSTREAM_ERROR_RATE=0.0" >> $GITHUB_ENV
+            echo "src=env" >> "$GITHUB_OUTPUT"
+            echo "PF_PARADOX_DENSITY=0.0" >> "$GITHUB_ENV"
+            echo "PF_SETTLE_P95_MS=0" >> "$GITHUB_ENV"
+            echo "PF_DOWNSTREAM_ERROR_RATE=0.0" >> "$GITHUB_ENV"
           fi
 
-      - uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Run Paradox Gate (shadow, non-blocking)
         shell: bash
+        continue-on-error: true
         run: |
           G=".gates/_ex/pulse_paradox_gate_ci_v1/pulse/gates/paradox"
           python "$G/gate.py" --mode shadow --policy "$G/policy.yaml"
 
       - name: Upload Paradox Gate summary (artifact)
-  if: always()
-  uses: actions/upload-artifact@v4
-  with:
-    name: pulse-paradox-gate-summary
-    path: artifacts/pulse_paradox_gate_summary.json
-    if-no-files-found: ignore     
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pulse-paradox-gate-summary
+          path: artifacts/pulse_paradox_gate_summary.json
+          if-no-files-found: ignore
 
-       
-     
-           - name: Debug list artifacts dir
+      - name: Debug list artifacts dir
         if: ${{ always() && github.event_name == 'pull_request' }}
         run: ls -la artifacts || true
 
-      - name: Generate PR triage comment (Why it failed / What to fix)
+      - name: Generate PR triage comment (why it failed / what to fix)
         if: ${{ always() && github.event_name == 'pull_request' }}
         continue-on-error: true
         run: |
@@ -83,39 +83,40 @@ jobs:
             --summary artifacts/pulse_paradox_gate_summary.json \
             --out triage_comment.md
 
-
-    
- - name: Post or update PR comment
-      if: ${{ always() && github.event_name == 'pull_request' }}
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const fs = require('fs');
-          const path = 'triage_comment.md';
-          if (!fs.existsSync(path)) {
-            console.log('No triage_comment.md found — skipping PR comment.');
-          } else {
-            const body = fs.readFileSync(path, 'utf8');
-            const marker = '<!-- pulse-triage -->';
-            const {data: comments} = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number
-            });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body
-              });
+      - name: Post or update PR comment
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'triage_comment.md';
+            if (!fs.existsSync(path)) {
+              console.log('No triage_comment.md found — skipping PR comment.');
             } else {
-              await github.rest.issues.createComment({
+              const body = fs.readFileSync(path, 'utf8');
+              const marker = '<!-- pulse-triage -->';
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body
+                issue_number: context.issue.number
               });
+              const existing = comments.find(
+                (c) => c.body && c.body.includes(marker)
+              );
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body
+                });
+              }
             }
-          }


### PR DESCRIPTION
Fix the pulse-paradox-gate workflow step structure and relax it so that
the Paradox Gate shadow run and PR triage/comment steps no longer fail
CI on HTTP/permission issues, while still uploading the summary artifact.

<!-- PULSE PR Template v1.0 — keep sections; fill what applies. -->

## Summary

Align the `pulse-paradox-gate` GitHub Actions workflow with the current
Paradox Gate tooling and make the shadow check non-blocking.

The workflow still runs the gate in shadow mode and produces a summary
artifact, but failures in optional steps (e.g. permission errors when
posting PR comments) no longer cause the entire check to fail.

## What's included

- [ ] Code
- [ ] Docs
- [x] CI / workflow
- [ ] Schemas
- [ ] Other

Files touched:

- `.github/workflows/pulse-paradox-gate.yml`

## Details

- Fix the step structure for:
  - uploading the Paradox Gate summary artifact,
  - debugging the artifacts directory,
  - generating the PR triage comment,
  - posting or updating the PR comment via `actions/github-script`.
- Mark the following steps as `continue-on-error`:
  - Paradox Gate shadow run,
  - PR triage generation,
  - PR comment post/update.

This keeps the Paradox Gate in **shadow** mode: it still runs and
produces `artifacts/pulse_paradox_gate_summary.json` when possible,
but HTTP/permission issues (for example missing comment permissions for
the integration) do not block or fail the PR.

## Behaviour / safety

- No gate policy or decision logic changes.
- Existing callers and policies are unaffected.
- The workflow remains informative (summary artifact + optional PR
  comment), but is no longer a hard gate for merges.
