### PR TITLE
docs: add AI Release Stability Engineering subtitle to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Releases: https://github.com/HKati/pulse-release-gates-0.1/releases
 
 # PULSE — Release Gates for Safe & Useful AI
 
+#### AI Release Stability Engineering
+
 > 💡 **Continuous expansion**
 >
 > PULSE is not a frozen snapshot. The core release gate semantics are stable,


### PR DESCRIPTION
## Why
Provide a concise domain label under the main title to make the repo’s focus immediately legible to quick reviewers (release gates, stability, audit).

## What changed
- Add a small subtitle (“AI Release Stability Engineering”) directly under the README H1.

## Scope
Docs-only change.
