### PR TITLE
test(fixtures): add transitions summary JSON for gate_overlay_tension fixture v0

### DIFF
--- a/tests/fixtures/transitions_gate_overlay_tension_v0/pulse_transitions_v0.json
+++ b/tests/fixtures/transitions_gate_overlay_tension_v0/pulse_transitions_v0.json
@@ -1,0 +1,8 @@
+{
+  "run_a": {
+    "status_sha1": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "run_b": {
+    "status_sha1": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a minimal `pulse_transitions_v0.json` to the gate_overlay_tension transitions fixture.

## What’s included
- `tests/fixtures/transitions_gate_overlay_tension_v0/pulse_transitions_v0.json`

## Why
The adapter uses run context (status_sha1) when available to keep atom IDs stable.

## Testing
Will be exercised by the paradox edges smoke workflow once the full fixture is present.
