### PR TITLE
test(gpt): add sample model invocation log

### DIFF
--- a/logs/logs/logs/model_invocations.jsonl
+++ b/logs/logs/logs/model_invocations.jsonl
@@ -1,0 +1,5 @@
+{"id": "req_001", "timestamp": "2025-11-30T22:10:00Z", "vendor": "internal_hpc", "model": "g_child_v0", "route": "hpc", "meta": {"comment": "internal G-child call"}}
+{"id": "req_002", "timestamp": "2025-11-30T22:11:00Z", "vendor": "openai", "model": "gpt-4.1-mini", "route": "external", "meta": {"comment": "assistant completion"}}
+{"id": "req_003", "timestamp": "2025-11-30T22:12:00Z", "vendor": "openai", "model": "gpt-4.1", "route": "external", "meta": {"comment": "tool-using agent"}}
+{"id": "req_004", "timestamp": "2025-11-30T22:13:00Z", "vendor": "anthropic", "model": "claude-3.5", "route": "external", "meta": {"comment": "eval run"}}
+{"id": "req_005", "timestamp": "2025-11-30T22:14:00Z", "vendor": "internal_hpc", "model": "g_child_v0", "route": "hpc", "meta": {"comment": "internal sanity check"}}


### PR DESCRIPTION
## Summary

This PR adds a small sample model invocation log for the GPT external
detection shadow workflow:

- new file: `logs/model_invocations.jsonl`

The file is synthetic and contains a mix of internal and external
model calls.

## Motivation

The GPT external detection overlay and the G snapshot report currently
show "No GPT external detection overlay found" because there is no
`logs/model_invocations.jsonl` for the detector to consume.

By adding a simple example log, we can exercise:

- `scripts/gpt_external_detector.py`
- the `GPT external detection (shadow)` workflow
- the GPT section of the G snapshot report.

## Implementation details

- New JSONL log: `logs/model_invocations.jsonl`
  - fields:
    - `id`: request id
    - `timestamp`: ISO 8601 UTC timestamp
    - `vendor`: e.g. `internal_hpc`, `openai`, `anthropic`
    - `model`: model name (e.g. `g_child_v0`, `gpt-4.1-mini`, `claude-3.5`)
    - `route`: `hpc` for internal calls, `external` for vendor calls
    - `meta`: small comment for readability
  - contains:
    - 2 internal calls (`vendor = internal_hpc`, `model = g_child_v0`)
    - 3 external calls (OpenAI and Anthropic models).

The file is fully synthetic and contains no real data or PII.
