### PR TITLE
ci: add overlay schema validation shadow workflow

### DIFF
--- a/.github/workflows/overlay_schema_validation_shadow.yml
+++ b/.github/workflows/overlay_schema_validation_shadow.yml
@@ -1,0 +1,32 @@
+name: Overlay schema validation (shadow)
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'schemas/**'
+      - 'scripts/validate_overlays.py'
+      - 'PULSE_safe_pack_v0/artifacts/**'
+      - '.github/workflows/overlay_schema_validation_shadow.yml'
+
+jobs:
+  overlay-schema-validation-shadow:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install jsonschema
+        run: |
+          python -m pip install --upgrade pip
+          pip install jsonschema
+
+      - name: Validate overlays against JSON Schemas
+        run: |
+          python scripts/validate_overlays.py --root .


### PR DESCRIPTION
## Summary

This PR adds a shadow GitHub Actions workflow to validate overlay JSON
files against their JSON Schemas:

- new file: `.github/workflows/overlay_schema_validation_shadow.yml`

The workflow runs `scripts/validate_overlays.py` in a CI-neutral way.

## Motivation

We now have JSON Schemas for the main overlays:

- `g_field_v0`
- `g_field_stability_v0`
- `g_epf_overlay_v0`
- `gpt_external_detection_v0`

and a helper script `scripts/validate_overlays.py` to validate them.

This workflow wires the validator into CI so we can spot schema
mismatches early, without turning them into hard release gates yet.

## Implementation details

- Workflow: `.github/workflows/overlay_schema_validation_shadow.yml`
  - triggers:
    - `workflow_dispatch` (manual)
    - `push` when:
      - any `schemas/**` file changes
      - `scripts/validate_overlays.py` changes
      - `PULSE_safe_pack_v0/artifacts/**` overlays change
      - the workflow file itself changes
  - job: `overlay-schema-validation-shadow`
    1. `Checkout repository` with `actions/checkout@v4`
    2. `Set up Python` with `actions/setup-python@v5` (Python 3.x)
    3. `Install jsonschema` via pip
    4. `Validate overlays against JSON Schemas`:
       - runs:
         ```bash
         python scripts/validate_overlays.py --root .
         ```
       - the script:
         - skips overlays that are not present (INFO only)
         - fails if any existing overlay does not conform to its schema

No existing gates or core CI workflows are modified; this is a
diagnostic shadow job only.

## Next steps

- Monitor the shadow workflow to see how often overlays fail validation.
- Once stable, consider turning specific schema checks into pre-release
  gates for high-risk packs.
