### PR TITLE
ci(pulse-pd): add adapter stub smoke to PD workflow

### DIFF
--- a/.github/workflows/pulse_pd_smoke.yml
+++ b/.github/workflows/pulse_pd_smoke.yml
@@ -61,6 +61,70 @@ jobs:
             --theta pulse_pd/examples/theta_cuts_example.json \
             --out pulse_pd/artifacts_ci/top_pi_events.csv \
             --topn 50
+      - name: Adapter stub smoke (CSV -> X.npz schema)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # 1) Create a tiny analysis-like CSV with IDs + weights + 2 features
+          python - <<'PY'
+          import csv, os
+          import numpy as np
+
+          os.makedirs("pulse_pd/artifacts_ci", exist_ok=True)
+          out_csv = "pulse_pd/artifacts_ci/adapter_stub_ci.csv"
+
+          rng = np.random.default_rng(0)
+          n = 200
+          x0 = rng.normal(size=n)
+          x1 = rng.normal(size=n)
+
+          with open(out_csv, "w", newline="", encoding="utf-8") as f:
+              w = csv.writer(f)
+              w.writerow(["run", "lumi", "event", "weight", "x0", "x1"])
+              for i in range(n):
+                  w.writerow([1, 10, int(1000 + i), 1.0, float(x0[i]), float(x1[i])])
+
+          print("Wrote CSV:", out_csv)
+          PY
+
+          # 2) Export to PULSE–PD X.npz schema
+          python -m pulse_pd.export_x_npz \
+            --in-csv pulse_pd/artifacts_ci/adapter_stub_ci.csv \
+            --out pulse_pd/artifacts_ci/X_adapter_stub_ci.npz \
+            --require-ids \
+            --make-event-id
+
+          # 3) Validate NPZ schema keys + shapes (fail-fast)
+          python - <<'PY'
+          import numpy as np
+
+          path = "pulse_pd/artifacts_ci/X_adapter_stub_ci.npz"
+          z = np.load(path, allow_pickle=True)
+          keys = set(z.keys())
+
+          required = {"X", "feature_names", "run", "lumi", "event", "event_id", "weight"}
+          missing = sorted(required - keys)
+          if missing:
+              raise SystemExit(f"Missing keys in NPZ: {missing}. Present: {sorted(keys)}")
+
+          X = z["X"]
+          if X.ndim != 2:
+              raise SystemExit(f"X must be 2D; got shape {X.shape}")
+
+          fn = z["feature_names"]
+          if len(fn) != X.shape[1]:
+              raise SystemExit(f"feature_names length {len(fn)} != d={X.shape[1]}")
+
+          n = X.shape[0]
+          for k in ["run", "lumi", "event", "event_id", "weight"]:
+              if z[k].shape[0] != n:
+                  raise SystemExit(f"{k} length mismatch: {z[k].shape[0]} != n={n}")
+
+          print("Adapter NPZ OK:", path)
+          print("Keys:", sorted(keys))
+          print("Shape:", X.shape)
+          PY
 
       - name: Assert artifacts exist
         shell: bash


### PR DESCRIPTION
## Summary
Extend the PULSE–PD smoke workflow with a minimal adapter-stub smoke step.

## Why
The adapter is the pipeline on-ramp. A small schema validation in CI prevents
silent breakage (missing keys, misaligned lengths, wrong X shape).

## What changed
- `.github/workflows/pulse_pd_smoke.yml`
  - Generate a tiny analysis-like CSV in CI
  - Run `python -m pulse_pd.export_x_npz`
  - Assert NPZ schema keys + basic shape invariants

## Test plan
- CI: `PULSE-PD smoke (toy pipeline)` should pass and show the adapter step logs.
