### PR TITLE
docs: link Pulse Demo v1 from README

### DIFF
--- a/docs/PULSE_demo_v1_paradox_stability_showcase.md
+++ b/docs/PULSE_demo_v1_paradox_stability_showcase.md
@@ -253,7 +253,8 @@ a compact, portable form that can later be instantiated:
 
 - as a GitHub notebook,
 - as a Kaggle demo,
-- or as a Pro forma artefact,
+-  or as an artefact in other notebook / dashboard environments,
+
 without changing the underlying idea:
 
 > PULSE treats paradox as a stable field state,


### PR DESCRIPTION
## Summary

This PR wires the new Pulse Demo v1 doc into the main README:

- Adds `docs/PULSE_demo_v1_paradox_stability_showcase.md` to the list of
  Topology v0 / Decision Engine v0 docs.

## Motivation

`PULSE_demo_v1_paradox_stability_showcase.md` is the first compact,
narrative demo that shows:

- how classical models behave on a paradoxical prompt (liar sentence),
- how a Pulse-style decision field response differs,
- and how field-level metrics (RDSI, EPF tension, Δ-direction error,
  meta-state) can quantify stability in that region.

Linking it from README makes this demo easy to discover for anyone
exploring the Topology v0 / Decision Engine v0 stack.

## What changed

- `README.md`
  - Add `docs/PULSE_demo_v1_paradox_stability_showcase.md` as an additional
    bullet under the Topology v0 / Decision Engine v0 docs list.

No changes to:

- PULSE_safe_pack_v0,
- schemas,
- or CI workflows.

## Risk / Compatibility

- Documentation-only change.
- No impact on gate definitions or existing CI.
