### PR TITLE
fix(epf-hazard): keep backward compatible recommend-* flags in calibrator

### DIFF
--- a/PULSE_safe_pack_v0/tools/epf_hazard_calibrate.py
+++ b/PULSE_safe_pack_v0/tools/epf_hazard_calibrate.py
@@ -104,22 +104,29 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         help="Optional path to write suggested thresholds as JSON.",
     )
 
-    # NEW: recommended feature set controls
     parser.add_argument(
-        "--max-features",
-        type=int,
-        default=64,
-        help="Maximum number of recommended_features to emit (default: 64).",
-    )
-    parser.add_argument(
-        "--min-coverage",
-        type=float,
-        default=0.80,
-        help=(
-            "Minimum coverage ratio in [0,1] for a feature to be recommended "
-            "(present_count / snapshot_event_count). Default: 0.80."
-        ),
-    )
+    "--min-coverage",
+    "--recommend-min-coverage",
+    dest="min_coverage",
+    type=float,
+    default=0.80,
+    help=(
+        "Minimum coverage ratio in [0,1] for a feature to be recommended "
+        "(alias: --recommend-min-coverage)."
+    ),
+)
+parser.add_argument(
+    "--max-features",
+    "--recommend-max-features",
+    dest="max_features",
+    type=int,
+    default=64,
+    help=(
+        "Maximum number of recommended_features to emit "
+        "(alias: --recommend-max-features)."
+    ),
+)
+
 
     return parser.parse_args(argv)
 


### PR DESCRIPTION
Summary

Restores compatibility with legacy CLI flags for the hazard calibrator.

Problem

Existing tests/automation call:

--recommend-min-coverage

--recommend-max-features

After the change, only --min-coverage/--max-features were accepted, causing argparse to fail before calibration runs.

Fix

Add recommend-* flags back as aliases mapped to the same destinations:

min_coverage

max_features

Compatibility

Backwards compatible + additive.

No gating / forecast behavior changes.