### PR TITLE
fix(schema): harmonise status.schema.json with status artefacts (add profile_id)

### DIFF
--- a/status.schema.json
+++ b/status.schema.json
@@ -1,4 +1,3 @@
----- START FILE ----
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "PULSE status.json (v0.1)",
@@ -9,19 +8,20 @@
       "type": "object",
       "required": ["commit", "profile_hash", "seed", "dataset_snapshot"],
       "properties": {
-        "commit": {"type": "string"},
-        "profile_hash": {"type": "string"},
-        "seed": {"type": "integer"},
-        "dataset_snapshot": {"type": "string"},
-        "timestamp_utc": {"type": "string"}
+        "commit": { "type": "string" },
+        "profile_hash": { "type": "string" },
+        "seed": { "type": "integer" },
+        "dataset_snapshot": { "type": "string" },
+        "timestamp_utc": { "type": "string" },
+        "profile_id": { "type": "string" }
       }
     },
     "results": {
       "type": "object",
       "properties": {
-        "security": {"type": "object"},
-        "quality": {"type": "object"},
-        "slo": {"type": "object"},
+        "security": { "type": "object" },
+        "quality": { "type": "object" },
+        "slo": { "type": "object" },
         "refusal_delta_pass": {},
         "external_all_pass": {}
       }
@@ -29,12 +29,11 @@
     "rds_index": {
       "type": "object",
       "properties": {
-        "ci_lower": {"type": "number"},
-        "ci_upper": {"type": "number"},
-        "runs": {"type": "integer"}
+        "ci_lower": { "type": "number" },
+        "ci_upper": { "type": "number" },
+        "runs": { "type": "integer" }
       }
     },
-    "notes": {"type": "string"}
+    "notes": { "type": "string" }
   }
 }
----- END FILE ----


### PR DESCRIPTION
## Summary

This PR updates `schemas/status.schema.json` to include the missing `profile_id`
field in the `run` block. This field is present in `status.json` generated by
`PULSE_safe_pack_v0/tools/run_all.py`, but was absent from the schema.

The update removes the only confirmed schema–artifact drift reported in the
Codex structural audit and improves consistency across the safe-pack ecosystem.

## Changes

- Added:
  ```json
  "profile_id": { "type": "string" }

under run.properties.

No other schema fields or constraints were modified.

Does not affect gate logic or CI behaviour.

Fully backward-compatible with existing outputs.

Motivation

Keeping the status schema aligned with the safe-pack generator ensures:

predictable structure for downstream tools,

correct validation for validate-status.yml,

cleaner integration with future topology/trace layers.

Validation

Schema validated successfully via:

validate-status workflow

jsonschema CLI (local test)

Impact

No breaking changes.
Purely a harmonisation fix to maintain contract integrity.