### PR TITLE
fix(tools): read promptguard attack_detect_rate in augment_status

### DIFF
--- a/PULSE_safe_pack_v0/tools/augment_status.py
+++ b/PULSE_safe_pack_v0/tools/augment_status.py
@@ -215,6 +215,7 @@ r = fold_external(
     "promptguard_summary.json",
     "promptguard_attack_detect_rate_max",
     "promptguard_attack_detect_rate",
+    key_in_json="attack_detect_rate",
 )
 if r is not None:
     oks.append(r)


### PR DESCRIPTION
### Summary

Codex correctly flagged that the Prompt Guard fold-in in
`tools/augment_status.py` never read the actual `attack_detect_rate`
field from `promptguard_summary.json`.

Because `fold_external` only falls back to `value` / `rate` /
`violation_rate` when `key_in_json` is omitted, the Prompt Guard metric
was always recorded as 0.0, even when the summary reported a higher
attack detection rate. As a result, Prompt Guard failures never gated
`external_all_pass`.

### What changed

- Updated the Prompt Guard fold-in call to:

  ```python
  r = fold_external(
      "promptguard_summary.json",
      "promptguard_attack_detect_rate_max",
      "promptguard_attack_detect_rate",
      key_in_json="attack_detect_rate",
  )
