### PR TITLE
docs: clarify repository layout and profiles role

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,15 +265,15 @@ Deterministic, fail‑closed gates in `check_gates.py` remain the **only** relea
 
 ---
 
-## Repository layout
+### Repository layout
+
 ```
-PULSE_safe_pack_v0/            # the pack (tools/, docs/, profiles/, artifacts/)
-badges/                         # CI-generated SVG badges (status, RDSI, Q-Ledger)
-hero_dark_4k.png, hero_light_4k.png, og_image_1200x630.png
-PULSE_one_pager.png | .pdf
-pulse_landing_snippet.html
-.github/workflows/pulse_ci.yml
-README.md
+- `PULSE_safe_pack_v0/` – self-contained PULSE safe-pack v0 (tools, core
+  policies and CI wiring; `pulse_policy.yml` is the CI source of truth)
+- `profiles/` – example / experimental profiles and threshold sets. These
+  are **not** used by CI unless explicitly referenced from
+  `PULSE_safe_pack_v0/pulse_policy.yml` or custom workflows.
+
 ```
 
 ---


### PR DESCRIPTION
## Summary

This PR updates the "Repository layout" section so that it is explicit
about:

- where the canonical CI policy lives, and
- how the root `profiles/` directory is intended to be used.

In short:

- `PULSE_safe_pack_v0/` is the self-contained safe-pack used by CI.
- `PULSE_safe_pack_v0/pulse_policy.yml` is the CI source of truth.
- `profiles/` contains example / experimental profiles only.

---

## Changes

- Updated the README "Repository layout" section to:
  - label `PULSE_safe_pack_v0/` as the main safe-pack (tools, policies,
    CI wiring),
  - describe `profiles/` as an example/experimental area that does not
    affect CI unless explicitly wired into `pulse_policy.yml` or custom
    workflows.

No code or gate behaviour is changed; this is a documentation-only PR.

---

## Rationale

Previously it was easy to misread the layout as if the root `profiles/`
directory was used directly by CI. The updated text makes it clear which
YAML files are authoritative for release gating and which are templates
for experimentation.
