### PR TITLE
docs(epf): mention hazard forecasting proto-module in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,17 @@ gates, see:
 
 ---
 
+#### EPF hazard forecasting (proto-module)
+
+The EPF safe pack also contains an experimental hazard-forecasting
+probe in `PULSE_safe_pack_v0/epf/epf_hazard_forecast.py`. It computes
+a simple early-warning index from the relationship between the current
+EPF field and a stable reference state, and classifies the result into
+GREEN / AMBER / RED zones. This module is prototype-only and does not
+participate in release gating yet.
+
+---
+
 ### Artifacts
 
 - `status_baseline.json` – deterministic decisions (source of truth)


### PR DESCRIPTION
## Summary

This PR updates the EPF experiment workflow section in `README.md` to
briefly mention the **EPF hazard forecasting proto-module** and point
readers to the relevant documentation.

The new text is placed just above the `### Artifacts` heading, so the
flow is:

- describe what the EPF experiment workflow does,
- mention that there is an EPF field-level hazard forecasting proto-module,
- list the concrete artifacts produced by the workflow.

## What changed

- Updated `README.md` in the EPF experiment section to reference:
  - the `PULSE_safe_pack_v0/epf/epf_hazard_forecast.py` proto-module, and/or
  - its detailed docs under `docs/epf_hazard_forecast.md` (if present).

No code, configs or gating logic were modified; this is a docs-only change.

## Rationale

We recently added an EPF hazard forecasting proto-module to the
PULSE_safe_pack_v0 safe pack. Mentioning it in the top-level README
makes it easier for users to discover this early-warning EPF feature
when they are already reading about the EPF experiment workflow and
its outputs.

## Testing

- Rendered README preview locally to ensure the new block appears in the
  right place (just above the "Artifacts" section) and the markdown
  formatting is correct.
