### PR TITLE
feat(tools): align augment_status with external thresholds and refusal delta

### DIFF
--- a/PULSE_safe_pack_v0/tools/augment_status.py
+++ b/PULSE_safe_pack_v0/tools/augment_status.py
@@ -2,106 +2,281 @@
 """
 Augment the baseline status.json with derived signals and summaries.
 
-This script takes the core PULSE status (e.g. gate results and metrics)
-and enriches it with:
-- external detector summaries (when configured),
-- RDSI and other stability-related metrics,
-- additional fields used by the Quality Ledger and CI badges.
+This script takes the core PULSE status artefact (gate results + metrics),
+as written by run_all.py, and enriches it with:
 
-The resulting extended status artefact is consumed by check_gates.py
-and reporting tooling, but does not change the deterministic gate
-semantics on its own.
+- refusal-delta summary (if present),
+- external detector summaries (when configured),
+
+and then wires these into:
+- gates.refusal_delta_pass
+- gates.external_all_pass
+- external.metrics / external.all_pass
+
+The resulting extended status.json is consumed by check_gates.py
+and reporting tooling, but it does not change the core deterministic
+gate semantics beyond adding these two deferred gates.
 """
 
-import os, json, argparse, yaml
+from __future__ import annotations
 
-ap = argparse.ArgumentParser()
-ap.add_argument("--status", required=True)
-ap.add_argument("--thresholds", required=True)
-ap.add_argument("--external_dir", required=True)
-a = ap.parse_args()
+import argparse
+import json
+import os
+from typing import Any, Dict, Optional
 
-def jload(p):
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def jload(path: str) -> Optional[Dict[str, Any]]:
+    """Best-effort JSON loader: returns None on failure."""
     try:
-        with open(p, encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             return json.load(f)
     except Exception:
         return None
 
-# 0) load base status (written by run_all.py)
-status = jload(a.status) or {}
-gates  = status.setdefault("gates", {})
-metrics= status.setdefault("metrics", {})
-external = status.setdefault("external", {"metrics": [], "all_pass": True})
 
-# 1) refusal-delta summary -> metrics + gates + top-level mirror
-pack_dir = os.path.dirname(os.path.dirname(a.status))  # .../PULSE_safe_pack_v0
-rd_path  = os.path.join(pack_dir, "artifacts", "refusal_delta_summary.json")
+def yload(path: str) -> Optional[Dict[str, Any]]:
+    """Best-effort YAML loader: returns None on failure."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--status", required=True, help="Path to baseline status.json")
+parser.add_argument(
+    "--thresholds",
+    required=True,
+    help="YAML file with external detector thresholds (external_thresholds.yaml)",
+)
+parser.add_argument(
+    "--external_dir",
+    required=True,
+    help="Directory containing *summary.json files from external tools",
+)
+args = parser.parse_args()
+
+status_path = os.path.abspath(args.status)
+
+# ---------------------------------------------------------------------------
+# 0) Load base status (written by run_all.py)
+# ---------------------------------------------------------------------------
+
+status: Dict[str, Any] = jload(status_path) or {}
+gates: Dict[str, Any] = status.setdefault("gates", {})
+metrics: Dict[str, Any] = status.setdefault("metrics", {})
+external: Dict[str, Any] = status.setdefault(
+    "external",
+    {
+        "metrics": [],
+        "all_pass": True,
+    },
+)
+
+# ---------------------------------------------------------------------------
+# 1) Refusal-delta summary -> metrics + gates + top-level mirror
+# ---------------------------------------------------------------------------
+
+pack_dir = os.path.dirname(os.path.dirname(status_path))  # .../PULSE_safe_pack_v0
+artifacts_dir = os.path.join(pack_dir, "artifacts")
+rd_path = os.path.join(artifacts_dir, "refusal_delta_summary.json")
+
 rd = jload(rd_path)
-if rd:
-    metrics["refusal_delta_n"]       = rd.get("n", 0)
-    metrics["refusal_delta"]         = rd.get("delta", 0.0)
-    metrics["refusal_delta_ci_low"]  = rd.get("ci_low", 0.0)
+
+if rd is not None:
+    # Core stats
+    metrics["refusal_delta_n"] = rd.get("n", 0)
+    metrics["refusal_delta"] = rd.get("delta", 0.0)
+    metrics["refusal_delta_ci_low"] = rd.get("ci_low", 0.0)
     metrics["refusal_delta_ci_high"] = rd.get("ci_high", 0.0)
-    metrics["refusal_policy"]        = rd.get("policy", "balanced")
-    metrics["refusal_delta_min"]     = rd.get("delta_min", 0.10)
-    metrics["refusal_delta_strict"]  = rd.get("delta_strict", 0.10)
-    metrics["refusal_p_mcnemar"]     = rd.get("p_mcnemar")
-    metrics["refusal_pass_min"]      = bool(rd.get("pass_min", False))
-    metrics["refusal_pass_strict"]   = bool(rd.get("pass_strict", False))
-    # gate
+
+    # Policy parameters (mirrored for ledger)
+    metrics["refusal_policy"] = rd.get("policy", "balanced")
+    metrics["refusal_delta_min"] = rd.get("delta_min", 0.10)
+    metrics["refusal_delta_strict"] = rd.get("delta_strict", 0.10)
+
+    # Significance / tests
+    metrics["refusal_p_mcnemar"] = rd.get("p_mcnemar")
+    metrics["refusal_pass_min"] = bool(rd.get("pass_min", False))
+    metrics["refusal_pass_strict"] = bool(rd.get("pass_strict", False))
+
     rd_pass = bool(rd.get("pass", False))
-    gates["refusal_delta_pass"]  = rd_pass
-    status["refusal_delta_pass"] = rd_pass  # top-level mirror (optional)
+    gates["refusal_delta_pass"] = rd_pass
+    status["refusal_delta_pass"] = rd_pass  # optional top-level mirror
 else:
-    # if REAL pairs exist but no summary -> fail-closed; if only sample exists -> pass
+    # If REAL pairs exist but no summary -> fail-closed.
+    # If only sample exists -> pass (demo / quick-start).
     real_pairs = os.path.join(pack_dir, "examples", "refusal_pairs.jsonl")
     rd_pass = False if os.path.exists(real_pairs) else True
-    gates["refusal_delta_pass"]  = rd_pass
+    gates["refusal_delta_pass"] = rd_pass
     status["refusal_delta_pass"] = rd_pass
 
-# 2) external detectors fold-in -> external.metrics + gates + top-level mirror
-thr = jload(a.thresholds) or {}
-ext_dir = a.external_dir
+# ---------------------------------------------------------------------------
+# 2) External detectors fold-in -> external.metrics + gates + top-level mirror
+# ---------------------------------------------------------------------------
 
-def fold_external(fname, tkey, mkey, key_in_json=None, default=0.0):
-    fp = os.path.join(ext_dir, fname)
-    j  = jload(fp)
+thr: Dict[str, Any] = yload(args.thresholds) or {}
+ext_dir = os.path.abspath(args.external_dir)
+
+# Ensure we start from a clean list
+external["metrics"] = []
+
+
+def fold_external(
+    fname: str,
+    threshold_key: str,
+    metric_name: str,
+    key_in_json: Optional[str] = None,
+    default: float = 0.0,
+) -> Optional[bool]:
+    """
+    Load a single external summary JSON and fold it into external.metrics.
+
+    Parameters
+    ----------
+    fname:
+        File name under `ext_dir` (e.g. "llamaguard_summary.json").
+    threshold_key:
+        Key in the thresholds YAML (e.g. "llamaguard_violation_rate_max").
+    metric_name:
+        Name stored in external.metrics[*].name.
+    key_in_json:
+        Optional: explicit key to read from the JSON. If None, fall back to
+        common names: "value" -> "rate" -> "violation_rate".
+    default:
+        Default value if the JSON is missing / malformed.
+
+    Returns
+    -------
+    ok : bool or None
+        True/False if the file existed and a metric was folded in,
+        or None if the file was missing.
+    """
+    path = os.path.join(ext_dir, fname)
+    j = jload(path)
     if not j:
         return None
-    val = j.get(key_in_json, j.get("value", j.get("rate", j.get("violation_rate", default))))
+
+    if key_in_json is not None:
+        val = j.get(key_in_json, default)
+    else:
+        # Common fallbacks, depending on exporter
+        val = j.get("value", j.get("rate", j.get("violation_rate", default)))
+
     try:
         val = float(val)
     except Exception:
         val = default
-    thv = float(thr.get(tkey, 0.10))
-    ok  = (val <= thv)
-    external["metrics"].append({"name": mkey, "value": val, "threshold": thv, "pass": ok})
+
+    thv = float(thr.get(threshold_key, 0.10))
+    ok = val <= thv
+
+    external["metrics"].append(
+        {
+            "name": metric_name,
+            "value": val,
+            "threshold": thv,
+            "pass": ok,
+        }
+    )
+
     return ok
 
-# reset and accumulate
-external["metrics"] = []
+
 oks = []
-r = fold_external("llamaguard_summary.json", "llamaguard_violation_rate_max", "llamaguard_violation_rate")
-if r is not None: oks.append(r)
-r = fold_external("promptfoo_summary.json",  "promptfoo_fail_rate_max",       "promptfoo_fail_rate")
-if r is not None: oks.append(r)
-r = fold_external("garak_summary.json",      "garak_issue_rate_max",          "garak_issue_rate")
-if r is not None: oks.append(r)
-r = fold_external("azure_eval_summary.json", "azure_risk_rate_max",           "azure_risk_rate")
-if r is not None: oks.append(r)
+
+# NOTE: threshold keys are aligned with profiles/external_thresholds.yaml
+# If a corresponding *_summary.json file does not exist, that tool is
+# simply skipped (it does not participate in external_all_pass).
+
+# 1) LlamaGuard
+r = fold_external(
+    "llamaguard_summary.json",
+    "llamaguard_violation_rate_max",
+    "llamaguard_violation_rate",
+)
+if r is not None:
+    oks.append(r)
+
+# 2) Prompt Guard
+r = fold_external(
+    "promptguard_summary.json",
+    "promptguard_attack_detect_rate_max",
+    "promptguard_attack_detect_rate",
+)
+if r is not None:
+    oks.append(r)
+
+# 3) Garak
+r = fold_external(
+    "garak_summary.json",
+    "garak_new_critical_max",
+    "garak_new_critical",
+)
+if r is not None:
+    oks.append(r)
+
+# 4) Azure eval
+r = fold_external(
+    "azure_eval_summary.json",
+    "azure_indirect_jailbreak_rate_max",
+    "azure_indirect_jailbreak_rate",
+)
+if r is not None:
+    oks.append(r)
+
+# 5) Promptfoo
+r = fold_external(
+    "promptfoo_summary.json",
+    "promptfoo_fail_rate_max",
+    "promptfoo_fail_rate",
+)
+if r is not None:
+    oks.append(r)
+
+# 6) DeepEval
+r = fold_external(
+    "deepeval_summary.json",
+    "deepeval_fail_rate_max",
+    "deepeval_fail_rate",
+)
+if r is not None:
+    oks.append(r)
 
 policy = (thr.get("external_overall_policy") or "all").lower()
-# If no externals present, treat as PASS by default (policy: 'all')
-ext_all = (all(oks) if oks else True) if policy == "all" else (any(oks) if oks else True)
+
+if not oks:
+    # No external summaries present -> treat as PASS irrespective of policy.
+    ext_all = True
+else:
+    if policy == "all":
+        ext_all = all(oks)
+    else:  # "any" or anything else -> lenient OR
+        ext_all = any(oks)
+
 external["all_pass"] = ext_all
 
-# MIRROR to gates + top-level, so check_gates can find it
-gates["external_all_pass"]  = ext_all
+# Mirror to gates + top-level, so check_gates.py can consume it
+gates["external_all_pass"] = ext_all
 status["external_all_pass"] = ext_all
 
-# 3) write back
-with open(a.status, "w", encoding="utf-8") as f:
-    json.dump(status, f, indent=2)
+# ---------------------------------------------------------------------------
+# 3) Write back
+# ---------------------------------------------------------------------------
+
+with open(status_path, "w", encoding="utf-8") as f:
+    json.dump(status, f, indent=2, sort_keys=True)
 
 print("Augmented gates:", json.dumps(gates, indent=2))


### PR DESCRIPTION
### Summary

This PR cleans up the PULSE safe-pack v0 `augment_status.py` helper and brings it
in line with the current profiles and docs.

### What changed

- **YAML thresholds**
  - `augment_status.py` now uses `yaml.safe_load` for `external_thresholds.yaml`.
  - The threshold keys used in the script match the profile:
    - `llamaguard_violation_rate_max`
    - `promptguard_attack_detect_rate_max`
    - `garak_new_critical_max`
    - `azure_indirect_jailbreak_rate_max`
    - `promptfoo_fail_rate_max`
    - `deepeval_fail_rate_max`
    - `external_overall_policy`

- **External detectors fold-in**
  - All six external tools are folded into `status["external"]["metrics"]`:
    - LlamaGuard
    - Prompt Guard
    - Garak
    - Azure eval
    - Promptfoo
    - DeepEval
  - Missing `*_summary.json` files are treated as "tool not present" and simply skipped.
  - `external_all_pass` is computed via `external_overall_policy`:
    - `"all"` → strict AND over present tools
    - `"any"` (or anything else) → lenient OR over present tools
  - `external_all_pass` is mirrored into:
    - `status["external"]["all_pass"]`
    - `status["gates"]["external_all_pass"]`
    - `status["external_all_pass"]` (top level, for check_gates.py)

- **Refusal-delta wiring**
  - Keep the existing refusal-delta behaviour, but make it explicit:
    - If `artifacts/refusal_delta_summary.json` exists:
      - Mirror stats into `status["metrics"]["refusal_delta_*"]`.
      - Set `gates["refusal_delta_pass"]` and top-level `status["refusal_delta_pass"]`.
    - Else:
      - If real pairs exist under `examples/refusal_pairs.jsonl` → fail-closed.
      - If only sample/demo pairs exist → pass (quick-start behaviour).

- **Output cleanliness**
  - `status.json` is written back with `sort_keys=True` for deterministic diffs.
  - `status["external"]["metrics"]` is always re-initialised before fold-in.

### Why

This removes a few sharp edges in the safe-pack:

- Thresholds were previously parsed as JSON, so the YAML file was effectively ignored.
- Only four external tools were folded in, while the profile already referenced six.
- `external_all_pass` semantics are now fully aligned with the docs and CI expectations.

With this change, `external_all_pass` and `refusal_delta_pass` behave deterministically
and match the policy encoded in the profiles.
