### PR TITLE
docs(pulse-pd): mention legacy export_root_npz alias

### DIFF
--- a/pulse_pd/hep/README.md
+++ b/pulse_pd/hep/README.md
@@ -80,6 +80,8 @@ python -m pulse_pd.export_top_pi_events \
 
 If X.npz contains event_id or run/lumi/event, the CSV exporter includes those columns for traceback.
 
+Legacy alias: `python -m pulse_pd.hep.export_root_npz ...` is supported, but `export_uproot_npz` is the canonical entrypoint.
+
 Troubleshooting (quick)
 
 “dtype=object” / jagged arrays: you likely selected a variable-length branch.


### PR DESCRIPTION
### Change
Add a one-line note to the HEP README clarifying that:
- `python -m pulse_pd.hep.export_root_npz ...` is still supported as a legacy alias
- `python -m pulse_pd.hep.export_uproot_npz ...` is the canonical entrypoint

### Why
Prevents confusion after the exporter module rename and makes backward-compat behavior explicit for users.
