### PR TITLE
feat(schemas): add g_field_v0 overlay schema

### DIFF
--- a/schemas/schemas/g_field_v0.schema.json
+++ b/schemas/schemas/g_field_v0.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "g_field_v0 overlay",
+  "description": "Contract for the internal G-child field overlay used by PULSE.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "version",
+    "source",
+    "created_at",
+    "summary",
+    "points"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "g_field_v0"
+    },
+    "source": {
+      "type": "string",
+      "description": "Origin of the overlay, e.g. internal_hpc_g_child."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "run_id": {
+      "type": ["string", "null"],
+      "description": "Optional run identifier or null."
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "num_points",
+        "g_mean",
+        "g_std"
+      ],
+      "properties": {
+        "num_points": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "g_mean": {
+          "type": "number"
+        },
+        "g_std": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    },
+    "points": {
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "id",
+          "g_value"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "g_value": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a JSON Schema for the internal G-child field overlay:

- new file: `schemas/g_field_v0.schema.json`

The schema formalizes the `g_field_v0.json` contract used between the
HPC G-child pipeline and the PULSE topology / diagnostics layer.

## Motivation

We already use `g_field_v0.json` as the contract for the internal
G-field overlay, and we have scripts and shadow workflows that produce
it.

Defining a schema allows us to:

- validate overlays in CI (now or later),
- keep the HPC side and PULSE side aligned on the same contract,
- and document the expected shape of the overlay in a machine-readable way.

## Implementation details

- New schema: `schemas/g_field_v0.schema.json`
  - `version` is fixed to `"g_field_v0"`.
  - `source` is a free-form string (e.g. `internal_hpc_g_child`).
  - `created_at` is an ISO 8601 date-time string.
  - `run_id` is a string or null.
  - `summary`:
    - required fields: `num_points`, `g_mean`, `g_std`
    - `num_points` is an integer ≥ 0
    - `g_std` is a number ≥ 0
    - additional fields are allowed.
  - `points`:
    - array of objects with `id` (string) and `g_value` (number)
    - additional fields per point are allowed.
  - `additionalProperties: true` at the top level to keep room for
    future extensions.

No runtime code or workflows are changed in this PR; it only adds a
schema artefact.

## Next steps

- Optionally add validation steps in CI that check generated
  `g_field_v0.json` overlays against this schema.
- Add similar schemas for:
  - `g_field_stability_v0`
  - `g_epf_overlay_v0`
  - `gpt_external_detection_v0`
