### PR TITLE
docs: add EPF hazard safety story

### DIFF
--- a/docs/epf_hazard_forecast.md
+++ b/docs/epf_hazard_forecast.md
@@ -9,6 +9,20 @@ between the current EPF field state and a stable reference.
 
 ---
 
+### Safety story: EPF hazard as early warning
+
+PULSE is not only about pass/fail gates; it also looks at the stability
+of the underlying field that generates those gates. The EPF hazard
+signal treats errors as **relationship distortions** between a current
+state and a stable reference, rather than isolated events. By tracking
+T (distance), S (stability), D (drift) and the early-warning index E,
+the hazard probe can raise a signal while the system is still
+technically "passing" all checks. This gives us time to spot and
+investigate emerging shifts in the field before they turn into visible
+failures in production.
+
+---
+
 ## High-level idea
 
 Instead of treating errors as isolated events, the module looks at how the


### PR DESCRIPTION
## Summary

This PR adds a short "safety story" section to the EPF hazard docs /
README to explain, in plain language, why the hazard signal exists and
how it relates to PULSE gates.

---

## What changed

- Introduced a new section:

  ```markdown
  ### Safety story: EPF hazard as early warning


which states that:

PULSE is not only about pass/fail gates,

the EPF hazard signal interprets errors as relationship distortions
between a current state and a stable reference,

by tracking T (distance), S (stability), D (drift) and E
(early-warning index), the system can raise signals while all gates
may still be technically passing,

this provides early warning for emerging field shifts before they
turn into visible production failures.

No code, adapters, tools or gate behaviour are modified in this PR.

Rationale

We already have detailed technical documentation for the EPF hazard
probe, adapter, log, inspector, plotting helper and gate policy.
However, we were missing a concise narrative explaining:

what problem the hazard signal is trying to solve,

how it complements binary gates,

why it matters from a safety perspective.

This "safety story" fills that gap at the top of the docs/README.

Testing

Rendered the updated markdown to verify:

the new section renders correctly in context,

headings and formatting are consistent with existing sections,

no unbalanced code fences or syntax issues.
