### PR TITLE
fix(pulse-pd): restore legacy export_root_npz entrypoint

### DIFF
--- a/pulse_pd/hep/export_root_npz.py
+++ b/pulse_pd/hep/export_root_npz.py
@@ -1,0 +1,12 @@
+"""
+Backward-compat entrypoint.
+
+Prefer:
+  python -m pulse_pd.hep.export_uproot_npz ...
+
+This wrapper forwards execution to the canonical module.
+"""
+import runpy
+
+if __name__ == "__main__":
+    runpy.run_module("pulse_pd.hep.export_uproot_npz", run_name="__main__")


### PR DESCRIPTION
### Problem
After standardizing the HEP exporter entrypoint as `pulse_pd.hep.export_uproot_npz`,
the legacy module path `pulse_pd.hep.export_root_npz` no longer existed and could break
existing scripts/pipelines (`ModuleNotFoundError`).

### Fix
Add a thin backward-compatible wrapper module:
- `pulse_pd.hep.export_root_npz` now forwards execution to `pulse_pd.hep.export_uproot_npz`.

### Why
Keeps docs clean (canonical entrypoint remains `export_uproot_npz`) while preserving backward compatibility.

### Test plan
- `python -m pulse_pd.hep.export_root_npz --help`
- `python -m pulse_pd.hep.export_uproot_npz --help`
