### PR TITLE
feat(core): add PULSE Core CI workflow

### DIFF
--- a/.github/workflows/pulse_core_ci.yml
+++ b/.github/workflows/pulse_core_ci.yml
@@ -1,0 +1,115 @@
+name: PULSE Core CI
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  pulse-core:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Locate PULSE pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          ROOT="$GITHUB_WORKSPACE"
+
+          if [ -d "$ROOT/PULSE_safe_pack_v0" ]; then
+            echo "PACK_DIR=$ROOT/PULSE_safe_pack_v0" >> "$GITHUB_ENV"
+          elif [ -f "$ROOT/PULSE_safe_pack_v0.zip" ]; then
+            unzip -q -o "$ROOT/PULSE_safe_pack_v0.zip"
+            echo "PACK_DIR=$ROOT/PULSE_safe_pack_v0" >> "$GITHUB_ENV"
+          else
+            RUN_ALL=$(find "$ROOT" -type f -name run_all.py -path "*/PULSE_safe_pack_v0/*" | head -n1 || true)
+            if [ -z "$RUN_ALL" ]; then
+              echo "::error::PULSE_safe_pack_v0 not found (expected folder or zip in repo root)."
+              exit 1
+            fi
+            echo "PACK_DIR=$(dirname "$(dirname "$RUN_ALL")")" >> "$GITHUB_ENV"
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Run PULSE Core pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          python "${PACK_DIR}/tools/run_all.py"
+
+      - name: Show gates snapshot
+        shell: bash
+        run: |
+          echo "----- status.json (gates) -----"
+          if command -v jq >/dev/null 2>&1; then
+            jq '.gates' "${PACK_DIR}/artifacts/status.json" || cat "${PACK_DIR}/artifacts/status.json"
+          else
+            cat "${PACK_DIR}/artifacts/status.json"
+          fi
+          echo "--------------------------------"
+
+      - name: Enforce Core gates (fail-closed)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Core profile: minimal deterministic gates for first-time adopters
+          REQ=(
+            pass_controls_refusal
+            pass_controls_sanit
+            sanitization_effective
+            q1_grounded_ok
+            q4_slo_ok
+          )
+
+          python "${PACK_DIR}/tools/check_gates.py" \
+            --status "${PACK_DIR}/artifacts/status.json" \
+            --require "${REQ[@]}"
+
+      - name: Export JUnit & SARIF
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p reports
+
+          # PULSE converters expect status.json in cwd
+          cp "${PACK_DIR}/artifacts/status.json" status.json
+
+          python "${PACK_DIR}/tools/status_to_junit.py" || echo "JUnit export failed (optional)"
+          python "${PACK_DIR}/tools/status_to_sarif.py" || echo "SARIF export failed (optional)"
+
+          if [ -f junit.xml ]; then
+            mv junit.xml reports/junit.xml
+          fi
+          if [ -f sarif.json ]; then
+            mv sarif.json reports/sarif.json
+          fi
+
+      - name: Upload PULSE Core artefacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pulse-core-report
+          path: |
+            ${{ env.PACK_DIR }}/artifacts/**
+            reports/junit.xml
+            reports/sarif.json


### PR DESCRIPTION
## Summary

This PR adds a dedicated **PULSE Core CI workflow** that enforces only the
minimal deterministic gate set recommended for first-time PULSE adopters.

The Core workflow is separate from the full PULSE CI, so teams can start
with a smaller, opinionated gate set before enabling EPF / paradox /
topology overlays.

---

## What changed

- Added `.github/workflows/pulse_core_ci.yml`:
  - locates `PULSE_safe_pack_v0` in the repo (folder or zip),
  - runs `tools/run_all.py` to produce `artifacts/status.json`,
  - enforces the Core gate set via `tools/check_gates.py`:

    - `pass_controls_refusal`
    - `pass_controls_sanit`
    - `sanitization_effective`
    - `q1_grounded_ok`
    - `q4_slo_ok`

  - exports JUnit and SARIF reports from `status.json`,
  - uploads PULSE artifacts and reports as a CI artifact.

- Does **not** modify the existing full PULSE workflow or gate list.

---

## Behavioural impact

- New CI job: **PULSE Core CI**.
- Fail-closed on the Core gate set only.
- No change to:
  - existing `pulse_ci.yml` behaviour,
  - existing gate evaluation logic.

Teams can:

- enable `PULSE Core CI` first,
- later migrate to / complement it with the full PULSE workflow.

---

## Testing

- YAML syntax validated locally.
- CI expected to:
  - run the new `PULSE Core CI` job,
  - fail if any Core gate fails,
  - produce JUnit + SARIF + PULSE artifacts.
