### PR TITLE
fix: paradox_field_v0 atom output contract cleanup

### DIFF
--- a/scripts/paradox_field_adapter_v0.py
+++ b/scripts/paradox_field_adapter_v0.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """
-paradox_field_adapter_v0 — minimal, stdlib-only generator for paradox_field_v0.json.
+paradox_field_adapter_v0 — stdlib-only generator for paradox_field_v0.json.
 
 Goal (v0):
-  - Create a schema-aligned *skeleton* artefact so the paradox layer exists
-    as a stable interface, even before atom extraction is implemented.
+  - Produce a stable paradox_field artefact (skeleton + optional atoms from transitions drift).
+  - Deterministic ordering and audit-friendly evidence payloads.
 
 Output:
-  { "paradox_field_v0": { "meta": {...}, "atoms": [] } }
+  { "paradox_field_v0": { "meta": {...}, "atoms": [...] } }
 
 Determinism:
   - By default, no wall-clock timestamp is emitted.
@@ -17,11 +17,19 @@ Determinism:
 from __future__ import annotations
 
 import argparse
+import csv
 import hashlib
 import json
 import os
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# Metric drift severity thresholds (v0 contract)
+METRIC_ABS_WARN = 0.01
+METRIC_ABS_CRIT = 0.05
+METRIC_REL_WARN = 0.01
+METRIC_REL_CRIT = 0.05
 
 
 def _sha1_file(path: str) -> str:
@@ -30,6 +38,10 @@ def _sha1_file(path: str) -> str:
         for chunk in iter(lambda: f.read(1 << 20), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+def _sha1_text(s: str) -> str:
+    return hashlib.sha1(s.encode("utf-8")).hexdigest()
 
 
 def _mkdirp_for_file(path: str) -> None:
@@ -43,10 +55,105 @@ def _require_file(path: str, label: str) -> None:
         raise SystemExit(f"[paradox_field_adapter_v0] {label} not found: {path}")
 
 
+def _read_json(path: str) -> Any:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _read_csv(path: str) -> List[Dict[str, str]]:
+    with open(path, "r", encoding="utf-8", newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def _safe_float(x: Any) -> Optional[float]:
+    try:
+        if x is None or x == "":
+            return None
+        if isinstance(x, bool):
+            return None
+        v = float(x)
+        if v != v or v in (float("inf"), float("-inf")):
+            return None
+        return v
+    except Exception:
+        return None
+
+
+def _safe_bool(x: Any) -> Optional[bool]:
+    if isinstance(x, bool):
+        return x
+    if isinstance(x, str):
+        s = x.strip().lower()
+        if s in ("true", "1", "yes", "y"):
+            return True
+        if s in ("false", "0", "no", "n"):
+            return False
+    return None
+
+
+def _atom_id(atom_type: str, key: str, a_sha1: str, b_sha1: str) -> str:
+    raw = f"{atom_type}|{key}|{a_sha1}|{b_sha1}"
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:12]
+
+
+def _severity_rank(label: str) -> Tuple[int, str]:
+    # We want critical items first in the output.
+    order = {"crit": 0, "warn": 1, "info": 2}
+    return (order.get(label, 99), label)
+
+
+def _metric_severity(delta: Optional[float], rel_delta: Optional[float]) -> str:
+    if delta is None:
+        return "info"
+
+    if (abs(delta) >= METRIC_ABS_CRIT) or (rel_delta is not None and abs(rel_delta) >= METRIC_REL_CRIT):
+        return "crit"
+    if (abs(delta) >= METRIC_ABS_WARN) or (rel_delta is not None and abs(rel_delta) >= METRIC_REL_WARN):
+        return "warn"
+    return "info"
+
+
+def _read_transitions_dir(path: str) -> Dict[str, Any]:
+    gate_csv = os.path.join(path, "pulse_gate_drift_v0.csv")
+    metric_csv = os.path.join(path, "pulse_metric_drift_v0.csv")
+    overlay_json = os.path.join(path, "pulse_overlay_drift_v0.json")
+    transitions_json = os.path.join(path, "pulse_transitions_v0.json")
+
+    _require_file(gate_csv, "pulse_gate_drift_v0.csv")
+    _require_file(metric_csv, "pulse_metric_drift_v0.csv")
+    _require_file(overlay_json, "pulse_overlay_drift_v0.json")
+
+    transitions = _read_json(transitions_json) if os.path.isfile(transitions_json) else {}
+
+    return {
+        "gate_csv": gate_csv,
+        "metric_csv": metric_csv,
+        "overlay_json": overlay_json,
+        "transitions_json": transitions_json if os.path.isfile(transitions_json) else "",
+        "gate_rows": _read_csv(gate_csv),
+        "metric_rows": _read_csv(metric_csv),
+        "overlay": _read_json(overlay_json),
+        "transitions": transitions,
+    }
+
+
+def _extract_run_sha1s(transitions: Dict[str, Any]) -> Tuple[str, str]:
+    run_a = transitions.get("run_a") if isinstance(transitions.get("run_a"), dict) else {}
+    run_b = transitions.get("run_b") if isinstance(transitions.get("run_b"), dict) else {}
+    a_sha1 = run_a.get("status_sha1") if isinstance(run_a.get("status_sha1"), str) else ""
+    b_sha1 = run_b.get("status_sha1") if isinstance(run_b.get("status_sha1"), str) else ""
+    return a_sha1, b_sha1
+
+
 def main() -> None:
-    ap = argparse.ArgumentParser(description="Generate paradox_field_v0.json (skeleton v0).")
+    ap = argparse.ArgumentParser(description="Generate paradox_field_v0.json (v0 skeleton + atoms).")
     ap.add_argument("--status", default="", help="Optional status.json path (adds sha1/meta).")
     ap.add_argument("--g-field", default="", help="Optional g_field_v0.json path (adds sha1/meta).")
+    ap.add_argument(
+        "--transitions-dir",
+        default="",
+        help="Optional transitions directory containing pulse_*_drift_v0 files.",
+    )
     ap.add_argument(
         "--out",
         default="PULSE_safe_pack_v0/artifacts/paradox_field_v0.json",
@@ -71,6 +178,16 @@ def main() -> None:
     meta: Dict[str, Any] = {
         "tool": "scripts/paradox_field_adapter_v0.py",
         "version": "v0",
+        "contract": {
+            "atoms_sorted_by": ["severity", "type", "atom_id"],
+            "severity_order": ["crit", "warn", "info"],
+            "metric_thresholds": {
+                "abs_warn": METRIC_ABS_WARN,
+                "abs_crit": METRIC_ABS_CRIT,
+                "rel_warn": METRIC_REL_WARN,
+                "rel_crit": METRIC_REL_CRIT,
+            },
+        },
     }
 
     if args.created_at is not None:
@@ -88,10 +205,177 @@ def main() -> None:
         meta["g_field_path"] = args.g_field
         meta["g_field_sha1"] = _sha1_file(args.g_field)
 
+    atoms: List[Dict[str, Any]] = []
+
+    if args.transitions_dir:
+        t = _read_transitions_dir(args.transitions_dir)
+        meta["transitions_dir"] = args.transitions_dir
+        meta["transitions_gate_csv_sha1"] = _sha1_file(t["gate_csv"])
+        meta["transitions_metric_csv_sha1"] = _sha1_file(t["metric_csv"])
+        meta["transitions_overlay_json_sha1"] = _sha1_file(t["overlay_json"])
+        if t["transitions_json"]:
+            meta["transitions_json_sha1"] = _sha1_file(t["transitions_json"])
+
+        run_a_sha1, run_b_sha1 = _extract_run_sha1s(t["transitions"])
+
+        # Fallback context fingerprint for atom IDs when run sha1s are not present.
+        ctx = _sha1_text(
+            meta["transitions_gate_csv_sha1"]
+            + meta["transitions_metric_csv_sha1"]
+            + meta["transitions_overlay_json_sha1"]
+            + str(meta.get("transitions_json_sha1", ""))
+        )
+        a_id_ctx = run_a_sha1 or ctx
+        b_id_ctx = run_b_sha1 or ctx
+
+        # ---- Gate flips -> gate_flip atoms
+        for row in t["gate_rows"]:
+            flip = str(row.get("flip", "")).strip().lower()
+            if flip not in ("1", "true"):
+                continue
+
+            gate_id = str(row.get("gate_id", "")).strip()
+            if not gate_id:
+                continue
+
+            status_a = str(row.get("status_a", "")).strip()
+            status_b = str(row.get("status_b", "")).strip()
+            title = f"Gate flip: {gate_id} {status_a or '?'} → {status_b or '?'}"
+
+            atom = {
+                "atom_id": _atom_id("gate_flip", gate_id, a_id_ctx, b_id_ctx),
+                "type": "gate_flip",
+                "severity": "crit",
+                "title": title,
+                "refs": {"gates": [gate_id], "metrics": [], "overlays": []},
+                "evidence": {
+                    "source": {"gate_drift_csv": os.path.basename(t["gate_csv"])},
+                    "gate": {
+                        "gate_id": gate_id,
+                        "group": row.get("group", "") or "",
+                        "status_a": status_a,
+                        "status_b": status_b,
+                        "pass_a": _safe_bool(row.get("pass_a")) if row.get("pass_a", "") != "" else "",
+                        "pass_b": _safe_bool(row.get("pass_b")) if row.get("pass_b", "") != "" else "",
+                        "flip": 1,
+                        "value_a": row.get("value_a", "") or "",
+                        "value_b": row.get("value_b", "") or "",
+                        "threshold": row.get("threshold", "") or "",
+                        "notes_a": row.get("notes_a", "") or "",
+                        "notes_b": row.get("notes_b", "") or "",
+                    },
+                    "presence": {
+                        "present_a": row.get("present_a", "") or "",
+                        "present_b": row.get("present_b", "") or "",
+                    },
+                },
+            }
+            atoms.append(atom)
+
+        # ---- Metric deltas -> metric_delta atoms (top 10 by |delta|)
+        metric_candidates: List[Tuple[str, Optional[float], Optional[float], float, Optional[float], str, str]] = []
+        for row in t["metric_rows"]:
+            metric = str(row.get("metric", "")).strip()
+            if not metric:
+                continue
+
+            delta = _safe_float(row.get("delta"))
+            if delta is None:
+                continue
+
+            a_val = _safe_float(row.get("a"))
+            b_val = _safe_float(row.get("b"))
+            rel_delta = _safe_float(row.get("rel_delta"))
+            present_a = str(row.get("present_a", "")).strip()
+            present_b = str(row.get("present_b", "")).strip()
+            metric_candidates.append((metric, a_val, b_val, delta, rel_delta, present_a, present_b))
+
+        metric_candidates.sort(key=lambda x: abs(x[3]), reverse=True)
+
+        for metric, a_val, b_val, delta, rel_delta, present_a, present_b in metric_candidates[:10]:
+            severity = _metric_severity(delta, rel_delta)
+            title = f"Metric drift: {metric} Δ={delta}"
+
+            atom = {
+                "atom_id": _atom_id("metric_delta", metric, a_id_ctx, b_id_ctx),
+                "type": "metric_delta",
+                "severity": severity,
+                "title": title,
+                "refs": {"gates": [], "metrics": [metric], "overlays": []},
+                "evidence": {
+                    "source": {"metric_drift_csv": os.path.basename(t["metric_csv"])},
+                    "metric": {
+                        "name": metric,
+                        "a": a_val if a_val is not None else "",
+                        "b": b_val if b_val is not None else "",
+                        "delta": delta,
+                        "rel_delta": rel_delta if rel_delta is not None else "",
+                    },
+                    "presence": {"present_a": present_a, "present_b": present_b},
+                    "thresholds": {
+                        "abs_warn": METRIC_ABS_WARN,
+                        "abs_crit": METRIC_ABS_CRIT,
+                        "rel_warn": METRIC_REL_WARN,
+                        "rel_crit": METRIC_REL_CRIT,
+                    },
+                },
+            }
+            atoms.append(atom)
+
+        # ---- Overlay changes -> overlay_change atoms
+        overlay_obj = t["overlay"]
+        if isinstance(overlay_obj, dict):
+            for overlay_name, overlay_block in overlay_obj.items():
+                if not isinstance(overlay_block, dict):
+                    continue
+
+                diff = overlay_block.get("top_level_diff")
+                if not isinstance(diff, dict):
+                    continue
+
+                changed_keys = diff.get("changed_keys")
+                if not isinstance(changed_keys, list) or not changed_keys:
+                    continue
+
+                a_sha1 = overlay_block.get("sha1_a", "") if isinstance(overlay_block.get("sha1_a"), str) else ""
+                b_sha1 = overlay_block.get("sha1_b", "") if isinstance(overlay_block.get("sha1_b"), str) else ""
+
+                title = f"Overlay changed: {overlay_name} ({len(changed_keys)} keys)"
+
+                atom = {
+                    "atom_id": _atom_id("overlay_change", overlay_name, a_sha1 or a_id_ctx, b_sha1 or b_id_ctx),
+                    "type": "overlay_change",
+                    "severity": "info",
+                    "title": title,
+                    "refs": {"gates": [], "metrics": [], "overlays": [str(overlay_name)]},
+                    "evidence": {
+                        "source": {"overlay_drift_json": os.path.basename(t["overlay_json"])},
+                        "overlay": {
+                            "name": str(overlay_name),
+                            "present_a": bool(overlay_block.get("present_a")),
+                            "present_b": bool(overlay_block.get("present_b")),
+                            "path_a": overlay_block.get("path_a", "") or "",
+                            "path_b": overlay_block.get("path_b", "") or "",
+                            "sha1_a": a_sha1,
+                            "sha1_b": b_sha1,
+                            "top_level_diff": {
+                                "added_keys": diff.get("added_keys", []) if isinstance(diff.get("added_keys"), list) else [],
+                                "removed_keys": diff.get("removed_keys", []) if isinstance(diff.get("removed_keys"), list) else [],
+                                "changed_keys": changed_keys,
+                                "note": diff.get("note", "") if isinstance(diff.get("note"), str) else "",
+                            },
+                        },
+                    },
+                }
+                atoms.append(atom)
+
+        # Stable ordering: crit -> warn -> info, then type, then atom_id
+        atoms.sort(key=lambda a: (_severity_rank(a.get("severity", "")), a.get("type", ""), a.get("atom_id", "")))
+
     out_obj = {
         "paradox_field_v0": {
             "meta": meta,
-            "atoms": [],
+            "atoms": atoms,
         }
     }
 


### PR DESCRIPTION
Cleans up `scripts/paradox_field_adapter_v0.py` v0 atom output to be audit-friendly and deterministic.

- Fix output object: single `atoms` key (no duplicates)
- Deterministic ordering: crit>warn>info, then type, then atom_id
- Metric severity thresholds tuned (warn>=0.01, crit>=0.05)
- Stable atom_id fallback when run status sha1 is missing
- Evidence includes thresholds for review/audit

Test:
- python -m py_compile scripts/paradox_field_adapter_v0.py
- python scripts/paradox_field_adapter_v0.py --transitions-dir ./out/transitions_runA_vs_runB --out ./out/transitions_runA_vs_runB/paradox_field_v0.json
