### PR TITLE
test: add integration tests for EPF hazard in run_all

### DIFF
--- a/tests/tools/test_run_all_hazard_integration.py
+++ b/tests/tools/test_run_all_hazard_integration.py
@@ -1,0 +1,67 @@
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+# Repository root (…/pulse-release-gates-0.1)
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+RUN_ALL = ROOT / "PULSE_safe_pack_v0" / "tools" / "run_all.py"
+ART = ROOT / "PULSE_safe_pack_v0" / "artifacts"
+
+
+def _run_run_all(extra_env: dict | None = None) -> dict:
+    """Run run_all.py and return the loaded status.json."""
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+
+    # Run from repo root so relative paths behave as in normal use.
+    subprocess.run(
+        [sys.executable, str(RUN_ALL)],
+        check=True,
+        cwd=str(ROOT),
+        env=env,
+    )
+
+    status_path = ART / "status.json"
+    assert status_path.exists(), f"status.json not found at {status_path}"
+    with status_path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_run_all_hazard_shadow_gate_default():
+    """By default the hazard gate is in shadow mode (always True)."""
+    status = _run_run_all()
+    gates = status["gates"]
+    metrics = status["metrics"]
+
+    # Gate is present but shadowed to True by default.
+    assert "epf_hazard_ok" in gates
+    assert gates["epf_hazard_ok"] is True
+
+    # Hazard metrics are surfaced.
+    for key in [
+        "hazard_T",
+        "hazard_S",
+        "hazard_D",
+        "hazard_E",
+        "hazard_zone",
+        "hazard_reason",
+        "hazard_ok",
+        "hazard_severity",
+    ]:
+        assert key in metrics, f"missing hazard metric: {key}"
+
+
+def test_run_all_hazard_gate_enforced_follows_metrics_ok():
+    """With EPF_HAZARD_ENFORCE=1, the gate must follow hazard_ok."""
+    status = _run_run_all({"EPF_HAZARD_ENFORCE": "1"})
+    gates = status["gates"]
+    metrics = status["metrics"]
+
+    assert "epf_hazard_ok" in gates
+    assert "hazard_ok" in metrics
+
+    # When enforcement is enabled, the gate should match the policy result.
+    assert gates["epf_hazard_ok"] == metrics["hazard_ok"]


### PR DESCRIPTION
## Summary

This PR adds simple integration tests for the EPF hazard behaviour in
the safe-pack entrypoint:

- `PULSE_safe_pack_v0/tools/run_all.py`

The goal is to verify the shadow gate and ENV-enforced gate behaviour
end-to-end via the generated `status.json`.

---

## What changed

- New test module:

  - `tests/tools/test_run_all_hazard_integration.py`

  which:

  - runs `run_all.py` from the repository root using `subprocess.run`,
  - loads `PULSE_safe_pack_v0/artifacts/status.json` and inspects its
    `gates` and `metrics` sections.

The tests cover two scenarios:

1. **Default (shadow gate)**

   - No `EPF_HAZARD_ENFORCE` set.
   - Asserts that:
     - `status["gates"]["epf_hazard_ok"]` exists and is `True`,
     - hazard metrics are present:
       - `hazard_T`, `hazard_S`, `hazard_D`, `hazard_E`,
       - `hazard_zone`, `hazard_reason`,
       - `hazard_ok`, `hazard_severity`.

2. **Enforced gate**

   - `EPF_HAZARD_ENFORCE=1` in the environment.
   - Asserts that:
     - `status["gates"]["epf_hazard_ok"]` exists,
     - `status["gates"]["epf_hazard_ok"] == status["metrics"]["hazard_ok"]`,
       i.e. the gate follows the policy decision when enforcement is
       enabled.

No changes were made to `run_all.py` or any other production code.

---

## Rationale

We already have unit tests for the EPF hazard probe and the gate policy,
but we did not yet have an end-to-end test that:

- runs the main entrypoint,
- exercises the hazard probe + adapter + policy,
- and verifies the resulting `status.json` structure.

These integration tests ensure that:

- the shadow gate behaves as expected by default,
- the ENV-enforced gate reflects the policy output, and
- future refactors of `run_all.py` do not silently break the EPF hazard
  integration.

---

## Testing

- Ran:

  ```bash
  pytest tests/tools/test_run_all_hazard_integration.py

and confirmed that both tests pass.

Verified that running run_all.py manually still produces
status.json, report_card.html and epf_hazard_log.jsonl as before.
