### PR TITLE
chore(repo): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,10 @@
-# .github/CODEOWNERS
-# Fallback: minden fájl -> @HKati
+# CODEOWNERS
+
+# Fallback: all files
 * @HKati
 
-# (Opcionális finomhangolás)
+# Optional refinement (future-friendly grouping)
 PULSE_safe_pack_v0/** @HKati
-docs/**                 @HKati
-profiles/**             @HKati
-.github/workflows/**    @HKati
+docs/** @HKati
+profiles/** @HKati
+.github/workflows/** @HKati


### PR DESCRIPTION
## Summary
Add a CODEOWNERS file to define default ownership for the repository.

## What’s included
- CODEOWNERS fallback for all files (and optional grouped paths)

## Impact
Administrative only. No code or CI behavior changes.
