### PR TITLE
chore: add docstring to run_all entrypoint

### DIFF
--- a/PULSE_safe_pack_v0/tools/run_all.py
+++ b/PULSE_safe_pack_v0/tools/run_all.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python3
+"""
+Run all PULSE safe-pack checks and generate core artifacts.
+
+This script is the main entrypoint for the PULSE_safe_pack_v0 "safe
+pack". It orchestrates the configured checks/profiles and produces the
+baseline status.json and related artifacts under the pack's artifacts
+directory, which are then consumed by CI workflows and reporting tools.
+"""
+
 import os, json, datetime, pathlib, random
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary

This PR adds a concise module-level docstring to
`PULSE_safe_pack_v0/tools/run_all.py` so that its role as the main
safe-pack entrypoint is clear at a glance.

---

## Changes

- `PULSE_safe_pack_v0/tools/run_all.py`
  - Add a docstring describing that the script orchestrates all
    configured safe-pack checks and produces the baseline `status.json`
    and artifacts used by CI and reporting tooling.

The shebang remains on the first line, and the script logic is not
changed. This is a small internal documentation / hygiene improvement.

---

## Rationale

`run_all.py` is the central entrypoint for executing the PULSE safe-pack
but previously had no top-level explanation. A short docstring makes the
intent clearer for future readers and contributors without altering any
behaviour.
