### PR TITLE
fix(tools): import ValidationError in trace validator

### DIFF
--- a/PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py
+++ b/PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py
@@ -16,7 +16,7 @@ import json
 import sys
 from pathlib import Path
 
-from jsonschema import Draft7Validator
+from jsonschema import Draft7Validator, ValidationError
 
 
 def load_json(path: Path):


### PR DESCRIPTION
## What

Update `PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py` so that
the new `hard_errors: list[ValidationError]` annotation does not break
module import.

- extend the jsonschema import to include `ValidationError`

## Why

The validator now annotates `hard_errors` as `list[ValidationError]`,
but the module only imported `Draft7Validator`. Without importing
`ValidationError`, Python raises `NameError` at function definition time
and the script cannot run.

This change fixes that by importing `ValidationError` from jsonschema,
so the validator remains runnable and the Codex P1 warning is resolved.

## How

- change `from jsonschema import Draft7Validator` to

  `from jsonschema import Draft7Validator, ValidationError`

No changes to validation logic or behaviour.
