### PR TITLE
ci: extend topology demo workflow with Topology v0 overlays

### DIFF
--- a/.github/workflows/pulse_topology_demo.yml
+++ b/.github/workflows/pulse_topology_demo.yml
@@ -76,8 +76,23 @@ jobs:
           python PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py \
             --schema schemas/PULSE_decision_trace_v0.schema.json \
             PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json
+      - name: Build paradox_field_v0 (demo)
+        run: |
+          python PULSE_safe_pack_v0/tools/pulse_paradox_atoms_v0.py \
+            --status-dir PULSE_safe_pack_v0/artifacts \
+            --output PULSE_safe_pack_v0/artifacts/paradox_field_v0.demo.ci.json \
+            --max-atom-size 4
 
-      - name: Upload topology demo artefacts
+      - name: Build decision_engine_v0 overlay (demo)
+        run: |
+          python PULSE_safe_pack_v0/tools/pulse_decision_engine_v0.py \
+            --status PULSE_safe_pack_v0/artifacts/status.json \
+            --stability-map PULSE_safe_pack_v0/artifacts/stability_map.demo.ci.json \
+            --paradox-field PULSE_safe_pack_v0/artifacts/paradox_field_v0.demo.ci.json \
+            --output PULSE_safe_pack_v0/artifacts/decision_engine_v0.demo.ci.json
+
+      
+          - name: Upload topology demo artefacts
         uses: actions/upload-artifact@v4
         with:
           name: pulse-topology-demo
@@ -85,3 +100,8 @@ jobs:
             PULSE_safe_pack_v0/artifacts/stability_map.demo.ci.json
             PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json
             PULSE_safe_pack_v0/artifacts/dual_view_v0.demo.ci.json
+            PULSE_safe_pack_v0/artifacts/paradox_field_v0.demo.ci.json
+            PULSE_safe_pack_v0/artifacts/decision_engine_v0.demo.ci.json
+   
+       
+


### PR DESCRIPTION
## Summary

This PR extends the existing `pulse-topology-demo` workflow to also build the
new Topology v0 overlays:

- `paradox_field_v0.demo.ci.json` via `pulse_paradox_atoms_v0.py`
- `decision_engine_v0.demo.ci.json` via `pulse_decision_engine_v0.py`

on top of the existing stability_map / decision_trace / dual_view demo artefacts.

## Details

In `.github/workflows/pulse_topology_demo.yml`:

- After generating `stability_map.demo.ci.json` and copying demo status
  artefacts, we now:
  - run `pulse_paradox_atoms_v0.py` over `PULSE_safe_pack_v0/artifacts/` to
    produce `paradox_field_v0.demo.ci.json`,
  - run `pulse_decision_engine_v0.py` with:
    - `--status` = `status.json`,
    - `--stability-map` = `stability_map.demo.ci.json`,
    - `--paradox-field` = `paradox_field_v0.demo.ci.json`,
    to produce `decision_engine_v0.demo.ci.json`.

- The upload step is updated to include:
  - `paradox_field_v0.demo.ci.json`
  - `decision_engine_v0.demo.ci.json`
  in the `pulse-topology-demo` artifact, next to:
  - `stability_map.demo.ci.json`
  - `decision_trace.demo.ci.json`
  - `dual_view_v0.demo.ci.json`.

## Motivation

- Integrate the new Topology v0 stack (paradox_field_v0 + decision_engine_v0)
  into the existing topology demo CI pipeline, so a single workflow produces
  all artefacts for dashboards and analysis.
- Keep everything non-blocking and demo-only; core CI still relies on the
  main PULSE workflows.

## Compatibility / Risk

- CI-only change.
- The `pulse-topology-demo` workflow remains non-blocking and uses the same
  synthetic status artefacts under `docs/examples/topology_demo_v0/`.
- No changes to `pulse_ci.yml` or gate enforcement.

## Testing

- Verified that the new tools are called with the same paths used in local
  docs examples (PULSE_safe_pack_v0/tools/pulse_paradox_atoms_v0.py and
  pulse_decision_engine_v0.py).
- First CI run of this workflow should now produce a `pulse-topology-demo`
  artifact containing five JSON files (stability_map, decision_trace,
  dual_view, paradox_field_v0, decision_engine_v0).
