### PR TITLE
feat(trace): add stability_tag for delta_curvature-aware decisions

### DIFF
--- a/PULSE_safe_pack_v0/tools/run_decision_engine.py
+++ b/PULSE_safe_pack_v0/tools/run_decision_engine.py
@@ -138,23 +138,31 @@ def build_decision_trace(stability_map: dict, state: dict) -> dict:
         "epf": instab.get("epf_component"),
     }
 
+    # Delta curvature (mezőhajlítás) – optional
+    delta_curv = state.get("delta_curvature") or {}
+    delta_value = delta_curv.get("value")
+    delta_band = delta_curv.get("band")
+
     # Gate- és EPF-információk
     gates = state.get("gate_summary") or {}
     epf = state.get("epf") or {}
 
-    # Paradoxon jelenlét: ha van paradox blokk, abból olvassuk ki
-    paradox_info = state.get("paradox") or {}
-    paradox_present = bool(paradox_info.get("present", False))
-
-    # ÚJ: mezőhajlítás a stability map state-ből
-    delta_curv = state.get("delta_curvature") or {}
-    delta_value = delta_curv.get("value")
-    delta_band = delta_curv.get("band")
+    # Paradoxon jelenlét – ha nincs explicit flag, default: False
+    paradox_present = bool(state.get("paradox_present", False))
 
     # Döntési szintű jelölések
     risk_level = compute_risk_level(score)
     action = decide_action(decision, state_type, score)
     dom = dominant_components(instab)
+
+    # Új: stability_tag – külön jelzés a mezőhajlításra érzékeny „jó” döntésekre
+    stability_tag: str | None = None
+    if score < 0.30:
+        # „jó” instabilitási tartomány
+        if delta_band == "high":
+            stability_tag = "unstably_good"
+        else:
+            stability_tag = "stable_good"
 
     component_str = ", ".join(
         f"{c['name']}={c['value']:.2f}" for c in dom
@@ -165,29 +173,39 @@ def build_decision_trace(stability_map: dict, state: dict) -> dict:
         f"(risk={risk_level}, dominant components: {component_str})."
     )
 
-    notes = [
+    notes: list[str] = [
         f"Deterministic release decision: {decision}.",
         f"Stability type: {state_type}.",
         f"Instability score: {score:.3f} (risk level: {risk_level}).",
     ]
+
     if dom:
         notes.append(
             "Dominant instability components: "
             + ", ".join(f"{c['name']}={c['value']:.3f}" for c in dom)
         )
+
     if gates:
         notes.append(
             "Gate summary: "
             f"safety {gates.get('safety_failed', 0)}/{gates.get('safety_total', 0)} "
             f"failed, quality {gates.get('quality_failed', 0)}/{gates.get('quality_total', 0)} failed."
         )
-    if delta_value is not None:
+
+    # Delta curvature-hez kapcsolódó megjegyzés – csak ha van értelmes jel
+    if delta_value is not None and delta_band in {"medium", "high"}:
+        band_label = delta_band.upper()
         notes.append(
-            f"Field curvature: delta={delta_value:.3f}, band={delta_band or 'n/a'}."
+            f"Delta curvature: {delta_value:.3f} ({band_label}); "
+            "decision may be field-sensitive even if metrics look clean."
         )
 
-    details = {
-        # --- schema-required mezők ---
+    # Ha van stability_tag, azt is jegyezzük meg emberi nyelven
+    if stability_tag is not None:
+        notes.append(f"Stability tag: {stability_tag}.")
+
+    # Alap, séma által várt mezők
+    details: dict = {
         "release_decision": decision,
         "stability_type": state_type,
         "instability_score": score,
@@ -195,18 +213,23 @@ def build_decision_trace(stability_map: dict, state: dict) -> dict:
         "gates": gates,
         "paradox_present": paradox_present,
         "epf": epf,
-        # --- extra, fejlesztőbarát mezők ---
-        "dominant_components": dom,
-        "gate_summary": gates,
-        "notes": notes,
     }
 
-    # ÚJ: csak akkor tesszük be, ha van értelmes delta_curvature
+    # Új, opcionális delta_curvature blokk – séma engedi (additionalProperties: true)
     if delta_value is not None:
-        details["field_curvature"] = {
-            "delta_curvature": delta_value,
+        details["delta_curvature"] = {
+            "value": float(delta_value),
             "band": delta_band,
         }
+
+    # Új: gép-barát stability_tag is bekerül a details alá (opcionális)
+    if stability_tag is not None:
+        details["stability_tag"] = stability_tag
+
+    # Extra, fejlesztőbarát mezők
+    details["dominant_components"] = dom
+    details["gate_summary"] = gates
+    details["notes"] = notes
 
     trace = {
         "version": "0.1",


### PR DESCRIPTION
## What

Extend the v0 decision trace with a machine-friendly `stability_tag`:

- classify low-instability runs as either `stable_good` or `unstably_good`
  based on the `delta_curvature` band
- expose the tag under `details.stability_tag`
- add a short human-readable note so dashboards and reviewers see it next to the summary

## Why

We now compute EPF Δ-hajlás (delta_curvature) in the stability map and surface it
into the decision trace. To make this signal easier to consume, the Decision Engine
should label cases where:

- the instability score is low (the run looks “good”), but
- the field curvature is high.

These “unstably-good” decisions are exactly the ones we want the Pro form and
dashboards to highlight.

## How

- update `build_decision_trace` in `PULSE_safe_pack_v0/tools/run_decision_engine.py`:
  - derive a `stability_tag` from `(instability_score, delta_curvature.band)`
    - `unstably_good` for low instability + `high` curvature
    - `stable_good` for low instability + non-high curvature
  - attach the tag as `details.stability_tag` (optional, schema allows extra fields)
  - append a note so the tag is visible in the textual trace
- keep all existing fields and schema contracts untouched.
