### PR TITLE
fix(history): grant actions permission for cache

### DIFF
--- a/.github/workflows/pulse_history_drift.yml
+++ b/.github/workflows/pulse_history_drift.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 env:
   HISTORY_FILE: logs/status_history.jsonl


### PR DESCRIPTION
## Summary

This PR fixes the permissions for the **PULSE History & Drift** workflow
so that the cache restore/save steps can access the GitHub Actions cache
API, addressing the Codex P1 feedback.

---

## What changed

- Updated `.github/workflows/pulse_history_drift.yml`:
  - extended the `permissions` block to include:
    - `actions: write`
  - kept `contents: write` unchanged.

This allows `actions/cache/restore@v4` and `actions/cache/save@v4` to
use the cache API without failing with "Resource not accessible by
integration".

---

## Behavioural impact

- Cache-based persistence of `logs/status_history.jsonl` now works as
  intended.
- No changes to:
  - gate logic,
  - PULSE artefact formats,
  - Core CI workflows.

---

## Testing

- Verified configuration against GitHub Actions permissions behaviour:
  - workflows with explicit `permissions` must explicitly list `actions`
    for cache APIs to work.
- No functional code changes; the actual history/drift scripts remain
  the same.
