### PR TITLE
docs(readme): add EPF hazard safety teaser

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,12 @@ In the current proto phase, the hazard signal is **diagnostic only**:
 it is logged, inspected and surfaced in status/reporting, but does not
 yet enforce any hard release gate.
 
+---
+
+> The EPF hazard signal is an early-warning layer on top of the usual
+> pass/fail gates: it looks at how the field is drifting and destabilising
+> before those drifts show up as hard failures. See the EPF hazard docs
+> for details.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR adds a short EPF hazard safety teaser to the README, close to
the existing "EPF hazard overview (proto pipeline)" section.

---

## What changed

- Updated `README.md` to include a one-paragraph teaser that explains
  the role of the EPF hazard signal:

  ```markdown
  > The EPF hazard signal is an early-warning layer on top of the usual
  > pass/fail gates: it looks at how the field is drifting and
  > destabilising before those drifts show up as hard failures. See the
  > EPF hazard docs for details.

The teaser is placed next to the EPF hazard overview so that readers
immediately see the safety motivation before diving into details.

No code, tools, policies or tests are changed in this PR.

Rationale

We already have detailed EPF hazard documentation and a README section
that describes the proto pipeline. What was missing is a compact
"why this matters" sentence at the top-level:

PULSE is not only about pass/fail gates,

the hazard signal acts as an early-warning field-level indicator,

it helps detect drifts before they become visible failures.

This teaser provides that safety story in one place and points readers
to the dedicated EPF hazard docs.

Testing

Rendered README.md in a markdown preview to verify:

the teaser appears in the intended place near the EPF hazard
overview,

the blockquote formatting renders correctly,

there are no unbalanced code fences or markdown syntax issues.