### PR TITLE
ci: fix decision trace validation in topology demo

### DIFF
--- a/.github/workflows/pulse_topology_demo.yml
+++ b/.github/workflows/pulse_topology_demo.yml
@@ -70,13 +70,12 @@ jobs:
           python -m jsonschema \
             -i PULSE_safe_pack_v0/artifacts/dual_view_v0.demo.ci.json \
             schemas/PULSE_dual_view_v0.schema.json
-     
-      - name: Validate decision trace with helper script
-  run: |
-    python PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py \
-      --trace PULSE_safe_pack_v0/artifacts/decision_trace.demo_ci.json \
-      --schema schemas/PULSE_decision_trace_v0.schema.json
 
+      - name: Validate decision trace with helper script
+        run: |
+          python PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py \
+            --trace PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json \
+            --schema schemas/PULSE_decision_trace_v0.schema.json
 
       - name: Upload topology demo artefacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The `Run topology demo` workflow now calls the decision trace validator
as a separate step.

Changes in `.github/workflows/pulse_topology_demo.yml`:

- Keep JSON Schema validation via `python -m jsonschema` unchanged.
- Add a `Validate decision trace with helper script` step that calls
  `PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py` with:
  - `--trace  PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json`
  - `--schema schemas/PULSE_decision_trace_v0.schema.json`

The previous versions of this step had indentation issues and passed an
unsupported `--name` flag, causing the workflow to fail before the
helper could run. The new version uses only the supported CLI flags and
matches the artefact filenames produced earlier in the job.

No changes to gate logic or artefacts; CI wiring only.
