### PR TITLE
docs(contributing): add contribution fast-path and Codex notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,21 @@
 
 Thanks for contributing to PULSE!
 
+---
+
+## Local development
+
+Quick checks (examples):
+- Run PULSE (baseline):
+  `python PULSE_safe_pack_v0/tools/run_all.py`
+
+- Run unit tests (if applicable in your change):
+  `pytest -q`
+
+Tip: If you use conda, prefer the repo's `environment.yml` to match CI as closely as possible.
+
+---
+
 ## Commit style: Conventional Commits
 Use Conventional Commits for PR titles and commit messages:
 
@@ -12,9 +27,23 @@ Use Conventional Commits for PR titles and commit messages:
 - `refactor(pack): simplify run_all entrypoint`
 - `test(q-ledger): add regression test for p95 latency`
 
+---
+
+## How to contribute (fast path)
+
+1) Open an issue first (unless it's a trivial typo).
+   - Bug: use **Bug report**
+   - Docs: use **Documentation**
+   - Feature: use **Feature request**
+2) Keep changes PR-sized and link the issue in the PR (e.g., `Closes #123`).
+3) Do not post security vulnerabilities in public issues.
+   Please use the Security Policy (see `SECURITY.md`).
+
 Types: feat, fix, docs, chore, ci, refactor, perf, test, build.  
 Keep the title ≤ 72 chars; explain **Why** and **How** in the body.
 
+---
+  
 ## DCO (Developer Certificate of Origin)
 All commits must be signed off:
 
@@ -24,6 +53,8 @@ All commits must be signed off:
 
 The name/email must match your GitHub account.  
 By signing off, you certify you have the right to submit the work under the project license.
+
+---
 
 ## Changelog
 Update `CHANGELOG.md` under **[Unreleased]** with your changes (Added/Changed/Fixed/Security/Docs).  
@@ -50,3 +81,10 @@ Codex is triggered when you:
 - mark a draft as ready,
 - or comment `@codex review` on a PR.
 ...
+
+Codex comments are advisory. Maintainers make the final decision.
+
+Please do not include secrets, credentials, or sensitive data in PR descriptions,
+logs, or artifacts. If you prefer not to receive an automated Codex review,
+mention it explicitly in the PR description.
+


### PR DESCRIPTION
## Summary
Polish CONTRIBUTING.md to reduce contributor friction and improve triage.

## What’s included
- A short “How to contribute (fast path)” section (issue templates + security note)
- Minimal local development commands (run PULSE + tests)
- Completed the Codex section with clear expectations and privacy guidance

## Impact
Additive / backwards-compatible (documentation only).

## Notes
No code or CI behavior changes.
