### PR TITLE
chore(schemas): move g_field_stability_v0 schema under schemas/schemas

### DIFF
--- a/schemas/schemas/schemas/g_field_stability_v0.schema.json
+++ b/schemas/schemas/schemas/g_field_stability_v0.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "g_field_stability_v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "created_at", "summary"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "g_field_stability_v0"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "num_runs",
+        "num_points",
+        "g_mean_global",
+        "g_std_global",
+        "max_gate_std",
+        "unstable_gates"
+      ],
+      "properties": {
+        "num_runs": { "type": "integer", "minimum": 0 },
+        "num_points": { "type": "integer", "minimum": 0 },
+        "g_mean_global": { "type": "number" },
+        "g_std_global": { "type": "number" },
+        "max_gate_std": { "type": "number" },
+        "unstable_gates": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "runs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["run_id", "created_at", "g_mean", "g_std"],
+        "properties": {
+          "run_id": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "g_mean": { "type": "number" },
+          "g_std": { "type": "number" }
+        }
+      }
+    },
+    "gates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "g_mean", "g_std", "max_delta", "is_unstable"],
+        "properties": {
+          "id": { "type": "string" },
+          "g_mean": { "type": "number" },
+          "g_std": { "type": "number" },
+          "max_delta": { "type": "number" },
+          "is_unstable": { "type": "boolean" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- PULSE PR Template v1.0 — keep sections; fill what applies. -->

## Summary
<!-- Short: what changes and why? -->

## What’s included
- [ ] Code
- [ ] Docs
- [ ] CI / workflow
- Paths / files touched:

## CI usage
```yaml
# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json
```

## Impact
- Additive / backwards-compatible
- Breaking change — details:
- Performance / SLO impact:
- Security considerations:

## Notes
- Follow-ups:
- Risks / mitigations:

## PULSE checklist (governance)
- [ ] PULSE CI is green on this PR
- [ ] Quality Ledger link (if enabled)
- [ ] Badges updated (PASS / RDSI / Q‑Ledger)
