### PR TITLE
docs(g-field): add g_field_v0 contract example

### DIFF
--- a/g_field_v0.json
+++ b/g_field_v0.json
@@ -1,0 +1,17 @@
+{
+  "version": "g_field_v0",
+  "source": "internal_hpc_g_child",
+  "created_at": "2025-11-30T12:34:56Z",
+  "run_id": "example-run-id",
+  "summary": {
+    "num_points": 1,
+    "g_mean": 0.81,
+    "g_std": 0.0
+  },
+  "points": [
+    {
+      "id": "trace-or-scenario-id",
+      "g_value": 0.79
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds an initial `g_field_v0.json` example file that documents the
intended contract for the internal G-child field overlay.

The file is **not** a runtime artifact, but a static example that shows:

- the top-level metadata (`version`, `source`, `created_at`, `run_id`)
- the `summary` block (`num_points`, `g_mean`, `g_std`)
- a minimal `points` array with `id` and `g_value`

## Motivation

Before wiring the G-child (HPC) field into the PULSE topology and EPF,
we want a concrete, versioned example of what a `g_field_v0` overlay
looks like on disk.

This makes it easier to:

- reason about the shape of the data,
- write adapters and stability probes,
- and document the field for other contributors.

## Implementation details

- New file: `g_field_v0.json`
  - static example with a single point
  - `source` is set to `internal_hpc_g_child`
  - `run_id` is a placeholder (`example-run-id`)

No logic changes, no CI changes.

## Testing

- JSON is syntactically valid (no comments, no trailing commas).
- Existing CI should be unaffected, as no scripts reference this file yet.

## Next steps

Follow-up PRs will:

- add `g_child_field_adapter.py` to generate real `g_field_v0.json` overlays,
- add `g_child_stability_probe.py` and `g_child_epf_bridge.py`,
- and wire the resulting overlays into the EPF / Paradox Field topology (read-only).
