### PR TITLE
test(gpt): add sample model_invocations log

### DIFF
--- a/logs/model_invocations.jsonl
+++ b/logs/model_invocations.jsonl
@@ -1,0 +1,5 @@
+{"id": "req_001", "timestamp": "2025-11-30T22:10:00Z", "vendor": "internal_hpc", "model": "g_child_v0", "route": "hpc", "meta": {"comment": "internal G-child call"}}
+{"id": "req_002", "timestamp": "2025-11-30T22:11:00Z", "vendor": "openai", "model": "gpt-4.1-mini", "route": "external", "meta": {"comment": "assistant completion"}}
+{"id": "req_003", "timestamp": "2025-11-30T22:12:00Z", "vendor": "openai", "model": "gpt-4.1", "route": "external", "meta": {"comment": "tool-using agent"}}
+{"id": "req_004", "timestamp": "2025-11-30T22:13:00Z", "vendor": "anthropic", "model": "claude-3.5", "route": "external", "meta": {"comment": "eval run"}}
+{"id": "req_005", "timestamp": "2025-11-30T22:14:00Z", "vendor": "internal_hpc", "model": "g_child_v0", "route": "hpc", "meta": {"comment": "internal sanity check"}}


### PR DESCRIPTION
## Summary

Add a small synthetic model invocation log for the GPT external
detection shadow workflow:

- new file: `logs/model_invocations.jsonl`

The log contains a mix of internal HPC G-child calls and external
vendor calls (OpenAI, Anthropic).

## Motivation

Without any `logs/model_invocations.jsonl`, the GPT external detection
(shadow) workflow and the G snapshot report always see an empty GPT
field and report "no GPT external detection overlay found".

This sample log allows the shadow workflows to exercise the GPT
sentinel pipeline and produce non-empty stats in the snapshot report.

## Details

- Format: JSONL (one JSON object per line).
- Fields:
  - `id`, `timestamp`
  - `vendor` (e.g. `internal_hpc`, `openai`, `anthropic`)
  - `model` (e.g. `g_child_v0`, `gpt-4.1`, `gpt-4.1-mini`, `claude-3.5`)
  - `route` (`hpc` or `external`)
  - `meta.comment` for readability
- Contains:
  - 2 internal HPC G-child calls
  - 3 external GPT calls

The data is fully synthetic and PII-free.
