### PR TITLE
docs(epf-hazard): add EPF Relational Grail teaser to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,18 @@ yet enforce any hard release gate.
 
 ---
 
+### EPF Relational Grail (hazard probe)
+
+The **EPF Relational Grail** is the relational hazard layer in the PULSE EPF
+stack: instead of waiting for a concrete error event, it monitors the
+relationship between the current state and a reference state and produces a
+scalar hazard index E(t) with GREEN / AMBER / RED zones.
+
+For the conceptual overview, calibration flow and CLI examples, see
+[docs/epf_relational_grail.md](docs/epf_relational_grail.md).
+
+---
+
 ### Artifacts
 
 - `status_baseline.json` – deterministic decisions (source of truth)


### PR DESCRIPTION
## Summary

Add a compact EPF Relational Grail section to the README.

The goal is to give the hazard layer a clear name and one-paragraph
description in the main landing page, without pulling in all of the
conceptual and calibration details (those will live in a separate
docs page).

## Changes

- `README.md`
  - Add a short **"EPF Relational Grail (hazard probe)"** section:
    - describe it as the relational hazard layer in the PULSE EPF
      stack, producing a scalar hazard index E(t) with GREEN /
      AMBER / RED zones,
    - point to `docs/epf_relational_grail.md` for the full
      conceptual overview and CLI examples.

## Behaviour

- Documentation-only change; no impact on code, CI or gates.
- The README now mentions the EPF Relational Grail by name and links
  to the future detailed docs page.

## Follow-ups

- Add `docs/epf_relational_grail.md` with the full description of the
  EPF Relational Grail, calibration flow and debug tooling in a
  separate commit/PR.
