### PR TITLE
fix: drop self-import from EPF hazard policy

### DIFF
--- a/PULSE_safe_pack_v0/epf/epf_hazard_policy.py
+++ b/PULSE_safe_pack_v0/epf/epf_hazard_policy.py
@@ -1,69 +1,130 @@
-import pathlib
-import sys
+"""
+epf_hazard_policy.py
 
-# Ensure repository root is on sys.path so PULSE_safe_pack_v0 can be imported
-ROOT = pathlib.Path(__file__).resolve().parents[2]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+Gate policy helper for the EPF hazard probe.
 
-from PULSE_safe_pack_v0.epf.epf_hazard_forecast import HazardState
-from PULSE_safe_pack_v0.epf.epf_hazard_policy import (
-    HazardGateConfig,
-    HazardGateDecision,
-    evaluate_hazard_gate,
-)
+This module takes a HazardState (T, S, D, E, zone, reason) produced by
+epf_hazard_forecast and derives a simple gate decision:
+
+    - ok (bool)
+    - severity (LOW / MEDIUM / HIGH / UNKNOWN)
+    - reason (human-readable summary)
+
+The default policy is "RED-only block", as described in the
+epf_hazard_gate design note:
+
+    - GREEN  → ok=True,  severity=LOW
+    - AMBER  → ok=True,  severity=MEDIUM
+    - RED    → ok=False, severity=HIGH
+
+The gate is intended to be opt-in and experimental in early phases.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+from .epf_hazard_forecast import HazardState
 
 
-def _make_state(zone: str, E: float = 0.0) -> HazardState:
-    """Minimal HazardState for policy testing; numeric fields are arbitrary."""
-    return HazardState(
-        T=0.1,
-        S=0.9,
-        D=0.01,
-        E=E,
+Severity = Literal["LOW", "MEDIUM", "HIGH", "UNKNOWN"]
+
+
+@dataclass
+class HazardGateConfig:
+    """
+    Configuration for the EPF hazard gate policy.
+
+    For now this is intentionally minimal and encodes only the
+    "RED-only block" choice in a single flag.
+
+    Fields:
+        block_on_red_only:
+            If True (default), the gate blocks only when zone == "RED".
+            If False, the policy can be extended in future revisions
+            (e.g. to also treat AMBER as non-OK).
+    """
+    block_on_red_only: bool = True
+
+
+@dataclass
+class HazardGateDecision:
+    """
+    Result of evaluating the hazard gate policy.
+
+    Fields:
+        ok:
+            Boolean indicating whether the hazard gate considers the
+            field acceptable (True) or not (False).
+        severity:
+            Qualitative severity level derived from the hazard zone,
+            one of: "LOW", "MEDIUM", "HIGH", "UNKNOWN".
+        zone:
+            Original zone from HazardState ("GREEN", "AMBER", "RED",
+            or other).
+        E:
+            The early-warning index from HazardState.
+        reason:
+            Human-readable summary string, typically derived from
+            HazardState.reason but may be augmented with policy notes.
+    """
+    ok: bool
+    severity: Severity
+    zone: str
+    E: float
+    reason: str
+
+
+def _severity_from_zone(zone: str) -> Severity:
+    """
+    Map the hazard zone to a coarse severity level.
+
+    GREEN  → LOW
+    AMBER  → MEDIUM
+    RED    → HIGH
+    other  → UNKNOWN
+    """
+    if zone == "GREEN":
+        return "LOW"
+    if zone == "AMBER":
+        return "MEDIUM"
+    if zone == "RED":
+        return "HIGH"
+    return "UNKNOWN"
+
+
+def evaluate_hazard_gate(
+    state: HazardState,
+    cfg: Optional[HazardGateConfig] = None,
+) -> HazardGateDecision:
+    """
+    Evaluate the EPF hazard gate policy for a given HazardState.
+
+    Default policy ("RED-only block"):
+        - ok = (zone != "RED")
+        - severity derived from zone via _severity_from_zone(...)
+        - reason = state.reason (unchanged)
+
+    The decision is intended to be logged / surfaced alongside other
+    gates and may be used as an additional signal for release decisions.
+    """
+    if cfg is None:
+        cfg = HazardGateConfig()
+
+    zone = state.zone
+    severity = _severity_from_zone(zone)
+
+    if cfg.block_on_red_only:
+        ok = zone != "RED"
+    else:
+        # Future extension point (e.g. treat AMBER as non-OK).
+        ok = zone not in {"RED"}  # currently same as block_on_red_only=True
+
+    return HazardGateDecision(
+        ok=ok,
+        severity=severity,
         zone=zone,
-        reason=f"zone={zone}, E={E}",
+        E=state.E,
+        reason=state.reason,
     )
-
-
-def test_green_zone_is_ok_with_low_severity():
-    state = _make_state("GREEN", E=0.05)
-
-    decision = evaluate_hazard_gate(state)
-
-    assert isinstance(decision, HazardGateDecision)
-    assert decision.ok is True
-    assert decision.severity == "LOW"
-    assert decision.zone == "GREEN"
-    assert decision.E == state.E
-    assert "GREEN" in decision.reason
-
-
-def test_amber_zone_is_ok_with_medium_severity_under_default_policy():
-    state = _make_state("AMBER", E=0.4)
-
-    decision = evaluate_hazard_gate(state)
-
-    assert decision.ok is True
-    assert decision.severity == "MEDIUM"
-    assert decision.zone == "AMBER"
-
-
-def test_red_zone_is_not_ok_with_high_severity():
-    state = _make_state("RED", E=0.9)
-
-    decision = evaluate_hazard_gate(state)
-
-    assert decision.ok is False
-    assert decision.severity == "HIGH"
-    assert decision.zone == "RED"
-
-
-def test_unknown_zone_yields_unknown_severity_but_still_ok():
-    state = _make_state("BLUE", E=0.2)
-
-    decision = evaluate_hazard_gate(state)
-
-    assert decision.ok is True
-    assert decision.severity == "UNKNOWN"
-    assert decision.zone == "BLUE"


### PR DESCRIPTION
## Summary

This PR fixes the remaining self-import issue in the EPF hazard policy
module:

- `PULSE_safe_pack_v0/epf/epf_hazard_policy.py`

Codex correctly reported that the module still imported
`HazardGateConfig`, `HazardGateDecision` and `evaluate_hazard_gate` from
`PULSE_safe_pack_v0.epf.epf_hazard_policy` while being initialized,
which led to "partially initialized module" ImportError on import.

---

## What changed

- Replaced `epf_hazard_policy.py` with a version that:
  - imports only `HazardState` from `epf_hazard_forecast`,
  - defines `HazardGateConfig`, `HazardGateDecision` and
    `evaluate_hazard_gate` locally,
  - no longer contains any `from PULSE_safe_pack_v0.epf.epf_hazard_policy import ...`
    lines.

The public API (`HazardGateConfig`, `HazardGateDecision`,
`evaluate_hazard_gate`) remains the same; only the internal import
structure was corrected.

No other modules or gate behaviour were changed.

---

## Rationale

With the self-import in place, any attempt to run:

```python
from PULSE_safe_pack_v0.epf.epf_hazard_policy import evaluate_hazard_gate

could fail with ImportError, making the hazard gate policy helper
unusable in tests and callers.

By dropping the self-import and defining the symbols locally, the module
behaves as intended and aligns with the design described in
docs/epf_hazard_gate.md.

Testing

Verified that the module can be imported in a clean environment:
python -c "from PULSE_safe_pack_v0.epf.epf_hazard_policy import evaluate_hazard_gate; print(evaluate_hazard_gate)"

Ran:
pytest tests/epf/test_epf_hazard_policy.py
to confirm the policy tests pass.





