### PR TITLE
ci: replace topology_v0 workflow with clean demo stack

### DIFF
--- a/.github/workflows/pulse_topology_v0.yml
+++ b/.github/workflows/pulse_topology_v0.yml
@@ -59,27 +59,19 @@ jobs:
           python "$SCRIPT" \
             --output PULSE_safe_pack_v0/artifacts/stability_map_v0_demo.ci.json
 
-      - name: Build decision_engine_v0 overlay (best-effort)
+      - name: Build decision_engine_v0 overlay
         run: |
-          STATUS_PATH="PULSE_safe_pack_v0/artifacts/status.json"
-          STAB_PATH="PULSE_safe_pack_v0/artifacts/stability_map_v0_demo.ci.json"
-          PARADOX_PATH="PULSE_safe_pack_v0/artifacts/paradox_field_v0.ci.json"
-          OUT_PATH="PULSE_safe_pack_v0/artifacts/decision_engine_v0.ci.json"
-
-          CMD="python PULSE_safe_pack_v0/tools/pulse_decision_engine_v0.py \
-            --status \"$STATUS_PATH\" \
-            --stability-map \"$STAB_PATH\" \
-            --output \"$OUT_PATH\""
-
-          if [ -f "$PARADOX_PATH" ]; then
-            echo "[topology_v0] using paradox field at $PARADOX_PATH"
-            CMD="$CMD --paradox-field \"$PARADOX_PATH\""
+          if [ -f PULSE_safe_pack_v0/tools/pulse_decision_engine_v0.py ]; then
+            SCRIPT="PULSE_safe_pack_v0/tools/pulse_decision_engine_v0.py"
           else
-            echo "[topology_v0] WARNING: paradox_field_v0.ci.json not found; running decision engine without paradox overlay"
+            SCRIPT="PULSE_safe_pack_v0/tools/PULSE_safe_pack_v0/tools/pulse_decision_engine_v0.py"
           fi
-
-          eval $CMD
-
+          echo "[topology_v0] using decision_engine_v0 tool at $SCRIPT"
+          python "$SCRIPT" \
+            --status PULSE_safe_pack_v0/artifacts/status.json \
+            --stability-map PULSE_safe_pack_v0/artifacts/stability_map_v0_demo.ci.json \
+            --paradox-field PULSE_safe_pack_v0/artifacts/paradox_field_v0.ci.json \
+            --output PULSE_safe_pack_v0/artifacts/decision_engine_v0.ci.json
 
       - name: Upload topology v0 artefacts
         uses: actions/upload-artifact@v4
@@ -90,5 +82,3 @@ jobs:
             PULSE_safe_pack_v0/artifacts/paradox_field_v0.ci.json
             PULSE_safe_pack_v0/artifacts/stability_map_v0_demo.ci.json
             PULSE_safe_pack_v0/artifacts/decision_engine_v0.ci.json
-
- 


### PR DESCRIPTION
## Summary

This PR replaces the `pulse_topology_v0.yml` workflow with a clean, consistent
demo stack for Topology v0.

The new workflow:

- runs the PULSE safe pack to produce `status.json`,
- builds `paradox_field_v0.ci.json` using the paradox atoms tool,
- builds `stability_map_v0_demo.ci.json` using the stability map demo tool,
- builds `decision_engine_v0.ci.json` using the decision engine v0 tool,
- uploads all artefacts as a single `pulse-topology-v0` CI artefact.

## Details

In `.github/workflows/pulse_topology_v0.yml`:

- remove previous partial edits and replace the job with a single
  `topology_v0` job that:
  - uses robust script path selection for:
    - `pulse_paradox_atoms_v0.py`
    - `pulse_stability_map_demo_v0.py`
    - `pulse_decision_engine_v0.py`
    (canonical tools path first, nested path as fallback),
  - writes the paradox field to `PULSE_safe_pack_v0/artifacts/paradox_field_v0.ci.json`,
  - writes the stability map demo to
    `PULSE_safe_pack_v0/artifacts/stability_map_v0_demo.ci.json`,
  - writes the decision engine overlay to
    `PULSE_safe_pack_v0/artifacts/decision_engine_v0.ci.json`.

- keep file naming consistent across:
  - build steps,
  - decision engine inputs,
  - and the upload-artifact step.

## Motivation

- Undo several incremental fixes and replace them with a single, coherent
  workflow definition.
- Ensure that the Topology v0 CI job:
  - no longer fails on missing or mismatched artefact names,
  - always produces a self-contained artefact bundle for dashboards and
    analysis.

## Risk / Compatibility

- CI-only change; no impact on core PULSE gates or the main `pulse_ci.yml`.
- The workflow remains non-blocking and is only used for the Topology v0
  demo stack.
