### PR TITLE
ci: rebuild EPF experiment shadow workflow

### DIFF
--- a/.github/workflows/epf_experiment.yml
+++ b/.github/workflows/epf_experiment.yml
@@ -6,6 +6,8 @@ on:
     branches: [ main ]
     paths:
       - 'PULSE_safe_pack_v0/**'
+      - 'tools/**'
+      - 'scripts/**'
       - 'pulse_gates.yaml'
       - '.github/workflows/epf_experiment.yml'
 
@@ -50,7 +52,6 @@ jobs:
           set -euo pipefail
           if [ -f PULSE_safe_pack_v0/tools/run_all.py ]; then
             echo "Running PULSE_safe_pack_v0/tools/run_all.py to produce baseline status.json..."
-            # EPF shadow futás soha ne törje el a workflow-t
             python PULSE_safe_pack_v0/tools/run_all.py || true
             if [ -f PULSE_safe_pack_v0/artifacts/status.json ]; then
               cp PULSE_safe_pack_v0/artifacts/status.json status.json
@@ -64,118 +65,82 @@ jobs:
             echo '{"metrics": {}}' > status.json
           fi
 
-            - name: Baseline (deterministic) or stub
+      - name: Baseline (deterministic) or stub
         id: base
         shell: bash
         run: |
           set -euo pipefail
-          if [ -f tools/check_gates.py ]; then
-            echo "Running baseline check_gates from tools/..."
-            python tools/check_gates.py --config pulse_gates.yaml \
-                   --status status_baseline.json \
-                   --defer-policy fail || true
-          elif [ -f scripts/check_gates.py ]; then
-            echo "Running baseline check_gates from scripts/..."
-            python scripts/check_gates.py --config pulse_gates.yaml \
-                   --status status_baseline.json \
-                   --defer-policy fail || true
+
+          # start from status.json (real baseline or stub)
+          if [ -f status.json ]; then
+            cp status.json status_baseline.json
           else
-            echo '{"decisions":{}}' > status_baseline.json
-            echo "No checker found; wrote stub status_baseline.json"
+            echo '{"decisions": {}}' > status_baseline.json
           fi
 
-
-          if [ -f PULSE_safe_pack_v0/tools/check_gates.py ]; then
-            echo "Running baseline check_gates from PULSE_safe_pack_v0..."
-            python PULSE_safe_pack_v0/tools/check_gates.py \
-                   --config pulse_gates.yaml \
-                   --status status_baseline.json \
-                   --defer-policy fail || true
-          elif [ -f tools/check_gates.py ]; then
+          if [ -f tools/check_gates.py ]; then
             echo "Running baseline check_gates from tools/..."
             python tools/check_gates.py \
-                   --config pulse_gates.yaml \
-                   --status status_baseline.json \
-                   --defer-policy fail || true
+              --config pulse_gates.yaml \
+              --status status_baseline.json \
+              --defer-policy fail || true
           elif [ -f scripts/check_gates.py ]; then
             echo "Running baseline check_gates from scripts/..."
             python scripts/check_gates.py \
-                   --config pulse_gates.yaml \
-                   --status status_baseline.json \
-                   --defer-policy fail || true
+              --config pulse_gates.yaml \
+              --status status_baseline.json \
+              --defer-policy fail || true
           else
             echo '{"decisions": {}}' > status_baseline.json
             echo "No checker found; wrote stub status_baseline.json"
           fi
 
-       - name: EPF shadow run (non-blocking) or stub
+      - name: EPF shadow run (non-blocking) or stub
         id: epf
         shell: bash
         run: |
           set -euo pipefail
+
+          # EPF shadow run starts from the same baseline input
+          if [ -f status.json ]; then
+            cp status.json status_epf.json
+          else
+            echo '{"experiments":{"epf":{}}}' > status_epf.json
+          fi
+
           if [ -f tools/check_gates.py ]; then
             echo "Running EPF shadow check_gates from tools/..."
-            python tools/check_gates.py --config pulse_gates.yaml \
-                   --status status_epf.json \
-                   --epf-shadow --seed 1737 \
-                   --defer-policy warn || true
+            python tools/check_gates.py \
+              --config pulse_gates.yaml \
+              --status status_epf.json \
+              --epf-shadow \
+              --seed 1737 \
+              --defer-policy warn || true
           elif [ -f scripts/check_gates.py ]; then
             echo "Running EPF shadow check_gates from scripts/..."
-            python scripts/check_gates.py --config pulse_gates.yaml \
-                   --status status_epf.json \
-                   --epf-shadow --seed 1737 \
-                   --defer-policy warn || true
-          else
-            echo '{"experiments":{"epf":{}}}' > status_epf.json
-            echo "No checker found; wrote stub status_epf.json"
-          fi
-
-
-         if [ -f PULSE_safe_pack_v0/tools/check_gates.py ]; then
-            echo "Running EPF shadow via PULSE_safe_pack_v0/tools/check_gates.py..."
-            python PULSE_safe_pack_v0/tools/check_gates.py \
-                   --config pulse_gates.yaml \
-                   --status status_epf.json \
-                   --epf-shadow \
-                   --seed 1737 \
-                   --defer-policy warn || true
-          elif [ -f tools/check_gates.py ]; then
-            echo "Running EPF shadow via tools/check_gates.py..."
-            python tools/check_gates.py \
-                   --config pulse_gates.yaml \
-                   --status status_epf.json \
-                   --epf-shadow \
-                   --seed 1737 \
-                   --defer-policy warn || true
-          elif [ -f scripts/check_gates.py ]; then
-            echo "Running EPF shadow via scripts/check_gates.py..."
             python scripts/check_gates.py \
-                   --config pulse_gates.yaml \
-                   --status status_epf.json \
-                   --epf-shadow \
-                   --seed 1737 \
-                   --defer-policy warn || true
+              --config pulse_gates.yaml \
+              --status status_epf.json \
+              --epf-shadow \
+              --seed 1737 \
+              --defer-policy warn || true
           else
             echo '{"experiments":{"epf":{}}}' > status_epf.json
             echo "No checker found; wrote stub status_epf.json"
           fi
 
-            - name: Compare & summarize
+      - name: Compare & summarize
         shell: bash
         run: |
           python - <<'PY'
           import json, pathlib
 
-          # Várt séma:
-          # - status_baseline.json: {"decisions": {"gate": "PASS"|"FAIL"|...}}
-          # - status_epf.json: {"experiments": {"epf": {"gate": {"decision": "..."} | "..."}}}
-
           def load_json(path, default):
-            try:
-              with open(path, "r", encoding="utf-8") as f:
-                return json.load(f)
-            except Exception:
-              return default
+              try:
+                  with open(path, "r", encoding="utf-8") as f:
+                      return json.load(f)
+              except Exception:
+                  return default
 
           a = load_json("status_baseline.json", {"decisions": {}})
           b = load_json("status_epf.json", {"experiments": {"epf": {}}})
@@ -185,18 +150,18 @@ jobs:
 
           dec_epf = {}
           for k, v in db.items():
-            if isinstance(v, dict):
-              dec = v.get("decision", v.get("status", v))
-            else:
-              dec = v
-            dec_epf[k] = dec
+              if isinstance(v, dict):
+                  dec = v.get("decision", v.get("status", v))
+              else:
+                  dec = v
+              dec_epf[k] = dec
 
           total = len(da)
           diffs = []
           for k, v in da.items():
-            dv = dec_epf.get(k)
-            if dv and dv != v:
-              diffs.append((k, v, dv))
+              dv = dec_epf.get(k)
+              if dv and dv != v:
+                  diffs.append((k, v, dv))
 
           summary = f"Total gates: {total}\nChanged (baseline->EPF): {len(diffs)}\n"
           for k, ba, ep in diffs[:20]:
@@ -205,18 +170,17 @@ jobs:
           pathlib.Path("epf_report.txt").write_text(summary, encoding="utf-8")
           print(summary)
 
-          # Struktúrált paradox összefoglaló a későbbi Topology / Paradox Field számára
           paradox = {
-            "total_gates": total,
-            "changed": len(diffs),
-            "examples": [
-              {"gate": k, "baseline": ba, "epf": ep}
-              for k, ba, ep in diffs[:5]
-            ],
+              "total_gates": total,
+              "changed": len(diffs),
+              "examples": [
+                  {"gate": k, "baseline": ba, "epf": ep}
+                  for k, ba, ep in diffs[:5]
+              ],
           }
           pathlib.Path("epf_paradox_summary.json").write_text(
-            json.dumps(paradox, indent=2, ensure_ascii=False),
-            encoding="utf-8"
+              json.dumps(paradox, indent=2, ensure_ascii=False),
+              encoding="utf-8"
           )
           PY
 
@@ -227,7 +191,6 @@ jobs:
             echo '```';
           } >> "$GITHUB_STEP_SUMMARY"
 
-          # Extra, egyértelmű státuszjelzés a summary végén
           if [ -f epf_paradox_summary.json ]; then
             changed=$(python - <<'PY'
           import json
@@ -251,7 +214,6 @@ jobs:
               } >> "$GITHUB_STEP_SUMMARY"
             fi
           fi
-
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

A previous edit to `.github/workflows/epf_experiment.yml` over-removed
and mis-indented key sections, leaving the EPF experiment workflow
effectively broken. This PR rewrites the workflow from scratch with the
intended structure and behaviour.

---

## What this workflow does

- Reuses the PULSE safe-pack baseline when available:
  - runs `PULSE_safe_pack_v0/tools/run_all.py`,
  - copies `PULSE_safe_pack_v0/artifacts/status.json` to a local
    `status.json`.

- Runs two gate evaluation passes from the same baseline:
  - **baseline** pass into `status_baseline.json`,
  - **EPF shadow** pass into `status_epf.json`.

  Both use the root `tools/check_gates.py` or `scripts/check_gates.py`
  with:
  - `--config pulse_gates.yaml`
  - `--status <status file>`
  - `--epf-shadow` / `--seed` / `--defer-policy` where applicable.

- Compares baseline vs EPF decisions:
  - writes `epf_report.txt` (human-readable diff),
  - writes `epf_paradox_summary.json` (total, changed, sample diffs).

- Surfaces the result in the Actions UI:
  - appends the report to `$GITHUB_STEP_SUMMARY`,
  - adds:
    - `⚠️ EPF shadow detected N gate(s)...` when `changed > 0`,
    - `✅ EPF shadow run: no gate-level decision changes detected.` when
      `changed == 0`.

- Uploads all EPF artifacts as a single `epf-ab-artifacts` bundle.

---

## Why this is safe

- The workflow is **diagnostic only**:
  - it is not required by branch protection,
  - it never mutates the main CI artifacts,
  - it does not influence any release gates.

- The main PULSE CI and pack-based gating remain unchanged; this restores
  the EPF shadow experiment as a non-blocking A/B harness.

---

## Notes

This PR also addresses previous Codex feedback:
- no longer calls `PULSE_safe_pack_v0/tools/check_gates.py` with
  unsupported flags,
- fixes indentation so the Baseline, EPF shadow and Compare steps are
  recognised as proper steps rather than being embedded in a `run: |`
  block.
