### PR TITLE
chore(manifest): fix pack_manifest drift by dropping stale tools/ci refs

### DIFF
--- a/PULSE_safe_pack_v0/pack_manifest.yml
+++ b/PULSE_safe_pack_v0/pack_manifest.yml
@@ -6,7 +6,6 @@ required:
   - path: tools/check_gates.py
   - path: tools/augment_status.py
   - path: tools/refusal_delta_calc.py
-  - path: tools/ci/update_badges.py
   - path: docs/METHODS_RDSI_QLEDGER.md
   - path: docs/EXTERNAL_DETECTORS.md
   - path: profiles/external_thresholds.yaml
@@ -21,7 +20,6 @@ required:
       count: 3
 
 optional:
-  - path: tools/ci/pr_comment_qledger.py
   - path: docs/LIGHTHOUSE_CASE_1.md
   - path: docs/COMPETITOR_RADAR_2025.md
 


### PR DESCRIPTION
## Summary

This PR updates `PULSE_safe_pack_v0/pack_manifest.yml` to remove references
to tools that are no longer present in the repository, resolving a manifest
drift issue highlighted in the structural audit.

## Changes

- Removed from `required`:
  - `tools/ci/update_badges.py`
- Removed from `optional`:
  - `tools/ci/pr_comment_qledger.py` (if present previously)

All other entries (safe-pack tools, docs, profiles, examples, artefacts)
remain unchanged.

## Motivation

- Keep the pack manifest aligned with the actual contents of
  `PULSE_safe_pack_v0/`.
- Avoid confusing users or tooling by listing non-existent tools as required
  or optional pack components.

## Impact

- No impact on gate logic or safe-pack runtime behaviour.
- CI continues to rely on the existing, in-tree tools.
- The manifest now accurately documents what the pack ships.
