### PR TITLE
docs(readme): add roadmap for G-shadow layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,32 @@ basic G-field stats (mean/min/max) and GPT usage stats (internal vs
 external calls, top vendors and models). It is CI-neutral and intended
 for diagnostic and governance dashboards.
 
+---
+
+### Roadmap (shadow layer)
+
+The current G-shadow layer is intentionally minimal: a small set of overlays and a
+shadow-only snapshot report that can be shipped safely in the PULSE safe pack.
+Next steps we are planning (non‑breaking, iterative) include:
+
+- **EPF overlay 2.0**  
+  Move from the current demo EPF panel to a more realistic EPF diagnostics overlay
+  (richer fields, clearer mapping to gates, better summary in the snapshot report).
+
+- **G‑field stability summaries**  
+  Extend the `g_field_stability` overlay from a raw diagnostic JSON block to
+  gate-level stability summaries and (optionally) simple historical trends.
+
+- **GPT usage overlays**  
+  Refine the GPT external detection overlay with scenario / product‑line breakdowns
+  and clearer attribution of “internal vs external” usage in the snapshot.
+
+- **Docs & UX for overlays**  
+  Add short “how to add a new overlay” guidance and more snapshot examples, so that
+  teams can plug in additional overlays without touching the core release gates.
 
 ---
+
 
 ### EPF (experimental, shadow-only)
 


### PR DESCRIPTION
## Summary

Add a new `### Roadmap (shadow layer)` section to the README, between the
G snapshot report (v0) description and the EPF (experimental, shadow-only)
section.

The roadmap makes the current scope of the G-shadow stack explicit and
outlines the next steps we have in mind.

## What changed

- Document that the current G-shadow stack is a v0, shadow-only layer
  (exercises data plumbing / CI, but does not enforce gates yet).
- Add short bullets for:
  - **EPF overlay 2.0** – move from the demo EPF panel towards a real EPF diagnostic overlay.
  - **G-field stability summaries** – gate-level stability summaries and simple trends.
  - **GPT usage overlays** – richer breakdowns for internal vs external usage.
  - **Docs & UX** – more human-friendly snapshot report + "how to add a new overlay".
  - **From shadow to gates** – criteria for promoting signals into actual release gates.

## Motivation

Make it clearer for readers (and reviewers) what the G-shadow layer is for today,
and where we intend to take it next, without committing to a specific timeline.
This also gives future PRs a stable place to reference when evolving overlays
or the snapshot report.

## Testing

- Rendered README locally / in GitHub preview.
- Checked headings and links render as expected.
- No code, policy or CI changes.
