### PR TITLE
docs: make determinism notes OS-agnostic

### DIFF
--- a/docs/DETERMINISM.md
+++ b/docs/DETERMINISM.md
@@ -1,88 +1,43 @@
-# Determinizmus & flakiness (lokál‑first, offline)
+# Determinism
 
-**Kiindulás:** nincs külső futtató, nincs konténer, nincs felhős detektor.  
-A PULSE determinisztikusan **értékel**, ha a lokális/CI környezet rögzített; a „fail‑closed” elv szerint **bármely bizonytalanság → FAIL**.
+PULSE is designed to be deterministic and audit-friendly when its runtime and inputs are pinned.
+This document collects the minimal, practical constraints required for reproducible runs.
 
-## Lokális reprodukálhatóság (runner nélkül)
-- **Python környezet**: használj `venv`‑et és rögzített csomagverziókat.
-~~~bash
-python -m venv .venv && source .venv/bin/activate
-pip install --upgrade pip
-pip install pyyaml jsonschema
-pip freeze > requirements.lock.txt
-~~~
-- **Seed**: egyetlen egységes `seed` mindenhol (logold a `status.json`‑ban).
-- **CPU‑first**: GPU nem szükséges; ha mégis GPU, kapcsold be a determinisztikát (lásd lejjebb).
-- **Külső hálózat tiltása**: ne hívj külső API‑kat/modellvégpontokat. A detektorok legyenek **offline/heurisztikusak** (regex, szabály, statikus modell).  
-  **Policy:** ha egy detektor hálózati erőforrást igényel → **FAIL‑closed**.
+## What “deterministic” means here
 
-## RNG & környezet – ajánlott beállítások
-Állítsd be az alábbiakat, hogy a futások megismételhetők legyenek (reproducibility).
+Given the same:
+- pack version (code + policies),
+- runner image / Python version,
+- inputs (logs, configs),
+- and fixed seeds,
 
-**Shell (Linux/macOS)**
-~~~bash
-export PYTHONHASHSEED=0
-~~~
+PULSE should produce identical gate outcomes and stable artefacts.
 
-**Windows (PowerShell)**
-~~~powershell
-$env:PYTHONHASHSEED = "0"
-~~~
+## Required controls
 
-**Python / NumPy / (opcionális) PyTorch**
-~~~python
-import random, numpy as np
-random.seed(12345)
-np.random.seed(12345)
+### 1) Pin the runtime
+- Pin the Python version (and any lockfile / environment spec you use).
+- Prefer CI runners or containers with explicit versioning.
 
-try:
-    import torch
-    torch.manual_seed(12345)
-    torch.use_deterministic_algorithms(True)
-    if torch.backends.cudnn:
-        torch.backends.cudnn.deterministic = True
-        torch.backends.cudnn.benchmark = False
-except Exception:
-    # PyTorch nem kötelező; CPU-only környezetben elhagyható
-    pass
-~~~
+### 2) Fix hash randomization
+Python string hashing can be randomized unless you set `PYTHONHASHSEED`.
 
-**Megjegyzés:** GPU hiányában a fenti seedelés elegendő; CPU‑n determinisztikus a futás.
+Requirement:
+- Set the environment variable `PYTHONHASHSEED=0` **before starting** Python.
 
-## Timeout / Retry / Cache
-- **Per‑rule timeout**, legfeljebb **1 retry**; ha kimerül → **FAIL‑closed**.
-- Detektoroknál **cache TTL**; minden bemenet/kimenet legyen **hash‑elve** (diagnosztika).
-- Hálózati erőforrás/hiba (ha mégis előfordulna) → **FAIL** (nincs „soft pass”).
+(How you set environment variables depends on your shell/runtime; keep it fixed across runs.)
 
-## EPF (shadow‑only) és RDSI — lokálisan is futtatható
-Az **EPF** kis amplitúdójú, **auditálható** perturbációt vizsgál **csak** a \[threshold − ε, threshold] sávban, **külön** lépésként.  
-**Soha** nem írja felül a baseline CI döntést; célja kizárólag diagnosztika.
+### 3) Fix random seeds
+If a component uses RNG, ensure the seed is fixed and recorded.
+- Prefer explicit `--seed` style knobs where available.
 
-**RDSI** (stabilitási mutató): `RDSI = 1 − p(change)`; 95% Wilson CI‑vel publikáljuk:
-- **RDSI ≥ 0.95** → stabil  
-- **0.85–0.95** → figyelendő  
-- **< 0.85** → billeg (küszöb/kalibráció szükséges)
+### 4) Avoid non-deterministic accelerators
+GPU kernels and some external tools can introduce variance.
+- If GPU is used anywhere in the pipeline, pin drivers + runtime and expect possible small numeric drift.
+- Shadow layers (e.g. EPF) must never change the deterministic PASS/FAIL gate semantics.
 
-## Offline detektorok (példák)
-- **PII/format invariáns**: reguláris kifejezések (e‑mail, tel., IBAN, JSON‑parse).  
-- **Toxicitás/helytelen nyelv**: tiltólista + szabályok (determinista).  
-- **Groundedness (egyszerű)**: hivatkozások/idézetek száma, kulcsszó‑fedezet.  
-- **Fairness (lightweight)**: csoportcímkés mintahalmaz + min‑over‑groups arányok.
+## Recommended practice
 
-## Flakiness runbook (lokál)
-1. **Ismételhetőség**: futtasd 3× ugyanazzal a seed‑del → azonos döntés?  
-2. **Környezet**: egyező Python és csomagverziók (`requirements.lock.txt`)?  
-3. **Detektor**: biztosan offline? (nincs hálózati hívás)  
-4. **Küszöb közelében**? → nézd az EPF/Audit naplót; kell‑e margin/újrakalibráció.  
-5. **Cache** ürítés, újrafuttatás: kizárja a „stale” állapotot.
-
-## Összefoglaló táblázat (lokál‑first)
-
-| Terület | Kötelező | Ajánlott |
-|---|---|---|
-| Python környezet | ✅ `venv` + verziózár | `requirements.lock.txt` commit |
-| Seed | ✅ rögzített | – |
-| CPU/GPU | ✅ CPU | GPU: determinisztika flag |
-| Detektor | ✅ offline/proxy | hálózat → FAIL‑closed |
-| Timeout/Retry | ✅ per‑rule | max 1 retry |
-| EPF | ✅ shadow‑only | RDSI jelentés (lokálban is) |
+- Run the canonical workflow in CI for the reference baseline.
+- When comparing runs, always compare artefacts produced by the same pinned environment.
+- If you introduce optional detectors/tools, treat them as *inputs* and pin their versions the same way.


### PR DESCRIPTION
## Why
The determinism notes included OS/shell-specific snippets (separate shell vs PowerShell examples),
which creates unnecessary OS emphasis in a developer-focused repo and triggers OS-specific doc audits.

## What changed
- Replaced OS/shell-labelled examples with platform-neutral guidance for reproducible runs:
  - pin runtime
  - fix `PYTHONHASHSEED` before starting Python
  - fix RNG seeds and record them

## Scope
Docs-only. No code paths, gates, or artifacts are changed.
