### PR TITLE
fix(paradox-field): fix adapter indentation + deterministic atom ordering

### DIFF
--- a/scripts/paradox_field_adapter_v0.py
+++ b/scripts/paradox_field_adapter_v0.py
@@ -368,14 +368,15 @@ def main() -> None:
                     },
                 }
                 atoms.append(atom)
-    # Deterministic ordering (severity -> type -> atom_id)
-    atoms.sort(key=lambda a: (_severity_rank(a.get("severity", "")),
-                              a.get("type", ""),
-                              a.get("atom_id", "")))
 
-      
-        # Stable ordering: crit -> warn -> info, then type, then atom_id
-        atoms.sort(key=lambda a: (_severity_rank(a.get("severity", "")), a.get("type", ""), a.get("atom_id", "")))
+    # Deterministic ordering (severity -> type -> atom_id)
+    atoms.sort(
+        key=lambda a: (
+            _severity_rank(a.get("severity", "")),
+            a.get("type", ""),
+            a.get("atom_id", ""),
+        )
+    )
 
     out_obj = {
         "paradox_field_v0": {


### PR DESCRIPTION
## Summary
Fixes a Python `IndentationError` in `scripts/paradox_field_adapter_v0.py` caused by a duplicated `atoms.sort()` block with wrong indentation.

## What changed
- Removed the stray/duplicated sort block that broke parsing
- Kept a single deterministic ordering for `atoms`:
  - `severity (crit>warn>info) -> type -> atom_id`
- Sorting is performed after all atom generation and right before emitting the JSON output

## Why
The adapter must be fail-closed and runnable in all environments. A syntax error blocks any downstream usage (Codex runner, CI, local compile).

## Testing
- ✅ `python -m py_compile scripts/paradox_field_adapter_v0.py`
- ✅ (optional) `python scripts/paradox_field_adapter_v0.py --transitions-dir <fixture_dir> --out ./out/paradox_field_v0.json`
