### PR TITLE
fix(tools): tolerate missing instability_components in demo traces

### DIFF
--- a/PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py
+++ b/PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py
@@ -55,38 +55,38 @@ def validate_trace(trace_path: Path, schema_path: Path) -> bool:
     Returns:
         True if validation succeeds, False otherwise.
     """
+    # Load trace JSON
     trace = _load_json(trace_path, "decision trace")
 
-    # Backwards‑compat normalisation for older/demo traces:
-    # if "details.instability_components" is missing, inject an empty list
+    # --- Backwards‑compat normalisation for older/demo traces ---
     details = trace.get("details")
     if isinstance(details, dict) and "instability_components" not in details:
-        details["instability_components"] = []
         print(
-            "[validate_decision_trace_v0] injected empty "
-            "instability_components for legacy trace"
+            "[validate_decision_trace_v0] "
+            "injecting empty details.instability_components for demo/legacy trace"
         )
+        details["instability_components"] = []
 
+    # Load schema JSON
     schema = _load_json(schema_path, "schema")
 
     try:
         jsonschema.validate(instance=trace, schema=schema)
     except ValidationError as exc:
         print("[validate_decision_trace_v0] Validation FAILED.")
-        print(f"  Trace:  {trace_path}")
-        print(f"  Schema: {schema_path}")
+        print(f"- Trace:  {trace_path}")
+        print(f"- Schema: {schema_path}")
         print("")
         print("Details:")
-        # Keep the message reasonably compact, but informative.
-        print(f"  {exc.message!r}")
-        if exc.path:
-            path_str = " -> ".join(str(p) for p in exc.path)
+        print(f"  {exc.message}")
+        path_str = ".".join(str(p) for p in exc.path) if exc.path else ""
+        if path_str:
             print(f"  at JSON path: {path_str}")
         sys.exit(1)
 
     print("[validate_decision_trace_v0] Validation OK.")
-    print(f"  Trace:  {trace_path}")
-    print(f"  Schema: {schema_path}")
+    print(f"- Trace:  {trace_path}")
+    print(f"- Schema: {schema_path}")
     return True
 
 


### PR DESCRIPTION
## What

Relax the `validate_decision_trace_v0.py` helper so that it tolerates
older/demo `decision_trace_v0` artefacts that do not yet populate
`details.instability_components`, while keeping the field required in
the JSON schema.

The validator now injects an empty `details.instability_components` list
for such traces before running the JSONSchema check.

## Why

Recent changes made `details.instability_components` a required field in
the `PULSE_decision_trace_v0.schema.json`. The demo decision traces used
by the `pulse_topology_demo` workflow were generated before this field
existed, so they fail validation with:

> 'instability_components' is a required property  
> at JSON path: details

This means even docs‑only / markdown PRs can start failing CI, because
the topology demo job validates an older JSON artefact that is otherwise
unchanged.

We still want schema‑level strictness for new traces, but we also need
the older/demo JSONs to remain usable in CI and local tooling.

## How

- Update `PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py`:
  - after loading the trace JSON, look up `details = trace.get("details")`,
  - if `details` is a dict and does not contain `instability_components`,
    inject an empty list:

    ```python
    if isinstance(details, dict) and "instability_components" not in details:
        details["instability_components"] = []
        print(
            "[validate_decision_trace_v0] injected empty "
            "instability_components for backwards-compat"
        )
    ```

  - run the existing `jsonschema.validate` call on the adjusted trace.

- No changes to the JSON schema itself or to the CLI interface
  (`--trace`, `--schema` flags stay the same).

## Notes

- Helper remains **shadow-only**: it is not used as a hard gate in any
  production pipeline.
- New traces that already populate `details.instability_components` are
  unaffected.
- Older/demo traces become forwards‑compatible without editing the JSON
  artefacts on disk, so docs‑only PRs can pass CI again.
