### PR TITLE
fix(ci): align check_gates invocation with CLI (--require)

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -145,7 +145,7 @@ jobs:
           fi
           python "${{ env.PACK_DIR }}/tools/check_gates.py" \
             --status "${{ env.PACK_DIR }}/artifacts/status.json" \
-            --required "${REQ[@]}"
+            --require "${REQ[@]}"
 
 
       - name: Update badges


### PR DESCRIPTION
## Summary

Fix the Enforce (Fail-Closed) step so that it calls `tools/check_gates.py`
with the correct `--require` flag.

## Changes

- Update `.github/workflows/pulse_ci.yml`:
  - replace `--required "${REQ[@]}"` with `--require "${REQ[@]}"` in the
    Enforce step.

## Rationale

- The current version of `check_gates.py` expects a `--require` argument:
  `--require REQUIRE [REQUIRE ...]`.
- Using `--required` causes the Enforce step to fail with a CLI usage
  error before any gates are actually evaluated.

## Testing

- Re-ran the `PULSE CI` workflow and verified that:
  - the Enforce step no longer fails with the `--require` usage error,
  - gates are evaluated as expected (and failures, if any, now reflect
    real gate conditions instead of a CLI mismatch).
