### PR TITLE
feat(pulse-pd): support named cuts in export_top_pi_events

### DIFF
--- a/pulse_pd/export_top_pi_events.py
+++ b/pulse_pd/export_top_pi_events.py
@@ -247,6 +247,8 @@ def main() -> int:
     res = run_pd_from_cuts(
         X,
         theta,
+        feature_names=fnames,
+
         ds_M=args.ds_M,
         mi_models=args.mi_models,
         mi_sigma=args.mi_sigma,


### PR DESCRIPTION
Summary: Forward feature_names into PD computation so exports remain correct with name-based theta.

Risk: Low; only adds an optional argument.