### PR TITLE
fix(ci): make topology demo artefact validation conditional

### DIFF
--- a/.github/workflows/pulse_topology_demo.yml
+++ b/.github/workflows/pulse_topology_demo.yml
@@ -59,19 +59,35 @@ jobs:
         # Only run validation if the main schema file is present
         if: ${{ hashFiles('schemas/PULSE_stability_map_v0.schema.json') != '' }}
         run: |
-          python -m jsonschema \
-            -i PULSE_safe_pack_v0/artifacts/stability_map.demo.ci.json \
-            schemas/PULSE_stability_map_v0.schema.json
+          # Validate stability_map demo if present
+          if [ -f "PULSE_safe_pack_v0/artifacts/stability_map.demo.ci.json" ]; then
+            python -m jsonschema \
+              -i PULSE_safe_pack_v0/artifacts/stability_map.demo.ci.json \
+              schemas/PULSE_stability_map_v0.schema.json
+          else
+            echo "No stability_map.demo.ci.json found, skipping stability map validation."
+          fi
 
-          python -m jsonschema \
-            -i PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json \
-            schemas/PULSE_decision_trace_v0.schema.json
+          # Validate decision_trace demo if present
+          if [ -f "PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json" ]; then
+            python -m jsonschema \
+              -i PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json \
+              schemas/PULSE_decision_trace_v0.schema.json
+          else
+            echo "No decision_trace.demo.ci.json found, skipping decision trace validation."
+          fi
 
-          python -m jsonschema \
-            -i PULSE_safe_pack_v0/artifacts/dual_view_v0.demo.ci.json \
-            schemas/PULSE_dual_view_v0.schema.json
+          # Validate dual_view demo if present
+          if [ -f "PULSE_safe_pack_v0/artifacts/dual_view_v0.demo.ci.json" ]; then
+            python -m jsonschema \
+              -i PULSE_safe_pack_v0/artifacts/dual_view_v0.demo.ci.json \
+              schemas/PULSE_dual_view_v0.schema.json
+          else
+            echo "No dual_view_v0.demo.ci.json found, skipping dual view validation."
+          fi
 
       - name: Validate decision trace with helper script
+        if: ${{ hashFiles('PULSE_safe_pack_v0/artifacts/decision_trace.demo.ci.json') != '' }}
         run: |
           python PULSE_safe_pack_v0/tools/validate_decision_trace_v0.py \
             --schema schemas/PULSE_decision_trace_v0.schema.json \


### PR DESCRIPTION
## Summary

This PR adjusts `pulse_topology_demo.yml` so that:

- jsonschema validations for:
  - `stability_map.demo.ci.json`
  - `decision_trace.demo.ci.json`
  - `dual_view_v0.demo.ci.json`
  are only run if the artefacts exist,
- the `validate_decision_trace_v0.py` helper only runs if the
  `decision_trace.demo.ci.json` demo file exists.

Previously, the workflow failed when `decision_trace.demo.ci.json` was
missing, even though this is meant to be a CI-neutral demo.

## Impact

- Topology demo no longer blocks PRs when demo artefacts are missing.
- Validations still run when demo JSONs are produced.
