### PR TITLE
chore(validate): add stability_map_v0 naming guard script

### DIFF
--- a/scripts/check_stability_map_naming.py
+++ b/scripts/check_stability_map_naming.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# NOTE: Keep all comments and user-facing messages in this file in English.
+
+"""
+PULSE stability map naming guard.
+
+This script enforces a consistent naming convention for the stability map file.
+
+Rules:
+- The legacy file name 'stability_map.json' must NOT exist in the repository root.
+- The versioned file 'stability_map_v0.json' MUST exist in the repository root.
+- No text file in the repository may still refer to 'stability_map.json'.
+
+It is intended to be executed in CI (GitHub Actions) but can also be run locally.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+TEXT_SUFFIXES = {".md", ".py", ".yml", ".yaml", ".json", ".toml", ".txt"}
+
+
+def main() -> int:
+    root = pathlib.Path(__file__).resolve().parents[1]
+
+    legacy = root / "stability_map.json"
+    current = root / "stability_map_v0.json"
+
+    errors: list[str] = []
+
+    # 1) The legacy file must not exist anymore.
+    if legacy.exists():
+        errors.append(
+            "Legacy file 'stability_map.json' still exists in the repository root. "
+            "Please rename it to 'stability_map_v0.json' and remove the old name."
+        )
+
+    # 2) The new versioned file must exist.
+    if not current.exists():
+        errors.append(
+            "Expected file 'stability_map_v0.json' in the repository root, "
+            "but it is missing."
+        )
+
+    # 3) No text files may still reference the legacy name.
+    bad_refs: list[str] = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in TEXT_SUFFIXES:
+            continue
+
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            # Skip binary or non-UTF-8 files.
+            continue
+
+        if "stability_map.json" in text:
+            rel = path.relative_to(root)
+            bad_refs.append(str(rel))
+
+    if bad_refs:
+        msg_lines = [
+            "Found references to legacy name 'stability_map.json' "
+            "in the following files:",
+            *[f"  - {p}" for p in bad_refs],
+        ]
+        errors.append("\n".join(msg_lines))
+
+    if errors:
+        print("❌ PULSE stability map naming check FAILED.\n")
+        for err in errors:
+            print("*", err)
+        print(
+            "\nThis script is intentionally maintained in English only to keep "
+            "repository output consistent."
+        )
+        return 1
+
+    print("✅ PULSE stability map naming check passed.")
+    print("The repository only uses the versioned file name 'stability_map_v0.json'.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add a small validation helper that enforces the versioned naming for the
stability map artefact.

## Changes

- Introduce `scripts/check_stability_map_naming.py`:
  - fails if `stability_map.json` still exists in the repo root,
  - fails if `stability_map_v0.json` is missing from the repo root,
  - scans text files for any remaining references to `stability_map.json`.

All messages and comments in the script are in English to keep CI logs and
repository output consistent.

## Motivation

We already use `stability_map_v0` as the conceptual name in schemas and docs.
This guard ensures that:
- only the versioned filename `stability_map_v0.json` is present in the root,
- no legacy references to `stability_map.json` leak back into the codebase.

## Testing

- Ran `python scripts/check_stability_map_naming.py` locally:
  - observed failure when `stability_map.json` exists or is referenced,
  - observed success once the file is renamed and all references are updated.
