### PR TITLE
docs(paradox-edges): add gate_metric_tension case study (fixture)

### DIFF
--- a/docs/paradox_edges_case_studies.md
+++ b/docs/paradox_edges_case_studies.md
@@ -1,23 +1,29 @@
-### Paradox edges case study — <rövid cím>
+
+### Paradox edges case study — Fixture: gate_metric_tension (v0)
 
 **Context**
-- transitions-dir: `<...>`
-- Goal: <mit vizsgáltatok?>
+- transitions-dir: `tests/fixtures/transitions_gate_metric_tension_v0`
+- Goal: Verify deterministic “edges = proven co-occurrences” export (no new truth, no causality).
 
 **Evidence (atoms)**
-- gate_flip atom_id: `<...>`
-  - gate_id: `<...>`, status: `<...→...>`
-- metric_delta atom_id: `<...>`
-  - metric: `<...>`, delta: `<...>`, rel_delta: `<...>`, severity: `<warn|crit>`
+- gate_flip atom_id: `c2fe8b5a2a47`
+  - gate_id/status: see `paradox_field_v0.json` → atom evidence for `c2fe8b5a2a47`
+- metric_delta atom_id: `a465b50d4bc6`
+  - metric/delta/severity: see `paradox_field_v0.json` → atom evidence for `a465b50d4bc6`
+- gate_metric_tension atom_id: `5e53007e2108`
+  - gate_atom_id: `c2fe8b5a2a47`
+  - metric_atom_id: `a465b50d4bc6`
 
 **Evidence (edges)**
-- edge_id: `<...>`
-  - type: `gate_metric_tension`
-  - src_atom_id: `<gate_flip atom_id>`
-  - dst_atom_id: `<metric_delta atom_id>`
+- edge_id: `b18598803db9ef5e`
+- type: `gate_metric_tension`
+- src_atom_id: `c2fe8b5a2a47`
+- dst_atom_id: `a465b50d4bc6`
+- rule: `gate_flip × metric_delta(warn|crit)`
 
 **Why it helped**
-- <1–3 bullet: gyorsabb triage? audit trail? regresszió “fingerprint”?>
+- Downstream-friendly index: consumers can use edges without re-diffing raw runs, while still linking back to concrete atoms/evidence.
+- Evidence-first stays intact: the edge asserts only a proven co-occurrence in the same run-pair drift output (no explanation/causality).
 
 **Follow-up**
-- <ha kell: új acceptance fixture? küszöb finomítás? csak megjegyzés>
+- Add 1–2 real (non-fixture) case studies before any deeper “content enrichment” (C.4).


### PR DESCRIPTION
### What
Adds a minimal, evidence-first case study for the v0 paradox edges flow using the existing fixture transitions directory.

The case study documents a single proven co-occurrence:
- gate_flip atom_id -> metric_delta atom_id
- linked by gate_metric_tension atom_id
- exported as gate_metric_tension edge_id in paradox_edges_v0.jsonl

### Why
We want downstream-friendly edges that behave as a deterministic index over atoms,
without introducing new “truth” or causality. This example anchors the concept in a stable fixture.

### How to test (CI/local)
python scripts/paradox_field_adapter_v0.py --transitions-dir ./tests/fixtures/transitions_gate_metric_tension_v0 --out ./out/paradox_field_v0.json
python scripts/export_paradox_edges_v0.py --in ./out/paradox_field_v0.json --out ./out/paradox_edges_v0.jsonl
python scripts/check_paradox_field_v0_contract.py --in ./out/paradox_field_v0.json
python scripts/check_paradox_edges_v0_contract.py --in ./out/paradox_edges_v0.jsonl --atoms ./out/paradox_field_v0.json
python scripts/check_paradox_edges_v0_acceptance_v0.py --in ./out/paradox_edges_v0.jsonl --atoms ./out/paradox_field_v0.json --min-count 1
