### PR TITLE
fix: clean up paradox histogram panel definitions

### DIFF
--- a/PULSE_safe_pack_v0/examples/_panels_v0_cells.py
+++ b/PULSE_safe_pack_v0/examples/_panels_v0_cells.py
@@ -534,7 +534,7 @@ def panel_paradox_zone_histogram(glob: Dict[str, Any]) -> None:
     plt.title("Paradox axes by zone")
     plt.tight_layout()
     plt.show()
-s
+
 def panel_paradox_tension_histogram(glob: Dict[str, Any]) -> None:
     """
     Histogram of paradox tension, grouped by zone.


### PR DESCRIPTION
## Summary

Clean up the paradox zone/tension histogram panels in `_panels_v0_cells.py`:

- remove a stray `s` token left between `panel_paradox_zone_histogram` and
  `panel_paradox_tension_histogram` that caused `NameError` on import,
- ensure both panels are wired from `run_all_panels` via `{"env": env}`.

No changes to core gate logic or Stability Map tools; this only affects the
trace dashboard demo notebook panels.
