### PR TITLE
chore: add docstrings to refusal_delta_calc and augment_status

### DIFF
--- a/PULSE_safe_pack_v0/tools/refusal_delta_calc.py
+++ b/PULSE_safe_pack_v0/tools/refusal_delta_calc.py
@@ -1,3 +1,12 @@
+"""
+Compute deltas and confidence intervals for refusal-related metrics.
+
+This script is used by the PULSE safe-pack to compare refusal metrics
+between a baseline and a candidate (for example, across model versions
+or configurations) and to produce summary statistics that can be
+surfaced in the Quality Ledger and related reports.
+"""
+
 #!/usr/bin/env python3
 import argparse, json, math, os
 from typing import Tuple


### PR DESCRIPTION
## Summary

This PR adds short module-level docstrings to two core tools in the
PULSE safe-pack so that their purpose is clear at a glance.

---

## Changes

- `PULSE_safe_pack_v0/tools/refusal_delta_calc.py`
  - Add a docstring explaining that the script computes deltas and
    confidence intervals for refusal-related metrics between baseline
    and candidate runs, for use in the Quality Ledger and reports.

- `PULSE_safe_pack_v0/tools/augment_status.py`
  - Add a docstring explaining that the script augments the core
    status.json with external detector summaries, RDSI and other
    derived signals consumed by check_gates and reporting tooling.

No functional changes are introduced; this is a code hygiene / internal
documentation improvement only.

---

## Rationale

These scripts play a central role in the PULSE pipeline but previously
had little or no top-level explanation. Adding concise docstrings makes
them easier to understand for future readers and contributors without
affecting behaviour.
