### PR TITLE
ci: add G-EPF overlay shadow workflow in canonical location

### DIFF
--- a/.github/workflows/g_epf_overlay_shadow.yml
+++ b/.github/workflows/g_epf_overlay_shadow.yml
@@ -1,0 +1,45 @@
+name: G-field EPF overlay (shadow)
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'scripts/g_child_epf_bridge.py'
+      - 'PULSE_safe_pack_v0/artifacts/**'
+      - '.github/workflows/g_epf_overlay_shadow.yml'
+
+jobs:
+  g-epf-overlay-shadow:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for G-field overlay
+        id: check_g_field
+        run: |
+          if [ -f "PULSE_safe_pack_v0/artifacts/g_field_v0.json" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "Found G-field overlay: PULSE_safe_pack_v0/artifacts/g_field_v0.json"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No G-field overlay found, skipping EPF bridge."
+          fi
+
+      - name: Build G-EPF overlay
+        if: steps.check_g_field.outputs.found == 'true'
+        run: |
+          python scripts/g_child_epf_bridge.py \
+            --g-field PULSE_safe_pack_v0/artifacts/g_field_v0.json \
+            --status-baseline PULSE_safe_pack_v0/artifacts/status_baseline.json \
+            --status-epf PULSE_safe_pack_v0/artifacts/status_epf.json \
+            --paradox-summary PULSE_safe_pack_v0/artifacts/epf_paradox_summary.json \
+            --output PULSE_safe_pack_v0/artifacts/g_epf_overlay_v0.json
+
+      - name: Upload G-EPF overlay artifact
+        if: steps.check_g_field.outputs.found == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: g-epf-overlays
+          path: PULSE_safe_pack_v0/artifacts/g_epf_overlay_v0.json


### PR DESCRIPTION
## Summary

This PR adds the G-EPF overlay shadow workflow in its correct location
under `.github/workflows/`:

- New file: `.github/workflows/g_epf_overlay_shadow.yml`

The workflow:

- triggers on changes to:
  - `scripts/g_child_epf_bridge.py`
  - `PULSE_safe_pack_v0/artifacts/**`
  - `.github/workflows/g_epf_overlay_shadow.yml`
- checks whether `PULSE_safe_pack_v0/artifacts/g_field_v0.json` exists,
- if present, runs `g_child_epf_bridge.py` to build
  `PULSE_safe_pack_v0/artifacts/g_epf_overlay_v0.json`,
- uploads the overlay as a CI artifact.

## Context

A misplaced copy previously lived under
`.github/workflows/.github/workflows/g_epf_overlay_shadow.yml` and has
been removed. This PR restores the workflow in the canonical path.

## Impact

- No changes to mainline PULSE gates.
- Provides a clean, CI-neutral shadow workflow for building G-EPF overlays.
