### PR TITLE
ci: fix shell syntax in GPT external shadow workflow

### DIFF
--- a/.github/workflows/gpt_external_shadow.yml
+++ b/.github/workflows/gpt_external_shadow.yml
@@ -22,7 +22,7 @@ jobs:
           if [ -f "logs/model_invocations.jsonl" ]; then
             echo "found=true" >> "$GITHUB_OUTPUT"
             echo "Found logs/model_invocations.jsonl"
-          else:
+          else
             echo "found=false" >> "$GITHUB_OUTPUT"
             echo "No logs/model_invocations.jsonl found, skipping GPT external detection."
           fi


### PR DESCRIPTION
## Summary

This PR fixes a shell syntax issue in the GPT external detection
shadow workflow:

- file: `.github/workflows/gpt_external_shadow.yml`

The "Check for model invocation log" step now uses valid bash syntax
for its conditional.

## Motivation

Codex correctly reported a P1 problem: the `run` block used `else:`
instead of `else` in a bash `if` statement.

That would cause a shell syntax error and make the step fail before
the detector or upload steps run, regardless of whether
`logs/model_invocations.jsonl` exists.

We want the workflow to be CI-neutral:

- if the log file is present → run the detector and upload the overlay
- if the log file is missing → skip the detector without failing the job

## Implementation details

- Updated `.github/workflows/gpt_external_shadow.yml`:

  - in the "Check for model invocation log" step, the `run` block is now:

    ```bash
    if [ -f "logs/model_invocations.jsonl" ]; then
      echo "found=true" >> "$GITHUB_OUTPUT"
      echo "Found logs/model_invocations.jsonl"
    else
      echo "found=false" >> "$GITHUB_OUTPUT"
      echo "No logs/model_invocations.jsonl found, skipping GPT external detection."
    fi
    ```

  - no other workflow keys were changed (`jobs`, `steps`, `runs-on`,
    `name`, `uses`, `run` remain the same).

## Testing

- Verified that the workflow definition parses correctly.
- Confirmed that:
  - when `logs/model_invocations.jsonl` is present, the detector and
    upload steps run, and
  - when it is missing, the job completes successfully and simply
    skips the detection steps.

Codex should no longer report a P1 badge for this workflow.
