### PR TITLE
docs: add Topology v0 + Decision Engine v0 quickstart

### DIFF
--- a/docs/PULSE_topology_v0_quickstart_decision_engine_v0.md
+++ b/docs/PULSE_topology_v0_quickstart_decision_engine_v0.md
@@ -60,6 +60,15 @@ atoms[] are paradox atoms (local MUS over gates).
 
 severity is a simple [0,1] score for how “hard” the paradox is.
 
+
+3. Step 2 — Build a stability_map_v0 demo
+
+For a real production pipeline, stability_map_v0 would be computed from
+multiple runs and perturbations. As a simple reference, the pack ships a
+small demo builder for the fairness–SLO–EPF mini cell.
+
+Run:
+
 python PULSE_safe_pack_v0/tools/pulse_stability_map_demo_v0.py ^
   --output PULSE_safe_pack_v0/artifacts/stability_map_v0_demo.json
 


### PR DESCRIPTION
## Summary

This PR adds an end-to-end quickstart for the Topology v0 overlays and
Decision Engine v0:

- `docs/PULSE_topology_v0_quickstart_decision_engine_v0.md`

The doc shows how to:

1. Mine paradox atoms into `paradox_field_v0.json` using
   `pulse_paradox_atoms_v0.py`.
2. Build a small `stability_map_v0_demo.json` using
   `pulse_stability_map_demo_v0.py`.
3. Combine `status.json`, `stability_map_v0` and `paradox_field_v0` into
   a `decision_engine_v0.json` using `pulse_decision_engine_v0.py`.
4. Interpret `release_state` and `stability_type`.

## Motivation

- Connect the individual Topology v0 tools into a single, copy-pasteable
  workflow.
- Give users a concrete reference for running the overlays on top of an
  existing PULSE status artefact.
- Clarify that these tools are diagnostic overlays and do not change core
  gating or CI.

## What’s included

- New doc:
  - `docs/PULSE_topology_v0_quickstart_decision_engine_v0.md`

No code or schema changes.

## Compatibility / Risk

- Documentation-only.
- No changes to PULSE_safe_pack_v0, schemas or CI workflows.

## Testing

- Previewed the markdown locally/in GitHub to verify headings and code
  blocks render correctly.
