### PR TITLE
ci: add pulse_topology_v0 demo workflow

### DIFF
--- a/.github/workflows/pulse_topology_v0.yml
+++ b/.github/workflows/pulse_topology_v0.yml
@@ -1,0 +1,67 @@
+name: PULSE Topology v0 (demo stack)
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "PULSE_safe_pack_v0/**"
+      - "schemas/**"
+      - "docs/**"
+      - ".github/workflows/pulse_topology_v0.yml"
+  pull_request:
+    paths:
+      - "PULSE_safe_pack_v0/**"
+      - "schemas/**"
+      - "docs/**"
+      - ".github/workflows/pulse_topology_v0.yml"
+
+jobs:
+  topology_v0:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Run PULSE safe pack (status.json)
+        run: |
+          python PULSE_safe_pack_v0/tools/run_all.py
+
+      - name: Build paradox_field_v0
+        run: |
+          python PULSE_safe_pack_v0/tools/pulse_paradox_atoms_v0.py \
+            --status-dir PULSE_safe_pack_v0/artifacts \
+            --output PULSE_safe_pack_v0/artifacts/paradox_field_v0.json \
+            --max-atom-size 4
+
+      - name: Build stability_map_v0 demo
+        run: |
+          python PULSE_safe_pack_v0/tools/pulse_stability_map_demo_v0.py \
+            --output PULSE_safe_pack_v0/artifacts/stability_map_v0_demo.json
+
+      - name: Build decision_engine_v0 overlay
+        run: |
+          python PULSE_safe_pack_v0/tools/pulse_decision_engine_v0.py \
+            --status PULSE_safe_pack_v0/artifacts/status.json \
+            --stability-map PULSE_safe_pack_v0/artifacts/stability_map_v0_demo.json \
+            --paradox-field PULSE_safe_pack_v0/artifacts/paradox_field_v0.json \
+            --output PULSE_safe_pack_v0/artifacts/decision_engine_v0.json
+
+      - name: Upload topology artefacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pulse-topology-v0
+          path: |
+            PULSE_safe_pack_v0/artifacts/paradox_field_v0.json
+            PULSE_safe_pack_v0/artifacts/stability_map_v0_demo.json
+            PULSE_safe_pack_v0/artifacts/decision_engine_v0.json


### PR DESCRIPTION
## Summary

This PR introduces a separate, non-blocking CI workflow for the Topology v0
stack:

- `.github/workflows/pulse_topology_v0.yml`

The workflow runs the safe pack to produce `status.json`, then builds:

- `paradox_field_v0.json` via `pulse_paradox_atoms_v0.py`,
- `stability_map_v0_demo.json` via `pulse_stability_map_demo_v0.py`,
- `decision_engine_v0.json` via `pulse_decision_engine_v0.py`,

and uploads them as a single CI artifact (`pulse-topology-v0`).

## Details

Workflow triggers:

- `workflow_dispatch` (manual runs),
- `push` and `pull_request` on:
  - `PULSE_safe_pack_v0/**`,
  - `schemas/**`,
  - `docs/**`,
  - `.github/workflows/pulse_topology_v0.yml`.

Job steps:

1. Checkout repo and set up Python (3.11, pip cache).
2. Install dependencies from `requirements.txt`.
3. Run `PULSE_safe_pack_v0/tools/run_all.py` to generate `status.json`.
4. Run:
   - `pulse_paradox_atoms_v0.py` → `paradox_field_v0.json`.
   - `pulse_stability_map_demo_v0.py` → `stability_map_v0_demo.json`.
   - `pulse_decision_engine_v0.py` → `decision_engine_v0.json`.
5. Upload all three JSON overlays as a `pulse-topology-v0` artifact.

## Motivation

- Make the Topology v0 stack (paradox_field_v0 + stability_map_v0 demo +
  decision_engine_v0) reproducible in CI without changing core release gates.
- Provide a ready-made artefact bundle for dashboards and governance tooling.

## Compatibility / Risk

- New workflow only; no changes to `.github/workflows/pulse_ci.yml`.
- Does not enforce any gates or block PRs.
- Safe to enable on public branches; can be made optional in branch
  protection rules if desired.

## Testing

- Verified the workflow shape locally (YAML lint) and that the commands match
  the existing tools:
  - `pulse_paradox_atoms_v0.py`
  - `pulse_stability_map_demo_v0.py`
  - `pulse_decision_engine_v0.py`.
- On CI, the first run should produce a `pulse-topology-v0` artifact containing
  the three JSON files under `PULSE_safe_pack_v0/artifacts/`.
