### PR TITLE
feat(run_all): log EPF hazard probe to JSONL

### DIFF
--- a/PULSE_safe_pack_v0/tools/run_all.py
+++ b/PULSE_safe_pack_v0/tools/run_all.py
@@ -8,9 +8,18 @@ baseline status.json and related artifacts under the pack's artifacts
 directory, which are then consumed by CI workflows and reporting tools.
 """
 
-import os, json, datetime, pathlib, random
+import os, json, datetime, pathlib, random, sys
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
+REPO_ROOT = ROOT.parent
+if str(REPO_ROOT) not in sys.path:
+  sys.path.insert(0, str(REPO_ROOT))
+
+from PULSE_safe_pack_v0.epf.epf_hazard_adapter import (
+  HazardRuntimeState,
+  probe_hazard_and_append_log,
+)
+
 art = ROOT / "artifacts"
 art.mkdir(parents=True, exist_ok=True)
 
@@ -55,7 +64,10 @@ with open(art / "status.json", "w", encoding="utf-8") as f:
   json.dump(status, f, indent=2)
 
 # Simple report card HTML
-rows = "\n".join([f"<tr><td>{k}</td><td>{'PASS' if v else 'FAIL'}</td></tr>" for k,v in gates.items()])
+rows = "\n".join([
+  f"<tr><td>{k}</td><td>{'PASS' if v else 'FAIL'}</td></tr>"
+  for k, v in gates.items()
+])
 html = f"""<!doctype html>
 <html><head><meta charset="utf-8"><title>PULSE Report Card</title>
 <style>
@@ -74,3 +86,33 @@ with open(art / "report_card.html", "w", encoding="utf-8") as f:
 
 print("Wrote", art / "status.json")
 print("Wrote", art / "report_card.html")
+
+# ---------------------------------------------------------------------------
+# EPF hazard demo logging (proto-level, diagnostic only)
+# ---------------------------------------------------------------------------
+
+hazard_runtime = HazardRuntimeState.empty()
+
+# For now we only use RDSI as a simple EPF proxy.
+current_snapshot = {"RDSI": metrics.get("RDSI", 0.5)}
+reference_snapshot = {"RDSI": 1.0}
+stability_metrics = {"RDSI": metrics.get("RDSI", 0.5)}
+
+hazard_state = probe_hazard_and_append_log(
+  gate_id="EPF_demo_RDSI",
+  current_snapshot=current_snapshot,
+  reference_snapshot=reference_snapshot,
+  stability_metrics=stability_metrics,
+  runtime_state=hazard_runtime,
+  log_dir=art,
+  extra_meta={
+    "created_utc": now,
+    "status_version": status.get("version"),
+  },
+)
+
+print(
+  "Logged EPF hazard probe:",
+  f"zone={hazard_state.zone}",
+  f"E={hazard_state.E:.3f}",
+)


### PR DESCRIPTION
## Summary

This PR wires the EPF hazard adapter into the demo safe-pack entrypoint
so that each `run_all.py` invocation emits a simple hazard log entry
based on RDSI.

---

## What changed

- Updated `PULSE_safe_pack_v0/tools/run_all.py` to:
  - add the repository root to `sys.path` so that
    `PULSE_safe_pack_v0.epf` can be imported when running the script as
    `python PULSE_safe_pack_v0/tools/run_all.py`,
  - import `HazardRuntimeState` and `probe_hazard_and_append_log` from
    `PULSE_safe_pack_v0.epf.epf_hazard_adapter`,
  - after generating `status.json` and `report_card.html`, construct a
    minimal hazard snapshot using:
      - `current_snapshot = {"RDSI": metrics["RDSI"]}`,
      - `reference_snapshot = {"RDSI": 1.0}`,
      - `stability_metrics = {"RDSI": metrics["RDSI"]}`,
  - call `probe_hazard_and_append_log(...)` with
    `log_dir=artifacts/`, `gate_id="EPF_demo_RDSI"`, and a fresh
    `HazardRuntimeState`,
  - print a short summary line with `zone` and `E`.

This produces an `epf_hazard_log.jsonl` artefact alongside the existing
`status.json` and `report_card.html` without changing any gate logic.

---

## Rationale

We already have:

- the core EPF hazard forecasting module,
- an adapter that writes JSONL logs, and
- docs describing `epf_hazard_log.jsonl`.

Wiring the adapter into `run_all.py` ensures that:

- every safe-pack run automatically generates at least one hazard
  record,
- downstream analysis can start from real CI runs (even in the demo
  pack), and
- we keep the integration strictly diagnostic-only in the proto phase.

A future PR can later replace the simple RDSI-only snapshot with a
richer EPF field snapshot once the underlying metrics are available.

---

## Testing

- Ran:

  ```bash
  python PULSE_safe_pack_v0/tools/run_all.py

Verified that:

status.json and report_card.html are still produced as before,

PULSE_safe_pack_v0/artifacts/epf_hazard_log.jsonl is created,

each run appends a JSONL line with gate_id, timestamp, hazard
and optional meta,

the script prints a short summary line with the hazard zone and
E index.
