### PR TITLE
feat: add G-field EPF bridge overlay script

### DIFF
--- a/scripts/g_child_epf_bridge.py
+++ b/scripts/g_child_epf_bridge.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+"""
+g_child_epf_bridge.py
+
+Bridge overlay between the G-field, EPF status and Paradox summary.
+CI-neutral, used only for governance and diagnostic purposes.
+"""
+
+import argparse
+import datetime as _dt
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+
+def _load_optional(path_str: str) -> Any:
+    if not path_str:
+        return None
+    p = Path(path_str)
+    if not p.is_file():
+        return None
+    with p.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _extract_gate_ids(obj: Any) -> List[str]:
+    """
+    Nagyon óvatos, generikus gate-id gyűjtés epf_paradox_summary-ből.
+    Nem feltételez konkrét sémát, csak megpróbál id / gate_id kulcsokat felszedni.
+    """
+    ids: Set[str] = set()
+
+    def walk(x: Any) -> None:
+        if isinstance(x, dict):
+            for k, v in x.items():
+                if k in ("gate_id", "id", "gate") and isinstance(v, str):
+                    ids.add(v)
+                else:
+                    walk(v)
+        elif isinstance(x, list):
+            for item in x:
+                walk(item)
+
+    walk(obj)
+    return sorted(ids)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Bridge overlay for G-field, EPF status and Paradox summary."
+    )
+    parser.add_argument("--g-field", required=True, help="Path to g_field_v0.json.")
+    parser.add_argument(
+        "--status-baseline",
+        required=False,
+        help="Optional path to status_baseline.json from EPF workflow.",
+    )
+    parser.add_argument(
+        "--status-epf",
+        required=False,
+        help="Optional path to status_epf.json from EPF workflow.",
+    )
+    parser.add_argument(
+        "--paradox-summary",
+        required=False,
+        help="Optional path to epf_paradox_summary.json.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output path for g_epf_overlay_v0.json.",
+    )
+    args = parser.parse_args()
+
+    g_field = _load_optional(args.g_field)
+    if g_field is None:
+        raise SystemExit(f"[ERROR] g_field_v0.json not found: {args.g_field}")
+
+    status_baseline = _load_optional(args.status_baseline) if args.status_baseline else None
+    status_epf = _load_optional(args.status_epf) if args.status_epf else None
+    paradox_summary = _load_optional(args.paradox_summary) if args.paradox_summary else None
+
+    paradox_gate_ids: List[str] = []
+    if paradox_summary is not None:
+        paradox_gate_ids = _extract_gate_ids(paradox_summary)
+
+    # Próbáljuk meg kiszedni azokat a G-pontokat, amelyeknek id-je paradox-gate-id-vel egyezik
+    g_points = g_field.get("points", []) if isinstance(g_field, dict) else []
+    g_on_paradox: List[Dict[str, Any]] = []
+    if paradox_gate_ids and isinstance(g_points, list):
+        ids_set = set(paradox_gate_ids)
+        for p in g_points:
+            pid = str(p.get("id", ""))
+            if pid in ids_set:
+                g_on_paradox.append(p)
+
+    created_at = _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+    overlay = {
+        "version": "g_epf_overlay_v0",
+        "created_at": created_at,
+        "g_field": g_field,
+        "status_baseline": status_baseline,
+        "status_epf": status_epf,
+        "epf_paradox_summary": paradox_summary,
+        "diagnostics": {
+            "paradox_gate_ids": paradox_gate_ids,
+            "g_points_on_paradox_gates": g_on_paradox,
+        },
+    }
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as f:
+        json.dump(overlay, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds the EPF bridge script for the internal G-field:

- new file: `scripts/g_child_epf_bridge.py`

The script ties together:

- `g_field_v0.json` (internal G-child field overlay),
- optional EPF baseline / EPF status files,
- and the Paradox summary,

and produces a consolidated `g_epf_overlay_v0.json` that can be used
for governance and diagnostic analysis.

## Motivation

After introducing the G-field contract, the adapter and the stability probe,
we want a thin bridge that brings the G-field and EPF/Paradox artefacts
into a single overlay:

- to see which gates appear in paradox summaries,
- and what G-values are associated with those gates,
- without touching any gating logic.

This helps reason about decision stability and paradox behaviour around
specific gates in the PULSE topology.

## Implementation details

- New script: `scripts/g_child_epf_bridge.py`
  - required input:
    - `--g-field`: path to `g_field_v0.json`
  - optional inputs:
    - `--status-baseline`: `status_baseline.json` from the EPF workflow
    - `--status-epf`: `status_epf.json` from the EPF workflow
    - `--paradox-summary`: `epf_paradox_summary.json`
  - writes:
    - `--output`: `g_epf_overlay_v0.json`

- The overlay structure:
  - `version: "g_epf_overlay_v0"`
  - `created_at` timestamp
  - embedded copies of:
    - G-field
    - baseline and EPF status
    - Paradox summary
  - `diagnostics` section with:
    - `paradox_gate_ids` (ids collected in a schema-agnostic way)
    - `g_points_on_paradox_gates` (subset of G-field points whose ids
      match paradox gate ids)

No gates or CI behaviour are modified; this is a read-only diagnostics layer.

## Usage

Example:

```bash
python scripts/g_child_epf_bridge.py \
  --g-field PULSE_safe_pack_v0/artifacts/g_field_v0.json \
  --status-baseline status_baseline.json \
  --status-epf status_epf.json \
  --paradox-summary epf_paradox_summary.json \
  --output PULSE_safe_pack_v0/artifacts/g_epf_overlay_v0.json

All inputs except --g-field are optional; missing files are simply ignored.

Testing

Ran the script locally with small sample JSONs:

verified that g_epf_overlay_v0.json is valid JSON,

confirmed that paradox gate ids are extracted and matched to G-field points.

Existing CI pipelines are unaffected; nothing depends on this overlay yet.

Next steps

Surface selected diagnostics from g_epf_overlay_v0.json in the topology /
governance reports.

Optionally add visualizations or dashboards for paradox vs G-field behaviour.