### PR TITLE
feat: add paradox weighted paradox-zone histogram panel

### DIFF
--- a/PULSE_safe_pack_v0/examples/_panels_v0_cells.py
+++ b/PULSE_safe_pack_v0/examples/_panels_v0_cells.py
@@ -890,21 +890,18 @@ def run_all_panels(glob: Dict[str, Any]) -> None:
     runs_df = env.get("runs_df")
 
     # Panels that expect the full glob (with "env") as input
-    panel_env_names = [
+        panel_env_names = [
         "panel_worry_index_v0",
         "panel_decision_zone_matrix_v0",
-
-        # NEW: paradox zone histogram panel
-        "panel_paradox_zone_histogram",
-
-        # már meglévő paradox / instability panelek
-        "panel_paradox_axes_pareto",
+        "panel_paradox_zone_histogram",     
+        "panel_paradox_tension_histogram",
         "panel_instability_rdsi_scatter",
+        "panel_paradox_axes_pareto",
         "panel_instability_timeline",
-
-        # ha van EPF panel a fájlban, ezt is bent hagyhatod:
-        # "panel_epf_overlay_v0",
+        "panel_epf_overview",
     ]
+
+    
 
     for name in panel_env_names:
         fn = globals().get(name)


### PR DESCRIPTION
## Summary

Add a severity-weighted paradox zone histogram panel to the PULSE trace dashboard.

The new panel:

- uses `runs_df` from the env and ensures a `severity` column via `ensure_severity_column`,
- aggregates a numeric severity weight per paradox zone,
- renders a simple bar chart for zone-level weighted activity,
- is wired into `run_all_panels(...)` after the existing zone and tension histogram views.

No changes to gate logic, schemas, or CI behaviour; dashboard-only change.
