### PR TITLE
docs(changelog): record Governance Pack overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Docs
 - `CITATION.cff`: add ORCID for Katalin Horvat; add software reference to ChatGPT (GPT‑5 Pro).
+- Add `docs/GOVERNANCE_PACK_v0.md`: overview of the optional Governance Pack
+  (Stability Map, Decision Engine, EPF/Paradox Playbook, G-field, history tools).
 
 ### Security
 - (no changes)


### PR DESCRIPTION
## Summary

This PR updates the changelog to record the new **Governance Pack overview**
document under the Unreleased/Docs section.

---

## What changed

- Updated `CHANGELOG` under **Unreleased → Docs**:
  - added an entry for `docs/GOVERNANCE_PACK_v0.md` as the Governance Pack
    overview.

---

## Behavioural impact

- Documentation-only change:
  - no modifications to gates or tooling,
  - no changes to CI workflows or fail-closed behaviour.

---

## Testing

- Verified the CHANGELOG entry renders correctly in markdown.
- No code or workflow changes; CI behaviour should be unaffected.
