### PR TITLE
docs: link Decision Trace v0 mini example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ For a detailed walkthrough, see:
 - `docs/PULSE_demo_v1_paradox_stability_showcase.md`
 - `docs/PULSE_decision_engine_v0_unstably_good_example.md`
 - `docs/PULSE_decision_engine_v0_unstably_bad_example.md`
+- `docs/PULSE_decision_trace_v0_mini_example.md`
 
 
 **Future Library index**


### PR DESCRIPTION
## Summary

This PR wires the new Decision Trace v0 mini example into the main README:

- Adds `docs/PULSE_decision_trace_v0_mini_example.md` to the list of
  Topology v0 / Decision Engine v0 docs.

## Motivation

`PULSE_decision_trace_v0_mini_example.md` provides a small, schematic
example of a `decision_trace_v0` object showing:

- baseline status evaluation,
- topology overlays (stability map + paradox field),
- final decision with `release_state` and `stability_type`.

Linking it from README makes it easy to discover and reuse alongside the
other Decision Field v0 docs.

## What changed

- `README.md`
  - Add `docs/PULSE_decision_trace_v0_mini_example.md` as an additional
    bullet under the Topology v0 / Decision Engine v0 docs list.

No changes to:

- PULSE_safe_pack_v0 tools,
- schemas,
- or CI workflows.

## Risk / Compatibility

- Documentation-only change.
- No behavioural impact.
