### PR TITLE
docs: add Decision Engine v0 unstably_good example

### DIFF
--- a/docs/PULSE_decision_engine_v0_unstably_good_example.md
+++ b/docs/PULSE_decision_engine_v0_unstably_good_example.md
@@ -1,0 +1,69 @@
+# Decision Engine v0 – `unstably_good` example
+
+This document provides a minimal example of a `decision_engine_v0.json`
+snippet where:
+
+- `release_state = "PROD_OK"`
+- `stability_type = "unstably_good"`
+
+The goal is to illustrate how a “green but structurally tense” release
+appears in the Decision Engine v0 overlay.
+
+---
+
+## Example JSON snippet
+
+Below is an example `decision_engine_v0` object inlined as JSON:
+
+    {
+      "decision_engine_v0": {
+        "version": "PULSE_decision_engine_v0",
+        "generated_at_utc": "2025-01-10T12:34:56Z",
+        "inputs": {
+          "status_path": "PULSE_safe_pack_v0/artifacts/status.json",
+          "stability_map_path": "PULSE_safe_pack_v0/artifacts/stability_map_v0_demo.json",
+          "paradox_field_path": "PULSE_safe_pack_v0/artifacts/paradox_field_v0.json"
+        },
+        "release_state": "PROD_OK",
+        "stability_type": "unstably_good",
+        "status_summary": {
+          "gate_count": 42,
+          "failed_gates": [],
+          "passed_gates": [
+            "quality.q3_fairness_ok",
+            "slo.q4_slo_ok"
+          ],
+          "rdsi": 0.94
+        },
+        "stability_summary": {
+          "cell_count": 1,
+          "delta_bend_max": 1.0
+        },
+        "paradox_summary": {
+          "atom_count": 3,
+          "severe_atom_count": 1
+        }
+      }
+    }
+
+### Interpretation
+
+- `release_state = "PROD_OK"`  
+  – all required gates pass; the release is “green” in the usual sense.
+
+- `stability_type = "unstably_good"`  
+  – topology signals (stability map + paradox field) indicate that:
+    - the local decision field is curved (`delta_bend_max > 0`), and/or
+    - there are non-trivial paradox atoms (`atom_count > 0`).
+
+**Intuition:**
+
+> The release is good (PROD_OK), but it lives in a structurally tense
+> region of the decision field. Small changes in data or thresholds may
+> flip the outcome.
+
+This example can be:
+
+- embedded in documentation,
+- used as a reference for dashboards,
+- or as a test fixture for tools that consume `decision_engine_v0` overlays.


### PR DESCRIPTION
## Summary

This PR adds a small example doc for Decision Engine v0:

- `docs/PULSE_decision_engine_v0_unstably_good_example.md`

The doc contains a minimal `decision_engine_v0` JSON snippet where:

- `release_state = "PROD_OK"`
- `stability_type = "unstably_good"`

and a short explanation of how to interpret this combination.

## Motivation

We already have:

- the Decision Engine v0 spec,
- Topology v0 docs,
- a CLI demo,
- governance patterns,
- and the Pulse Demo v1 paradox stability showcase.

What was missing is a concrete, copyable JSON example for one of the key
stability types: `unstably_good` (green but structurally tense).

This example can be reused in:

- dashboards,
- test fixtures,
- further docs and demos.

## What’s included

- New document:
  - `docs/PULSE_decision_engine_v0_unstably_good_example.md`

No changes to:

- PULSE_safe_pack_v0 tools,
- schemas,
- or CI workflows.

## Risk / Compatibility

- Documentation-only change.
- No behavioural impact.
