### PR TITLE
ci: add GPT external detection shadow workflow

### DIFF
--- a/.github/workflows/gpt_external_shadow.yml
+++ b/.github/workflows/gpt_external_shadow.yml
@@ -1,0 +1,43 @@
+name: GPT external detection (shadow)
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'scripts/gpt_external_detector.py'
+      - 'logs/**'
+      - '.github/workflows/gpt_external_shadow.yml'
+
+jobs:
+  gpt-external-shadow:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for model invocation log
+        id: check_log
+        run: |
+          if [ -f "logs/model_invocations.jsonl" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "Found logs/model_invocations.jsonl"
+          else:
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No logs/model_invocations.jsonl found, skipping GPT external detection."
+          fi
+
+      - name: Run GPT external detector
+        if: steps.check_log.outputs.found == 'true'
+        run: |
+          mkdir -p PULSE_safe_pack_v0/artifacts
+          python scripts/gpt_external_detector.py \
+            --input logs/model_invocations.jsonl \
+            --output PULSE_safe_pack_v0/artifacts/gpt_external_detection_v0.json
+
+      - name: Upload GPT external detection overlay
+        if: steps.check_log.outputs.found == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: gpt-external-detection
+          path: PULSE_safe_pack_v0/artifacts/gpt_external_detection_v0.json


### PR DESCRIPTION
## Summary

This PR adds a shadow GitHub Actions workflow for the external GPT
detector:

- new file: `.github/workflows/gpt_external_shadow.yml`

The workflow runs `scripts/gpt_external_detector.py` on a JSONL log of
model invocations (if present) and publishes a
`gpt_external_detection_v0.json` overlay as an artifact.

## Motivation

We now have:

- the G-child field overlays,
- the G-EPF overlay,
- and the `gpt_external_detector.py` sentinel script.

This workflow wires the detector into CI in a CI-neutral way so we can
observe external GPT/vendor usage from logs without affecting any gates.

## Implementation details

- New workflow: `.github/workflows/gpt_external_shadow.yml`
  - triggers:
    - `workflow_dispatch` (manual)
    - `push` when:
      - `scripts/gpt_external_detector.py` changes
      - anything under `logs/` changes
      - the workflow file itself changes
  - steps:
    1. `Checkout repository`
    2. `Check for model invocation log`:
       - looks for `logs/model_invocations.jsonl`
       - if missing, sets `found=false` and skips the rest
    3. `Run GPT external detector` (if `found=true`):
       - ensures `PULSE_safe_pack_v0/artifacts` exists
       - runs:
         ```bash
         python scripts/gpt_external_detector.py \
           --input logs/model_invocations.jsonl \
           --output PULSE_safe_pack_v0/artifacts/gpt_external_detection_v0.json
         ```
    4. `Upload GPT external detection overlay`:
       - uploads `gpt_external_detection_v0.json` as a
         `gpt-external-detection` artifact.

No release gates or core CI behaviour are modified; this is a diagnostic
shadow workflow only.

## Usage

- Provide a JSONL log at `logs/model_invocations.jsonl` with one record
  per model invocation (e.g. containing `vendor`/`provider` and
  `model`/`deployment` fields).
- Trigger **GPT external detection (shadow)** via:
  - the Actions tab (Run workflow), or
  - a push that updates the log or the detector.

After a successful run, download the `gpt-external-detection` artifact
and inspect `gpt_external_detection_v0.json`.

## Next steps

- Optionally surface parts of `gpt_external_detection_v0.json` in the
  topology / governance reports (e.g. counts of external GPT usage per
  vendor/model).
- Align the log path with any future central logging/observability
  conventions.
