### PR TITLE
ci: fix overlay schema validation workflow paths

### DIFF
--- a/.github/workflows/overlay_schema_validation_shadow.yml
+++ b/.github/workflows/overlay_schema_validation_shadow.yml
@@ -5,8 +5,10 @@ on:
   push:
     paths:
       - 'schemas/**'
+      - 'schemas/schemas/**'
       - 'scripts/validate_overlays.py'
       - 'PULSE_safe_pack_v0/artifacts/**'
+      - '*.json'
       - '.github/workflows/overlay_schema_validation_shadow.yml'
 
 jobs:


### PR DESCRIPTION
## Summary

This PR adjusts the overlay schema validation shadow workflow so that
its path filters match the current repo layout.

- file: `.github/workflows/overlay_schema_validation_shadow.yml`

## Motivation

Codex reported that the validation job only triggered on changes under
`PULSE_safe_pack_v0/artifacts/**`, while in this repo:

- some overlays currently live at the repo root (e.g. `g_field_v0.json`),
- and schemas may be under both `schemas/` and `schemas/schemas/`.

As a result, real overlay or schema updates could happen without
triggering the shadow validation job.

## Implementation details

- Updated the `on.push.paths` section to include:
  - `schemas/**`
  - `schemas/schemas/**`
  - `scripts/validate_overlays.py`
  - `PULSE_safe_pack_v0/artifacts/**`
  - `*.json`
  - `.github/workflows/overlay_schema_validation_shadow.yml`
- The job itself is unchanged:
  - checks out the repo,
  - sets up Python 3.x,
  - installs `jsonschema`,
  - runs:
    ```bash
    python scripts/validate_overlays.py --root .
    ```

This keeps the workflow CI-neutral but ensures it actually runs when
overlays or schemas change.

## Next steps

- Monitor the shadow validation job for a few runs to confirm that it
  covers all relevant overlay and schema updates.
- Once the layout stabilises, we can simplify the path filters or
  tighten them around the final artefact locations.
