### PR TITLE
ci(pulse-pd): assert top-PI CSV event_id backfill in smoke workflow

### DIFF
--- a/.github/workflows/pulse_pd_smoke.yml
+++ b/.github/workflows/pulse_pd_smoke.yml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: read
   actions: write
+
 jobs:
   smoke:
     runs-on: ubuntu-latest
@@ -38,68 +39,60 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install numpy matplotlib
-      
+
       - name: HEP adapters compile/import (deps-free)
         run: |
           python -m py_compile pulse_pd/hep/export_uproot_npz.py pulse_pd/hep/export_root_npz.py
           python - <<'PY'
-          import pulse_pd.hep.export_uproot_npz as u
-          import pulse_pd.hep.export_root_npz as r
+          import pulse_pd.hep.export_uproot_npz as u  # noqa: F401
+          import pulse_pd.hep.export_root_npz as r    # noqa: F401
           print("OK: HEP adapters import + compile without uproot")
           PY
 
       - name: Generate toy X (with IDs)
         run: |
-          python -m pulse_pd.examples.make_toy_X \
-            --out pulse_pd/examples/X_toy_ci.npz \
-            --n 2000 \
-            --seed 0
+          python -m pulse_pd.examples.make_toy_X --out pulse_pd/examples/X_toy_ci.npz --n 2000 --seed 0
 
       - name: Run cut-based PD (writes artifacts)
         run: |
-          python -m pulse_pd.run_cut_pd \
-            --x pulse_pd/examples/X_toy_ci.npz \
-            --theta pulse_pd/examples/theta_cuts_example.json \
-            --dims 0 1 \
-            --out pulse_pd/artifacts_ci
+          python -m pulse_pd.run_cut_pd --x pulse_pd/examples/X_toy_ci.npz --theta pulse_pd/examples/theta_cuts_example.json --dims 0 1 --out pulse_pd/artifacts_ci
 
       - name: Export top PI events (CSV)
         run: |
-          python -m pulse_pd.export_top_pi_events \
+          python -m pulse_pd.export_top_pi_events --x pulse_pd/examples/X_toy_ci.npz --theta pulse_pd/examples/theta_cuts_example.json --out pulse_pd/artifacts_ci/top_pi_events.csv --topn 50
+
       - name: Build CI NPZ without event_id (run/lumi/event only)
         run: |
           python - <<'PY'
           import os
           import numpy as np
 
-          os.makedirs("pulse_pd/artifacts_run", exist_ok=True)
+          os.makedirs("pulse_pd/artifacts_ci", exist_ok=True)
 
+          rng = np.random.default_rng(0)
           n, d = 25, 3
-          X = np.random.randn(n, d).astype(np.float32)
+          X = rng.standard_normal((n, d)).astype(np.float32)
 
-          run  = np.full(n, 1, dtype=np.int64)
+          run = np.full(n, 1, dtype=np.int64)
           lumi = np.arange(n, dtype=np.int64)
           event = np.arange(1000, 1000 + n, dtype=np.int64)
 
           feature_names = np.asarray([f"x{i}" for i in range(d)], dtype=object)
 
           np.savez(
-              "pulse_pd/artifacts_run/X_ci_no_event_id.npz",
+              "pulse_pd/artifacts_ci/X_ci_no_event_id.npz",
               X=X,
               feature_names=feature_names,
               run=run,
               lumi=lumi,
               event=event,
           )
-          print("Wrote pulse_pd/artifacts_run/X_ci_no_event_id.npz")
+          print("Wrote pulse_pd/artifacts_ci/X_ci_no_event_id.npz")
           PY
+
       - name: Export top-PI events (CI NPZ without event_id)
         run: |
-          python -m pulse_pd.export_top_pi_events \
-            --x pulse_pd/artifacts_run/X_ci_no_event_id.npz \
-            --theta pulse_pd/examples/theta_cuts_example.json \
-            --out pulse_pd/artifacts_run/top_pi_events_ci.csv \
-            --topn 10
+          python -m pulse_pd.export_top_pi_events --x pulse_pd/artifacts_ci/X_ci_no_event_id.npz --theta pulse_pd/examples/theta_cuts_example.json --out pulse_pd/artifacts_ci/top_pi_events_ci.csv --topn 10
 
       - name: Assert top-PI CSV has traceback columns + event_id backfill
         run: |
@@ -107,7 +100,7 @@ jobs:
           import csv
           from pathlib import Path
 
-          p = Path("pulse_pd/artifacts_run/top_pi_events_ci.csv")
+          p = Path("pulse_pd/artifacts_ci/top_pi_events_ci.csv")
           assert p.exists(), f"Missing expected CSV: {p}"
 
           with p.open("r", encoding="utf-8", newline="") as f:
@@ -132,11 +125,7 @@ jobs:
 
           print("OK: top-PI CSV includes traceback columns and event_id backfill works")
           PY
-            
-            --x pulse_pd/examples/X_toy_ci.npz \
-            --theta pulse_pd/examples/theta_cuts_example.json \
-            --out pulse_pd/artifacts_ci/top_pi_events.csv \
-            --topn 50
+
       - name: Adapter stub smoke (CSV -> X.npz schema)
         shell: bash
         run: |
@@ -219,3 +208,4 @@ jobs:
           name: pulse-pd-smoke-artifacts
           path: |
             pulse_pd/artifacts_ci/**
+            pulse_pd/examples/X_toy_ci.npz


### PR DESCRIPTION
### What
Extend the PULSE–PD smoke workflow with a regression check for top-PI CSV traceback stability.

### How
- Create a small CI NPZ with `run/lumi/event` but no `event_id`.
- Run `pulse_pd.export_top_pi_events` to produce `top_pi_events_ci.csv`.
- Assert the CSV header contains `event_id, run, lumi, event` and that
  `event_id == "run:lumi:event"` for exported rows.

### Why
Prevents future regressions where traceback identifiers silently disappear or change format.
