### PR TITLE
ci(pulse-pd): guard Dropzone artifacts in smoke workflow

### DIFF
--- a/.github/workflows/pulse_pd_smoke.yml
+++ b/.github/workflows/pulse_pd_smoke.yml
@@ -199,6 +199,12 @@ jobs:
           test -f pulse_pd/artifacts_ci/top_pi_events.csv
           test -f pulse_pd/artifacts_ci/pd_scatter.png
           test -f pulse_pd/artifacts_ci/pi_heatmap.png
+
+          # Dropzone v0 artifacts (regression guard)
+          test -f pulse_pd/artifacts_ci/pd_run_meta.json
+          test -f pulse_pd/artifacts_ci/pd_zones_v0.jsonl
+          test -f pulse_pd/artifacts_ci/pd_peaks_v0.json
+
           echo "OK: PULSE-PD toy smoke artifacts present."
 
       - name: Upload artifacts (debug)


### PR DESCRIPTION
Add smoke assertions for Dropzone v0 artifacts produced by run_cut_pd:
- pd_run_meta.json
- pd_zones_v0.jsonl
- pd_peaks_v0.json

This prevents silent regressions where downstream tooling would break.
