### PR TITLE
ci: integrate decision trace validator into topology demo workflow

### DIFF
--- a/.github/workflows/pulse_topology_demo.yml
+++ b/.github/workflows/pulse_topology_demo.yml
@@ -70,6 +70,11 @@ jobs:
           python -m jsonschema \
             -i PULSE_safe_pack_v0/artifacts/dual_view_v0.demo.ci.json \
             schemas/PULSE_dual_view_v0.schema.json
+     
+      - name: Validate decision trace with helper script
+        run: |
+          python PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py \
+            PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json
 
       - name: Upload topology demo artefacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Wire the `validate_decision_trace_v0.py` helper into the
`pulse-topology-demo` workflow so that the demo decision trace artefact
is validated both via `jsonschema` CLI and via the dev helper script.

The new step:

- runs after the existing `python -m jsonschema` validations,
- calls:

  ```bash
  python PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py \
    PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json
