### PR TITLE
docs: introduce paradox math v0 intro note

### DIFF
--- a/docs/PULSE_paradox_math_v0_intro.md
+++ b/docs/PULSE_paradox_math_v0_intro.md
@@ -1,0 +1,65 @@
+# PULSE Paradox Math v0 – Intro
+
+**Status:** draft v0  
+**Scope:** conceptual + light formalisation for PULSE paradox modules
+
+This note introduces a minimal mathematical language for talking about
+“paradox” inside PULSE:
+
+- how we represent a paradox as a *tengely* (axis) + A / ¬A pair,
+- how we turn that into measurable tension on a [0, 1] scale,
+- how we aggregate paradox atoms into a field over runs,
+- how this connects to the existing PULSE artefacts
+  (`paradox_field_v0`, `paradox_history_v0`, delta_curvature, EPF).
+
+The goal is not to build a full formal logic, but to have **just enough
+structure** that different panels, metrics and tools refer to the *same*
+underlying objects.
+
+---
+
+## 1. Paradox axes and atoms
+
+### 1.1 Paradox axis
+
+A paradox axis is a named dimension where two principles can come into
+tension.
+
+Formally, a **ParadoxAxis** is:
+
+- an identifier `axis_id` (e.g. `epf_field_vs_policy_field`),
+- an informal description (text),
+- optional metadata about the source (policy, training, governance, etc.).
+
+For now, we only care about the `axis_id` as a stable key.
+
+### 1.2 Paradox atom
+
+A **ParadoxAtom** is a single, local paradox instance on one axis.
+
+It has:
+
+- `axis_id`: which axis this atom lives on,
+- `A`: a textual statement / principle (source 1),
+- `notA`: an opposing statement / principle (source 2),
+- `direction`: how the system moved between A and ¬A,
+- `tension_score ∈ [0, 1]`: how strong the conflict is,
+- optional `zone ∈ {green, yellow, red}`,
+- optional context (run_id, scope, segment, anchors in the topology).
+
+In JSON terms (already in the schemas):
+
+```json
+{
+  "axis_id": "epf_field_vs_policy_field",
+  "A": "Model should stay close to the trained EPF manifold.",
+  "notA": "Model should aggressively follow user intent even off-manifold.",
+  "direction": "towards_notA",
+  "tension_score": 0.78,
+  "zone": "red",
+  "context": {
+    "run_id": "run_023",
+    "scope": "prod",
+    "segment": "safety_shadow"
+  }
+}


### PR DESCRIPTION
## What

Add a new documentation note that introduces a minimal mathematical
backbone for PULSE paradox modules:

- define what a ParadoxAxis and ParadoxAtom are,
- formalise the `tension_score ∈ [0,1]` and zone thresholds
  (green / yellow / red),
- describe how single-run paradox fields (`paradox_field_v0`) are
  summarised (max_tension, counts, dominant_axes),
- outline how paradox history over runs leads to the existing
  zone/tension histograms,
- connect paradox metrics to EPF, instability and delta_curvature,
- state basic invariants (normalisation, monotonicity, non-gating in v0).

The content lives in:

- `docs/PULSE_paradox_math_v0_intro.md`

## Why

The existing paradox docs focus on pipelines and artefacts
(`paradox_field_v0`, resolution plans, dashboards), but there was no
single place that:

- clearly defines what a paradox axis and atom are in mathematical terms,
- explains what `tension_score` is supposed to mean,
- documents the intended relationship between paradox metrics and EPF /
  instability signals.

This note gives Pro / advanced users a shared conceptual model so that
different panels and tools refer to the same underlying quantities.

## How

- add `docs/PULSE_paradox_math_v0_intro.md` with:

  - sections on axes, atoms, tension scores and zones,
  - a description of per-run paradox fields and cross-run history,
  - a short discussion of how paradox metrics line up with EPF and
    delta_curvature,
  - explicit v0 invariants and non-gating guarantees.

No changes to schemas, tools or CI; this is a documentation-only PR.
