### PR TITLE
docs: link README EPF section to paradox runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ The EPF experiment workflow is **optional and CI-neutral**. It is intended
 for research and diagnostics (borderline gates, paradox analysis) and does
 not participate in release gating.
 
+For guidance on what to do when baseline and EPF disagree on specific
+gates, see:
+
+- `docs/PARADOX_RUNBOOK.md`
 
 ---
 


### PR DESCRIPTION
## Summary

This PR updates the README so that the EPF section links directly to the
new paradox/EPF runbook.

The goal is to make it easy for maintainers to discover the guidance
document that explains what to do when the EPF experiment workflow
reports differences between baseline and EPF gate decisions.

---

## Changes

- `README.md`
  - Add a short note in the EPF section pointing to:
    - `docs/PARADOX_RUNBOOK.md`

No code or CI logic is changed; this is a documentation-only link
addition.
