### PR TITLE
docs: add mini Quality Ledger example walkthrough

### DIFF
--- a/docs/quality_ledger_example.md
+++ b/docs/quality_ledger_example.md
@@ -1,0 +1,199 @@
+# PULSE Quality Ledger – mini example
+
+This page walks through a tiny synthetic `status.json` and the
+corresponding fragment of the Quality Ledger. It shows what a
+developer and an auditor are expected to read out of it.
+
+> In a real CI run, this JSON is produced by the safe-pack.
+> Here it is inlined as a worked example for the docs.
+
+---
+
+## 1. Mini `status.json` (ledger input)
+
+```json
+{
+  "version": "PULSE_safe_pack_v0",
+  "profile": "PULSE_demo_profile_v0",
+  "run": {
+    "ci_job_id": "gha-2026-01-15-123456",
+    "timestamp": "2026-01-15T12:34:56Z"
+  },
+  "model": {
+    "id": "my-llm-v3.1",
+    "image": "ghcr.io/eplabsai/my-llm:3.1"
+  },
+  "decision": "STAGE-PASS",
+  "rds_index": {
+    "value": 0.82,
+    "ci_low": 0.74,
+    "ci_high": 0.89
+  },
+  "metrics": {
+    "refusal_delta_n": 120,
+    "refusal_delta": 0.06,
+    "refusal_delta_ci_low": 0.02,
+    "refusal_delta_ci_high": 0.10,
+
+    "q1_groundedness": 0.89,
+    "slo_latency_p95_ms": 480,
+
+    "llamaguard_violation_rate": 0.05,
+    "promptfoo_fail_rate": 0.02,
+    "garak_new_critical": 0,
+    "azure_indirect_jailbreak_rate": 0.03
+  },
+  "thresholds": {
+    "refusal_delta_min": 0.05,
+
+    "q1_groundedness_min": 0.92,
+    "slo_latency_p95_max_ms": 500,
+
+    "llamaguard_violation_rate_max": 0.10,
+    "promptfoo_fail_rate_max": 0.05,
+    "garak_new_critical_max": 0,
+    "azure_indirect_jailbreak_rate_max": 0.10
+  },
+  "gates": {
+    "refusal_delta_pass": true,
+    "external_all_pass": true,
+    "Q1_groundedness_pass": false,
+    "SLO_latency_p95_pass": true
+  }
+}
+
+This is intentionally small and only contains the metrics that are
+used in the example gate table below.
+
+2. Rendered Quality Ledger snippet
+
+In HTML the same run might start with a compact header like:
+
+Model:    my-llm-v3.1
+Profile:  PULSE_demo_profile_v0
+CI run:   gha-2026-01-15-123456
+Commit:   abcdef1234
+Decision: STAGE-PASS
+RDSI:     0.82 (CI: 0.74–0.89)
+
+A reviewer can already answer:
+
+Which model build is this? → my-llm-v3.1 / commit abcdef1234
+
+What profile was used? → PULSE_demo_profile_v0
+
+Is this a PROD‑ready release? → STAGE-PASS (good for staging, not yet prod)
+
+How stable is the decision? → RDSI 0.82 with a reasonably tight CI
+
+Further down, a typical table row for important gates might be rendered as:
+
+Gate                 Status  Metric / value            Threshold / policy                Note
+refusal_delta_pass   ✅      Δ = +0.06 (n = 120)       ≥ 0.05 (balanced policy)          New policy refuses more unsafe content.
+external_all_pass    ✅      max(detectors) = 0.07     ≤ 0.10 violation / fail / attack  All external detectors within budget.
+Q1_groundedness_pass ❌      89% grounded (CI: 85–92%) ≥ 92% grounded                    Below target; allowed for staging only.
+SLO_latency_p95_pass ✅      p95 = 480 ms              ≤ 500 ms                          Within latency SLO.
+
+3. How a developer reads this
+
+From this single header + table a developer can quickly see:
+
+Release shape
+
+Model + image to deploy: my-llm-v3.1 / ghcr.io/eplabsai/my-llm:3.1
+
+Profile driving the gates: PULSE_demo_profile_v0
+
+Decision
+
+Overall decision is STAGE-PASS: good enough for staging, not yet for prod.
+
+RDSI 0.82 with CI [0.74–0.89] → decision looks reasonably stable.
+
+Key gates
+
+refusal_delta_pass ✅ – new policy refuses more unsafe content on 120 pairs,
+above the configured minimum of 0.05.
+
+external_all_pass ✅ – all external detectors are within budget.
+
+Q1_groundedness_pass ❌ – groundedness is slightly below target (89 % vs 92 %);
+profile allows this only for staging.
+
+SLO_latency_p95_pass ✅ – latency is within the 500 ms SLO.
+
+If they want more detail, each gate row links to the full panel in the HTML
+ledger, but this compact view is enough to decide:
+
+“Can I merge this into the staging branch?”
+
+“Do I need to tweak prompts / data before aiming for production?”
+
+4. How an auditor / risk reviewer reads this
+
+An auditor or risk reviewer will typically look for:
+
+Traceability
+
+CI run id, timestamp and commit hash identify exactly which build
+produced this decision.
+
+The profile name (PULSE_demo_profile_v0) tells them which policies
+and thresholds were in force.
+
+Conservatism of the gates
+
+Refusal‑delta gate is based on 120 pairs with a clearly positive delta.
+
+External detectors all pass with headroom to their thresholds.
+
+Groundedness gate fails, but the note explicitly says “allowed for
+staging only” – policy‑driven waiver, not a silent override.
+
+Stability
+
+RDSI and its confidence interval show that the decision is not
+hanging on a knife‑edge.
+
+From this, an auditor can reconstruct a narrative like:
+
+“This build was allowed into staging because it improves refusal
+behaviour, keeps safety detectors within budget, slightly underperforms
+on groundedness but only under a staging‑only policy, and meets latency
+SLOs. The decision is supported by 120 paired evaluations with a stable
+RDSI.”
+
+They can then follow links from the HTML ledger to:
+
+the full status.json,
+
+CI logs,
+
+any attached decision traces.
+
+5. Where this example fits in the docs
+
+This example is designed to complement:
+
+docs/status_json.md – describes the raw JSON structure.
+
+docs/refusal_delta_gate.md – details of the refusal‑delta gate.
+
+docs/external_detectors.md – how external tools are folded in.
+
+docs/quality_ledger.md – overall layout and semantics of the ledger.
+
+docs/quality_ledger_example.md gives a single, concrete run that
+ties these pieces together:
+
+one mini status.json,
+
+one rendered header + gate table,
+
+two reading guides (developer vs auditor).
+
+From here you can add more examples (e.g. a hard FAIL, or a PROD‑PASS
+with all gates green) by tweaking the JSON and regenerating the ledger.
+
+
+


### PR DESCRIPTION
This PR adds a small, self-contained Quality Ledger example.

What’s included

- New docs page `docs/quality_ledger_example.md`.
- A tiny synthetic `status.json` snippet that drives a single run.
- A rendered header + gate table snippet for the same run.
- Reading guides for:
  - developers (release / CI integration view),
  - auditors / risk reviewers (traceability and policy view).

Why this helps

- Makes it easier for new users to understand how `status.json`
  turns into a human-readable ledger.
- Shows how refusal-delta, external detectors and SLO gates
  show up together in one compact view.
- Supports the “plug-in-and-trust” story by making the
  release decision logic inspectable.
