### PR TITLE
test(fixtures): add gate drift CSV for gate_overlay_tension fixture v0

### DIFF
--- a/tests/fixtures/transitions_gate_overlay_tension_v0/pulse_gate_drift_v0.csv
+++ b/tests/fixtures/transitions_gate_overlay_tension_v0/pulse_gate_drift_v0.csv
@@ -1,0 +1,2 @@
+gate_id,group,status_a,status_b,pass_a,pass_b,flip,value_a,value_b,threshold,notes_a,notes_b,present_a,present_b
+quality_helpfulness,quality,PASS,FAIL,True,False,1,,,,,,1,1


### PR DESCRIPTION
## Summary
Adds a minimal `pulse_gate_drift_v0.csv` to drive a gate flip in the gate_overlay_tension fixture.

## What’s included
- `tests/fixtures/transitions_gate_overlay_tension_v0/pulse_gate_drift_v0.csv`

## Why
The paradox adapter needs at least one gate flip to produce tension atoms/edges.

## Testing
Will be exercised by the paradox edges smoke workflow once the full fixture is present.
