### PR TITLE
feat(schemas): add g_epf_overlay_v0 schema

### DIFF
--- a/schemas/g_epf_overlay_v0.schema.json
+++ b/schemas/g_epf_overlay_v0.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "g_epf_overlay_v0",
+  "description": "Bridge overlay between the G-field, EPF status and Paradox summary.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "version",
+    "created_at",
+    "g_field",
+    "diagnostics"
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "g_epf_overlay_v0"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "g_field": {
+      "type": "object",
+      "description": "Embedded g_field_v0 overlay.",
+      "additionalProperties": true
+    },
+    "status_baseline": {
+      "type": ["object", "null"],
+      "description": "Optional EPF baseline status object.",
+      "additionalProperties": true
+    },
+    "status_epf": {
+      "type": ["object", "null"],
+      "description": "Optional EPF status object for the EPF run.",
+      "additionalProperties": true
+    },
+    "epf_paradox_summary": {
+      "type": ["object", "null"],
+      "description": "Optional paradox summary object from EPF.",
+      "additionalProperties": true
+    },
+    "diagnostics": {
+      "type": "object",
+      "required": [
+        "paradox_gate_ids",
+        "g_points_on_paradox_gates"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "paradox_gate_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "g_points_on_paradox_gates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "type": ["string", "null"]
+              },
+              "g_value": {
+                "type": ["number", "null"]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a JSON Schema for the G-EPF bridge overlay:

- new file: `schemas/g_epf_overlay_v0.schema.json`

The schema documents the structure of `g_epf_overlay_v0.json` produced
by `scripts/g_child_epf_bridge.py`.

## Motivation

We already generate G-EPF overlays that combine:

- the internal G-field (`g_field_v0`),
- optional EPF status artefacts,
- and the paradox summary diagnostics.

Defining a schema for `g_epf_overlay_v0` helps:

- keep the bridge output consistent over time,
- document the structure for topology/governance consumers,
- and enable optional schema validation in CI.

## Implementation details

- `version` is fixed to `"g_epf_overlay_v0"`.
- `created_at` is an ISO 8601 date-time string.
- `g_field`:
  - an embedded object representing a `g_field_v0` overlay,
  - modelled as a generic object with `additionalProperties: true` to
    avoid coupling the schemas too tightly.
- `status_baseline`, `status_epf`, `epf_paradox_summary`:
  - each is an object or null,
  - `additionalProperties: true` to accept the existing EPF shapes.
- `diagnostics`:
  - required fields:
    - `paradox_gate_ids`: array of strings (gate ids seen in the
      paradox summary)
    - `g_points_on_paradox_gates`: array of objects
      (subset of G-field points whose ids match paradox gates)
  - for `g_points_on_paradox_gates`, `id` and `g_value` are optional
    but typed; additional fields are allowed.

No runtime code or workflows are changed in this PR; it only adds the
schema artefact.

## Next steps

- Optionally add a schema validation step to check
  `g_epf_overlay_v0.json` overlays in a shadow CI job.
- Consider surfacing selected diagnostics from the overlay in the
  topology/governance reports (e.g. G-values on paradox gates).
