### PR TITLE
ci: add G-field shadow workflow

### DIFF
--- a/.github/workflows/g_field_shadow.yml
+++ b/.github/workflows/g_field_shadow.yml
@@ -1,0 +1,43 @@
+name: G-field overlays (shadow)
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'scripts/g_child_field_adapter.py'
+      - 'hpc/**'
+      - '.github/workflows/g_field_shadow.yml'
+
+jobs:
+  g-field-shadow:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for HPC snapshots
+        id: check_snapshots
+        run: |
+          if [ -f "hpc/g_snapshots.jsonl" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "Found hpc/g_snapshots.jsonl"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No hpc/g_snapshots.jsonl found, skipping G-field overlay."
+          fi
+
+      - name: Build G-field overlay from HPC snapshots
+        if: steps.check_snapshots.outputs.found == 'true'
+        run: |
+          mkdir -p PULSE_safe_pack_v0/artifacts
+          python scripts/g_child_field_adapter.py \
+            --snapshots hpc/g_snapshots.jsonl \
+            --output PULSE_safe_pack_v0/artifacts/g_field_v0.json
+
+      - name: Upload G-field overlay artifact
+        if: steps.check_snapshots.outputs.found == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: g-field-overlays
+          path: PULSE_safe_pack_v0/artifacts/g_field_v0.json


### PR DESCRIPTION
## Summary

This PR adds a shadow GitHub Actions workflow for the internal G-field:

- new file: `.github/workflows/g_field_shadow.yml`

The workflow runs the G-child field adapter against `hpc/g_snapshots.jsonl`
and publishes a `g_field_v0.json` overlay as an artifact.

## Motivation

We want the PULSE repo to be able to generate G-field overlays on its own,
without depending on any private HPC code.

This shadow workflow lets us:

- exercise `scripts/g_child_field_adapter.py` directly in CI,
- use the public `hpc/g_snapshots.jsonl` fixture as input,
- and inspect the resulting `g_field_v0.json` overlays from the Actions UI.

It stays CI-neutral and does not affect the core release gates.

## Implementation details

- New workflow: `.github/workflows/g_field_shadow.yml`
  - triggers:
    - `workflow_dispatch` (manual)
    - `push` when:
      - `scripts/g_child_field_adapter.py` changes
      - anything under `hpc/` changes
      - the workflow file itself changes
  - steps:
    1. `actions/checkout@v4`
    2. `Check for HPC snapshots`:
       - if `hpc/g_snapshots.jsonl` exists, set `found=true`
       - otherwise, `found=false` and the rest of the steps are skipped
    3. `Build G-field overlay from HPC snapshots` (if `found=true`):
       - ensures `PULSE_safe_pack_v0/artifacts` exists
       - runs:
         ```bash
         python scripts/g_child_field_adapter.py \
           --snapshots hpc/g_snapshots.jsonl \
           --output PULSE_safe_pack_v0/artifacts/g_field_v0.json
         ```
    4. `Upload G-field overlay artifact` (if `found=true`):
       - uploads `PULSE_safe_pack_v0/artifacts/g_field_v0.json`
         under the `g-field-overlays` artifact name.

- No existing workflows, gates or CI checks are modified.

## Usage

- Manually:
  - Go to **Actions → G-field overlays (shadow)** and click **Run workflow**.
- Or trigger via push:
  - editing `hpc/g_snapshots.jsonl` or the adapter script will automatically
    run the workflow.

After a successful run, download the `g-field-overlays` artifact to inspect
`g_field_v0.json`.

## Testing

- Verified that the workflow:
  - skips cleanly when `hpc/g_snapshots.jsonl` is missing,
  - runs the adapter and produces `g_field_v0.json` when the file is present,
  - uploads the overlay as an artifact.
- No impact on existing CI pipelines or release gates.
