### PR TITLE
ci: rebuild overlays before G snapshot report

### DIFF
--- a/.github/workflows/g_snapshot_report_shadow.yml
+++ b/.github/workflows/g_snapshot_report_shadow.yml
@@ -24,6 +24,49 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Rebuild G-field overlay (optional)
+        run: |
+          mkdir -p PULSE_safe_pack_v0/artifacts
+          if [ -f "hpc/g_snapshots.jsonl" ] && [ -f "PULSE_safe_pack_v0/artifacts/status.json" ]; then
+            echo "[INFO] Rebuilding g_field_v0 overlay..."
+            python scripts/g_child_field_adapter.py \
+              --snapshots hpc/g_snapshots.jsonl \
+              --status PULSE_safe_pack_v0/artifacts/status.json \
+              --output PULSE_safe_pack_v0/artifacts/g_field_v0.json
+          else
+            echo "[INFO] Missing hpc/g_snapshots.jsonl or PULSE_safe_pack_v0/artifacts/status.json, skipping G-field overlay rebuild."
+          fi
+
+      - name: Rebuild GPT external detection overlay (optional)
+        run: |
+          if [ -f "logs/model_invocations.jsonl" ]; then
+            mkdir -p PULSE_safe_pack_v0/artifacts
+            echo "[INFO] Rebuilding gpt_external_detection_v0 overlay..."
+            python scripts/gpt_external_detector.py \
+              --input logs/model_invocations.jsonl \
+              --output PULSE_safe_pack_v0/artifacts/gpt_external_detection_v0.json
+          else
+            echo "[INFO] No logs/model_invocations.jsonl found, skipping GPT external overlay rebuild."
+          fi
+
+      - name: Rebuild G-EPF overlay (optional)
+        run: |
+          if [ -f "PULSE_safe_pack_v0/artifacts/g_field_v0.json" ] \
+             && [ -f "status_baseline.json" ] \
+             && [ -f "status_epf.json" ] \
+             && [ -f "epf_paradox_summary.json" ]; then
+            mkdir -p PULSE_safe_pack_v0/artifacts
+            echo "[INFO] Rebuilding g_epf_overlay_v0 overlay..."
+            python scripts/g_child_epf_bridge.py \
+              --g-field PULSE_safe_pack_v0/artifacts/g_field_v0.json \
+              --status-baseline status_baseline.json \
+              --status-epf status_epf.json \
+              --paradox-summary epf_paradox_summary.json \
+              --output PULSE_safe_pack_v0/artifacts/g_epf_overlay_v0.json
+          else
+            echo "[INFO] Missing EPF baseline/EPF/paradox inputs, skipping G-EPF overlay rebuild."
+          fi
+
       - name: Build G snapshot report
         run: |
           mkdir -p PULSE_safe_pack_v0/artifacts
@@ -37,3 +80,4 @@ jobs:
         with:
           name: g-snapshot-report
           path: PULSE_safe_pack_v0/artifacts/g_snapshot_report_v0.md
+


### PR DESCRIPTION
## Summary

This PR updates the G snapshot report shadow workflow so that it
attempts to rebuild the relevant overlays before generating the report.

- file: `.github/workflows/g_snapshot_report_shadow.yml`

## Motivation

Codex correctly pointed out that the original snapshot workflow only
checked out the repo and called `scripts/g_snapshot_report.py`, without
ever building or fetching the overlays it depends on.

Because each workflow runs on a clean runner, the overlays from other
shadow workflows are not present on disk. As a result, the report always
marked all sources as "missing", which defeats the purpose of the
snapshot, even though the overlay generators exist.

## Implementation details

- Added three optional rebuild steps before the report:

  1. **Rebuild G-field overlay (optional)**  
     - runs `scripts/g_child_field_adapter.py` when both:
       - `hpc/g_snapshots.jsonl`
       - `PULSE_safe_pack_v0/artifacts/status.json`
       are present.
     - otherwise logs an INFO message and skips.

  2. **Rebuild GPT external detection overlay (optional)**  
     - runs `scripts/gpt_external_detector.py` when
       `logs/model_invocations.jsonl` is present.
     - otherwise logs an INFO message and skips.

  3. **Rebuild G-EPF overlay (optional)**  
     - runs `scripts/g_child_epf_bridge.py` when:
       - `PULSE_safe_pack_v0/artifacts/g_field_v0.json`
       - `status_baseline.json`
       - `status_epf.json`
       - `epf_paradox_summary.json`
       are present.
     - otherwise logs an INFO message and skips.

- The final step still runs:

  ```bash
  python scripts/g_snapshot_report.py \
    --root . \
    --format markdown \
    --output PULSE_safe_pack_v0/artifacts/g_snapshot_report_v0.md

The job remains CI-neutral: missing inputs only cause overlays to be
skipped, not the workflow to fail.

Impact

When inputs are available, the G snapshot report now includes real
G-field / EPF / GPT overlay information.

When inputs are missing, behaviour is unchanged except for clearer
INFO logs.

Next steps

Optionally wire this snapshot workflow to run after specific shadow
overlay workflows or update docs to explain how to provide the
optional inputs locally.