### PR TITLE
feat(epf-hazard): add snapshot allow/deny policy for JSONL logging

### DIFF
--- a/tests/test_epf_hazard_adapter_snapshot_policy_unit.py
+++ b/tests/test_epf_hazard_adapter_snapshot_policy_unit.py
@@ -1,0 +1,64 @@
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from PULSE_safe_pack_v0.epf.epf_hazard_adapter import sanitize_snapshot_for_log
+
+
+def test_snapshot_policy_allowed_prefixes_filters_keys():
+    snap = {
+        "a": 1.0,
+        "b": 2.0,
+        "nest": {
+            "a": 3.0,
+            "c": 4.0,
+        },
+    }
+
+    sanitized, meta = sanitize_snapshot_for_log(
+        snap,
+        allowed_prefixes=["a", "nest.a"],
+    )
+
+    assert sanitized == {"a": 1.0, "nest": {"a": 3.0}}
+    assert meta["kept"] == 2
+    assert "policy" in meta
+    assert "allowed_prefixes" in meta["policy"]
+
+
+def test_snapshot_policy_deny_keys_drops_subtree():
+    snap = {
+        "keep": 1.0,
+        "deny": {"x": 2.0, "y": 3.0},
+    }
+
+    sanitized, meta = sanitize_snapshot_for_log(
+        snap,
+        deny_keys=["deny"],
+    )
+
+    assert sanitized == {"keep": 1.0}
+    assert meta["kept"] == 1
+    assert "policy" in meta
+    assert "deny_keys" in meta["policy"]
+
+
+def test_snapshot_policy_allow_then_deny_specific_leaf():
+    snap = {
+        "metrics": {
+            "RDSI": 0.9,
+            "secret": 123.0,
+        }
+    }
+
+    sanitized, meta = sanitize_snapshot_for_log(
+        snap,
+        allowed_prefixes=["metrics"],
+        deny_keys=["metrics.secret"],
+    )
+
+    assert sanitized == {"metrics": {"RDSI": 0.9}}
+    assert meta["kept"] == 1


### PR DESCRIPTION
Summary

Snapshot sanitizer now supports deterministic allow/deny policy via dotted-path prefixes.

Why

As we expand snapshot_current with more metrics, we need explicit control over what gets logged to JSONL (audit-friendly, avoids accidental noisy keys).

What changed

epf_hazard_adapter.py

sanitize_snapshot_for_log(..., allowed_prefixes, deny_keys)

probe_hazard_and_append_log(..., snapshot_allowed_prefixes, snapshot_deny_keys)

Added unit tests for allow/deny behavior.

Compatibility

Defaults preserve current behavior (log all numeric keys if policy not provided).

Fail-open: policy only constrains logging, not forecasting or gating.