### PR TITLE
ci: add paradox edges smoke workflow

### DIFF
--- a/.github/workflows/paradox_edges_smoke.yml
+++ b/.github/workflows/paradox_edges_smoke.yml
@@ -2,51 +2,64 @@ name: paradox-edges-smoke
 
 on:
   push:
+    paths:
+      - "scripts/**"
+      - "tests/fixtures/**"
+      - ".github/workflows/paradox_edges_smoke.yml"
   pull_request:
+    paths:
+      - "scripts/**"
+      - "tests/fixtures/**"
+      - ".github/workflows/paradox_edges_smoke.yml"
 
 jobs:
   smoke:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Compile (fail-closed)
+      - name: Compile scripts
         run: |
           set -euxo pipefail
           python -m py_compile \
             scripts/paradox_field_adapter_v0.py \
+            scripts/export_paradox_edges_v0.py \
             scripts/check_paradox_field_v0_contract.py \
             scripts/check_paradox_edges_v0_contract.py \
             scripts/check_paradox_edges_v0_acceptance_v0.py
 
-      - name: Generate paradox_field + paradox_edges from fixture
+      - name: Smoke (fixture -> atoms -> edges -> checks)
         run: |
           set -euxo pipefail
           rm -rf out
           mkdir -p out
 
+          # 1) Generate paradox_field_v0.json (atoms)
           python scripts/paradox_field_adapter_v0.py \
             --transitions-dir ./tests/fixtures/transitions_gate_metric_tension_v0 \
             --out ./out/paradox_field_v0.json
 
+          # 2) Export paradox_edges_v0.jsonl (edges)  ✅ FIX: this was missing
+          python scripts/export_paradox_edges_v0.py \
+            --in ./out/paradox_field_v0.json \
+            --out ./out/paradox_edges_v0.jsonl
+
+          # 3) Assert artefacts exist
           test -f ./out/paradox_field_v0.json
           test -f ./out/paradox_edges_v0.jsonl
 
-      - name: Contract checks (fail-closed)
-        run: |
-          set -euxo pipefail
+          # 4) Contract checks (fail-closed)
           python scripts/check_paradox_field_v0_contract.py --in ./out/paradox_field_v0.json
           python scripts/check_paradox_edges_v0_contract.py --in ./out/paradox_edges_v0.jsonl --atoms ./out/paradox_field_v0.json
 
-      - name: Acceptance checks (fixture must contain)
-        run: |
-          set -euxo pipefail
+          # 5) Acceptance checks (fixture must contain)
           python scripts/check_paradox_edges_v0_acceptance_v0.py \
             --in ./out/paradox_edges_v0.jsonl \
             --atoms ./out/paradox_field_v0.json \
@@ -58,11 +71,11 @@ jobs:
             --type gate_metric_tension \
             --min-count 1
 
-      - name: Upload outputs (debug)
-        if: always()
+      - name: Upload artifacts on failure
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: paradox-edges-smoke-out
-          path: |
-            out/paradox_field_v0.json
-            out/paradox_edges_v0.jsonl
+          path: out
+          if-no-files-found: ignore
+


### PR DESCRIPTION
## Summary
Introduce a dedicated CI smoke workflow for the paradox edges layer (C.3).

## What it runs
- Fixture → `paradox_field_adapter_v0.py` → outputs:
  - `out/paradox_field_v0.json`
  - `out/paradox_edges_v0.jsonl`
- Contract checks (fail-closed)
- Acceptance checks (fixture must contain)
- Artifact upload for debugging

## Why
This makes C.3 deterministic, audit-friendly, and regression-protected:
edges remain “proven co-occurrences derived from atoms”.

## Testing
CI-only (GitHub Actions). Artifacts uploaded on failure for inspection.
