### PR TITLE
docs: make quickstart OS-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,17 @@ From **findings** to **fuses**. Run **PULSE before you ship**: deterministic, **
 
 ## Quickstart
 
-Run:
+```console
+python PULSE_safe_pack_v0/tools/run_all.py
 
-    python PULSE_safe_pack_v0/tools/run_all.py
-    python PULSE_safe_pack_v0/tools/check_gates.py --status PULSE_safe_pack_v0/artifacts/status.json --require pass_controls_refusal effect_present psf_monotonicity_ok psf_mono_shift_resilient pass_controls_comm psf_commutativity_ok psf_comm_shift_resilient pass_controls_sanit sanitization_effective sanit_shift_resilient psf_action_monotonicity_ok psf_idempotence_ok psf_path_independence_ok psf_pii_monotonicity_ok q1_grounded_ok q2_consistency_ok q3_fairness_ok q4_slo_ok
+python PULSE_safe_pack_v0/tools/check_gates.py \
+  --status PULSE_safe_pack_v0/artifacts/status.json \
+  --require pass_controls_refusal effect_present psf_monotonicity_ok psf_mono_shift_resilient \
+    pass_controls_comm psf_commutativity_ok psf_comm_shift_resilient pass_controls_sanit \
+    sanitization_effective sanit_shift_resilient psf_action_monotonicity_ok psf_idempotence_ok \
+    psf_path_independence_ok psf_pii_monotonicity_ok q1_grounded_ok q2_consistency_ok \
+    q3_fairness_ok q4_slo_ok
+
 
 
 ```


### PR DESCRIPTION
## Why
The README Quickstart contained OS/shell-specific variants (separate runner vs PowerShell snippets),
which can create the appearance of OS targeting and triggers OS-specific doc audits.

## What changed
- Replaced the OS/shell-specific Quickstart subsections with a single canonical, shell-agnostic
  command sequence (no OS labels, no shell line-continuation operators).

## Scope
Docs-only. No code paths, gates, or artifacts are changed.
