### PR TITLE
feat: add pulse-summary launcher for status summaries

### DIFF
--- a/pulse-summary
+++ b/pulse-summary
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# pulse-summary - tiny launcher for the PULSE status summary helper.
+#
+# Usage (from the repo root):
+#   ./pulse-summary --status path/to/status.json
+#
+# By default it will fall back to PULSE_safe_pack_v0/artifacts/status.json
+# if no --status argument is provided (handled inside print_status_summary.py).
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+python "$SCRIPT_DIR/PULSE_safe_pack_v0/tools/print_status_summary.py" "$@"


### PR DESCRIPTION
This PR adds a small `pulse-summary` helper script at the repository root.

What it does
------------

* Introduces a `./pulse-summary` shell launcher that simply forwards all
  arguments to `PULSE_safe_pack_v0/tools/print_status_summary.py`.
* Keeps the existing CLI behaviour from `print_status_summary.py`, including
  the default `--status` path fallback to `PULSE_safe_pack_v0/artifacts/status.json`.

Why this is useful
------------------

* Developers no longer need to remember or type the full Python path:
  instead of

      python PULSE_safe_pack_v0/tools/print_status_summary.py --status path/to/status.json

  they can simply run

      ./pulse-summary --status path/to/status.json

* Matches the spirit of the "developer comfort" layer: quick, human-readable
  summaries of `refusal_delta_pass`, `external_all_pass` and overall decision
  without digging into JSON.

Scope
-----

* No changes to gate logic or metrics.
* Only adds a thin CLI wrapper script; behaviour remains fully defined by
  `print_status_summary.py` and the underlying `status.json` schema.
