### PR TITLE
fix(tools): make decision trace validator tolerant of missing instability_components

### DIFF
--- a/docs/FUTURE_LIBRARY.md
+++ b/docs/FUTURE_LIBRARY.md
@@ -224,12 +224,16 @@ EPF / paradox field.
 
 4. Run all cells.
 
-   The notebook will render:
+The notebook will render, among other things:
 
-   - paradox history across runs (zones and tensions),
-   - instability / risk score trends over time,
-   - EPF signal trends, if EPF is enabled,
-   - high‑level resolution hints derived from the paradox history.
+- paradox history across runs (zones and tensions),
+- instability / risk-zone trends over time,
+- decision streaks over PASS / FAIL runs,
+- Pareto coverage for paradox axes,
+- a weighted Paradox histogram by zone (v0),
+- EPF signal trends and overlays, if EPF is enabled,
+- an EPF-only histogram panel (v0) for the distribution of EPF scores,
+- high-level resolution hints derived from the paradox history.
 
 ---
 


### PR DESCRIPTION
## Summary

Make the decision trace schema validator tolerant of older/demo traces
that do not yet contain `details.instability_components`, while keeping
the field required in the schema.

## Changes

- Update `PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py`:
  - after loading the trace JSON, inspect `trace.get("details")`,
  - if it is a dict and does not contain `instability_components`,
    inject `details["instability_components"] = []`,
  - then load the schema and run the existing JSONSchema validation
    against the adjusted trace object.

## Rationale

- `PULSE_decision_trace_v0.schema.json` now requires
  `details.instability_components`, but demo artefacts such as
  `decision_trace.demo_ci.json` used by the topology demo do not yet
  populate this field.
- Rather than breaking demos and non-critical flows, the validator
  provides a minimal default for older traces while keeping the schema
  strict for new producers.

## Testing

- Re-ran the "Run topology demo..." workflow:
  - confirmed that "Validate decision trace with helper script" no
    longer fails with a missing `instability_components` error,
  - confirmed that traces which already include `instability_components`
    still validate as before.
