### PR TITLE
feat(epf-hazard): emit feature_coverage and recommended_features in calibration JSON

### DIFF
--- a/PULSE_safe_pack_v0/tools/epf_hazard_calibrate.py
+++ b/PULSE_safe_pack_v0/tools/epf_hazard_calibrate.py
@@ -16,11 +16,17 @@ Also (Relational Grail groundwork):
   output JSON artifact when sample counts are sufficient.
 
 Feature allowlist:
-- optional --feature-allowlist can be used to constrain which dotted keys
-  are considered for feature_scalers emission, and is written into the output
-  JSON artifact as "feature_allowlist".
-- This allowlist can later be honored by hazard adapter autowire to keep
-  the Relational Grail disciplined and low-noise.
+- optional --feature-allowlist constrains which dotted keys are considered for
+  feature_scalers emission, and is written into the output JSON as "feature_allowlist".
+
+NEW (Step 4): coverage + recommendations
+- compute per-feature coverage across snapshot-bearing entries:
+    coverage = present_count / snapshot_event_count
+- emit "feature_coverage" into the artifact (optionally restricted by allowlist)
+- emit "recommended_features" (stable, deterministic) based on:
+    * scaler exists for the feature (robust scaler fitted)
+    * coverage >= recommend_min_coverage
+    * limited to recommend_max_features
 """
 
 from __future__ import annotations
@@ -114,6 +120,21 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
             "feature_scalers emission and to persist into the calibration JSON "
             'artifact as "feature_allowlist". Example: "RDSI,external.fail_rate".'
         ),
+    )
+    parser.add_argument(
+        "--recommend-min-coverage",
+        type=float,
+        default=0.95,
+        help=(
+            "Minimum per-feature coverage (present_count / snapshot_event_count) "
+            "required to be included in recommended_features (default: 0.95)."
+        ),
+    )
+    parser.add_argument(
+        "--recommend-max-features",
+        type=int,
+        default=64,
+        help="Maximum number of recommended_features to emit (default: 64).",
     )
     parser.add_argument(
         "--out-json",
@@ -260,6 +281,85 @@ def global_stats(values: List[float]) -> Dict[str, float]:
     }
 
 
+def _build_feature_coverage(
+    *,
+    snapshot_event_count: int,
+    feature_values: Mapping[str, List[float]],
+    feature_present_counts: Mapping[str, int],
+    restrict_keys: Optional[List[str]] = None,
+) -> Dict[str, Dict[str, float]]:
+    """
+    Build per-feature coverage statistics.
+
+    Output per key:
+      - present_count (int)
+      - missing_count (int)
+      - coverage (float in [0,1])
+      - value_count (int)
+    """
+    if snapshot_event_count <= 0:
+        return {}
+
+    if restrict_keys is not None:
+        keys = list(restrict_keys)
+    else:
+        keys = sorted(set(feature_present_counts.keys()) | set(feature_values.keys()))
+
+    out: Dict[str, Dict[str, float]] = {}
+    for k in sorted(set(keys)):
+        present = int(feature_present_counts.get(k, 0))
+        missing = int(snapshot_event_count - present)
+        cov = float(present) / float(snapshot_event_count) if snapshot_event_count > 0 else 0.0
+        vcount = int(len(feature_values.get(k, [])))
+        out[k] = {
+            "present_count": present,
+            "missing_count": missing,
+            "coverage": cov,
+            "value_count": vcount,
+        }
+    return out
+
+
+def _select_recommended_features(
+    *,
+    feature_coverage: Mapping[str, Mapping[str, float]],
+    scaler_keys: List[str],
+    min_coverage: float,
+    max_features: int,
+) -> List[str]:
+    """
+    Select recommended features deterministically.
+
+    Criteria:
+      - feature has a fitted scaler (must be in scaler_keys)
+      - coverage >= min_coverage
+
+    Sorting:
+      - higher coverage first
+      - higher present_count next
+      - then lexicographic key
+    """
+    if max_features <= 0:
+        return []
+
+    scaler_set = set(scaler_keys)
+    candidates: List[str] = []
+    for k in scaler_keys:
+        cov = feature_coverage.get(k, {})
+        c = cov.get("coverage")
+        if isinstance(c, (int, float)) and float(c) >= float(min_coverage):
+            candidates.append(k)
+
+    def _sort_key(k: str):
+        cov = feature_coverage.get(k, {})
+        coverage = float(cov.get("coverage", 0.0))
+        present = int(cov.get("present_count", 0))
+        return (-coverage, -present, k)
+
+    candidates = sorted(set(candidates), key=_sort_key)
+    return candidates[:max_features]
+
+
 def main(argv: List[str]) -> int:
     args = parse_args(argv)
 
@@ -273,6 +373,14 @@ def main(argv: List[str]) -> int:
 
     if args.min_samples <= 0:
         print(f"invalid --min-samples: {args.min_samples}", file=sys.stderr)
+        return 1
+
+    if not (0.0 <= args.recommend_min_coverage <= 1.0):
+        print(f"invalid --recommend-min-coverage: {args.recommend_min_coverage}", file=sys.stderr)
+        return 1
+
+    if args.recommend_max_features <= 0:
+        print(f"invalid --recommend-max-features: {args.recommend_max_features}", file=sys.stderr)
         return 1
 
     feature_allowlist = _parse_feature_allowlist(args.feature_allowlist)
@@ -305,6 +413,20 @@ def main(argv: List[str]) -> int:
 
     # Collect feature values for robust scalers (from snapshot_current).
     snapshot_event_count, feature_values, feature_present_counts = collect_feature_values_from_entries(entries)
+
+    # Coverage keys:
+    # - if allowlist provided -> report coverage for allowlist keys (even if absent)
+    # - else -> report coverage for observed keys
+    restrict_coverage_keys: Optional[List[str]] = None
+    if allowset:
+        restrict_coverage_keys = sorted(allowset)
+
+    feature_coverage = _build_feature_coverage(
+        snapshot_event_count=snapshot_event_count,
+        feature_values=feature_values,
+        feature_present_counts=feature_present_counts,
+        restrict_keys=restrict_coverage_keys,
+    )
 
     print(f"Loaded {len(entries)} log entries from {log_path}")
     print(f"Gates with numeric E: {len(by_gate)}")
@@ -353,6 +475,8 @@ def main(argv: List[str]) -> int:
 
     # Fit robust feature scalers if enough snapshot-bearing events exist.
     feature_scalers_payload: Dict[str, Any] = {}
+    fitted_scaler_keys: List[str] = []
+
     if snapshot_event_count >= args.min_samples and feature_values:
         scalers: Dict[str, RobustScaler] = {}
 
@@ -368,8 +492,10 @@ def main(argv: List[str]) -> int:
                 continue
 
         if scalers:
+            fitted_scaler_keys = sorted(scalers.keys())
+
             missing: Dict[str, int] = {}
-            for key in sorted(scalers.keys()):
+            for key in fitted_scaler_keys:
                 missing[key] = int(snapshot_event_count - feature_present_counts.get(key, 0))
 
             artifact = FeatureScalersArtifactV0(
@@ -378,6 +504,16 @@ def main(argv: List[str]) -> int:
                 features=scalers,
             )
             feature_scalers_payload = artifact.to_dict()
+
+    # Recommended features are derived from (fitted scalers) ∩ (coverage threshold).
+    recommended_features: List[str] = []
+    if snapshot_event_count > 0 and fitted_scaler_keys and feature_coverage:
+        recommended_features = _select_recommended_features(
+            feature_coverage=feature_coverage,
+            scaler_keys=fitted_scaler_keys,
+            min_coverage=float(args.recommend_min_coverage),
+            max_features=int(args.recommend_max_features),
+        )
 
     if args.out_json is not None:
         payload: Dict[str, Any] = {
@@ -396,6 +532,15 @@ def main(argv: List[str]) -> int:
         if feature_allowlist:
             payload["feature_allowlist"] = feature_allowlist
 
+        # Additive: feature coverage + recommendation knobs (only if snapshots exist)
+        if snapshot_event_count > 0:
+            payload["feature_coverage"] = feature_coverage
+            payload["recommendation"] = {
+                "min_coverage": float(args.recommend_min_coverage),
+                "max_features": int(args.recommend_max_features),
+            }
+            payload["recommended_features"] = recommended_features
+
         # Additive: only include feature_scalers if computed.
         if feature_scalers_payload:
             payload["feature_scalers"] = feature_scalers_payload
@@ -406,8 +551,20 @@ def main(argv: List[str]) -> int:
 
         print()
         print(f"Wrote JSON suggestions to {args.out_json}")
+
+        if snapshot_event_count > 0:
+            print(
+                f"Computed feature_coverage for {len(feature_coverage)} feature(s) "
+                f"(snapshot_event_count={snapshot_event_count})"
+            )
+            print(
+                f"Recommended_features: {len(recommended_features)} "
+                f"(min_coverage={args.recommend_min_coverage:.2f}, max={args.recommend_max_features})"
+            )
+
         if feature_allowlist:
             print(f"Included feature_allowlist with {len(feature_allowlist)} key(s)")
+
         if feature_scalers_payload:
             n_feats = len(feature_scalers_payload.get("features", {}))
             print(f"Included feature_scalers for {n_feats} feature(s)")


### PR DESCRIPTION

Summary

Calibrator now emits feature_coverage and recommended_features into the thresholds artifact.

Why

Allows data-driven selection of stable feature sets for the Relational Grail.

Makes allowlist decisions measurable (coverage, missingness) instead of ad hoc.

What changed

PULSE_safe_pack_v0/tools/epf_hazard_calibrate.py

new CLI flags: --recommend-min-coverage, --recommend-max-features

output JSON gains:

feature_coverage

recommendation (knobs)

recommended_features

Compatibility

Additive, fail-open: does not affect gating; only the offline artifact format is extended.