### PR TITLE
test(fixtures): add overlay drift JSON for gate_overlay_tension fixture v0

### DIFF
--- a/tests/fixtures/transitions_gate_overlay_tension_v0/pulse_overlay_drift_v0.json
+++ b/tests/fixtures/transitions_gate_overlay_tension_v0/pulse_overlay_drift_v0.json
@@ -1,0 +1,16 @@
+{
+  "g_field_v0": {
+    "present_a": 1,
+    "present_b": 1,
+    "path_a": "g_field_v0.json",
+    "path_b": "g_field_v0.json",
+    "sha1_a": "1111111111111111111111111111111111111111",
+    "sha1_b": "2222222222222222222222222222222222222222",
+    "top_level_diff": {
+      "added_keys": [],
+      "removed_keys": [],
+      "changed_keys": ["nodes"],
+      "note": ""
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds a minimal `pulse_overlay_drift_v0.json` that includes a non-empty `changed_keys`
for `g_field_v0` in the gate_overlay_tension transitions fixture.

## What’s included
- `tests/fixtures/transitions_gate_overlay_tension_v0/pulse_overlay_drift_v0.json`

## Why
Overlay tension requires an overlay_change signal (non-empty changed_keys) to be present.

## Testing
Will be exercised by the paradox edges smoke workflow once the full fixture is present.
