### PR TITLE
chore(pulse-pd): mark examples as a package

### DIFF
--- a/pulse_pd/examples/__init__.py
+++ b/pulse_pd/examples/__init__.py
@@ -1,0 +1,1 @@
+# Examples package for PULSE–PD.


### PR DESCRIPTION
## Summary
Add `pulse_pd/examples/__init__.py` so examples can be executed as a module package.

## Changes
- Add `pulse_pd/examples/__init__.py`

## Why
Enables commands like:
- `python -m pulse_pd.examples.make_toy_X`

## Impact
Additive / backwards-compatible.
