### PR TITLE
chore(pulse-pd): add module entrypoint quickstart

### DIFF
--- a/pulse_pd/__main__.py
+++ b/pulse_pd/__main__.py
@@ -1,0 +1,22 @@
+"""
+Entry-point helper for running PULSE–PD modules.
+
+Usage examples:
+  python -m pulse_pd.demo_toy --out pulse_pd/artifacts --n 5000 --seed 0
+
+  python -m pulse_pd.examples.make_toy_X --out pulse_pd/examples/X_toy.npz --n 5000 --seed 0
+
+  python -m pulse_pd.run_cut_pd \
+    --x pulse_pd/examples/X_toy.npz \
+    --theta pulse_pd/examples/theta_cuts_example.json \
+    --dims 0 1 \
+    --out pulse_pd/artifacts_run
+"""
+
+def main() -> int:
+    print(__doc__.strip())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Add `pulse_pd/__main__.py` to provide a quickstart entrypoint.

## Changes
- Add `pulse_pd/__main__.py` printing usage hints for:
  - `python -m pulse_pd.demo_toy`
  - `python -m pulse_pd.run_cut_pd`
  - `python -m pulse_pd.examples.make_toy_X`

## Why
Improves usability (especially on Windows) and reduces path/import friction.

## Impact
Additive / backwards-compatible.
