### PR TITLE
docs: link Decision Engine v0 unstably_bad example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,10 +338,14 @@ not for core gating. The source of truth for release decisions remains
 
 For a detailed walkthrough, see:
 
-- `docs/PULSE_topology_v0_mini_example_fairness_slo_epf.md`  
-- `docs/PULSE_topology_v0_quickstart_decision_engine_v0.md`  
+- `docs/PULSE_topology_v0_mini_example_fairness_slo_epf.md`
+- `docs/PULSE_topology_v0_quickstart_decision_engine_v0.md`
 - `docs/PULSE_topology_v0_cli_demo.md`
 - `docs/PULSE_topology_v0_governance_patterns.md`
+- `docs/PULSE_demo_v1_paradox_stability_showcase.md`
+- `docs/PULSE_decision_engine_v0_unstably_good_example.md`
+- `docs/PULSE_decision_engine_v0_unstably_bad_example.md`
+
 
 **Future Library index**
 


### PR DESCRIPTION
## Summary

This PR wires the new Decision Engine v0 `unstably_bad` example into the
main README:

- Adds `docs/PULSE_decision_engine_v0_unstably_bad_example.md` to the list
  of Topology v0 / Decision Engine v0 docs.

## Motivation

`PULSE_decision_engine_v0_unstably_bad_example.md` provides a minimal,
copyable JSON snippet showing a Decision Engine v0 overlay classified as:

- `release_state = "BLOCK"`
- `stability_type = "unstably_bad"`

Linking it from README makes it easy to find and reuse alongside the
existing `unstably_good` example in dashboards, notebooks, tests, and
further docs.

## What changed

- `README.md`
  - Add `docs/PULSE_decision_engine_v0_unstably_bad_example.md` as an
    additional bullet under the Topology v0 / Decision Engine v0 docs list.

No changes to:

- PULSE_safe_pack_v0 tools,
- schemas,
- or CI workflows.

## Risk / Compatibility

- Documentation-only change.
- No behavioural impact.
