### PR TITLE
docs: link Topology v0 CLI demo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,9 @@ For a detailed walkthrough, see:
 
 - `docs/PULSE_topology_v0_mini_example_fairness_slo_epf.md`  
 - `docs/PULSE_topology_v0_quickstart_decision_engine_v0.md`
+- `docs/PULSE_topology_v0_mini_example_fairness_slo_epf.md`  
+- `docs/PULSE_topology_v0_quickstart_decision_engine_v0.md`  
+- `docs/PULSE_topology_v0_cli_demo.md`
 
 
 **Future Library index**


### PR DESCRIPTION
## Summary

This PR wires the new Topology v0 CLI demo into the main README:

- Adds `docs/PULSE_topology_v0_cli_demo.md` to the list of Topology v0 docs
  under the "Topology v0 and Decision Engine v0" section.

## Motivation

The CLI demo shows how to run the Topology v0 stack (paradox_field_v0,
stability_map_v0 demo, decision_engine_v0) entirely from the command line,
without touching CI workflows.

Linking it from README makes it easy for users to:

- discover the CLI path alongside:
  - the mini fairness–SLO–EPF example, and
  - the decision engine quickstart,
- and quickly see how to get real artefacts (paradox field + decision engine)
  out of an existing PULSE status artefact.

## What’s changed

- `README.md`
  - Add `docs/PULSE_topology_v0_cli_demo.md` to the Topology v0 docs list.

No changes to:

- PULSE_safe_pack_v0,
- schemas,
- or CI workflows.

## Risk / Compatibility

- Documentation-only change.
- No impact on gate definitions or existing CI.
