### PR TITLE
docs: describe field_curvature and stability_tag in memory/trace v0

### DIFF
--- a/docs/PULSE_memory_trace_v0_walkthrough.md
+++ b/docs/PULSE_memory_trace_v0_walkthrough.md
@@ -115,6 +115,47 @@ This group of views shows how paradox behaviour is distributed across runs, not 
 - **Paradox zone histogram (weighted)** – same zones, but each run is weighted by its overall tension / risk, so a few very tense runs can dominate.
 - **Paradox tension histogram** – distribution of the scalar "max tension" metric across runs (low / medium / high tails).
 
+### Field curvature and stability tags (Δ-hajlás)
+
+The memory / trace dashboard v0 can optionally surface a simple
+field-curvature signal derived from the Stability Map:
+
+- per-state `delta_curvature` (value + band),
+- and a discrete `stability_tag` emitted by the Decision Engine.
+
+At a high level:
+
+- **delta_curvature.value**  
+  is a normalised second-derivative style measure over the instability
+  history: how sharply the field bends around this state.
+- **delta_curvature.band**  
+  buckets the raw value into `low`, `medium` or `high` (with `n/a`
+  for states where curvature is not defined).
+- **stability_tag**  
+  is a coarse label for low-instability states:
+  - `stable_good` – low instability and low/medium field curvature,
+  - `unstably_good` – low instability but *high* field curvature.
+
+The exact thresholds for `low` / `medium` / `high` are not meant to be
+hard guarantees; they are developer-facing heuristics that highlight
+regimes where:
+
+- the gates and instability score look fine,
+- but the underlying EPF field is bending aggressively.
+
+In practice, you can read these signals as:
+
+- `stable_good`:  
+  everything points in the same direction – both the metrics and the
+  field curvature look clean.
+- `unstably_good`:  
+  a “good on paper” decision that happens in a tightly curved region
+  of the field. These are often the most interesting runs to
+  investigate in the Pro form or in deeper trace views.
+
+None of these signals change gate behaviour in v0 – they are
+purely diagnostic tags layered on top of the existing topology and
+decision traces.
 
 #### How to read these plots in practice
 


### PR DESCRIPTION
## What

Extend the memory / trace walkthrough with a short description of the
new field-curvature and stability_tag signals:

- explain how `delta_curvature` is derived and banded,
- document the `stable_good` vs `unstably_good` stability_tag semantics,
- clarify that these are diagnostics-only tags on top of the existing
  topology and decision traces.

## Why

We now compute EPF Δ-hajlás (delta_curvature) on the Stability Map and
surface it into the v0 decision_trace as `details.delta_curvature` and
`details.stability_tag`. The memory / trace docs should make it clear:

- what these signals mean,
- how to interpret `unstably_good` decisions,
- and that none of this changes gate behaviour in v0.

## How

- documentation-only change in:
  - `docs/PULSE_memory_trace_v0_walkthrough.md`

No changes to tools, schemas or gate logic.
