### PR TITLE
docs(glossary): record GLOSSARY_v0 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `CITATION.cff`: add ORCID for Katalin Horvat; add software reference to ChatGPT (GPT‑5 Pro).
 - Add `docs/GOVERNANCE_PACK_v0.md`: overview of the optional Governance Pack
   (Stability Map, Decision Engine, EPF/Paradox Playbook, G-field, history tools).
+Docs
+- Add `docs/GLOSSARY_v0.md`: working glossary for core PULSE terms across the safe-pack, Core profile and Governance Pack.
 
 ### Security
 - (no changes)


### PR DESCRIPTION
## Summary

This PR updates the changelog to record the new **PULSE glossary**
document under the Unreleased/Docs section.

---

## What changed

- Updated `CHANGELOG` under **Unreleased → Docs**:
  - added an entry for `docs/GLOSSARY_v0.md` as the working glossary for
    core PULSE terms across the safe-pack, Core profile and Governance Pack.

---

## Behavioural impact

- Documentation-only change:
  - no modifications to gates or artefact schemas,
  - no changes to CI workflows or fail-closed behaviour.

---

## Testing

- Verified the CHANGELOG entry renders correctly in markdown.
- No code or workflow changes; CI behaviour should be unaffected.
