### PR TITLE
feat(epf-hazard): add hazard threshold debug helper

### DIFF
--- a/PULSE_safe_pack_v0/tools/epf_hazard_debug.py
+++ b/PULSE_safe_pack_v0/tools/epf_hazard_debug.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+epf_hazard_debug.py
+
+Small helper to introspect the EPF Relational Grail (hazard forecasting)
+thresholds on a given environment.
+
+It prints:
+- whether a calibration artefact exists,
+- what the artefact reports (sample count, global warn/crit),
+- what HazardConfig() actually uses as warn/crit thresholds.
+
+This is a developer-only tool; it does not change any gate behaviour.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+from typing import Any, Dict, Optional, Tuple
+
+
+def add_pack_to_sys_path() -> pathlib.Path:
+    """
+    Ensure PULSE_safe_pack_v0/ is on sys.path so we can import epf_hazard_forecast
+    when running this script as:
+
+        python PULSE_safe_pack_v0/tools/epf_hazard_debug.py
+    """
+    script_path = pathlib.Path(__file__).resolve()
+    pack_root = script_path.parents[1]  # .../PULSE_safe_pack_v0
+    if str(pack_root) not in sys.path:
+        sys.path.insert(0, str(pack_root))
+    return pack_root
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Debug the EPF hazard thresholds (baseline vs calibrated)."
+    )
+    parser.add_argument(
+        "--calibration",
+        type=pathlib.Path,
+        default=None,
+        help=(
+            "Optional explicit path to a calibration JSON artefact. "
+            "If omitted, uses the default path from epf_hazard_forecast."
+        ),
+    )
+    return parser.parse_args()
+
+
+def load_calibration_summary(path: pathlib.Path) -> Tuple[bool, Dict[str, Any]]:
+    """
+    Try to load a minimal summary from a calibration artefact:
+    - present: bool
+    - data: dict with 'warn', 'crit', 'count' (when available)
+    """
+    if not path.exists():
+        return False, {}
+
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError:
+        return True, {"error": "json_decode_error"}
+
+    global_cfg = data.get("global", {})
+    stats = global_cfg.get("stats", {}) or {}
+    count = stats.get("count")
+    warn = global_cfg.get("warn_threshold")
+    crit = global_cfg.get("crit_threshold")
+
+    summary: Dict[str, Any] = {}
+    if count is not None:
+        summary["count"] = count
+    if warn is not None:
+        summary["warn_threshold"] = warn
+    if crit is not None:
+        summary["crit_threshold"] = crit
+
+    return True, summary
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    pack_root = add_pack_to_sys_path()
+
+    # Import after we fixed sys.path
+    from epf_hazard_forecast import (  # type: ignore
+        HazardConfig,
+        CALIBRATION_PATH,
+        DEFAULT_WARN_THRESHOLD,
+        DEFAULT_CRIT_THRESHOLD,
+        MIN_CALIBRATION_SAMPLES,
+    )
+
+    args = parse_args()
+
+    calibration_path = args.calibration or CALIBRATION_PATH
+
+    print("EPF Relational Grail — hazard threshold debug")
+    print("================================================")
+    print(f"Pack root           : {pack_root}")
+    print(f"Calibration file    : {calibration_path}")
+    print(f"Min samples (guard) : {MIN_CALIBRATION_SAMPLES}")
+    print()
+
+    present, summary = load_calibration_summary(calibration_path)
+    print("Baseline thresholds (built-in):")
+    print(f"  warn_threshold = {DEFAULT_WARN_THRESHOLD:.4f}")
+    print(f"  crit_threshold = {DEFAULT_CRIT_THRESHOLD:.4f}")
+    print()
+
+    if not present:
+        print("Calibration artefact:")
+        print("  <not found>")
+    else:
+        print("Calibration artefact:")
+        if "error" in summary:
+            print(f"  error: {summary['error']}")
+        else:
+            count = summary.get("count", "<missing>")
+            warn = summary.get("warn_threshold", "<missing>")
+            crit = summary.get("crit_threshold", "<missing>")
+            print(f"  stats.count        = {count}")
+            print(f"  global.warn_thresh = {warn}")
+            print(f"  global.crit_thresh = {crit}")
+    print()
+
+    cfg = HazardConfig()
+    print("Effective HazardConfig() thresholds:")
+    print(f"  warn_threshold = {cfg.warn_threshold:.4f}")
+    print(f"  crit_threshold = {cfg.crit_threshold:.4f}")
+    print()
+
+    # Quick note on whether we are using baseline or calibrated.
+    using_baseline = (
+        abs(cfg.warn_threshold - DEFAULT_WARN_THRESHOLD) < 1e-9
+        and abs(cfg.crit_threshold - DEFAULT_CRIT_THRESHOLD) < 1e-9
+    )
+    if using_baseline:
+        print("Decision:")
+        print("  Using BASELINE thresholds (calibration missing/insufficient).")
+    else:
+        print("Decision:")
+        print("  Using CALIBRATED thresholds from artefact.")
+    print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add a small developer-facing helper to introspect the EPF Relational
Grail (hazard forecasting) thresholds on a given environment.

The goal is to make it trivial to answer:

- What are the built-in baseline thresholds?
- Is there a calibration artefact present?
- If yes, what does it say (sample count, global warn/crit)?
- What thresholds does `HazardConfig()` actually use right now
  (baseline vs calibrated)?

## Changes

- `PULSE_safe_pack_v0/tools/epf_hazard_debug.py`
  - Ensures `PULSE_safe_pack_v0/` is on `sys.path` when the script is
    run as:

    ```bash
    python PULSE_safe_pack_v0/tools/epf_hazard_debug.py
    ```

  - Imports from `epf_hazard_forecast`:
    - `HazardConfig`
    - `CALIBRATION_PATH`
    - `DEFAULT_WARN_THRESHOLD`
    - `DEFAULT_CRIT_THRESHOLD`
    - `MIN_CALIBRATION_SAMPLES`

  - Prints:
    - pack root and calibration path,
    - the built-in baseline thresholds (`DEFAULT_WARN_THRESHOLD`,
      `DEFAULT_CRIT_THRESHOLD`),
    - a minimal summary of the calibration artefact
      (`stats.count`, `global.warn_threshold`, `global.crit_threshold`,
      or an error if the JSON is invalid),
    - the effective `HazardConfig()` `warn_threshold` / `crit_threshold`,
    - a short decision note:
      - "Using BASELINE thresholds..." or
      - "Using CALIBRATED thresholds from artefact."

  - Supports an optional `--calibration` flag to point at a custom
    calibration JSON path when needed.

## Behaviour

- The script is **read-only**:
  - It does not modify any artefacts, configs, or gates.
  - It is purely diagnostic for developers.

- It reflects the current logic in `epf_hazard_forecast`:
  - If the artefact is missing / invalid or has too few samples
    (`stats.count < MIN_CALIBRATION_SAMPLES`), `HazardConfig` falls
    back to the baseline 0.3 / 0.7 thresholds.
  - Otherwise, it uses the calibrated `global.warn_threshold` /
    `global.crit_threshold`.

On the current demo state (1 log entry, `stats.count = 1`), the debug
script will show that:

- the calibration artefact exists and reports warn/crit ≈ 0.08,
- but `HazardConfig()` still uses the baseline 0.3 / 0.7 because the
  sample count is below the guard.

## Usage

From the repo root:

```bash
python PULSE_safe_pack_v0/tools/epf_hazard_debug.py

Optional explicit calibration path:

python PULSE_safe_pack_v0/tools/epf_hazard_debug.py \
  --calibration /path/to/epf_hazard_thresholds_v0.json

Impact

Additive, no behaviour change in gates or CI.

No performance impact on normal runs; this tool is only executed
explicitly by developers.

Follow-ups

Consider linking this tool from the README section describing the
EPF Relational Grail and hazard calibration.

Optionally extend the output with a one-line “summary classification”
of how aggressive the current thresholds are (e.g. based on recent
alert volume).
