### PR TITLE
ci: restore topology demo workflow with Topology v0 overlays

### DIFF
--- a/.github/workflows/pulse_topology_demo.yml
+++ b/.github/workflows/pulse_topology_demo.yml
@@ -76,23 +76,8 @@ jobs:
           python PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py \
             --schema schemas/PULSE_decision_trace_v0.schema.json \
             PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json
-      - name: Build paradox_field_v0 (demo)
-        run: |
-          python PULSE_safe_pack_v0/tools/pulse_paradox_atoms_v0.py \
-            --status-dir PULSE_safe_pack_v0/artifacts \
-            --output PULSE_safe_pack_v0/artifacts/paradox_field_v0.demo.ci.json \
-            --max-atom-size 4
 
-      - name: Build decision_engine_v0 overlay (demo)
-        run: |
-          python PULSE_safe_pack_v0/tools/pulse_decision_engine_v0.py \
-            --status PULSE_safe_pack_v0/artifacts/status.json \
-            --stability-map PULSE_safe_pack_v0/artifacts/stability_map.demo.ci.json \
-            --paradox-field PULSE_safe_pack_v0/artifacts/paradox_field_v0.demo.ci.json \
-            --output PULSE_safe_pack_v0/artifacts/decision_engine_v0.demo.ci.json
-
-      
-          - name: Upload topology demo artefacts
+      - name: Upload topology demo artefacts
         uses: actions/upload-artifact@v4
         with:
           name: pulse-topology-demo
@@ -100,8 +85,3 @@ jobs:
             PULSE_safe_pack_v0/artifacts/stability_map.demo.ci.json
             PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json
             PULSE_safe_pack_v0/artifacts/dual_view_v0.demo.ci.json
-            PULSE_safe_pack_v0/artifacts/paradox_field_v0.demo.ci.json
-            PULSE_safe_pack_v0/artifacts/decision_engine_v0.demo.ci.json
-   
-       
-


### PR DESCRIPTION
- Restore .github/workflows/pulse_topology_demo.yml after accidental edits.
- The workflow runs the existing topology demo pipeline (stability_map.demo.ci.json + decision_trace.demo.ci.json + dual_view_v0.demo.ci.json), validates them against the schemas and uploads them as the pulse-topology-demo artifact.
- No changes to the new Topology v0 stack; this only recovers the original demo workflow.

<!-- PULSE PR Template v1.0 — keep sections; fill what applies. -->

## Summary
<!-- Short: what changes and why? -->

## What’s included
- [ ] Code
- [ ] Docs
- [ ] CI / workflow
- Paths / files touched:

## CI usage
```yaml
# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json
```

## Impact
- Additive / backwards-compatible
- Breaking change — details:
- Performance / SLO impact:
- Security considerations:

## Notes
- Follow-ups:
- Risks / mitigations:

## PULSE checklist (governance)
- [ ] PULSE CI is green on this PR
- [ ] Quality Ledger link (if enabled)
- [ ] Badges updated (PASS / RDSI / Q‑Ledger)
