### PR TITLE
fix(ci): wire decision trace validator in topology demo workflow

### DIFF
--- a/.github/workflows/pulse_topology_demo.yml
+++ b/.github/workflows/pulse_topology_demo.yml
@@ -72,9 +72,11 @@ jobs:
             schemas/PULSE_dual_view_v0.schema.json
      
       - name: Validate decision trace with helper script
-        run: |
-          python PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py \
-            PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json
+  run: |
+    python PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py \
+      --trace PULSE_safe_pack_v0/artifacts/decision_trace.demo_ci.json \
+      --schema schemas/PULSE_decision_trace_v0.schema.json
+
 
       - name: Upload topology demo artefacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Use the new `validate_decision_trace_v0.py` CLI in `pulse_topology_demo.yml`:

- pass `--trace` and `--schema` explicitly,
- let the helper handle older/demo traces that are missing `instability_components`.

This keeps the jsonschema-based validation but makes the topology demo workflow tolerant of older decision trace artefacts.
