### PR TITLE
docs(contributing): add Codex and layout notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,19 @@ Policy/threshold changes must include rationale and update `profiles/` + `docs/`
 - Quality Ledger attached (link to Pages if enabled, or artifact).
 - Badges updated by CI.
 - If profiles/thresholds changed: rationale + docs.
+
+---
+
+## Automated review (Codex)
+
+This GitHub repository is configured to use Codex
+(`chatgpt-codex-connector` bot) as an external AI reviewer for pull
+requests. Codex itself is not part of the PULSE codebase; it runs as a
+GitHub integration.
+
+Codex is triggered when you:
+
+- open a PR for review,
+- mark a draft as ready,
+- or comment `@codex review` on a PR.
+...


### PR DESCRIPTION
## Summary

This PR extends the existing CONTRIBUTING.md with a small section on:

- how Codex (chatgpt-codex-connector) is used for automated PR review,
- how P1 findings are treated as blocking until resolved,
- a quick reminder of the repository layout and how to think about
  governance-related changes.

The existing sections on Conventional Commits, DCO, changelog updates
and the PR checklist remain unchanged.

---

## Changes

- `CONTRIBUTING.md`
  - Add a "Codex (chatgpt-codex-connector) review" section explaining
    how Codex is triggered and what P1 findings mean.
  - Add a short "Repository layout and scope" reminder, pointing out
    the role of the safe-pack, docs, workflows and example profiles.

No code or CI behaviour changes; this is a documentation-only update to
help contributors work smoothly with the repo's automation and structure.
