### PR TITLE
feat: add CLI helper for status summaries

### DIFF
--- a/PULSE_safe_pack_v0/tools/print_status_summary.py
+++ b/PULSE_safe_pack_v0/tools/print_status_summary.py
@@ -48,9 +48,20 @@ def print_summary(status: Dict[str, Any]) -> None:
     profile = status.get("profile", "-")
     decision = status.get("decision", "-")
 
+        # RDSI (Release Decision Stability Index)
+    rds_lo = get_nested(status, "rds_index", "ci_lower")
+    rds_hi = get_nested(status, "rds_index", "ci_upper")
     rds_value = get_nested(status, "rds_index", "value")
-    rds_lo = get_nested(status, "rds_index", "ci_low")
-    rds_hi = get_nested(status, "rds_index", "ci_high")
+
+    if rds_lo is not None and rds_hi is not None:
+
+        if rds_value is None:
+            rds_value = (rds_lo + rds_hi) / 2.0
+
+        lines.append(
+            f"RDSI: {rds_value:.2f} (CI: {rds_lo:.2f}–{rds_hi:.2f})"
+        )
+
 
     gates = status.get("gates", {}) or {}
 


### PR DESCRIPTION
This PR adds a small CLI helper to make PULSE status artefacts easier to
inspect from the command line.

### What it does

- Introduces `PULSE_safe_pack_v0/tools/print_status_summary.py`.
- Loads a `status.json` artefact (default:
  `PULSE_safe_pack_v0/artifacts/status.json`).
- Prints a compact summary with:
  - model id
  - profile
  - overall decision
  - RDSI (if present)
  - key gate booleans (`refusal_delta_pass`, `external_all_pass`,
    `quality_slo_pass`, `overall_pass` when available).
- Handles missing fields gracefully so it can work with future profiles, too.

### Why this is useful

- Gives developers and release owners a quick, human-readable view of a run
  without having to open the full JSON.
- Complements the Quality Ledger: the ledger is the rich HTML view, while
  this CLI is the fast terminal check.
- Fits well with the new quickstart safe-pack example, which already
  generates a deterministic `status.json`.
