### PR TITLE
docs(paradox-edges): add v0 fixture case studies for edges export

### DIFF
--- a/docs/paradox_edges_case_studies.md
+++ b/docs/paradox_edges_case_studies.md
@@ -88,3 +88,68 @@ python scripts/check_paradox_edges_v0_acceptance_v0.py \
 
 ### Follow-up
 - Add 1–2 real (non-fixture) case studies before deeper “content enrichment” (C.4).
+
+---
+
+# Paradox edges case studies (v0)
+
+Edges are **proven co-occurrences** derived from atoms; they do **not** introduce new truth or causality.
+Nodes remain atoms. Edges are a downstream-friendly index layer.
+
+---
+
+## Case study — Fixture: gate_metric_tension (v0)
+
+### Context
+- transitions-dir: `tests/fixtures/transitions_gate_metric_tension_v0`
+- Goal: Verify deterministic “edges = proven co-occurrences” export (no new truth, no causality).
+
+### Evidence (atoms)
+- gate_flip atom_id: `c2fe8b5a2a47`
+- metric_delta atom_id: `a465b50d4bc6`
+- gate_metric_tension atom_id: `5e53007e2108`
+  - gate_atom_id: `c2fe8b5a2a47`
+  - metric_atom_id: `a465b50d4bc6`
+
+### Evidence (edges)
+- edge_id: `b18598803db9ef5e`
+- type: `gate_metric_tension`
+- src_atom_id: `c2fe8b5a2a47`
+- dst_atom_id: `a465b50d4bc6`
+- rule: `gate_flip × metric_delta(warn|crit)`
+
+### Why it helped
+- Downstream-friendly index: consumers can use edges without re-diffing raw runs, while still linking back to concrete atoms/evidence.
+- Evidence-first stays intact: the edge asserts only a proven co-occurrence in the same run-pair drift output (no explanation/causality).
+
+### Follow-up
+Add 1–2 real (non-fixture) case studies before any deeper “content enrichment” (C.4).
+
+---
+
+## Case study — Fixture: gate_overlay_tension (v0)
+
+### Context
+- transitions-dir: `tests/fixtures/transitions_gate_overlay_tension_v0`
+- Goal: Verify deterministic “gate flip + overlay drift” co-occurrence export as edges.
+
+### Evidence (atoms)
+- gate_flip atom_id: `<gate_flip_atom_id>`
+- overlay_change atom_id: `<overlay_change_atom_id>`
+- gate_overlay_tension atom_id: `<gate_overlay_tension_atom_id>`
+  - gate_atom_id: `<gate_flip_atom_id>`
+  - overlay_atom_id: `<overlay_change_atom_id>`
+
+### Evidence (edges)
+- edge_id: `<edge_id>`
+- type: `gate_overlay_tension`
+- src_atom_id: `<gate_flip_atom_id>`
+- dst_atom_id: `<overlay_change_atom_id>`
+- rule: `<rule>`
+
+### Why it helped
+- Downstream-friendly: quickly surfaces “gate flip + overlay drift” co-occurrence without re-diffing runs.
+- Evidence-first: edge is only a proven co-occurrence in the same run-pair drift output (no explanation/causality).
+
+### Follow-up
+Add 1–2 real (non-fixture) case studies before deeper “content enrichment” (C.4).


### PR DESCRIPTION
## Summary
Adds `docs/paradox_edges_case_studies_v0.md` to capture v0 case studies for the paradox edges layer.

## What’s included
- A filled fixture case study for `gate_metric_tension`
- A template fixture case study for `gate_overlay_tension` (to be filled from Codex run output)

## Why
Keeps the “edges = proven co-occurrences” philosophy explicit and provides downstream-friendly examples
without introducing new truth or causality.

## Testing
Docs-only change.
