### PR TITLE
ci: surface EPF baseline vs shadow diff status

### DIFF
--- a/.github/workflows/epf_experiment.yml
+++ b/.github/workflows/epf_experiment.yml
@@ -108,7 +108,7 @@ jobs:
             echo "No checker found; wrote stub status_baseline.json"
           fi
 
-            - name: EPF shadow run (non-blocking) or stub
+       - name: EPF shadow run (non-blocking) or stub
         id: epf
         shell: bash
         run: |
@@ -160,7 +160,7 @@ jobs:
             echo "No checker found; wrote stub status_epf.json"
           fi
 
-      - name: Compare & summarize
+            - name: Compare & summarize
         shell: bash
         run: |
           python - <<'PY'
@@ -226,6 +226,32 @@ jobs:
             cat epf_report.txt;
             echo '```';
           } >> "$GITHUB_STEP_SUMMARY"
+
+          # Extra, egyértelmű státuszjelzés a summary végén
+          if [ -f epf_paradox_summary.json ]; then
+            changed=$(python - <<'PY'
+          import json
+          try:
+              with open("epf_paradox_summary.json", "r", encoding="utf-8") as f:
+                  data = json.load(f)
+          except Exception:
+              data = {}
+          print(data.get("changed", 0))
+          PY
+            )
+            if [ "$changed" -gt 0 ] 2>/dev/null; then
+              {
+                echo "";
+                echo "⚠️ EPF shadow detected ${changed} gate(s) with different decisions than the baseline.";
+              } >> "$GITHUB_STEP_SUMMARY"
+            else
+              {
+                echo "";
+                echo "✅ EPF shadow run: no gate-level decision changes detected.";
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

This PR makes EPF vs baseline differences more visible in the GitHub
Actions summary for the EPF experiment workflow.

Previously, the A/B step wrote `epf_report.txt` and
`epf_paradox_summary.json`, but the summary only showed the raw report.
Now we also emit a concise status line indicating whether any gates
actually changed.

---

## Changes

- In `.github/workflows/epf_experiment.yml`:
  - After generating `epf_paradox_summary.json`, read its `changed` field.
  - Append a one-line status to `$GITHUB_STEP_SUMMARY`:
    - `⚠️ EPF shadow detected N gate(s) with different decisions than the baseline.`
      when `changed > 0`.
    - `✅ EPF shadow run: no gate-level decision changes detected.` when
      `changed == 0`.

The existing artifacts (`status_baseline.json`, `status_epf.json`,
`epf_report.txt`, `epf_paradox_summary.json`) remain unchanged.

---

## Rationale

The EPF experiment is a diagnostic, shadow-only workflow. Its main value
is to highlight where EPF and the deterministic gates disagree. By
surfacing a clear "changed vs not changed" signal in the GitHub summary,
it becomes much easier to spot paradox candidates without diving into
the full report on every run.

No release gates or CI-required workflows are affected.
