### PR TITLE
docs: add quickstart link for EPF hazard example

### DIFF
--- a/docs/epf_hazard_forecast.md
+++ b/docs/epf_hazard_forecast.md
@@ -177,3 +177,20 @@ This prototype is intentionally simple. Potential future extensions:
 - richer explanations including which metrics contributed most to `T`,
 - wiring the hazard signal into actual release gates as an optional
   early-warning quality gate.
+
+---
+
+## Quickstart
+
+To see the hazard probe in action on a small synthetic time series, run:
+
+```bash
+python examples/epf_hazard_quickstart.py
+
+
+The script maintains a short T history, calls forecast_hazard(...)
+on each step, and prints T, S, D, E together with the selected
+zone and the explanation string. This is a minimal way to get an
+intuition for how the early-warning index evolves over time.
+
+


### PR DESCRIPTION
## Summary

This PR improves the EPF hazard forecasting docs by adding a small
**Quickstart** section that links directly to the runnable example:

- `examples/epf_hazard_quickstart.py`

---

## What changed

- Updated `docs/epf_hazard_forecast.md` to append a `## Quickstart`
  section at the end of the document.
- The new block shows how to run:

  ```bash
  python examples/epf_hazard_quickstart.py
and briefly explains that the script:

maintains a short T history,

calls forecast_hazard(...) on each step,

prints T, S, D, E, the zone and the explanation string.

No library code or configs were changed; this is documentation only.

Rationale

We already have:

the EPF hazard probe implementation, and

a small example script under examples/.

This Quickstart link connects the two in the docs, making it easy for
readers to go from theory to a concrete, runnable example with a single
command.

Testing

Rendered docs/epf_hazard_forecast.md in a markdown preview to
verify:

the new section renders correctly,

the bash code block is formatted as expected,

there are no broken links or syntax errors.