### PR TITLE
docs: document epf_hazard_log.jsonl artefact

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,37 +365,31 @@ participate in release gating yet.
   Line-oriented JSON log produced by the EPF hazard adapter. Each line
   is a single hazard probe event with the following structure:
 
-  ```json
-  {
-    "gate_id": "<gate-or-field-id>",
-    "timestamp": "<iso-utc>",
-    "hazard": {
-      "T": 0.41,
-      "S": 0.94,
-      "D": 0.03,
-      "E": 0.12,
-      "zone": "GREEN",
-      "reason": "E=0.120, T=0.410, S=0.940, D=0.030 → field stable, no near-term hazard signal."
-    },
-    "meta": {
-      "run_id": "...",
-      "commit": "...",
-      "experiment_id": "..."
-    }
-  }
+      {
+        "gate_id": "<gate-or-field-id>",
+        "timestamp": "<iso-utc>",
+        "hazard": {
+          "T": 0.41,
+          "S": 0.94,
+          "D": 0.03,
+          "E": 0.12,
+          "zone": "GREEN",
+          "reason": "E=0.120, T=0.410, S=0.940, D=0.030 → field stable, no near-term hazard signal."
+        },
+        "meta": {
+          "run_id": "...",
+          "commit": "...",
+          "experiment_id": "..."
+        }
+      }
 
----
-
-Notes:
-
-One line per probe invocation (per gate / per cycle).
-
-meta is optional and may contain run-specific identifiers.
-
-This artefact is diagnostic only in the proto phase: it is used
-for analysis and calibration of thresholds, not as a hard release
-gate.
-
+  Notes:
+  - One line per probe invocation (per gate / per cycle).
+  - `meta` is optional and may contain run-specific identifiers.
+  - This artefact is **diagnostic only** in the proto phase: it is used
+    for analysis and calibration of thresholds, not as a hard release
+    gate.
+  
 ---
 
 ### Optional config (per gate)


### PR DESCRIPTION
## Summary

This PR updates the EPF experiment documentation to include the new
`epf_hazard_log.jsonl` artefact produced by the EPF hazard adapter.

---

## What changed

- Added a bullet under the EPF experiment **Artifacts** section
  describing:

  - the file name: `epf_hazard_log.jsonl`,
  - that it is a line-oriented JSON log,
  - the structure of each entry:

    ```json
    {
      "gate_id": "...",
      "timestamp": "...",
      "hazard": {
        "T": ...,
        "S": ...,
        "D": ...,
        "E": ...,
        "zone": "...",
        "reason": "..."
      },
      "meta": { ... } // optional
    }
    ```

  - and that it is currently a diagnostic / calibration artefact, not a
    hard gating signal.

No source code or adapters were changed in this PR; only documentation.

---

## Rationale

We recently added an EPF hazard adapter that logs probe results to
`epf_hazard_log.jsonl`. Documenting this artefact:

- makes it discoverable for users running EPF experiments,
- clarifies the JSON shape needed for downstream analysis,
- and sets expectations that, in the proto phase, the log is for
  diagnostics and threshold tuning rather than enforcement.

---

## Testing

- Rendered the updated markdown (README / EPF docs) to verify:
  - the new bullet renders correctly in the Artifacts list,
  - the nested JSON code block is formatted as expected,
  - there are no broken links or syntax errors.
