### PR TITLE
chore(schema): add optional delta_curvature to stability map v0

### DIFF
--- a/schemas/schemas/PULSE_stability_map_v0.schema.json
+++ b/schemas/schemas/PULSE_stability_map_v0.schema.json
@@ -293,7 +293,24 @@
           },
           "additionalProperties": true
         },
-        "epf_field_v0": {
+               "delta_curvature": {
+          "type": "object",
+          "description": "Directional curvature of instability across states/runs (EPF Δ-hajlás).",
+          "properties": {
+            "value": {
+              "type": ["number", "null"],
+              "description": "Numeric delta-curvature value for this state, or null if not defined."
+            },
+            "band": {
+              "type": ["string", "null"],
+              "enum": ["low", "medium", "high", "n/a", null],
+              "description": "Binned delta-curvature band for this state."
+            }
+          },
+          "additionalProperties": false
+        },
+
+       "epf_field_v0": {
           "type": "object",
           "description": "EPF fizikai mező v0 ehhez az állapothoz (phi/theta/energy + horgonyok).",
           "properties": {


### PR DESCRIPTION
## What

Extend `PULSE_stability_map_v0.schema.json` so that it recognises the
new `delta_curvature` field on each `ReleaseState`:

- add a `delta_curvature` object under `$defs.ReleaseState.properties` with:
  - `value`: number | null
  - `band`: "low" | "medium" | "high" | "n/a" | null
- keep `delta_curvature` **optional** (do not add it to the `required` list)

## Why

The stability map builder now attaches an EPF delta_curvature
("mezőhajlítás") annotation to each state based on the instability.score
history. The schema needs to reflect this so that:

- new stability_map artefacts with `delta_curvature` validate cleanly,
- older artefacts without the field remain valid.

## How

- schema-only change in `schemas/PULSE_stability_map_v0.schema.json`
- no changes to builders, gates or CI logic
- `delta_curvature` remains a developer-facing, shadow-only field on
  the Stability Map
