### PR TITLE
feat(core): add PULSE Core policy profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - aggregates safety/quality gate outcomes, RDSI and EPF (`epf_L`) into a single instability score with transparent components
   - assigns a coarse stability type per run (`STABLE`, `METASTABLE`, `UNSTABLE`, `PARADOX`, `COLLAPSE`)
   - does not modify any existing fail-closed release-gate behaviour
+- Core policy profile `PULSE_safe_pack_v0/profiles/pulse_policy_core.yaml`:
+  - documents the minimal recommended deterministic gate set for first-time PULSE adopters
+  - encodes a CI-neutral refusal-delta stability policy without changing the existing fail-closed behaviour
 
 ### Changed
 - README: add DOI badge above the PULSE badges; keep badges.


### PR DESCRIPTION
## Summary

This PR introduces a **PULSE Core policy profile** and documents it in the
Unreleased section of the changelog.

The goal is to make the minimal recommended deterministic gate set explicit
and machine-readable for first-time PULSE adopters, without changing any
existing fail-closed behaviour yet.

---

## What changed

- Added `PULSE_safe_pack_v0/profiles/pulse_policy_core.yaml`:
  - `profile_id: "core_v0"`, label `"PULSE Core (minimal deterministic gates)"`.
  - Human-readable description for the Core profile.
  - `core_required_gates` list:
    - `pass_controls_refusal`
    - `pass_controls_sanit`
    - `sanitization_effective`
    - `q1_grounded_ok`
    - `q4_slo_ok`
  - Optional `gates` block with a concrete configuration for `q1_groundedness`.
  - `refusal_delta` block:
    - balanced vs strict policy
    - `delta_min` / `delta_strict` thresholds
    - `alpha`, `require_significance`, `significance`
    - explicitly CI-neutral (`ci_neutral: true`).

- Updated `CHANGELOG` under **Unreleased → Added**:
  - added an entry for
    `PULSE_safe_pack_v0/profiles/pulse_policy_core.yaml`,
  - clarified that it documents the minimal deterministic gate set and
    encodes a CI-neutral refusal-delta stability policy.

---

## Behavioural impact

- No change to:
  - current CI workflows,
  - existing gate enforcement,
  - fail-closed behaviour.

- The new profile is **configuration-only**:
  - it becomes effective only when referenced from
    `PULSE_safe_pack_v0/pulse_policy.yml` or from a custom CI workflow.

Follow-up work (separate PRs):

- Wire the Core profile into the default `pulse_policy.yml` if we want to make
  it the default for new integrations.
- Optionally expose a Core-level refusal-delta gate once we are happy with
  the policy and thresholds.

---

## Testing

- YAML syntax validated locally.
- No Python code or workflows changed in this PR.
- CI should run as before; only new config + changelog content is added.
