### PR TITLE
docs: refresh memory/trace dashboard demo notebook

### DIFF
--- a/PULSE_safe_pack_v0/examples/PULSE_memory_trace_dashboard_v0_demo.ipynb
+++ b/PULSE_safe_pack_v0/examples/PULSE_memory_trace_dashboard_v0_demo.ipynb
@@ -4,7 +4,30 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "# PULSE Memory / Trace Dashboard v0 – Demo\n"
+        "# PULSE memory / trace dashboard v0 (demo)\n",
+        "\n",
+        "This notebook is a small, developer-focused dashboard built on top of the\n",
+        "\"memory / trace summariser v0\" artefacts. It is intended to explore how\n",
+        "paradox axes and EPF signals behave over time, not to change any gate\n        decisions.\n",
+        "\n",
+        "The notebook reads JSON artefacts such as:\n",
+        "\n",
+        "- `paradox_history_v0.json`\n",
+        "- `delta_log_v0.json`\n",
+        "- `paradox_resolution_v0.json`\n",
+        "- `paradox_resolution_dashboard_v0.json`\n",
+        "- `topology_dashboard_v0.json` (optional)\n",
+        "\n",
+        "and uses the shared panel helpers in `_memory_trace_panels_v0_cells.py`\n",
+        "to render a few views over time:\n",
+        "\n",
+        "- paradox history across runs,\n",
+        "- stability / risk zone trends,\n",
+        "- EPF signal trends (if available),\n",
+        "- resolution hints based on the paradox history.\n",
+        "\n",
+        "To use this notebook, make sure the above artefacts exist (see the\n",
+        "Future Library docs), then run the cell below.\n"
       ]
     },
     {
@@ -13,9 +36,12 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from _memory_trace_panels_v0_cells import run_all_panels\n",
+        "# PULSE memory / trace dashboard v0 – demo driver\n",
         "\n",
-        "run_all_panels(globals())\n"
+        "from PULSE_safe_pack_v0.examples import _memory_trace_panels_v0_cells as panels\n",
+        "\n",
+        "# Let the panels module build the env and run all dashboard views.\n",
+        "panels.run_all_panels(globals())\n"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

Refresh `PULSE_memory_trace_dashboard_v0_demo.ipynb` so it acts as a thin,
readable driver around the shared `_memory_trace_panels_v0_cells.py` module.

- Add a markdown header explaining what the memory / trace dashboard does
  and which JSON artefacts it expects.
- Replace the notebook contents with a minimal two-cell layout:
  a descriptive header and a single driver cell calling
  `panels.run_all_panels(globals())`.

## Behaviour

- Notebook-only change; no impact on gates, Stability Map, or tooling.
- Makes the memory / trace demo easier to understand and run.
