### PR TITLE
docs: extend paradox math intro with EPF vs policy axis example

### DIFF
--- a/docs/PULSE_paradox_math_v0_intro.md
+++ b/docs/PULSE_paradox_math_v0_intro.md
@@ -63,3 +63,154 @@ In JSON terms (already in the schemas):
     "segment": "safety_shadow"
   }
 }
+
+
+---
+
+## 8. Worked example: `epf_field_vs_policy_field` axis
+
+This section walks through a single paradox axis across a few runs to
+show how ParadoxAtoms, per-run fields and history fit together.
+
+### 8.1 Axis definition
+
+We consider the axis:
+
+```text
+epf_field_vs_policy_field
+
+
+with the following informal semantics:
+
+A: the model should remain in an EPF-stable regime
+(close to the EPF manifold, with contraction factor L ≲ 1.0),
+
+¬A: the model should aggressively follow user intent, even if this
+pulls behaviour off the EPF manifold (L > 1.0 in some regions).
+
+This axis captures the tension between EPF stability and
+product/policy pressure.
+
+8.2 A single run: a red paradox atom
+
+Consider a run run_023 where:
+
+- EPF reports a mildly non-contractive regime (e.g. L ≈ 1.12),
+
+- gates still pass (STAGE-PASS or PROD-PASS),
+
+- the model behaviour clearly favours user intent over EPF stability.
+
+A corresponding ParadoxAtom on this axis could look like:
+
+with the following informal semantics:
+
+A: the model should remain in an EPF-stable regime
+(close to the EPF manifold, with contraction factor L ≲ 1.0),
+
+¬A: the model should aggressively follow user intent, even if this
+pulls behaviour off the EPF manifold (L > 1.0 in some regions).
+
+This axis captures the tension between EPF stability and
+product/policy press
+
+
+{
+  "axis_id": "epf_field_vs_policy_field",
+  "A": "Model behaviour stays close to the EPF-stable manifold (L <= 1.0).",
+  "notA": "Model behaviour aggressively follows user intent even when EPF L > 1.0.",
+  "direction": "towards_notA",
+  "tension_score": 0.78,
+  "zone": "red",
+  "context": {
+    "run_id": "run_023",
+    "scope": "prod",
+    "segment": "high_risk_prompts"
+  }
+}
+
+Here:
+
+direction = "towards_notA" records that the system moved towards the
+user-intent side of the axis,
+
+tension_score = 0.78 puts this conflict in the high/critical range,
+
+zone = "red" is derived from the score via the global thresholds.
+
+If this run has a few more atoms on other axes, the per-run paradox
+field might summarise as:
+
+"paradox_field_v0": {
+  "atoms": [
+    { "...": "epf_field_vs_policy_field (tension=0.78, zone=red)" },
+    { "...": "safety_vs_productivity (tension=0.52, zone=yellow)" },
+    { "...": "policy_consistency (tension=0.25, zone=green)" }
+  ],
+  "summary": {
+    "max_tension": 0.78,
+    "num_atoms": 3,
+    "num_red_zones": 1,
+    "num_yellow_zones": 1,
+    "dominant_axes": [
+      "epf_field_vs_policy_field"
+    ]
+  }
+}
+
+
+The summary makes it clear that:
+
+- the worst paradox in this run lives on epf_field_vs_policy_field,
+
+- there is exactly one red-zone atom,
+
+- the dominant axis is EPF vs policy.
+
+8.3 Evolution across runs
+
+Now look at three consecutive runs on the same axis:
+
+| run_id  | direction         | tension_score | zone   |
+| ------- | ----------------- | ------------- | ------ |
+| run_021 | towards_stability | 0.18          | green  |
+| run_022 | unresolved        | 0.47          | yellow |
+| run_023 | towards_notA      | 0.78          | red    |
+
+Interpretation:
+
+- run_021 lives in a comfortable, EPF-aligned regime (green),
+
+- run_022 shows a noticeable but unresolved tension (yellow),
+
+- run_023 resolves strongly in favour of ¬A, i.e. policy over EPF (red).
+
+In the paradox-history views this shows up as:
+
+- zone histograms shifting mass from green → yellow → red on this axis,
+
+- tension histograms developing a tail in the 0.7–0.8 range,
+
+- epf_field_vs_policy_field appearing more often among dominant_axes.
+
+When combined with EPF and instability signals:
+
+- EPF L creeping above 1.0,
+
+- instability remaining moderate,
+
+- but delta_curvature increasing,
+
+the dashboard can highlight states that are numerically “good” but
+conceptually unstably good on this axis:
+
+- paradox tension is high,
+
+- the EPF field is bending,
+
+- and the decision trace can mark these runs with a stability_tag
+such as "unstably_good".
+
+This worked example illustrates how a single axis can provide a
+narrative thread across multiple runs, and how paradox, EPF and
+delta-curvature metrics reinforce each other.


### PR DESCRIPTION
## What

Extend `docs/PULSE_paradox_math_v0_intro.md` with a full worked example
for the `epf_field_vs_policy_field` paradox axis:

- define A / ¬A semantics for EPF stability vs product/policy pressure,
- show a single red-zone `ParadoxAtom` in JSON,
- illustrate how a per-run `paradox_field_v0` summary is derived,
- walk through three consecutive runs on the same axis
  (`run_021` → `run_022` → `run_023`),
- explain how paradox tension, EPF L and `delta_curvature` interact
  to produce an `unstably_good` stability tag.

## Why

The earlier sections introduced atoms, fields and histories in the
abstract, but did not show a concrete axis end-to-end. This example:

- gives Pro users a narrative handle on what a “red” paradox actually is,
- shows how the paradox history views relate to raw JSON artefacts,
- ties together paradox, EPF and delta-curvature signals in one story.

## How

- Update `docs/PULSE_paradox_math_v0_intro.md`:
  - add section **8. Worked example: `epf_field_vs_policy_field` axis**
  - include JSON snippets for the atom and per-run field summary
  - add a small table for the three-run evolution

Docs-only change; no code, schemas or CI behaviour are touched.
