### PR TITLE
docs: document developer tools and decision trace validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ python PULSE_safe_pack_v0/tools/check_gates.py `
 - **Report Card** → `PULSE_safe_pack_v0/artifacts/report_card.html`
 - **Status JSON** → `PULSE_safe_pack_v0/artifacts/status.json`
 
+### Developer tools (optional)
+
+These helpers are intended for local validation and inspection; they do not
+change any CI behaviour or gate logic.
+
+- Trace dashboard demo notebook → `PULSE_safe_pack_v0/examples/trace_dashboard_v0.ipynb`
+- Decision trace schema validator → `PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py`  
+  Validate `decision_trace_v0*.json` artefacts against
+  `schemas/PULSE_decision_trace_v0.schema.json` using `jsonschema`.
+
 ### Try PULSE on your repo (5 minutes)
 
 1. **Copy the pack** to your repo root:


### PR DESCRIPTION
## Summary

Add a small **"Developer tools (optional)"** section next to the Artifacts list in the README.

The section:
- points to the trace dashboard demo notebook and the decision trace schema validator,
- marks them as developer-only helpers for local inspection and validation,
- explicitly notes that they do not change CI behaviour or gate logic.

## Rationale

This makes it easier for new contributors to discover the existing notebook and schema validator,
and reassures them that running these tools is safe: they do not modify artefacts, gates, or CI
workflows.

## Testing

- Previewed the README on GitHub to confirm that the new heading and bullets render correctly.
