### PR TITLE
chore(ci): keep shebang first in CLI tools

### DIFF
--- a/PULSE_safe_pack_v0/tools/refusal_delta_calc.py
+++ b/PULSE_safe_pack_v0/tools/refusal_delta_calc.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Compute deltas and confidence intervals for refusal-related metrics.
 
@@ -7,7 +8,6 @@ or configurations) and to produce summary statistics that can be
 surfaced in the Quality Ledger and related reports.
 """
 
-#!/usr/bin/env python3
 import argparse, json, math, os
 from typing import Tuple
 


### PR DESCRIPTION
## Summary

This PR fixes the placement of module-level docstrings in two CLI tools
so that the shebang remains on the first line and direct execution
continues to work as expected.

Codex flagged that the new docstrings had been inserted above the
shebang, causing the scripts to no longer start with `#!` and breaking
`./script.py` style invocations.

---

## Changes

- `PULSE_safe_pack_v0/tools/refusal_delta_calc.py`
  - Move the module docstring below the `#!/usr/bin/env python3` line.

- `PULSE_safe_pack_v0/tools/augment_status.py`
  - Move the module docstring below the `#!/usr/bin/env python3` line.

The content of the docstrings and the script logic are unchanged; only
the ordering of the first lines has been adjusted to preserve the
CLI shebang semantics.

---

## Rationale

These scripts are intended to be executable as CLI tools. Keeping the
shebang on the first line ensures the OS dispatches them to Python
correctly, while still allowing a proper module-level docstring.
