### PR TITLE
ci: guard EPF gate checks when pulse_gates.yaml is missing

### DIFF
--- a/.github/workflows/epf_experiment.yml
+++ b/.github/workflows/epf_experiment.yml
@@ -71,11 +71,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          # start from status.json (real baseline or stub)
+          # Start from status.json (real baseline or stub)
           if [ -f status.json ]; then
             cp status.json status_baseline.json
           else
             echo '{"decisions": {}}' > status_baseline.json
+          fi
+
+          # If there is no EPF gate config, stay in stub mode
+          if [ ! -f pulse_gates.yaml ]; then
+            echo "::warning::pulse_gates.yaml not found; baseline gate evaluation will run in stub mode."
+            exit 0
           fi
 
           if [ -f tools/check_gates.py ]; then
@@ -106,6 +112,12 @@ jobs:
             cp status.json status_epf.json
           else
             echo '{"experiments":{"epf":{}}}' > status_epf.json
+          fi
+
+          # If there is no EPF gate config, stay in stub mode
+          if [ ! -f pulse_gates.yaml ]; then
+            echo "::warning::pulse_gates.yaml not found; EPF shadow run will use stub decisions."
+            exit 0
           fi
 
           if [ -f tools/check_gates.py ]; then


### PR DESCRIPTION
## Summary

Codex reported that `.github/workflows/epf_experiment.yml` calls
`tools/scripts/check_gates.py --config pulse_gates.yaml` even though
no `pulse_gates.yaml` file exists in this repository, causing a masked
FileNotFoundError and effectively disabling the EPF A/B evaluation.

This PR makes the EPF experiment workflow explicitly guard against the
missing config.

---

## Changes

- In the **Baseline** step:
  - After preparing `status_baseline.json`, check for `pulse_gates.yaml`.
  - If the file is missing, log a warning and `exit 0` so the step
    remains stub-only instead of attempting to run `check_gates.py`
    with a non-existent config.

- In the **EPF shadow** step:
  - After preparing `status_epf.json`, use the same presence check.
  - If `pulse_gates.yaml` is missing, log a warning and `exit 0`,
    leaving `status_epf.json` as a stub.

The actual `check_gates.py` invocation is unchanged when
`pulse_gates.yaml` is present.

---

## Rationale

- Keeps the EPF experiment workflow safe and non-failing in a clean
  checkout where no pulse_gates.yaml is provided.
- Still allows downstream users (or future versions of this repo)
  to supply a pulse_gates.yaml to get full EPF A/B behaviour.
- Resolves the Codex complaint about running gate checks with a
  missing configuration file.
