### PR TITLE
fix: call Pareto coverage panel with env in demo

### DIFF
--- a/PULSE_safe_pack_v0/examples/_panels_v0_cells.py
+++ b/PULSE_safe_pack_v0/examples/_panels_v0_cells.py
@@ -616,5 +616,6 @@ def run_all_panels(env: Dict[str, Any]):
     panel_instab_rdsi_quadrants(runs_df)
     panel_decision_streaks(runs_df)
     print("=== Done. CSVs in ../artifacts ===")
-    panel_paradox_axes_pareto(glob)
+    panel_paradox_axes_pareto({"env": e})
+
 


### PR DESCRIPTION
## Summary

Wire the paradox axes Pareto coverage panel in the PULSE trace dashboard demo
so that it uses the constructed `env` dict instead of the undefined `glob`
variable.

This avoids a `NameError` in `_panels_v0_cells.py` and ensures the new
Pareto panel actually runs in the demo notebook.

## Details

- Update the `run_all_panels(...)` call site to pass `{"env": e}` into
  `panel_paradox_axes_pareto(...)`.
- No changes to panel logic or plots, only the wiring for the new panel.
- Keeps the other panels and CSV export behaviour unchanged.
