### PR TITLE
chore(pulse-pd): add package initializer

### DIFF
--- a/pulse_pd/__init__.py
+++ b/pulse_pd/__init__.py
@@ -1,0 +1,12 @@
+"""
+PULSE–PD: Paradoxon Diagram tooling (v0).
+
+Core metrics:
+- DS: Decision Stability
+- MI: Model Inconsistency
+- GF: Gate Friction
+- PI: Paradox Index
+"""
+
+from .pd import compute_ds, compute_mi, compute_gf, compute_pi  # noqa: F401
+from .cut_adapter import run_pd_from_cuts  # noqa: F401


### PR DESCRIPTION
## Summary
Add `pulse_pd/__init__.py` to make PULSE–PD a proper Python package and expose stable imports.

## Changes
- Add `pulse_pd/__init__.py`
- Re-export:
  - `compute_ds`, `compute_mi`, `compute_gf`, `compute_pi`
  - `run_pd_from_cuts`

## Why
Avoid import/path issues and provide a clean public API for PULSE–PD modules.

## Impact
Additive / backwards-compatible.
