### PR TITLE
docs: clarify profile layout and CI policy source

### DIFF
--- a/profiles/README.md
+++ b/profiles/README.md
@@ -1,0 +1,34 @@
+# Profiles and gate policies
+
+This directory contains **example profiles and policy variants** for PULSE.
+
+The canonical policy used by the main PULSE CI lives in:
+
+- `PULSE_safe_pack_v0/pulse_policy.yml`
+
+That file is the **source of truth** for release gating in this repository.
+The profiles here are intended for:
+
+- experimentation,
+- documentation and comparison of different trade-offs,
+- downstream projects that want to start from a known template.
+
+## Files
+
+- `external_thresholds.yaml`  
+  Example thresholds for external detectors and risk margins. The pack may
+  ship its own minimal version under `PULSE_safe_pack_v0/profiles/`; this
+  copy is for full-length examples and experimentation.
+
+- `balanced-prod.yaml`  
+  A more "balanced" profile intended as a starting point for production-like
+  setups. It is **not** automatically used by CI; adopt it explicitly if you
+  want this behaviour.
+
+## Notes
+
+- The main PULSE CI references `PULSE_safe_pack_v0/pulse_policy.yml`.
+- Changes here do **not** automatically affect CI unless you wire them into
+  that policy (or into your own workflows).
+- When publishing snapshots (e.g. via Zenodo/DOI), both the pack policy and
+  these example profiles can be included to document the available options.


### PR DESCRIPTION
## Summary

This PR clarifies how gate profiles are organised in the repository and
which policy file is actually used by CI.

In short:

- `PULSE_safe_pack_v0/pulse_policy.yml` is the canonical CI policy.
- `profiles/` is for example and experimental profiles, not wired into CI
  by default.

---

## Changes

- **profiles/README.md**

  - New documentation file explaining:
    - the role of `PULSE_safe_pack_v0/pulse_policy.yml` as the source of
      truth for release gating,
    - how `profiles/external_thresholds.yaml` and `profiles/balanced-prod.yaml`
      are intended as templates / examples,
    - that changes in `profiles/` do not affect CI unless explicitly wired
      into the pack policy or custom workflows.

- **README.md / Repository layout**

  - Updated the "Repository layout" section so that:
    - `PULSE_safe_pack_v0/` is described as the self-contained safe-pack
      used by CI,
    - `profiles/` is described as an example / experimental area for
      alternative profiles and thresholds.

---

## Rationale

Previous structure could be misread as if the root `profiles/` directory
was used directly by CI. This makes it explicit that:

- CI reads from `PULSE_safe_pack_v0/pulse_policy.yml`,
- `profiles/` is for documentation, experimentation and downstream reuse.

No code or gate behaviour is changed; this is documentation-only.
