### PR TITLE
docs(trace): update Memory/trace dashboard docs with EPF histogram

### DIFF
--- a/docs/FUTURE_LIBRARY.md
+++ b/docs/FUTURE_LIBRARY.md
@@ -224,16 +224,18 @@ EPF / paradox field.
 
 4. Run all cells.
 
-   The notebook will render:
+   The notebook will render, among other things:
 
 - paradox history across runs (zones and tensions),
-- instability / risk-zone trends over time,
-- decision streaks over PASS / FAIL runs,
+- instability / risk‑zone score trends over time,
+- decision streaks across PASS / FAIL runs,
 - Pareto coverage for paradox axes,
 - a weighted Paradox histogram by zone (v0),
-- EPF overview panels and overlays, if EPF is enabled,
-- an EPF-only histogram panel (v0) for the distribution of EPF scores or flags,
-- high-level resolution hints derived from the paradox history.
+- EPF signal trends, if EPF artefacts are present,
+- EPF overview panels (overlays / timelines),
+- an EPF‑only histogram panel (v0) for the distribution of EPF scores or flags,
+- high‑level resolution hints derived from the paradox history.
+
 
 ### Memory / trace dashboard — FAQ (v0)
 


### PR DESCRIPTION
## Summary

Update the Memory / trace summariser v0 documentation to reflect the
current dashboard panels, including the new EPF-only histogram, and add
a small FAQ about artefacts and behaviour.

## Changes

- Extend the "The notebook will render" list with decision streaks,
  Pareto coverage, weighted Paradox histogram and EPF histogram.
- Add a "Memory / trace dashboard — FAQ (v0)" section describing:
  - where JSON artefacts are expected,
  - which artefacts are required vs optional,
  - that the dashboard is read-only and does not affect gates.
