### PR TITLE
docs(artifacts): add sample G‑EPF overlay diagnostic

### DIFF
--- a/g_epf_overlay_v0.json
+++ b/g_epf_overlay_v0.json
@@ -2,25 +2,27 @@
   "version": "g_epf_overlay_v0",
   "created_at": "2025-12-01T13:30:00Z",
   "source": "sample",
+
   "summary": {
-    "num_gates": 2,
-    "num_paradox_like": 1,
-    "num_regressions": 0
+    "num_runs": 1,
+    "num_panels": 1,
+    "num_gates": 3,
+    "num_failed_gates": 1
   },
-  "gates": [
+
+  "g_field": {},
+  "diagnostics": {},
+
+  "panels": [
     {
-      "id": "paradox_gate_1",
-      "description": "Reference EPF/Paradox gate with low delta vs baseline.",
-      "delta": 0.02,
-      "decision": "GO",
-      "is_paradox_like": false
-    },
-    {
-      "id": "paradox_gate_2",
-      "description": "Synthetic paradox-like gate with higher delta.",
-      "delta": 0.08,
-      "decision": "NO_GO",
-      "is_paradox_like": true
+      "panel_id": "paradox_gate_1",
+      "label": "Paradox Gate #1",
+      "suite": "EPF demo",
+      "num_traces": 16,
+      "num_gates": 3,
+      "num_failed_gates": 1,
+      "status": "unstable",
+      "notes": "Synthetic EPF overlay sample; not used for real gating."
     }
   ]
 }


### PR DESCRIPTION
Adds a small synthetic G‑EPF overlay sample:

- new file: g_epf_overlay_v0.json
- shows two example gates (one “paradox-like”, one normal)
- intended for schema validation and the G‑snapshot report EPF section

This sample is diagnostic/shadow-only and does not change any release gates.
