### PR TITLE
test(tools): cover external detector fold-in and promptguard attack_detect_rate

### DIFF
--- a/tests/test_augment_status_external.py
+++ b/tests/test_augment_status_external.py
@@ -1,116 +1,127 @@
 import json
-import os
 import subprocess
 import sys
 from pathlib import Path
-from textwrap import dedent
+
+# Path to augment_status.py
+ROOT = Path(__file__).resolve().parents[1]
+AUGMENT_STATUS = ROOT / "PULSE_safe_pack_v0" / "tools" / "augment_status.py"
 
 
-def run_augment_status(tmp_path, thresholds, externals):
+def run_augment_status(tmp_path, thresholds, external_summaries):
     """
-    Helper to run tools/augment_status.py against a tiny fake status.json
-    and a set of external summaries.
+    Build a tiny temporary safe-pack, run augment_status.py on it,
+    then return the parsed status.json.
     """
-    repo_root = Path(__file__).resolve().parents[1]
-    tools_dir = repo_root / "PULSE_safe_pack_v0" / "tools"
-    script = tools_dir / "augment_status.py"
+    tmp_path = Path(tmp_path)
 
-    pack_dir = tmp_path / "PULSE_safe_pack_v0"
+    # Minimal pack layout: pack/artifacts/status.json
+    pack_dir = tmp_path / "pack"
     artifacts_dir = pack_dir / "artifacts"
-    external_dir = tmp_path / "externals"
-
     artifacts_dir.mkdir(parents=True, exist_ok=True)
-    external_dir.mkdir(parents=True, exist_ok=True)
 
     status_path = artifacts_dir / "status.json"
+    with status_path.open("w", encoding="utf-8") as f:
+        json.dump({"gates": {}, "metrics": {}}, f)
+
+    # Thresholds
     thresholds_path = tmp_path / "thresholds.json"
+    with thresholds_path.open("w", encoding="utf-8") as f:
+        json.dump(thresholds, f)
 
-    status = {"gates": {}, "metrics": {}}
-    status_path.write_text(json.dumps(status), encoding="utf-8")
+    # External detector summaries
+    external_dir = tmp_path / "external"
+    external_dir.mkdir(exist_ok=True)
+    for fname, payload in external_summaries.items():
+        with (external_dir / fname).open("w", encoding="utf-8") as f:
+            json.dump(payload, f)
 
-    thresholds_path.write_text(json.dumps(thresholds), encoding="utf-8")
+    # Run augment_status.py
+    subprocess.check_call(
+        [
+            sys.executable,
+            str(AUGMENT_STATUS),
+            "--status",
+            str(status_path),
+            "--thresholds",
+            str(thresholds_path),
+            "--external_dir",
+            str(external_dir),
+        ]
+    )
 
-    for name, payload in externals.items():
-        (external_dir / name).write_text(json.dumps(payload), encoding="utf-8")
-
-    cmd = [
-        sys.executable,
-        str(script),
-        "--status",
-        str(status_path),
-        "--thresholds",
-        str(thresholds_path),
-        "--external_dir",
-        str(external_dir),
-    ]
-    subprocess.check_call(cmd)
-
-    return json.loads(status_path.read_text(encoding="utf-8"))
+    # Read back the augmented status.json
+    with status_path.open(encoding="utf-8") as f:
+        return json.load(f)
 
 
-def test_external_detectors_all_pass(tmp_path):
-    """
-    Happy path: all external detectors are below threshold,
-    overall gate should pass and metrics should be present.
-    """
+def test_external_all_pass_when_all_detectors_under_threshold(tmp_path):
     thresholds = {
         "llamaguard_violation_rate_max": 0.10,
         "promptfoo_fail_rate_max": 0.10,
-        "garak_issue_rate_max": 0.10,
-        "azure_risk_rate_max": 0.10,
-        "promptguard_attack_detect_rate_max": 0.10,
+        "garak_new_critical_max": 10.0,
+        "azure_indirect_jailbreak_rate_max": 0.10,
         "external_overall_policy": "all",
     }
 
-    externals = {
+    external = {
         "llamaguard_summary.json": {"violation_rate": 0.05},
         "promptfoo_summary.json": {"fail_rate": 0.02},
-        "garak_summary.json": {"issue_rate": 0.01},
-        "azure_eval_summary.json": {"risk_rate": 0.03},
-        # Prompt Guard uses a non‑standard key: attack_detect_rate
+        # Garak adapter: new_critical -> garak_new_critical
+        "garak_summary.json": {"new_critical": 1.0},
+        # Azure adapter: violation_rate -> azure_indirect_jailbreak_rate
+        "azure_eval_summary.json": {"violation_rate": 0.03},
+        # Prompt Guard uses non‑standard key: attack_detect_rate
         "promptguard_summary.json": {"attack_detect_rate": 0.04},
     }
 
-    status = run_augment_status(tmp_path, thresholds, externals)
+    status = run_augment_status(tmp_path, thresholds, external)
 
+    # Overall gate should pass
     assert status["gates"]["external_all_pass"] is True
     assert status["external_all_pass"] is True
 
-    ext = status.get("external", {})
-    metrics = {m["name"]: m for m in ext.get("metrics", [])}
+    external_block = status.get("external", {})
+    metrics = {m["name"]: m for m in external_block.get("metrics", [])}
 
+    # Per-detector metrics
     assert metrics["llamaguard_violation_rate"]["value"] == 0.05
     assert metrics["promptfoo_fail_rate"]["value"] == 0.02
-    assert metrics["garak_issue_rate"]["value"] == 0.01
-    assert metrics["azure_risk_rate"]["value"] == 0.03
-    # Key point: we really picked up attack_detect_rate
+    assert metrics["garak_new_critical"]["value"] == 1.0
+    assert metrics["azure_indirect_jailbreak_rate"]["value"] == 0.03
     assert metrics["promptguard_attack_detect_rate"]["value"] == 0.04
 
 
-def test_external_detectors_fail_closed_when_over_threshold(tmp_path):
-    """
-    If any detector exceeds its threshold under 'all' policy,
-    the external_all_pass gate must fail.
-    """
+def test_external_all_pass_fails_when_any_detector_exceeds_threshold(tmp_path):
     thresholds = {
         "llamaguard_violation_rate_max": 0.10,
         "promptfoo_fail_rate_max": 0.10,
-        "garak_issue_rate_max": 0.10,
-        "azure_risk_rate_max": 0.10,
-        "promptguard_attack_detect_rate_max": 0.10,
+        "garak_new_critical_max": 10.0,
+        "azure_indirect_jailbreak_rate_max": 0.10,
         "external_overall_policy": "all",
     }
 
-    externals = {
+    external = {
         "llamaguard_summary.json": {"violation_rate": 0.05},
         "promptfoo_summary.json": {"fail_rate": 0.02},
-        "garak_summary.json": {"issue_rate": 0.01},
-        "azure_eval_summary.json": {"risk_rate": 0.03},
-        # Over the threshold: should flip the gate to False
-        "promptguard_summary.json": {"attack_detect_rate": 0.25},
+        "garak_summary.json": {"new_critical": 1.0},
+        # Push Azure over the configured threshold so the gate flips to FAIL
+        "azure_eval_summary.json": {"violation_rate": 0.25},
+        "promptguard_summary.json": {"attack_detect_rate": 0.04},
     }
 
-    status = run_augment_status(tmp_path, thresholds, externals)
+    status = run_augment_status(tmp_path, thresholds, external)
 
+    # Overall gate should fail
     assert status["gates"]["external_all_pass"] is False
     assert status["external_all_pass"] is False
+
+    external_block = status.get("external", {})
+    metrics = {m["name"]: m for m in external_block.get("metrics", [])}
+
+    # Per-detector metrics (values still surfaced even when the gate fails)
+    assert metrics["llamaguard_violation_rate"]["value"] == 0.05
+    assert metrics["promptfoo_fail_rate"]["value"] == 0.02
+    assert metrics["garak_new_critical"]["value"] == 1.0
+    assert metrics["azure_indirect_jailbreak_rate"]["value"] == 0.25
+    assert metrics["promptguard_attack_detect_rate"]["value"] == 0.04


### PR DESCRIPTION
This PR adds a small test module for `PULSE_safe_pack_v0/tools/augment_status.py`
focused on the external detector summaries.

What it does
------------

* Creates `tests/test_augment_status_external.py`.
* Exercises the `--external_dir` logic with tiny JSON summaries for:
  * LlamaGuard
  * promptfoo
  * garak
  * Azure eval
  * Prompt Guard (using the `attack_detect_rate` key)
* Verifies that:
  * Per-detector metrics end up in `status["external"]["metrics"]` with
    the expected names and values.
  * The `external_all_pass` gate and its top-level mirror behave as
    expected under `external_overall_policy = "all"`:
    * all metrics under threshold → gate passes,
    * one metric over threshold → gate fails.

Why this matters
----------------

We recently fixed the Prompt Guard adapter and fold-in to use its
`attack_detect_rate` field instead of a generic `value`/`rate` key.
This test suite makes sure that:

* Prompt Guard is actually wired through correctly;
* future changes to the thresholds or external adapters won't silently
  break the `external_all_pass` gate.

The tests follow the same style as the refusal-delta gate tests and only
use synthetic JSON artefacts.
