### PR TITLE
docs(hpc): add example G-child snapshots JSONL

### DIFF
--- a/hpc/g_snapshots.jsonl
+++ b/hpc/g_snapshots.jsonl
@@ -1,0 +1,3 @@
+{"id": "scenario_001", "g_value": 0.82}
+{"id": "scenario_002", "g_value": 0.76}
+{"id": "scenario_003", "g_value": 0.91}


### PR DESCRIPTION
## Summary

This PR adds an example HPC snapshot file for the G-child integration:

- new file: `hpc/g_snapshots.jsonl`

The file contains a few dummy records in JSONL format, each with:

- `id`: a scenario identifier
- `g_value`: a floating-point G score

## Motivation

Before wiring in the real (private) HPC pipeline, we want a simple,
in-repo input file that the G-child field adapter can consume.

This lets us:

- run `scripts/g_child_field_adapter.py` directly,
- generate a real `g_field_v0.json` overlay from the PULSE repo,
- and later swap the dummy snapshots for HPC-generated ones without
  changing the interface.

## Implementation details

- New directory (if not present): `hpc/`
- New file: `hpc/g_snapshots.jsonl`
  - three example lines:
    - `scenario_001`, `scenario_002`, `scenario_003`
    - each with a `g_value` between 0 and 1
  - pure JSONL, no brackets, no trailing commas.

No gates, CI or workflows are changed in this PR.

## Next steps

- Add a shadow GitHub Actions workflow that:
  - runs `scripts/g_child_field_adapter.py` on `hpc/g_snapshots.jsonl`,
  - produces `PULSE_safe_pack_v0/artifacts/g_field_v0.json`,
  - and uploads the overlay as an artifact.
- Later, replace the dummy snapshots with real HPC-generated data.
