### PR TITLE
fix(trace): wire instability_components to actual instability payload

### DIFF
--- a/PULSE_safe_pack_v0/tools/run_decision_engine.py
+++ b/PULSE_safe_pack_v0/tools/run_decision_engine.py
@@ -127,15 +127,15 @@ def build_decision_trace(stability_map: dict, state: dict) -> dict:
     instab = state.get("instability") or {}
     score = float(instab.get("score", 0.0) or 0.0)
 
-    # Instability components object a sémához igazítva
-    # Próbáljuk először az "instability.components" dictet használni,
-    # ha ilyen nincs, akkor közvetlenül az "instability" dictből olvasunk.
-    components = instab.get("components") or instab
+    # Az instability payloadban ezek a kulcsok vannak:
+    #   safety_component, quality_component, rdsi_component, epf_component
+    # Ezeket térképezzük át a schema szerinti nevekre:
     instability_components = {
-        "safety": components.get("safety"),
-        "quality": components.get("quality"),
-        "rds1": components.get("rds1") or components.get("rdsi"),
-        "epf": components.get("epf"),
+        "safety": instab.get("safety_component"),
+        "quality": instab.get("quality_component"),
+        # a séma "rds1"-et vár, de az input "rdsi_component":
+        "rds1": instab.get("rdsi_component"),
+        "epf": instab.get("epf_component"),
     }
 
     # Gate- és EPF-információk
@@ -184,7 +184,7 @@ def build_decision_trace(stability_map: dict, state: dict) -> dict:
         "risk_level": risk_level,
         "summary": summary,
         "details": {
-            # --- kötelező mezők a sémában ---
+            # --- schema-required mezők ---
             "release_decision": decision,
             "stability_type": state_type,
             "instability_score": score,
@@ -192,13 +192,14 @@ def build_decision_trace(stability_map: dict, state: dict) -> dict:
             "gates": gates,
             "paradox_present": paradox_present,
             "epf": epf,
-            # --- extra, fejlesztőbarát mezők (a séma engedi az extra kulcsokat) ---
+            # --- extra, fejlesztőbarát mezők ---
             "dominant_components": dom,
             "gate_summary": gates,
             "notes": notes,
         },
     }
     return trace
+
 
 
 


### PR DESCRIPTION
## What

Follow up on the previous decision trace/schema alignment by fixing the
source of `details.instability_components` in
`PULSE_safe_pack_v0/tools/run_decision_engine.py`:

- read `safety_component`, `quality_component`, `rds1_component` and
  `epf_component` from the `instability` dict
- map them to the schema-level fields:
  - `instability_components.safety`
  - `instability_components.quality`
  - `instability_components.rds1`
  - `instability_components.epf`

The rest of the decision trace structure is unchanged.

## Why

The v0 schema already exposes `instability_components` as a structured
breakdown of the instability score. The previous implementation added
the field but populated it from non-existent `safety`/`quality`/`rds1`/`epf`
keys, so all component values were `null` in practice.

This meant:

- the helper validation passed (the schema allows nulls),
- but consumers of the v0 schema could not see the real component
  contributions.

Wiring the field to the actual `*_component` values fixes that without
changing the schema.

## How

- code-only change in `build_decision_trace()`
- no changes to schemas or gate logic
- pipeline behaviour unchanged except that the emitted
  `instability_components` now carry real numbers instead of nulls
