### PR TITLE
docs: link Topology v0 governance patterns from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,11 +339,9 @@ not for core gating. The source of truth for release decisions remains
 For a detailed walkthrough, see:
 
 - `docs/PULSE_topology_v0_mini_example_fairness_slo_epf.md`  
-- `docs/PULSE_topology_v0_quickstart_decision_engine_v0.md`
-- `docs/PULSE_topology_v0_mini_example_fairness_slo_epf.md`  
 - `docs/PULSE_topology_v0_quickstart_decision_engine_v0.md`  
 - `docs/PULSE_topology_v0_cli_demo.md`
-
+- `docs/PULSE_topology_v0_governance_patterns.md`
 
 **Future Library index**
 


### PR DESCRIPTION
## Summary

This PR wires the new governance-focused Topology v0 doc into the main README:

- Adds `docs/PULSE_topology_v0_governance_patterns.md` to the list of
  Topology v0 docs under the "Topology v0 and Decision Engine v0" section.

## Motivation

`PULSE_topology_v0_governance_patterns.md` describes how to use the Topology v0
stack (status, paradox_field_v0, stability_map_v0, decision_engine_v0) in
release boards and dashboards, especially via `release_state` and
`stability_type`.

Linking it from README ensures that:

- users discover the governance patterns alongside:
  - the mini fairness–SLO–EPF example,
  - the decision engine quickstart, and
  - the CLI demo.

## What changed

- `README.md`
  - Add `docs/PULSE_topology_v0_governance_patterns.md` as an additional
    bullet in the Topology v0 docs list.

No changes to:

- PULSE_safe_pack_v0 tools,
- schemas,
- or CI workflows.

## Risk / Compatibility

- Documentation-only change.
- No impact on gate definitions or existing CI.
