### PR TITLE
chore(ci): rewrite pulse workflow and add decision trace shadow check

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -51,6 +51,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pyyaml
 
+      - name: Install decision trace validator deps
+        run: |
+          python -m pip install jsonschema
+
       - name: Ensure directories
         shell: bash
         run: |
@@ -67,7 +71,8 @@ jobs:
 
       - name: Run PULSE
         shell: bash
-        run: python "${{ env.PACK_DIR }}/tools/run_all.py"
+        run: |
+          python "${{ env.PACK_DIR }}/tools/run_all.py"
 
       - name: Compute refusal-delta (policy-config)
         shell: bash
@@ -81,6 +86,7 @@ jobs:
             echo "::error::refusal_delta_calc.py not found under ${{ env.PACK_DIR }}"
             exit 1
           fi
+
           REAL="${{ env.PACK_DIR }}/examples/refusal_pairs.jsonl"
           if [ -f "$REAL" ]; then
             PAIRS="$REAL"
@@ -95,6 +101,7 @@ jobs:
             fi
             echo "Using SAMPLE pairs: $PAIRS"
           fi
+
           POL="${{ env.PACK_DIR }}/profiles/pulse_policy.yaml"
           python "$RD" \
             --pairs "$PAIRS" \
@@ -108,14 +115,13 @@ jobs:
           cat "${{ env.PACK_DIR }}/artifacts/refusal_delta_summary.json" || true
           echo "-------------------------------------"
 
-            - name: Augment status (external + top-level flags)
+      - name: Augment status (external + top-level flags)
         shell: bash
         run: |
           python "${{ env.PACK_DIR }}/tools/augment_status.py" \
             --status "${{ env.PACK_DIR }}/artifacts/status.json" \
             --thresholds "${{ env.PACK_DIR }}/profiles/external_thresholds.yaml" \
             --external_dir "${{ env.PACK_DIR }}/artifacts/external"
-
 
       - name: Show gates snapshot
         shell: bash
@@ -124,7 +130,13 @@ jobs:
           jq '.gates' "${{ env.PACK_DIR }}/artifacts/status.json" || cat "${{ env.PACK_DIR }}/artifacts/status.json" || true
           echo "--------------------------------"
 
-            - name: Enforce (Fail-Closed)
+      - name: Validate decision trace schema (shadow)
+        shell: bash
+        continue-on-error: true
+        run: |
+          python "${{ env.PACK_DIR }}/tools/validate_decision_trace_v0.py" || echo "decision trace validation failed (shadow)"
+
+      - name: Enforce (Fail-Closed)
         shell: bash
         run: |
           set -euo pipefail
@@ -143,10 +155,10 @@ jobs:
           else
             echo "No real pairs; refusal_delta_pass not required"
           fi
+
           python "${{ env.PACK_DIR }}/tools/check_gates.py" \
             --status "${{ env.PACK_DIR }}/artifacts/status.json" \
             --required "${REQ[@]}"
-
 
       - name: Update badges
         if: always()
@@ -172,7 +184,7 @@ jobs:
             git push
           fi
 
-            - name: Export JUnit & SARIF
+      - name: Export JUnit & SARIF
         if: always()
         shell: bash
         run: |
@@ -193,7 +205,6 @@ jobs:
           if [ -f sarif.json ]; then
             mv sarif.json reports/sarif.json
           fi
-
 
       - name: Upload artifacts
         if: always()


### PR DESCRIPTION
## Summary

Rewrite the `.github/workflows/pulse_ci.yml` workflow to make the main
PULSE CI job explicit and robust, and to add a non-blocking decision
trace schema validation step.

## Changes

- Locate or unzip the `PULSE_safe_pack_v0` pack and expose `PACK_DIR`
  via `$GITHUB_ENV`.
- Run `tools/run_all.py` and compute refusal-delta using
  `tools/refusal_delta_calc.py` with real or sample pairs.
- Print a refusal-delta summary from `artifacts/refusal_delta_summary.json`.
- Augment `artifacts/status.json` with external and top-level flags via
  `tools/augment_status.py`, passing:
  - `--status artifacts/status.json`
  - `--thresholds profiles/external_thresholds.yaml`
  - `--external_dir artifacts/external`.
- Show a gates snapshot from `artifacts/status.json`.
- Add a non-blocking "Validate decision trace schema (shadow)" step
  that runs `tools/validate_decision_trace_v0.py` and uses
  `continue-on-error: true` so it does not gate the pipeline.
- Enforce gates in a dedicated "Enforce (Fail-Closed)" step using
  `tools/check_gates.py` with the existing set of required gates and the
  optional `refusal_delta_pass`.
- Update badges with `tools/ci/update_badges.py` and commit them
  back to the repository when they change.
- Export JUnit and SARIF by:
  - copying `artifacts/status.json` into the working directory,
  - running `tools/status_to_junit.py` and `tools/status_to_sarif.py`,
  - moving `junit.xml` and `sarif.json` into the `reports/` folder.
- Upload the pack artifacts, badges and reports as a `pulse-report`
  artifact.
- Keep the `tools-tests` job that runs exporter smoke tests under
  `tests/test_exporters.py`.

## Rationale

- Makes the CI pipeline easier to reason about and less fragile with
  respect to path and indentation issues.
- Adds a shadow decision trace schema validation step to surface
  problems with `decision_trace_v0` artefacts early, without changing
  the existing fail-closed gate behaviour.

## Testing

- Ran the updated `PULSE CI` workflow and verified that:
  - the pack is located or unzipped and `PACK_DIR` is set correctly,
  - the refusal-delta summary is produced and printed,
  - the "Augment status", "Show gates snapshot" and "Enforce (Fail-Closed)"
    steps run as separate workflow steps,
  - the "Validate decision trace schema (shadow)" step runs and logs
    validation output without gating the job,
  - JUnit and SARIF reports are generated under `reports/` and uploaded
    as part of the `pulse-report` artifact,
  - the `tools-tests` job passes.
