### PR TITLE
fix: correct validation script for decision trace artifacts

### DIFF
--- a/.github/workflows/pulse_topology_demo.yml
+++ b/.github/workflows/pulse_topology_demo.yml
@@ -72,10 +72,12 @@ jobs:
             schemas/PULSE_dual_view_v0.schema.json
      
       - name: Validate decision trace with helper script
-  run: |
-    python PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py \
-      --trace PULSE_safe_pack_v0/artifacts/decision_trace.demo_ci.json \
-      --schema schemas/PULSE_decision_trace_v0.schema.json
+        run: |
+          python PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py \
+           --trace PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json \
+           --schema schemas/PULSE_decision_trace_v0.schema.json \
+           --name "demo.ci"
+
 
 
       - name: Upload topology demo artefacts


### PR DESCRIPTION
Updated the validation script to use the correct artifact file and added a name parameter.

<!-- PULSE PR Template v1.0 — keep sections; fill what applies. -->

## Summary
<!-- Short: what changes and why? -->

## What’s included
- [ ] Code
- [ ] Docs
- [ ] CI / workflow
- Paths / files touched:

## CI usage
```yaml
# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json
```

## Impact
- Additive / backwards-compatible
- Breaking change — details:
- Performance / SLO impact:
- Security considerations:

## Notes
- Follow-ups:
- Risks / mitigations:

## PULSE checklist (governance)
- [ ] PULSE CI is green on this PR
- [ ] Quality Ledger link (if enabled)
- [ ] Badges updated (PASS / RDSI / Q‑Ledger)
