### PR TITLE
docs: surface memory/trace dashboard in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ change any CI behaviour or gate logic.
 - Decision trace schema validator → `PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py`  
   Validate `decision_trace_v0*.json` artefacts against
   `schemas/PULSE_decision_trace_v0.schema.json` using `jsonschema`.
+- Memory / trace dashboard demo → `PULSE_safe_pack_v0/examples/PULSE_memory_trace_dashboard_v0_demo.ipynb`
 
 ### Try PULSE on your repo (5 minutes)
 


### PR DESCRIPTION
## Summary

Surface the `PULSE_memory_trace_dashboard_v0_demo.ipynb` notebook in the
README's Developer tools (optional) section.

This makes it easier for developers to discover the memory / trace
dashboard v0 demo, next to the existing topology trace dashboard and
decision trace schema validator.

## Notes

- No code or CI behaviour changes.
- Developer-only documentation update.
