### PR TITLE
test(fixtures): add metric drift CSV for gate_overlay_tension fixture v0

### DIFF
--- a/tests/fixtures/transitions_gate_overlay_tension_v0/pulse_metric_drift_v0.csv
+++ b/tests/fixtures/transitions_gate_overlay_tension_v0/pulse_metric_drift_v0.csv
@@ -1,0 +1,2 @@
+metric,a,b,delta,rel_delta,present_a,present_b
+rdsi,0.88,0.881,0.001,0.001136,1,1


### PR DESCRIPTION
## Summary
Adds a minimal `pulse_metric_drift_v0.csv` for the gate_overlay_tension fixture.

## What’s included
- `tests/fixtures/transitions_gate_overlay_tension_v0/pulse_metric_drift_v0.csv`

## Why
The adapter expects the metric drift CSV to exist in a transitions-dir.
Values are chosen to avoid triggering metric warn/crit severity in this fixture.

## Testing
Will be exercised by the paradox edges smoke workflow once the full fixture is present.
