### PR TITLE
docs: add PULSE Visual Map v0 iconography

### DIFF
--- a/docs/PULSE_visual_map_v0.md
+++ b/docs/PULSE_visual_map_v0.md
@@ -1,0 +1,259 @@
+# PULSE Visual Map v0 – iconography for the Decision Field
+
+This document defines a small, shared **visual vocabulary** for Pulse
+and the Decision Field v0 layer.
+
+The goal is not to standardise UI design, but to provide **lightweight
+icons and glyphs** that can be reused across:
+
+- docs,
+- slides,
+- lab notes,
+- and demo artefacts.
+
+All icons here are **non-normative**: they are meant as a visual
+language, not as strict design requirements.
+
+---
+
+## 1. Paradox Core Seal
+
+**Icon**
+
+- `[(0 1)_P]`
+
+**Meaning**
+
+> *Paradox origin: two surface values unified into one higher‑order field
+> state (P).*
+
+- `0` and `1` represent a classical Boolean pair.
+- `_P` marks that we are not in plain bit space any more, but in a
+  **paradox-aware field**.
+- The brackets `[...]` indicate a *sealed* unit: the paradox bit-pair is
+  treated as a single state in the Decision Field.
+
+**Typical use**
+
+- Signature mark in docs (e.g. next to “Paradox Field” sections).
+- Optional “core symbol” in diagrams that show paradox origin.
+- GitHub / lab profile tagline element, e.g. in bios or headers.
+
+---
+
+## 2. EPF Mini Icon
+
+**Icon**
+
+- `⦿〰〰〰`
+
+**Meaning**
+
+> *EPF – Evaluation / Paradox Frontier and Energy / Potential Field.*
+
+The icon encodes:
+
+- `⦿` – a source / core,
+- `〰〰〰` – waves or a field radiating outward.
+
+EPF is intentionally **multi-readable**:
+
+- as *Evaluation / Paradox Frontier* (the boundary where evaluation and
+  paradox meet),
+- and as *Energy / Potential Field* (a stability / tension field).
+
+**Typical use**
+
+- Inline marker for EPF-related text.
+- Small icon next to sections that discuss field tension or shadow
+  fields.
+
+---
+
+## 3. Paradox Field Icon
+
+**Icon**
+
+- `⇄`
+
+**Meaning**
+
+> *A and ¬A defining each other inside one field.*
+
+The double arrow expresses:
+
+- mutual dependence,
+- bidirectional constraint,
+- no simple “one way” implication.
+
+It is not “A vs ¬A” as a conflict, but **A ⇄ ¬A** as a structured,
+co‑defining pair in the Decision Field.
+
+**Typical use**
+
+- Before headings and callouts that describe paradox fields.
+- In diagrams to mark regions with active paradox structure.
+
+---
+
+## 4. RDSI Stability Gauge
+
+**Icons**
+
+Three equivalent micro-gauges:
+
+- `◔—◑—◕`
+- `[ ■ ▣ □ ]`
+- `▁▃▆█`
+
+**Meaning**
+
+> *RDSI – Release Decision Stability Index; stability and instability
+> indicators.*
+
+These are all stylised ways of showing **low → medium → high** stability:
+
+- Left side (`◔`, `□`, `▁`) – lower stability / more volatility.
+- Middle (`◑`, `▣`, `▃`) – medium stability.
+- Right side (`◕`, `■`, `█`) – high stability.
+
+No exact numeric mapping is defined here; the icons are meant as:
+
+- small glyphs for legends,
+- visual hints next to RDSI values in mockups or diagrams.
+
+**Typical use**
+
+- Legend elements in diagrams that display RDSI.
+- Inline hints in docs, e.g. “RDSI: 0.91 `◕`”.
+
+---
+
+## 5. Directional Error (Δ)
+
+**Icons**
+
+- `Δ̃`
+- `⇀Δ`
+- `Δ⇁`
+- `ΔΔΔ`
+
+**Meaning**
+
+> *Drift from an ideal paradox-balanced field.*
+
+Directional error is not just a scalar; it can have **direction** and
+**mode**:
+
+- `Δ̃` – small, subtle deviation.
+- `⇀Δ` – drift in one direction (e.g. toward SLO over fairness).
+- `Δ⇁` – drift in the opposite direction.
+- `ΔΔΔ` – oscillatory / unstable behaviour, the system bouncing between
+  directions.
+
+**Typical use**
+
+- In field diagrams to show dominant drift direction.
+- Next to stability analyses when describing *how* the system tries to
+  escape a balanced paradox state.
+
+---
+
+## 6. Pulse Mini-Spiral
+
+**Icons**
+
+- `⟳`
+- `↻`
+- `⟲⟲`
+
+**Meaning**
+
+> *Mini Pulse spiral; dynamic field evolution.*
+
+These icons represent:
+
+- iterative decision cycles,
+- repeated evaluation under changing conditions,
+- the process nature of Pulse (not a one-shot judgement).
+
+**Typical use**
+
+- Next to sections that describe iterative evaluation or repeated
+  releases.
+- In diagrams that show “next pulse / next iteration”.
+
+---
+
+## 7. EP-go1 Icon
+
+**Icons**
+
+- `•⧖●`
+- `•⟶●`
+- `•~●`
+
+**Meaning**
+
+> *Two sources → one field.*
+
+These icons represent:
+
+- two distinct sources (e.g. two models, or two perspectives) that
+  feed into one shared field,
+- or two collaborating agents that co-create a Decision Field.
+
+`•⧖●` can be read as *time / delay / synchronisation* between sources,  
+`•⟶●` as a direct flow,  
+`•~●` as a softer, field-like influence.
+
+**Typical use**
+
+- In lab docs for co-creation setups.
+- As a small emblem for collaborations where multiple systems or
+  modalities define one shared field.
+
+---
+
+## 8. E•Paradox Labs Icon
+
+**Icons**
+
+- `E•P`
+- `⟦E•P⟧`
+
+**Meaning**
+
+> *The lab / workshop signature mark.*
+
+This icon marks:
+
+- artefacts, notes, or experiments that belong to the “E•Paradox Labs”
+  workshop space,
+- without implying that they are stable, production PULSE components.
+
+`⟦E•P⟧` suggests *bracketed*, experimental context.
+
+**Typical use**
+
+- On internal / experimental docs.
+- At the top of lab notebooks or design sketches.
+
+---
+
+## 9. Usage notes
+
+- All icons in this document are **optional**:
+  - they are a shared visual vocabulary,
+  - not binding UI or branding requirements.
+- Different fonts and platforms may render some Unicode glyphs
+  differently (e.g. `⧖`, `⟲`), so it is recommended to:
+  - test the icons in the target environment,
+  - or fall back to simpler ASCII approximations where needed.
+- New icons can be added in future versions (e.g. `PULSE_visual_map_v1`)
+  as the Decision Field and its tooling evolve.
+
+The purpose of **PULSE Visual Map v0** is to make the Decision Field
+recognisable at a glance: even a few small glyphs (`[(0 1)_P]`,
+`⇄`, `⦿〰〰〰`, `◔—◑—◕`) should be enough to signal that we are inside
+the Pulse field-language, not a generic metrics dashboard.


### PR DESCRIPTION
## Summary

This PR adds a visual-identity / iconography document for the Decision
Field v0 layer:

- `docs/PULSE_visual_map_v0.md`

The doc defines a v0 "visual map" of small icons for:

- paradox core seal (`[(0 1)_P]`),
- EPF mini icon (`⦿〰〰〰`),
- paradox field (`⇄`),
- RDSI stability gauge (`◔—◑—◕`, `[ ■ ▣ □ ]`, `▁▃▆█`),
- directional error (Δ),
- Pulse mini-spiral,
- EP-go1,
- and the E•Paradox Labs mark.

## Motivation

Pulse is not only a set of tools and schemas but also a distinct
field-level way of thinking about releases (paradox fields, EPF,
RDSI, Δ-direction error, etc.). Having a small, shared icon vocabulary
helps:

- make docs and slides visually coherent,
- signal "we are in the Pulse field-language", not a generic metrics
  dashboard,
- give lab artefacts (notes, sketches) a lightweight, recognisable
  signature.

## What changed

- New document:
  - `docs/PULSE_visual_map_v0.md`

No changes to:

- PULSE_safe_pack_v0 tools,
- schemas,
- or CI workflows.

## Risk / Compatibility

- Documentation-only change.
- Icons are explicitly non-normative and optional.
