### PR TITLE
docs: link Decision Field v0 5-minute tour from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,8 +336,10 @@ These components are intended for **analysis, dashboards and governance**,
 not for core gating. The source of truth for release decisions remains
 `status.json` + `PULSE_safe_pack_v0/tools/check_gates.py` + the CI workflow.
 
-For a detailed walkthrough, see:
+For a detailed overview and examples, see:
 
+- `docs/PULSE_decision_field_v0_overview.md`
+- `docs/PULSE_decision_field_v0_5_minute_tour.md`
 - `docs/PULSE_topology_v0_mini_example_fairness_slo_epf.md`
 - `docs/PULSE_topology_v0_quickstart_decision_engine_v0.md`
 - `docs/PULSE_topology_v0_cli_demo.md`


### PR DESCRIPTION
## Summary

This PR wires the new Decision Field v0 "5-minute tour" doc into the main
README:

- Adds `docs/PULSE_decision_field_v0_5_minute_tour.md` to the list of
  Decision Field / Topology docs, right after the high-level overview.

## Motivation

`PULSE_decision_field_v0_5_minute_tour.md` provides a very quick, hands-on
introduction to the Decision Field v0 layer:

- run the PULSE safe pack to get `status.json`,
- build `paradox_field_v0.json`,
- run Decision Engine v0 to get `decision_engine_v0.json`.

Linking it from README makes this "just run it" entry point easy to find
for new users, before they dive into the deeper specs and examples.

## What changed

- `README.md`
  - Add `docs/PULSE_decision_field_v0_5_minute_tour.md` to the Decision
    Field / Topology docs list.

No changes to:

- PULSE_safe_pack_v0 tools,
- schemas,
- or CI workflows.

## Risk / Compatibility

- Documentation-only change.
- No behavioural impact.
