### PR TITLE
fix(external-metrics): fold promptfoo/garak metrics and rename hazard tests

### DIFF
--- a/PULSE_safe_pack_v0/tools/augment_status.py
+++ b/PULSE_safe_pack_v0/tools/augment_status.py
@@ -225,6 +225,7 @@ r = fold_external(
     "garak_summary.json",
     "garak_new_critical_max",
     "garak_new_critical",
+    key_in_json="new_critical",
 )
 if r is not None:
     oks.append(r)
@@ -243,6 +244,7 @@ r = fold_external(
     "promptfoo_summary.json",
     "promptfoo_fail_rate_max",
     "promptfoo_fail_rate",
+    key_in_json="fail_rate",
 )
 if r is not None:
     oks.append(r)

--- a/tests/test_epf_hazard_forecast_unit.py
+++ b/tests/test_epf_hazard_forecast_unit.py
@@ -4,7 +4,7 @@ import json
 import pathlib
 import unittest
 
-from PULSE_safe_pack_v0.epf_hazard_forecast import (
+from PULSE_safe_pack_v0.epf.epf_hazard_forecast import (
     compute_T,
     estimate_S,
     estimate_D,


### PR DESCRIPTION
## Summary

Tighten external metric folding and clean up the EPF hazard forecast
unit tests.

## Changes

- `PULSE_safe_pack_v0/tools/augment_status.py`
  - Read **Promptfoo** `fail_rate` from `promptfoo_summary.json` and
    fold it into:
    - `promptfoo_fail_rate_max`
    - `promptfoo_fail_rate`
  - Read **Garak** `new_critical` from `garak_summary.json` and fold it
    into:
    - `garak_new_critical_max`
    - `garak_new_critical`

- `tests/test_epf_hazard_forecast_unit.py`
  - Rename the hazard forecast unit test module to avoid pytest
    collection conflicts.
  - Update imports to use the current path
    `PULSE_safe_pack_v0.epf.epf_hazard_forecast`.

## Rationale

- Ensures external detector metrics (Promptfoo, Garak) are folded from
  the correct JSON fields, so the aggregated status reflects the actual
  evaluation results.
- Aligns unit tests with the EPF module layout and avoids collisions
  between test module names and the implementation module.

## Testing

```bash
pytest -q
