### PR TITLE
docs(case-studies): add paradox edges case study template

### DIFF
--- a/docs/paradox_edges_case_studies.md
+++ b/docs/paradox_edges_case_studies.md
@@ -1,0 +1,23 @@
+### Paradox edges case study — <rövid cím>
+
+**Context**
+- transitions-dir: `<...>`
+- Goal: <mit vizsgáltatok?>
+
+**Evidence (atoms)**
+- gate_flip atom_id: `<...>`
+  - gate_id: `<...>`, status: `<...→...>`
+- metric_delta atom_id: `<...>`
+  - metric: `<...>`, delta: `<...>`, rel_delta: `<...>`, severity: `<warn|crit>`
+
+**Evidence (edges)**
+- edge_id: `<...>`
+  - type: `gate_metric_tension`
+  - src_atom_id: `<gate_flip atom_id>`
+  - dst_atom_id: `<metric_delta atom_id>`
+
+**Why it helped**
+- <1–3 bullet: gyorsabb triage? audit trail? regresszió “fingerprint”?>
+
+**Follow-up**
+- <ha kell: új acceptance fixture? küszöb finomítás? csak megjegyzés>


### PR DESCRIPTION
## Summary
Add a minimal case study template for documenting paradox_edges as evidence-first co-occurrences derived from atoms.

## What’s included
- New doc template under `docs/` to capture:
  - context (transitions dir / goal)
  - evidence (atoms)
  - evidence (edges)
  - why it helped + follow-up

## Notes
This does not introduce new logic or “truth”; it standardizes how we document triage/audit value from the paradox edges layer.

## Testing
N/A (docs-only change)
