### PR TITLE
feat: paradox_field v0 tension atoms (gate ↔ overlay)

### DIFF
--- a/gate_overlay_tension
+++ b/gate_overlay_tension
@@ -1,0 +1,27 @@
+{
+  "atom_id": "9f0c1a2b3d4e",
+  "type": "gate_overlay_tension",
+  "severity": "crit",
+  "title": "Tension: gate flip with overlay drift (quality_helpfulness ↔ g_field_v0)",
+  "refs": {
+    "gates": ["quality_helpfulness"],
+    "metrics": [],
+    "overlays": ["g_field_v0"]
+  },
+  "evidence": {
+    "gate_atom_id": "a1b2c3d4e5f6",
+    "overlay_atom_id": "112233445566",
+    "gate": {
+      "gate_id": "quality_helpfulness",
+      "group": "quality",
+      "status_a": "PASS",
+      "status_b": "FAIL"
+    },
+    "overlay": {
+      "name": "g_field_v0",
+      "changed_keys_count": 2,
+      "changed_keys_sample": ["some_key_1", "some_key_2"]
+    },
+    "rule": "gate_flip present AND overlay_change present => tension atom"
+  }
+}


### PR DESCRIPTION
Adds `gate_overlay_tension` atoms to `paradox_field_v0` when gate flips co-occur with overlay drift.

This is a v0 relational layer:
- no semantic inference
- deterministic evidence-only links (gate_flip atom_id ↔ overlay_change atom_id)
- stable ordering for audit/review

Test:
python scripts/paradox_field_adapter_v0.py --transitions-dir ./out/transitions_runA_vs_runB --out ./out/transitions_runA_vs_runB/paradox_field_v0.json
