### PR TITLE
ci: add G-EPF overlay shadow workflow

### DIFF
--- a/.github/workflows/.github/workflows/g_epf_overlay_shadow.yml
+++ b/.github/workflows/.github/workflows/g_epf_overlay_shadow.yml
@@ -1,0 +1,45 @@
+name: G-field EPF overlay (shadow)
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'scripts/g_child_epf_bridge.py'
+      - 'PULSE_safe_pack_v0/artifacts/**'
+      - '.github/workflows/g_epf_overlay_shadow.yml'
+
+jobs:
+  g-epf-overlay-shadow:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for G-field overlay
+        id: check_g_field
+        run: |
+          if [ -f "PULSE_safe_pack_v0/artifacts/g_field_v0.json" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "Found G-field overlay: PULSE_safe_pack_v0/artifacts/g_field_v0.json"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No G-field overlay found, skipping EPF bridge."
+          fi
+
+      - name: Build G-EPF overlay
+        if: steps.check_g_field.outputs.found == 'true'
+        run: |
+          python scripts/g_child_epf_bridge.py \
+            --g-field PULSE_safe_pack_v0/artifacts/g_field_v0.json \
+            --status-baseline PULSE_safe_pack_v0/artifacts/status_baseline.json \
+            --status-epf PULSE_safe_pack_v0/artifacts/status_epf.json \
+            --paradox-summary PULSE_safe_pack_v0/artifacts/epf_paradox_summary.json \
+            --output PULSE_safe_pack_v0/artifacts/g_epf_overlay_v0.json
+
+      - name: Upload G-EPF overlay artifact
+        if: steps.check_g_field.outputs.found == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: g-epf-overlays
+          path: PULSE_safe_pack_v0/artifacts/g_epf_overlay_v0.json


### PR DESCRIPTION
## Summary

This PR adds a second shadow workflow for the internal G-field:

- new file: `.github/workflows/g_epf_overlay_shadow.yml`

The workflow runs the `g_child_epf_bridge.py` script to combine the
G-field overlay with optional EPF/Paradox artefacts and publishes a
`g_epf_overlay_v0.json` file as an artifact.

## Motivation

After wiring in:

- the G-field contract (`g_field_v0.json`),
- the G-child adapter,
- and the first `G-field overlays (shadow)` workflow,

we want a way to bring the G-field and EPF/Paradox overlays together
in a single diagnostic artefact.

The G-EPF overlay can be used later by:

- the topology / governance reports,
- manual analysis in the EPF experiments,
- or future dashboards.

## Implementation details

- New workflow: `.github/workflows/g_epf_overlay_shadow.yml`
  - triggers:
    - `workflow_dispatch` (manual)
    - `push` when:
      - `scripts/g_child_epf_bridge.py` changes
      - anything under `PULSE_safe_pack_v0/artifacts/` changes
      - the workflow file itself changes

  - steps:
    1. `actions/checkout@v4`
    2. `Check for G-field overlay`:
       - looks for `PULSE_safe_pack_v0/artifacts/g_field_v0.json`
       - if not found, sets `found=false` and skips the rest
    3. `Build G-EPF overlay` (if `found=true`):
       - calls:
         ```bash
         python scripts/g_child_epf_bridge.py \
           --g-field PULSE_safe_pack_v0/artifacts/g_field_v0.json \
           --status-baseline PULSE_safe_pack_v0/artifacts/status_baseline.json \
           --status-epf PULSE_safe_pack_v0/artifacts/status_epf.json \
           --paradox-summary PULSE_safe_pack_v0/artifacts/epf_paradox_summary.json \
           --output PULSE_safe_pack_v0/artifacts/g_epf_overlay_v0.json
         ```
       - EPF/Paradox inputs are optional; missing files are handled by
         the script.
    4. `Upload G-EPF overlay artifact`:
       - uploads `PULSE_safe_pack_v0/artifacts/g_epf_overlay_v0.json`
         under the `g-epf-overlays` artifact name.

No gates or core CI behaviour are changed; this is a read-only,
diagnostic overlay on top of existing artefacts.

## Usage

- Make sure the `G-field overlays (shadow)` workflow has produced
  a `g_field_v0.json` under `PULSE_safe_pack_v0/artifacts/`.
- Optionally run any EPF experiment workflows that generate:
  - `status_baseline.json`
  - `status_epf.json`
  - `epf_paradox_summary.json`
- Then run **G-field EPF overlay (shadow)** manually from the Actions tab
  or let it trigger on a relevant push.

After a successful run, download the `g-epf-overlays` artifact and
inspect `g_epf_overlay_v0.json`.

## Testing

- Verified locally that `g_child_epf_bridge.py`:
  - works when only `g_field_v0.json` is present,
  - augments the overlay when EPF/Paradox JSONs are available.
- The workflow is CI-neutral: missing artefacts only cause the job
  to skip or produce a partial overlay, not to fail existing gates.
