### PR TITLE
docs: add Pulse Demo v1 paradox stability showcase

### DIFF
--- a/docs/PULSE_demo_v1_paradox_stability_showcase.md
+++ b/docs/PULSE_demo_v1_paradox_stability_showcase.md
@@ -1,0 +1,261 @@
+# PULSE Demo v1 — The missing architecture (paradox stability showcase)
+
+This document describes a minimal, demonstrable "Pulse Demo v1":
+
+- not just theory or prose,
+- but a **demonstration template** that can later be turned into:
+  - a GitHub notebook,
+  - a Kaggle demo,
+  - and a Pro forma artefact.
+
+The demo focuses on a single phenomenon:
+
+> A paradox where classical scaling and classical AI models become unstable,
+> but PULSE remains stable and can *measure* this stability.
+
+---
+
+## 1. Goal
+
+The demo is designed to show a behaviour that:
+
+- classical LLMs and scaling **cannot** handle cleanly:
+  - paradox,
+  - unstable decision surfaces,
+  - meta-level inconsistency,
+  - direction errors,
+  - field-stability issues,
+
+while:
+
+- PULSE:
+  - stays **stable** in the paradox regime,
+  - exposes a **decision field** instead of a single label,
+  - and provides **field metrics** (RDSI, EPF tension, Δ-direction error).
+
+This is not another model, another eval, or another score.
+It is a demonstration of a **missing architecture layer**.
+
+---
+
+## 2. Part 1 — The paradox where classical AI breaks
+
+### 2.1. The question
+
+A simple, well-known paradoxical prompt to any large model:
+
+> “The sentence you are reading right now is false.  
+> Is this statement true or false?”
+
+### 2.2. Expected classical behaviour
+
+Empirically and conceptually, large models tend to exhibit:
+
+- **unstable answers**
+  - sometimes “true”, sometimes “false”,
+  - sometimes “both” or switching under small rephrasing.
+
+- **oscillation between truth values**
+  - true → false → true → … across runs or paraphrases.
+
+- **long, evasive explanations**
+  - meta-talk about “self-reference”
+  - without a concrete, stable classification.
+
+- **occasional failures**
+  - confusion,
+  - internal inconsistency between explanation and final answer.
+
+This is where scaling runs into a wall:
+
+- more parameters, more data, more RLHF do not remove the paradox,
+- they often just make the explanation *longer*.
+
+The underlying issue:
+
+> The model is implicitly forced into a **binary decision** (true/false)  
+> in a region of the decision field that is **structurally paradoxical**.
+
+---
+
+## 3. Part 2 — A Pulse-style stable response
+
+The Pulse demo does **not** try to force a binary answer.  
+Instead, it recognises that we are in a **paradox field region**.
+
+A short, demonstrative Pulse-style response:
+
+> “This is a self-referential paradox.  
+> The decision is not a binary true/false classification, but a field state.  
+>  
+> The path ‘true → false’ and the path ‘false → true’ form an unstable  
+> double cycle.  
+>  
+> The stable region is a PARADOX STATE, where the two values mutually  
+> maintain each other.  
+>  
+> → Pulse-field result: paradox-true (paradox acknowledged and stabilised).”
+
+Key idea:
+
+- We move from:
+  - “Is the sentence *true*?”  
+  to:
+  - “**What is the stable region of the decision field around this sentence?**”
+
+The Pulse answer is:
+
+- **stable** (it does not oscillate between “true” and “false”),
+- **field-aware** (speaks about paths, cycles, region),
+- and explicitly marks a **paradox state**.
+
+---
+
+## 4. Part 3 — The Pulse measurement layer
+
+The real breakthrough is not only that Pulse answers stably,
+but that it can **measure** and expose the stability of this paradox region.
+
+The demo assumes a small set of *field metrics*:
+
+- **RDSI – Release Decision Stability Index**
+- **EPF shadow field tension**
+- **Δ-direction error**
+- **Meta-state signal**
+
+The specific numeric values in the demo are illustrative, not yet tied to a
+concrete implementation — they are part of the *template*.
+
+### 4.1. RDSI — Release Decision Stability Index
+
+A scalar in `[0, 1]`:
+
+- `0` → completely unstable decision region (chaotic, oscillatory),
+- `1` → fully stabilised decision region.
+
+In the demo:
+
+- `RDSI = 0.91`
+
+Interpretation:
+
+- the paradox region is **stably encoded** as a paradox state,
+- no oscillation between “true” and “false”,
+- repeated queries in the same context converge to the same field state.
+
+### 4.2. EPF shadow field tension
+
+EPF (Evaluation / Paradox Frontier) is a conceptual “shadow field”:
+
+- it describes:
+  - how much **latent tension** there is in the field around the decision,
+  - even when outputs look superficially calm.
+
+In the demo:
+
+- EPF tension is **low**:
+
+  > “Low EPF tension — the local field does not ‘heat up’,  
+  > the model does not disintegrate under the paradox.”
+
+Interpretation:
+
+- the paradox is acknowledged and “parked” in a dedicated field region,
+- the surrounding decision field stays calm.
+
+### 4.3. Δ-direction error
+
+A directional error signal:
+
+- measures how much the model tries to “escape” the paradox by:
+  - drifting toward “true”,
+  - or drifting toward “false”,
+  - instead of staying in the paradox state.
+
+In the demo:
+
+- `Δ-direction error = 0.03`
+
+Interpretation:
+
+- almost no directional drift:
+  - the model is not trying to “run away” in one direction,
+  - the paradox state is accepted as a stable point.
+
+### 4.4. Meta-state signal
+
+A concise meta-label for the field:
+
+- e.g. `"paradox_field_stabilised"`.
+
+In the demo:
+
+> Meta-signal: `"paradox-field / stabilised"`
+
+Interpretation:
+
+- the system recognises:
+  - “I am in a paradox decision field,”
+  - “this is not a normal true/false region,”
+  - “and the paradox has been stabilised as such.”
+
+This is the layer many researchers have been intuitively searching for:
+a meta-state where the system *knows* it is in a paradox field and does
+not try to flatten it to a single bit.
+
+---
+
+## 5. Part 4 — Three-line summary of the demo
+
+This is the short version aimed at the wider technical audience:
+
+1. **Classical models collapse under paradox**  
+   – oscillation, inconsistency, or evasive explanations.
+
+2. **Pulse gives a stable, field-level decision**  
+   – it moves from “true/false” to a “paradox state” in the decision field.
+
+3. **Pulse *measures* this stability**  
+   – via RDSI, EPF shadow tension, and Δ-direction error, plus a meta-state.
+
+This is not just a different answer.
+It is a demonstration that:
+
+> “There exists an architecture layer above classical scaling that handles
+> paradoxical and unstable regions as explicit field structures.”
+
+---
+
+## 6. Part 5 — Towards Demo v2
+
+Pulse Demo v1 is intentionally minimal:
+
+- one paradox,
+- one field-level answer,
+- a small set of illustrative metrics.
+
+A Demo v2 can add:
+
+- a **visual RDSI curve**  
+  – showing stability across multiple runs / perturbations.
+- an **EPF heatmap**  
+  – showing how tension varies across neighbouring prompts / conditions.
+- a **Δ-direction error mini-diagram**  
+  – e.g. a vector field showing possible “escape directions”.
+- a `Pulse_demo_v1.ipynb` notebook  
+  – with:
+    - code cells for classical LLM behaviour vs Pulse-style field output,
+    - plots for RDSI, EPF, Δ-direction error,
+    - and a small dashboard-like view.
+
+The present document is the **demonstration template**:
+a compact, portable form that can later be instantiated:
+
+- as a GitHub notebook,
+- as a Kaggle demo,
+- or as a Pro forma artefact,
+without changing the underlying idea:
+
+> PULSE treats paradox as a stable field state,
+> and provides a measurable, feszültségmentes decision field
+> where classical scaling only oscillates.


### PR DESCRIPTION
## Summary

This PR adds a demonstration template for Pulse Demo v1:

- `docs/PULSE_demo_v1_paradox_stability_showcase.md`

The doc describes a paradox scenario (liar sentence) and contrasts
classical LLM behaviour (oscillation, inconsistency) with a Pulse-style
stable, field-level response. It introduces illustrative field metrics
(RDSI, EPF shadow tension, Δ-direction error, meta-state) as the basis
for future notebook and dashboard demos.

## Motivation

The Topology v0 and Decision Engine v0 docs describe:

- how the decision field is structured (paradox_field_v0, stability_map_v0),
- how release_state and stability_type are computed,
- and how governance can use them.

What was missing is a compact, narrative demo that:

- can be shown to others as "Pulse in action",
- focuses on a single paradox where classical models struggle,
- and demonstrates Pulse's ability to stabilise and measure that region.

Pulse Demo v1 is intended as:

- a portable explanation,
- and a template for future artefacts:
  - `Pulse_demo_v1.ipynb`,
  - Kaggle/Pro-forma demos, etc.

## What’s included

- New document:
  - `docs/PULSE_demo_v1_paradox_stability_showcase.md`

No changes to:

- tools,
- schemas,
- or CI workflows.

## Risk / Compatibility

- Documentation-only change.
- Does not claim that the metrics (RDSI, EPF, Δ-direction error) are fully
  implemented yet; they are presented as a demonstration template and
  conceptual target for future work.
