### PR TITLE
fix(tools): use package-relative import for delta_curvature helpers

### DIFF
--- a/PULSE_safe_pack_v0/tools/build_stability_map.py
+++ b/PULSE_safe_pack_v0/tools/build_stability_map.py
@@ -16,7 +16,19 @@ from pathlib import Path
 from datetime import datetime, timezone
 import argparse
 
-from metrics_delta_curvature import compute_delta_curvatures, band_delta_curvature
+try:
+    # Ha csomagként importáljuk: PULSE_safe_pack_v0.tools.build_stability_map
+    from .metrics_delta_curvature import (
+        compute_delta_curvatures,
+        band_delta_curvature,
+    )
+except ImportError:
+    # Ha közvetlenül scriptként futtatjuk:
+    # python PULSE_safe_pack_v0/tools/build_stability_map.py
+    from metrics_delta_curvature import (
+        compute_delta_curvatures,
+        band_delta_curvature,
+    )
 
 
 def load_json(path: Path):


### PR DESCRIPTION
## What

Fix the import of the delta_curvature helpers in
`PULSE_safe_pack_v0/tools/build_stability_map.py` so that the module
works both:

- when executed directly as a script, and
- when imported as part of the `PULSE_safe_pack_v0.tools` package.

## How

Replace the absolute import:

```python
from metrics_delta_curvature import compute_delta_curvatures, band_delta_curvature
