### PR TITLE
feat(schemas): add g_field_stability_v0 schema

### DIFF
--- a/schemas/schemas/g_field_stability_v0.schema.json
+++ b/schemas/schemas/g_field_stability_v0.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "g_field_stability_v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "created_at", "summary"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "g_field_stability_v0"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "num_runs",
+        "num_points",
+        "g_mean_global",
+        "g_std_global",
+        "max_gate_std",
+        "unstable_gates"
+      ],
+      "properties": {
+        "num_runs": { "type": "integer", "minimum": 0 },
+        "num_points": { "type": "integer", "minimum": 0 },
+        "g_mean_global": { "type": "number" },
+        "g_std_global": { "type": "number" },
+        "max_gate_std": { "type": "number" },
+        "unstable_gates": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "runs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["run_id", "created_at", "g_mean", "g_std"],
+        "properties": {
+          "run_id": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "g_mean": { "type": "number" },
+          "g_std": { "type": "number" }
+        }
+      }
+    },
+    "gates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "g_mean", "g_std", "max_delta", "is_unstable"],
+        "properties": {
+          "id": { "type": "string" },
+          "g_mean": { "type": "number" },
+          "g_std": { "type": "number" },
+          "max_delta": { "type": "number" },
+          "is_unstable": { "type": "boolean" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a JSON Schema for the `g_field_stability_v0` overlay:

- new file: `schemas/schemas/g_field_stability_v0.schema.json`

The schema is used by `scripts/validate_overlays.py` and the
"Overlay schema validation (shadow)" workflow.

## Details

The schema covers:

- top-level fields:
  - `version` (const `g_field_stability_v0`)
  - `created_at` (ISO 8601 date-time)
  - optional `source` string
- `summary` object:
  - `num_runs`, `num_points`
  - `g_mean_global`, `g_std_global`
  - `max_gate_std`, `unstable_gates`
- `runs` array:
  - `run_id`, `created_at`, `g_mean`, `g_std`
- `gates` array:
  - `id`, `g_mean`, `g_std`, `max_delta`, `is_unstable`

`additionalProperties: false` is used to keep the overlay contract
tight and predictable.

## Motivation

The overlay schema validation shadow job was failing with:

> `g_field_stability_v0: schema file not found`

because there was no schema file for this overlay. With this schema in
place, the validation job can check stability overlays and the G
snapshot report can safely consume them.
