### PR TITLE
fix(tools): make decision trace validator tolerant of missing instability_components

### DIFF
--- a/docs/PULSE_memory_trace_v0_walkthrough.md
+++ b/docs/PULSE_memory_trace_v0_walkthrough.md
@@ -101,3 +101,96 @@ python3 PULSE_safe_pack_v0/tools/append_delta_log_v0.py \
 This last step appends a single JSON line entry to `delta_log_v0.jsonl`,
 capturing a compact snapshot of the run (decision, stability, paradox and EPF
 snapshots, plus optional git metadata).
+
+
+## New panels in the memory / trace dashboard v0
+
+### Paradox histograms (zones and tensions)
+
+**Inputs:** `paradox_history_v0.json`.
+
+This group of views shows how paradox behaviour is distributed across runs, not just over time:
+
+- **Paradox zone histogram** – how many runs ended in each zone (green / yellow / red / unknown).
+- **Paradox zone histogram (weighted)** – same zones, but each run is weighted by its overall tension / risk, so a few very tense runs can dominate.
+- **Paradox tension histogram** – distribution of the scalar "max tension" metric across runs (low / medium / high tails).
+
+
+#### How to read these plots in practice
+
+A few quick rules of thumb when you're looking at the paradox histograms:
+
+- **Mostly green, tension mass near zero**  
+  The experiment is spending almost all its time in the safe zone. Occasional
+  yellow runs are fine as long as the tension histogram stays tightly
+  concentrated near zero.
+
+- **A long yellow tail with rare red spikes**  
+  This usually means the system is probing the boundary of the safe region.
+  Check whether the tail got heavier after a specific change (new model
+  version, new prompt family, new deployment cohort).
+
+- **Noticeable shift of mass towards high tension**  
+  When the “max tension” histogram clearly moves right over time, treat it as
+  an early warning sign. The gates might still pass, but you are running with
+  less margin than before.
+
+- **Frequent red runs, heavy high‑tension tail**  
+  This is usually a bad sign: either the paradox configuration is too lax, or
+  the underlying behaviour actually got riskier. In either case, don't blindly
+  accept this as the new normal – investigate and document the change.
+
+Whenever you change paradox tuning, use these plots as a quick sanity check
+that you did not accidentally move a lot of probability mass into the
+high‑tension regime.
+
+Use these plots when you want to:
+
+- see whether the experiment mostly lives in the safe zone, or keeps touching yellow / red,
+- check for heavy tails (e.g. many low-tension runs with a small cluster of very high-tension ones),
+- sanity‑check that paradox tuning changes actually move mass between the buckets.
+
+All of these panels are read‑only: they do not influence any gate decisions.
+
+### EPF signal overview (optional)
+
+**Inputs:** `paradox_history_v0.json` (for alignment) and, if present, `epf_history_v0.json`.
+
+When EPF shadow is enabled, the dashboard adds an EPF section that plots per‑run aggregates for the EPF field, for example:
+
+- min / max / average `phi_potential`,
+- min / max / average `theta_distortion`,
+- a simple trend line over run index.
+
+The goal is to answer questions such as:
+
+- "Did the EPF signal react when paradox tension changed?"
+- "Are we slowly drifting into a regime where EPF distortion is always high?"
+
+If EPF artefacts are missing, the panel quietly skips rendering and prints a short note in the console; the rest of the dashboard continues to work.
+
+These panels are developer‑facing diagnostics only. They are safe to run in shadow mode and do not affect any gate behaviour.
+
+
+#### Typical EPF patterns
+
+In practice, EPF is most useful when you watch it side‑by‑side with paradox
+tension:
+
+- **Flat, low EPF distortion while tension moves around**  
+  Good: the system is exploring different paradox regimes without the EPF
+  signal going unstable.
+
+- **EPF distortion spikes exactly when tension jumps**  
+  This is often what you want from a shadow EPF: it reacts when the model is
+  pushed into strange corners of the paradox configuration.
+
+- **EPF distortion slowly creeping up over many runs**  
+  Treat this as a “boiling frog” pattern. Nothing obviously broke in a single
+  run, but the baseline got worse. It’s usually worth checking recent changes
+  in prompts, routing policies, or model versions.
+
+- **EPF stuck in a permanently high state**  
+  Either the EPF configuration is too sensitive, or the underlying behaviour
+  really is degraded. In both cases, the shadow panel has done its job: you
+  should decide whether to re‑tune EPF or tighten the release gates.


### PR DESCRIPTION
## What

Extend the `PULSE_memory_trace_v0_walkthrough` documentation with more
details about the memory / trace dashboard v0:

- describe the new paradox histogram panels (zones and tensions) and
  their JSON inputs,
- explain the EPF signal overview section and how it lines up with
  `paradox_history_v0.json` / `epf_history_v0.json`,
- add a **"How to read these plots in practice"** subsection with simple
  rules of thumb for common histogram shapes,
- add a **"Typical EPF patterns"** subsection to help interpret common
  shadow-mode behaviours.

## Why

Previously the walkthrough focused on how to generate the artifacts and
what each panel shows, but it did not explain:

- what a “good” vs “worrying” paradox histogram looks like,
- how to think about heavy tails and high-tension mass,
- how to recognise slow drifts in the EPF signal.

This made the dashboard harder to use for people who are not deeply
embedded in the paradox/EPF internals. The new sections are meant to
bridge that gap and give more narrative support for reading the plots.

## How

- documentation-only change in `docs/PULSE_memory_trace_v0_walkthrough.md`
- no changes to gate logic, schemas, or tooling behaviour
- safe to ship as a standalone docs update
