### PR TITLE
test(paradox-field): add fail-closed contract check script

### DIFF
--- a/scripts/check_paradox_field_v0_contract.py
+++ b/scripts/check_paradox_field_v0_contract.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Fail-closed contract check for paradox_field_v0.json")
+    ap.add_argument("--transitions-dir", required=True, help="Directory containing pulse_*_drift_v0 outputs")
+    ap.add_argument("--out", required=True, help="Output paradox_field_v0.json path")
+    args = ap.parse_args()
+
+    # 1) Generate paradox field from transitions drift (must succeed)
+    subprocess.check_call([
+        sys.executable,
+        "scripts/paradox_field_adapter_v0.py",
+        "--transitions-dir", args.transitions_dir,
+        "--out", args.out,
+    ])
+
+    # 2) Contract checks (fail-closed)
+    if not os.path.isfile(args.out):
+        raise SystemExit(f"[check] missing output json: {args.out}")
+
+    o = json.load(open(args.out, "r", encoding="utf-8"))
+    root = o.get("paradox_field_v0")
+    if not isinstance(root, dict):
+        raise SystemExit("[check] missing paradox_field_v0 root object")
+
+    atoms = root.get("atoms")
+    if not isinstance(atoms, list) or len(atoms) == 0:
+        raise SystemExit("[check] atoms must be a non-empty list")
+
+    # must contain gate_overlay_tension
+    tensions = [a for a in atoms if isinstance(a, dict) and a.get("type") == "gate_overlay_tension"]
+    if not tensions:
+        raise SystemExit("[check] missing gate_overlay_tension atoms")
+
+    t0 = tensions[0]
+    if not t0.get("title"):
+        raise SystemExit("[check] tension atom must have title")
+
+    ev = t0.get("evidence", {})
+    if not isinstance(ev, dict):
+        raise SystemExit("[check] tension atom evidence must be an object")
+
+    if not ev.get("gate_atom_id"):
+        raise SystemExit("[check] tension evidence missing gate_atom_id")
+    if not ev.get("overlay_atom_id"):
+        raise SystemExit("[check] tension evidence missing overlay_atom_id")
+
+    print("[check] OK: paradox_field_v0 atoms + tension contract")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary
Adds an initial stdlib-only, fail-closed contract check script for paradox_field_v0.json.

- New: scripts/check_paradox_field_v0_contract.py
- Purpose: deterministic contract validation for generated paradox_field_v0 output (fail-closed on malformed structure)
- This PR introduced the first version of the checker; it is later refined in PR #592 to:
  - follow the schema-compliant root ($.paradox_field_v0.atoms),
  - avoid requiring any tension atom presence (validate links only if present),
  - and use an --in <json> interface.

Why this exists
- Keep the evidence channel audit-friendly: deterministic, reproducible checks that fail closed on structural contract breaks.
- Avoid turning “signal presence” into a contract requirement (that belongs in fixture acceptance, not contract validation).

How to test (current behavior; see PR #592)
1) Produce a paradox_field_v0.json with the adapter:
   python scripts/paradox_field_adapter_v0.py --transitions-dir <DIR> --out out/paradox_field_v0.json

2) Run contract validation:
   python scripts/check_paradox_field_v0_contract.py --in out/paradox_field_v0.json
