### PR TITLE
fix(history): persist status history across workflow runs

### DIFF
--- a/.github/workflows/pulse_history_drift.yml
+++ b/.github/workflows/pulse_history_drift.yml
@@ -10,6 +10,11 @@ on:
 permissions:
   contents: write
 
+env:
+  HISTORY_FILE: logs/status_history.jsonl
+  HISTORY_CACHE_KEY: pulse-history-${{ github.ref_name }}-${{ github.run_number }}
+  HISTORY_CACHE_PREFIX: pulse-history-${{ github.ref_name }}-
+
 jobs:
   history-drift:
     runs-on: ubuntu-latest
@@ -17,6 +22,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Restore status history cache
+        id: restore-history
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.HISTORY_FILE }}
+          key: ${{ env.HISTORY_CACHE_KEY }}
+          restore-keys: |
+            ${{ env.HISTORY_CACHE_PREFIX }}
 
       - name: Locate PULSE pack
         shell: bash
@@ -61,7 +75,7 @@ jobs:
 
           python scripts/append_status_history.py \
             --status "${PACK_DIR}/artifacts/status.json" \
-            --output "logs/status_history.jsonl" \
+            --output "${HISTORY_FILE}" \
             --run-id "${GITHUB_RUN_ID:-}"
 
       - name: Prepare last-two-run status snapshots
@@ -69,7 +83,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          HISTORY_PATH="logs/status_history.jsonl"
+          HISTORY_PATH="${HISTORY_FILE}"
           TMP_DIR="logs/_tmp_diff"
 
           if [ ! -f "$HISTORY_PATH" ]; then
@@ -81,7 +95,7 @@ jobs:
           import json
           import os
 
-          history_path = "logs/status_history.jsonl"
+          history_path = os.environ.get("HISTORY_FILE", "logs/status_history.jsonl")
           tmp_dir = "logs/_tmp_diff"
 
           if not os.path.exists(history_path):
@@ -144,13 +158,20 @@ jobs:
             --format markdown \
             --output "logs/diff_last_two_runs.md"
 
+      - name: Save status history cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.HISTORY_FILE }}
+          key: ${{ env.HISTORY_CACHE_KEY }}
+
       - name: Upload history & drift artefacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: pulse-history-drift
           path: |
-            logs/status_history.jsonl
+            ${{ env.HISTORY_FILE }}
             logs/diff_last_two_runs.json
             logs/diff_last_two_runs.md
             logs/_tmp_diff/status_prev.json


### PR DESCRIPTION
## Summary

This PR updates the **PULSE History & Drift** workflow to keep
`logs/status_history.jsonl` persistent across workflow runs, addressing
the Codex feedback about using a fresh checkout without restoring
history.

---

## What changed

- Updated `.github/workflows/pulse_history_drift.yml`:
  - introduced `HISTORY_FILE`, `HISTORY_CACHE_KEY` and
    `HISTORY_CACHE_PREFIX` env vars,
  - added a `Restore status history cache` step:
    - uses `actions/cache/restore@v4`
    - restores `logs/status_history.jsonl` from a branch-scoped cache
      using:
      - `key: pulse-history-${{ github.ref_name }}-${{ github.run_number }}`
      - `restore-keys: pulse-history-${{ github.ref_name }}-`
  - kept the existing steps that:
    - run the PULSE pack,
    - append the current run's `status.json` to `logs/status_history.jsonl`,
    - compute minimal gate-level diffs between the last two runs.
  - added a `Save status history cache` step:
    - uses `actions/cache/save@v4`
    - saves the updated `logs/status_history.jsonl` under the current
      run's cache key.

---

## Behavioural impact

- History is now carried over between workflow runs:
  - the diff step sees a growing `logs/status_history.jsonl` instead of
    starting from an empty file on every fresh checkout,
  - drift between runs can be inspected as intended.
- No changes to:
  - Core CI workflows,
  - gate evaluation logic,
  - PULSE artefact formats.

---

## Testing

- Verified that:
  - the first run creates a history file and cache,
  - subsequent runs restore the history file, append a new entry, and
    save an updated cache under a new key,
  - the diff step runs once at least two history entries exist.
- Confirmed that missing cache on the very first run still produces a
  valid history file locally.
