### PR TITLE
ci: add G snapshot report shadow workflow

### DIFF
--- a/.github/workflows/g_snapshot_report_shadow.yml
+++ b/.github/workflows/g_snapshot_report_shadow.yml
@@ -1,0 +1,39 @@
+name: G snapshot report (shadow)
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'scripts/g_snapshot_report.py'
+      - 'PULSE_safe_pack_v0/artifacts/g_field_v0.json'
+      - 'PULSE_safe_pack_v0/artifacts/g_field_stability_v0.json'
+      - 'PULSE_safe_pack_v0/artifacts/g_epf_overlay_v0.json'
+      - 'PULSE_safe_pack_v0/artifacts/gpt_external_detection_v0.json'
+      - '.github/workflows/g_snapshot_report_shadow.yml'
+
+jobs:
+  g-snapshot-report-shadow:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Build G snapshot report
+        run: |
+          mkdir -p PULSE_safe_pack_v0/artifacts
+          python scripts/g_snapshot_report.py \
+            --root . \
+            --format markdown \
+            --output PULSE_safe_pack_v0/artifacts/g_snapshot_report_v0.md
+
+      - name: Upload G snapshot report
+        uses: actions/upload-artifact@v4
+        with:
+          name: g-snapshot-report
+          path: PULSE_safe_pack_v0/artifacts/g_snapshot_report_v0.md


### PR DESCRIPTION
## Summary

This PR adds a shadow GitHub Actions workflow that generates a
human-readable G snapshot report from the existing overlays:

- new file: `.github/workflows/g_snapshot_report_shadow.yml`

The workflow runs `scripts/g_snapshot_report.py` in markdown mode and
publishes `g_snapshot_report_v0.md` as an artifact.

## Motivation

We now produce several G-related overlays in shadow CI:

- `g_field_v0.json` (G-field overlay)
- `g_field_stability_v0.json` (stability overlay)
- `g_epf_overlay_v0.json` (G + EPF / Paradox bridge)
- `gpt_external_detection_v0.json` (GPT external sentinel)

The `g_snapshot_report.py` helper can combine these into a single,
human-readable snapshot that is useful for review and governance.

## Implementation details

- Workflow: `.github/workflows/g_snapshot_report_shadow.yml`
  - triggers:
    - `workflow_dispatch` (manual)
    - `push` when:
      - `scripts/g_snapshot_report.py` changes
      - G-related overlays under `PULSE_safe_pack_v0/artifacts/**` change
      - the workflow file itself changes
  - job `g-snapshot-report-shadow`:
    1. Checkout repository (actions/checkout@v4)
    2. Set up Python 3.x (actions/setup-python@v5)
    3. Build G snapshot report:
       ```bash
       mkdir -p PULSE_safe_pack_v0/artifacts
       python scripts/g_snapshot_report.py \
         --root . \
         --format markdown \
         --output PULSE_safe_pack_v0/artifacts/g_snapshot_report_v0.md
       ```
    4. Upload G snapshot report:
       - uploads `PULSE_safe_pack_v0/artifacts/g_snapshot_report_v0.md`
         as the `g-snapshot-report` artifact.

The workflow is CI-neutral and does not affect any release gates.

## Usage

- Run the G-related shadow workflows (G-field, G-EPF, GPT external) so
  that overlays are available.
- Then trigger **G snapshot report (shadow)** from the Actions tab, or
  rely on the push triggers when overlays change.

After a successful run, download the `g-snapshot-report` artifact and
inspect `g_snapshot_report_v0.md` as a consolidated view of the
G-field, EPF interaction, and external GPT usage.
