### PR TITLE
chore(pulse-pd): add HEP adapter namespace package

### DIFF
--- a/pulse_pd/hep/__init__.py
+++ b/pulse_pd/hep/__init__.py
@@ -1,0 +1,6 @@
+"""
+HEP-native adapters for PULSE–PD.
+
+These modules are optional and keep external dependencies (e.g. uproot) behind
+runtime imports so importing `pulse_pd` stays lightweight.
+"""


### PR DESCRIPTION
## Summary
Add the `pulse_pd.hep` package initializer.

## Why
We want a clean namespace for HEP-native adapters (ROOT/HEP I/O), while keeping
the core `pulse_pd` import lightweight and avoiding mandatory heavy dependencies.

## What changed
- Added `pulse_pd/hep/__init__.py`

## Notes
This PR is scaffolding only; functional exporters will follow in the next PR.
