### PR TITLE
fix: simplify memory trace dashboard driver

### DIFF
--- a/PULSE_safe_pack_v0/examples/PULSE_memory_trace_dashboard_v0_demo.ipynb
+++ b/PULSE_safe_pack_v0/examples/PULSE_memory_trace_dashboard_v0_demo.ipynb
@@ -7,8 +7,9 @@
         "# PULSE memory / trace dashboard v0 (demo)\n",
         "\n",
         "This notebook is a small, developer-focused dashboard built on top of the\n",
-        "\"memory / trace summariser v0\" artefacts. It is intended to explore how\n",
-        "paradox axes and EPF signals behave over time, not to change any gate\n        decisions.\n",
+        "**memory / trace summariser v0** artefacts. It is intended to explore how\n",
+        "paradox axes and EPF signals behave over time, not to change any gate\n",
+        "decisions.\n",
         "\n",
         "The notebook reads JSON artefacts such as:\n",
         "\n",
@@ -27,7 +28,7 @@
         "- resolution hints based on the paradox history.\n",
         "\n",
         "To use this notebook, make sure the above artefacts exist (see the\n",
-        "Future Library docs), then run the cell below.\n"
+        "`Future Library` docs), then run the cell below.\n"
       ]
     },
     {
@@ -36,12 +37,11 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# PULSE memory / trace dashboard v0 – demo driver\n",
+        "# PULSE memory / trace dashboard v0 - demo driver\n",
         "\n",
-        "from PULSE_safe_pack_v0.examples import _memory_trace_panels_v0_cells as panels\n",
+        "from _memory_trace_panels_v0_cells import run_all_panels\n",
         "\n",
-        "# Let the panels module build the env and run all dashboard views.\n",
-        "panels.run_all_panels(globals())\n"
+        "run_all_panels(globals())\n"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

Simplify the `PULSE_memory_trace_dashboard_v0_demo.ipynb` driver cell so it
uses a simple relative import from the local `_memory_trace_panels_v0_cells`
module:

```python
from _memory_trace_panels_v0_cells import run_all_panels
run_all_panels(globals())
