### PR TITLE
docs: add EPF hazard quickstart example

### DIFF
--- a/examples/epf_hazard_quickstart.py
+++ b/examples/epf_hazard_quickstart.py
@@ -1,0 +1,42 @@
+from PULSE_safe_pack_v0.epf.epf_hazard_forecast import (
+    HazardConfig,
+    forecast_hazard,
+)
+
+
+def main():
+    cfg = HazardConfig()
+    history_T: list[float] = []
+
+    # very small toy loop
+    snapshots = [
+        {"m": 1.0},
+        {"m": 1.05},
+        {"m": 1.10},
+        {"m": 1.30},
+        {"m": 1.80},
+    ]
+    reference = {"m": 1.0}
+
+    for step, current in enumerate(snapshots):
+        stability_metrics = {"RDSI": 0.9}  # pretend fairly stable
+        state = forecast_hazard(
+            current_snapshot=current,
+            reference_snapshot=reference,
+            stability_metrics=stability_metrics,
+            history_T=history_T,
+            cfg=cfg,
+        )
+        history_T.append(state.T)
+
+        print(
+            f"t={step:02d}  T={state.T:.3f}  S={state.S:.2f}  "
+            f"D={state.D:.3f}  E={state.E:.3f}  zone={state.zone}"
+        )
+        print("   reason:", state.reason)
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds a small runnable example for the **EPF hazard forecasting
proto-module**:

- `examples/epf_hazard_quickstart.py`

The example demonstrates how to maintain `history_T`, call
`forecast_hazard(...)`, and interpret the resulting `HazardState`.

---

## What changed

- New file: `examples/epf_hazard_quickstart.py`

The script:

- creates a `HazardConfig` with default parameters,
- defines a simple list of synthetic snapshots that gradually drift
  away from a baseline,
- keeps a `history_T: list[float]` across steps,
- calls:

  ```python
  state = forecast_hazard(
      current_snapshot=current,
      reference_snapshot=reference,
      stability_metrics={"RDSI": rdsi_value},
      history_T=history_T,
      cfg=cfg,
  )


appends state.T to history_T for the next iteration,

prints a compact line per timestep:

T, S, D, E, and the zone, plus

the human-readable reason string returned by the module.

No library code or configuration is modified; this is an example-only
addition.

Rationale

We already have:

an EPF hazard probe implementation, and

unit tests covering its core behaviour.

This example fills the gap between docs and tests by providing a
minimal, copy-pasteable script that:

shows how to use the API in practice,

makes it easy to observe how E(t) and the zone change over time as
the field drifts,

can be used as a starting point for notebooks or dashboards.

Testing

Ran the example locally with:

python examples/epf_hazard_quickstart.py

Verified that:

the script imports HazardConfig and forecast_hazard correctly,

it prints a short time series of T/S/D/E values and zones without
errors.

