### PR TITLE
test(fixtures): add metric drift CSV fixture (gate_metric_tension v0)

### DIFF
--- a/tests/fixtures/transitions_gate_metric_tension_v0/pulse_metric_drift_v0.csv
+++ b/tests/fixtures/transitions_gate_metric_tension_v0/pulse_metric_drift_v0.csv
@@ -1,0 +1,3 @@
+metric,a,b,delta,rel_delta,present_a,present_b
+rdsi,0.88,0.86,-0.02,-0.0227272727,1,1
+


### PR DESCRIPTION
Adds `tests/fixtures/transitions_gate_metric_tension_v0/pulse_metric_drift_v0.csv`.

- Minimal and deterministic: one numeric metric delta.
- Compatible with the drift CSV contract expected by `scripts/paradox_field_adapter_v0.py`.
- Supports C.2 tension acceptance workflows (gate_flip × metric_delta[w|c]).
