### PR TITLE
fix(tools): harden decision trace validator required-field handling

### DIFF
--- a/PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py
+++ b/PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py
@@ -35,14 +35,13 @@ def validate_trace(trace_path: Path, schema_path: Path) -> int:
     warned_missing_instability_components = False
 
     for err in errors:
-        # Tolerate exactly this one case:
-        #   - "instability_components" is a required property
-        #   - at JSON path: details
+        # Toleráljuk pontosan ezt az egy esetet:
+        #  - "'instability_components' is a required property"
+        #  - a JSON path: details
         if (
             err.validator == "required"
-            and isinstance(err.validator_value, list)
-            and "instability_components" in err.validator_value
             and list(err.path) == ["details"]
+            and "'instability_components' is a required property" in str(err.message)
         ):
             if not warned_missing_instability_components:
                 print(
@@ -51,10 +50,26 @@ def validate_trace(trace_path: Path, schema_path: Path) -> int:
                     "Tolerating for backward compatibility."
                 )
                 warned_missing_instability_components = True
-            # do not treat this as a hard error
+            # nem tekintjük hard errornak
             continue
 
+        # minden más hiba marad kemény hiba
         hard_errors.append(err)
+
+    if hard_errors:
+        print("[validate_decision_trace_v0] Validation FAILED.")
+        print(f"- Trace:  {trace_path}")
+        print(f"- Schema: {schema_path}")
+        print("\nDetails:")
+        for err in hard_errors:
+            json_path = "/".join(str(p) for p in err.path) or "<root>"
+            print(f"  - {err.message}")
+            print(f"    at JSON path: {json_path}")
+        return 1
+
+    print("[validate_decision_trace_v0] Validation OK.")
+    return 0
+
 
     if hard_errors:
         print("[validate_decision_trace_v0] Validation FAILED.")


### PR DESCRIPTION
## What

Tighten the special-case logic in `validate_decision_trace_v0.py` so that
only a missing `details.instability_components` field is treated as a
soft warning. All other required fields under `details` remain hard
validation errors.

## Why

The previous implementation checked:

- `err.validator == "required"`
- `"instability_components" in err.validator_value`
- `list(err.path) == ["details"]`

However, `err.validator_value` for a `required` error is the **full list
of required properties** (e.g. `["release_decision", "stability_type",
"instability_score", "instability_components", ...]`). This means that
any missing required field under `details` would still contain
`"instability_components"` in that list, and thus be downgraded to a
warning.

As a result, traces missing `details.release_decision` or `details.epf`
could slip through as "valid", which is not intended.

## How

- examine each `ValidationError` from jsonschema
- treat it as soft only if:

  - `err.validator == "required"`,
  - `list(err.path) == ["details"]`, and
  - `err.message` contains `"'instability_components' is a required property"`

- all other errors continue to be collected as hard errors and cause a
  non-zero exit code

This keeps the validator tolerant of missing `instability_components`
for legacy traces, while still enforcing the rest of the schema.
