### PR TITLE
docs: extend Topology v0 mini example with Q3–Q4 paradox atom

### DIFF
--- a/docs/PULSE_topology_v0_mini_example_fairness_slo_epf.md
+++ b/docs/PULSE_topology_v0_mini_example_fairness_slo_epf.md
@@ -148,4 +148,271 @@ fields that are safe to add as optional extensions on top of the existing
       "tags": ["topology_demo_v0", "fairness_vs_slo", "epf_interaction"]
     }
   ]
+
+
+## 5. Paradox atom: Q₃ vs Q₄ (local MUS)
+
+Using multiple configurations with different (α, B) pairs (fairness threshold and SLO budget),
+we can observe a local paradox atom where:
+
+- `q3_fairness_ok` is satisfiable alone (some configs pass),
+- `q4_slo_ok` is satisfiable alone (other configs pass),
+- but **no configuration** in a given (α, B) box satisfies both simultaneously.
+
+Formally, the gate pair `{q3_fairness_ok, q4_slo_ok}` is a minimal unsatisfiable set (MUS)
+over that box.
+
+An example paradox_field_v0 fragment:
+
+```jsonc
+{
+  "paradox_field_v0": {
+    "version": "PULSE_paradox_field_v0",
+    "generated_at_utc": "2025-11-27T00:00:00Z",
+    "atoms": [
+      {
+        "atom_id": "atom_fairness_vs_slo_demo",
+        "gates": ["q3_fairness_ok", "q4_slo_ok"],
+        "minimal": true,
+        "severity": 0.9,
+        "parameter_box": {
+          "fairness_threshold": [0.7, 0.9],
+          "slo_budget_ms": [200, 300]
+        },
+        "comment": "No (alpha, B) combination satisfies both fairness and SLO in this region; explicit tradeoff required."
+      }
+    ]
+  }
 }
+```
+
+This shows how Topology v0 can expose the fairness–SLO tradeoff as an explicit, machine‑readable
+object (`paradox_field_v0`), rather than burying it in a single scalar score.
+
+## 5. Paradox atom: Q₃ vs Q₄ (local MUS)
+
+Using multiple configurations with different (α, B) pairs (fairness threshold and SLO budget),
+we can observe a local paradox atom where:
+
+- `q3_fairness_ok` is satisfiable alone (some configs pass),
+- `q4_slo_ok` is satisfiable alone (other configs pass),
+- but **no configuration** in a given (α, B) box satisfies both simultaneously.
+
+Formally, the gate pair `{q3_fairness_ok, q4_slo_ok}` is a minimal unsatisfiable set (MUS)
+over that box.
+
+An example paradox_field_v0 fragment:
+
+```jsonc
+{
+  "paradox_field_v0": {
+    "version": "PULSE_paradox_field_v0",
+    "generated_at_utc": "2025-11-27T00:00:00Z",
+    "atoms": [
+      {
+        "atom_id": "atom_fairness_vs_slo_demo",
+        "gates": ["q3_fairness_ok", "q4_slo_ok"],
+        "minimal": true,
+        "severity": 0.9,
+        "parameter_box": {
+          "fairness_threshold": [0.7, 0.9],
+          "slo_budget_ms": [200, 300]
+        },
+        "comment": "No (alpha, B) combination satisfies both fairness and SLO in this region; explicit tradeoff required."
+      }
+    ]
+  }
+}
+```
+
+This shows how Topology v0 can expose the fairness–SLO tradeoff as an explicit, machine‑readable
+object (`paradox_field_v0`), rather than burying it in a single scalar score.
+## 5. Paradox atom: Q₃ vs Q₄ (local MUS)
+
+Using multiple configurations with different (α, B) pairs (fairness threshold and SLO budget),
+we can observe a local paradox atom where:
+
+- `q3_fairness_ok` is satisfiable alone (some configs pass),
+- `q4_slo_ok` is satisfiable alone (other configs pass),
+- but **no configuration** in a given (α, B) box satisfies both simultaneously.
+
+Formally, the gate pair `{q3_fairness_ok, q4_slo_ok}` is a minimal unsatisfiable set (MUS)
+over that box.
+
+An example paradox_field_v0 fragment:
+
+```jsonc
+{
+  "paradox_field_v0": {
+    "version": "PULSE_paradox_field_v0",
+    "generated_at_utc": "2025-11-27T00:00:00Z",
+    "atoms": [
+      {
+        "atom_id": "atom_fairness_vs_slo_demo",
+        "gates": ["q3_fairness_ok", "q4_slo_ok"],
+        "minimal": true,
+        "severity": 0.9,
+        "parameter_box": {
+          "fairness_threshold": [0.7, 0.9],
+          "slo_budget_ms": [200, 300]
+        },
+        "comment": "No (alpha, B) combination satisfies both fairness and SLO in this region; explicit tradeoff required."
+      }
+    ]
+  }
+}
+```
+
+This shows how Topology v0 can expose the fairness–SLO tradeoff as an explicit, machine‑readable
+object (`paradox_field_v0`), rather than burying it in a single scalar score.
+## 5. Paradox atom: Q₃ vs Q₄ (local MUS)
+
+Using multiple configurations with different (α, B) pairs (fairness threshold and SLO budget),
+we can observe a local paradox atom where:
+
+- `q3_fairness_ok` is satisfiable alone (some configs pass),
+- `q4_slo_ok` is satisfiable alone (other configs pass),
+- but **no configuration** in a given (α, B) box satisfies both simultaneously.
+
+Formally, the gate pair `{q3_fairness_ok, q4_slo_ok}` is a minimal unsatisfiable set (MUS)
+over that box.
+
+An example paradox_field_v0 fragment:
+
+```jsonc
+{
+  "paradox_field_v0": {
+    "version": "PULSE_paradox_field_v0",
+    "generated_at_utc": "2025-11-27T00:00:00Z",
+    "atoms": [
+      {
+        "atom_id": "atom_fairness_vs_slo_demo",
+        "gates": ["q3_fairness_ok", "q4_slo_ok"],
+        "minimal": true,
+        "severity": 0.9,
+        "parameter_box": {
+          "fairness_threshold": [0.7, 0.9],
+          "slo_budget_ms": [200, 300]
+        },
+        "comment": "No (alpha, B) combination satisfies both fairness and SLO in this region; explicit tradeoff required."
+      }
+    ]
+  }
+}
+```
+
+This shows how Topology v0 can expose the fairness–SLO tradeoff as an explicit, machine‑readable
+object (`paradox_field_v0`), rather than burying it in a single scalar score.
+## 5. Paradox atom: Q₃ vs Q₄ (local MUS)
+
+Using multiple configurations with different (α, B) pairs (fairness threshold and SLO budget),
+we can observe a local paradox atom where:
+
+- `q3_fairness_ok` is satisfiable alone (some configs pass),
+- `q4_slo_ok` is satisfiable alone (other configs pass),
+- but **no configuration** in a given (α, B) box satisfies both simultaneously.
+
+Formally, the gate pair `{q3_fairness_ok, q4_slo_ok}` is a minimal unsatisfiable set (MUS)
+over that box.
+
+An example paradox_field_v0 fragment:
+
+```jsonc
+{
+  "paradox_field_v0": {
+    "version": "PULSE_paradox_field_v0",
+    "generated_at_utc": "2025-11-27T00:00:00Z",
+    "atoms": [
+      {
+        "atom_id": "atom_fairness_vs_slo_demo",
+        "gates": ["q3_fairness_ok", "q4_slo_ok"],
+        "minimal": true,
+        "severity": 0.9,
+        "parameter_box": {
+          "fairness_threshold": [0.7, 0.9],
+          "slo_budget_ms": [200, 300]
+        },
+        "comment": "No (alpha, B) combination satisfies both fairness and SLO in this region; explicit tradeoff required."
+      }
+    ]
+  }
+}
+```
+
+This shows how Topology v0 can expose the fairness–SLO tradeoff as an explicit, machine‑readable
+object (`paradox_field_v0`), rather than burying it in a single scalar score.
+## 5. Paradox atom: Q₃ vs Q₄ (local MUS)
+
+Using multiple configurations with different (α, B) pairs (fairness threshold and SLO budget),
+we can observe a local paradox atom where:
+
+- `q3_fairness_ok` is satisfiable alone (some configs pass),
+- `q4_slo_ok` is satisfiable alone (other configs pass),
+- but **no configuration** in a given (α, B) box satisfies both simultaneously.
+
+Formally, the gate pair `{q3_fairness_ok, q4_slo_ok}` is a minimal unsatisfiable set (MUS)
+over that box.
+
+An example paradox_field_v0 fragment:
+
+```jsonc
+{
+  "paradox_field_v0": {
+    "version": "PULSE_paradox_field_v0",
+    "generated_at_utc": "2025-11-27T00:00:00Z",
+    "atoms": [
+      {
+        "atom_id": "atom_fairness_vs_slo_demo",
+        "gates": ["q3_fairness_ok", "q4_slo_ok"],
+        "minimal": true,
+        "severity": 0.9,
+        "parameter_box": {
+          "fairness_threshold": [0.7, 0.9],
+          "slo_budget_ms": [200, 300]
+        },
+        "comment": "No (alpha, B) combination satisfies both fairness and SLO in this region; explicit tradeoff required."
+      }
+    ]
+  }
+}
+```
+
+This shows how Topology v0 can expose the fairness–SLO tradeoff as an explicit, machine‑readable
+object (`paradox_field_v0`), rather than burying it in a single scalar score.
+
+5. Paradox atom: Q₃ vs Q₄ (local MUS)
+
+Using multiple configurations with different (α, B) pairs (fairness threshold and SLO budget),
+we can observe a local paradox atom where:
+
+q3_fairness_ok is satisfiable alone (some configs pass),
+
+q4_slo_ok is satisfiable alone (other configs pass),
+
+but no configuration in a given (α, B) box satisfies both simultaneously.
+
+Formally, the gate pair {q3_fairness_ok, q4_slo_ok} is a minimal unsatisfiable set (MUS)
+over that box.
+
+'''
+{
+  "paradox_field_v0": {
+    "version": "PULSE_paradox_field_v0",
+    "generated_at_utc": "2025-11-27T00:00:00Z",
+    "atoms": [
+      {
+        "atom_id": "atom_fairness_vs_slo_demo",
+        "gates": ["q3_fairness_ok", "q4_slo_ok"],
+        "minimal": true,
+        "severity": 0.9,
+        "parameter_box": {
+          "fairness_threshold": [0.7, 0.9],
+          "slo_budget_ms": [200, 300]
+        },
+        "comment": "No (alpha, B) combination satisfies both fairness and SLO in this region; explicit tradeoff required."
+      }
+    ]
+  }
+}
+
+An example paradox_field_v0 fragment:


### PR DESCRIPTION
## Summary

This PR extends the Topology v0 mini example doc:

- `docs/PULSE_topology_v0_mini_example_fairness_slo_epf.md`

A new section ("5. Paradox atom: Q3 vs Q4 (local MUS)") is added to describe:

- how `q3_fairness_ok` and `q4_slo_ok` can form a local paradox atom
  (minimal unsatisfiable set) over a small (alpha, B) box, and
- how this maps into a `paradox_field_v0` fragment.

The section ends with a short sentence explaining that Topology v0 exposes the
fairness–SLO tradeoff as an explicit, machine-readable object instead of a
single scalar score.

## Motivation

- Connect the earlier 2x2 cell example (fairness, SLO, EPF) to the new
  `paradox_field_v0` schema.
- Give readers a concrete, narrative explanation of what a "paradox atom"
  means in the fairness–SLO context.

## What’s included

- Doc update only:
  - new Section 5 in
    `docs/PULSE_topology_v0_mini_example_fairness_slo_epf.md`,
    including the Q3 vs Q4 paradox atom description and closing sentence.

## Compatibility / Risk

- Documentation-only.
- No changes to PULSE_safe_pack_v0 tools, schemas already merged, or CI.

## Testing

- Previewed the markdown rendering in GitHub’s editor to ensure headings and
  lists render correctly.
