### PR TITLE
fix: use status.gates in pulse_decision_engine_v0

### DIFF
--- a/PULSE_safe_pack_v0/tools/pulse_decision_engine_v0.py
+++ b/PULSE_safe_pack_v0/tools/pulse_decision_engine_v0.py
@@ -55,12 +55,19 @@ def _summarise_status(status: Dict[str, Any]) -> Dict[str, Any]:
       - failed_gates[]
       - passed_gates[]
       - optional RDSI-ish metrics if present.
-    """
-    results = status.get("results", {})
-    if not isinstance(results, dict):
-        results = {}
 
-    gates = _collect_gates_from_results(results)
+    For pack-generated artefacts, gate flags live under top-level 'gates'.
+    We fall back to 'results' for any older/alternative shapes.
+    """
+    # Prefer the pack's top-level 'gates' block if present.
+    gates_root = status.get("gates")
+    if not isinstance(gates_root, dict):
+        # Fallback: some experimental runs may still use 'results'.
+        gates_root = status.get("results")
+        if not isinstance(gates_root, dict):
+            gates_root = {}
+
+    gates = _collect_gates_from_results(gates_root)
     total = len(gates)
     failed = [name for name, ok in gates.items() if not ok]
     passed = [name for name, ok in gates.items() if ok]


### PR DESCRIPTION
## Summary

This PR fixes how `pulse_decision_engine_v0` reads gate flags from PULSE
status artefacts.

Previously, the decision engine only looked under `status["results"]` for
boolean gate flags. However, `tools/run_all.py` and the CI workflows write
gate flags under the top-level `gates` block in `status.json`. As a result:

- pack-generated status.json artefacts had `gate_count = 0`,
- `release_state` and `stability_type` were always `UNKNOWN`,
- the diagnostic overlay did not reflect real gate outcomes.

## Changes

In `_summarise_status(status)`:

- prefer `status["gates"]` as the source of gate flags (pack/CI shape),
- fall back to `status["results"]` only if `gates` is missing,
- keep the rest of the summarisation logic unchanged.

This aligns the decision engine with the pack’s actual status.json contract.

## Motivation

- Make Decision Engine v0 usable on real PULSE runs produced by the safe pack
  and CI workflows.
- Ensure that `release_state` and `stability_type` in `decision_engine_v0`
  match the underlying gate field instead of being permanently `UNKNOWN`.

## Compatibility / Risk

- Behaviour change is limited to `pulse_decision_engine_v0` diagnostics.
- Core `check_gates.py`, gate definitions and CI behaviour remain unchanged.
- Artefacts that use a `results` block instead of `gates` are still supported
  via the fallback.

## Testing

- Ran `pulse_decision_engine_v0.py` locally on:
  - a status.json with top-level `gates` → non-zero gate_count and expected
    release_state / stability_type,
  - a synthetic status.json with only `results` → still recognised via the
    fallback.
