### PR TITLE
fix(ci): align topology demo decision trace helper with validator CLI

### DIFF
--- a/.github/workflows/pulse_topology_demo.yml
+++ b/.github/workflows/pulse_topology_demo.yml
@@ -74,8 +74,8 @@ jobs:
       - name: Validate decision trace with helper script
         run: |
           python PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py \
-            --trace PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json \
-            --schema schemas/PULSE_decision_trace_v0.schema.json
+            --schema schemas/PULSE_decision_trace_v0.schema.json \
+            PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json
 
       - name: Upload topology demo artefacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What

Update the `pulse-topology-demo` GitHub Actions workflow to call
`validate_decision_trace_v0.py` with the current CLI:

- use `--schema schemas/PULSE_decision_trace_v0.schema.json`
- pass `PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json`
  as the positional `TRACE_JSON` argument
- remove the obsolete `--trace` flag

## Why

The helper script no longer supports a `--trace` option and instead
expects:

```text
validate_decision_trace_v0.py [-h] [--schema SCHEMA] TRACE_JSON
