### PR TITLE
feat(schemas): add gpt_external_detection_v0 overlay schema

### DIFF
--- a/schemas/gpt_external_detection_v0.schema.json
+++ b/schemas/gpt_external_detection_v0.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "gpt_external_detection_v0 overlay",
+  "description": "Contract for the external GPT/vendor detection overlay produced by gpt_external_detector.py.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "version",
+    "created_at",
+    "input_file",
+    "summary",
+    "records"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "gpt_external_detection_v0"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "input_file": {
+      "type": "string",
+      "description": "Path to the input JSONL log file used by the detector."
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "total_records",
+        "num_external_gpt",
+        "num_internal",
+        "num_unknown",
+        "vendors",
+        "models"
+      ],
+      "properties": {
+        "total_records": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "num_external_gpt": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "num_internal": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "num_unknown": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "vendors": {
+          "type": "object",
+          "description": "Map of vendor name (lowercased) to count.",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "models": {
+          "type": "object",
+          "description": "Map of model name (lowercased) to count.",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    },
+    "records": {
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "idx",
+          "is_external_gpt",
+          "is_internal",
+          "reason"
+        ],
+        "properties": {
+          "idx": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "1-based line index in the input JSONL file."
+          },
+          "id": {
+            "type": ["string", "null"],
+            "description": "Optional request / trace id associated with the record."
+          },
+          "is_external_gpt": {
+            "type": "boolean"
+          },
+          "is_internal": {
+            "type": "boolean"
+          },
+          "vendor": {
+            "type": ["string", "null"]
+          },
+          "model": {
+            "type": ["string", "null"]
+          },
+          "reason": {
+            "type": "string",
+            "description": "Short explanation of the detection decision."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a JSON Schema for the GPT external detection overlay:

- new file: `schemas/gpt_external_detection_v0.schema.json`

The schema formalizes the `gpt_external_detection_v0.json` contract used
by `scripts/gpt_external_detector.py` and the GPT external detection
shadow workflow.

## Motivation

We now generate `gpt_external_detection_v0.json` overlays in CI via the
`gpt_external_shadow` workflow. Defining a schema allows us to:

- validate overlays in CI (now or later),
- keep the detector and topology/governance layer aligned on the same
  data shape,
- and document the expected structure in a machine-readable way.

## Implementation details

- New schema: `schemas/gpt_external_detection_v0.schema.json`
  - Top-level:
    - `version`: fixed to `"gpt_external_detection_v0"`
    - `created_at`: ISO 8601 date-time string
    - `input_file`: string path to the JSONL log used as input
  - `summary`:
    - required counts: `total_records`, `num_external_gpt`,
      `num_internal`, `num_unknown`
    - `vendors` and `models`: objects mapping lowercased names to
      integer counts
    - `additionalProperties: true` for flexibility
  - `records[]`:
    - required fields: `idx`, `is_external_gpt`, `is_internal`, `reason`
    - optional: `id` (string or null), `vendor`, `model`
    - `idx` is an integer >= 1 (1-based line index)
    - `reason` is a short explanation of the detection decision
  - `additionalProperties: true` at both top level and record level for
    forward-compatibility.

No runtime code or workflows are changed; this PR only adds a schema
artefact.

## Next steps

- Optionally add a schema validation step in CI that checks generated
  `gpt_external_detection_v0.json` overlays against this schema.
- Add similar schemas (if desired) for:
  - `g_field_stability_v0`
  - `g_epf_overlay_v0`
