### PR TITLE
docs(paradox-edges): clean case studies (fixtures + synthetic e2e)

### DIFF
--- a/docs/paradox_edges_case_studies.md
+++ b/docs/paradox_edges_case_studies.md
@@ -1,100 +1,10 @@
 
-### Paradox edges case study — Fixture: gate_metric_tension (v0)
-
-**Context**
-- transitions-dir: `tests/fixtures/transitions_gate_metric_tension_v0`
-- Goal: Verify deterministic “edges = proven co-occurrences” export (no new truth, no causality).
-
-**Evidence (atoms)**
-- gate_flip atom_id: `c2fe8b5a2a47`
-  - gate_id/status: see `paradox_field_v0.json` → atom evidence for `c2fe8b5a2a47`
-- metric_delta atom_id: `a465b50d4bc6`
-  - metric/delta/severity: see `paradox_field_v0.json` → atom evidence for `a465b50d4bc6`
-- gate_metric_tension atom_id: `5e53007e2108`
-  - gate_atom_id: `c2fe8b5a2a47`
-  - metric_atom_id: `a465b50d4bc6`
-
-**Evidence (edges)**
-- edge_id: `b18598803db9ef5e`
-- type: `gate_metric_tension`
-- src_atom_id: `c2fe8b5a2a47`
-- dst_atom_id: `a465b50d4bc6`
-- rule: `gate_flip × metric_delta(warn|crit)`
-
-**Why it helped**
-- Downstream-friendly index: consumers can use edges without re-diffing raw runs, while still linking back to concrete atoms/evidence.
-- Evidence-first stays intact: the edge asserts only a proven co-occurrence in the same run-pair drift output (no explanation/causality).
-
-**Follow-up**
-- Add 1–2 real (non-fixture) case studies before any deeper “content enrichment” (C.4).
-
----
-
-## Paradox edges case study — Fixture: gate_overlay_tension (v0)
-
-### Context
-- transitions-dir: `tests/fixtures/transitions_gate_overlay_tension_v0`
-- Goal: Verify deterministic `gate_overlay_tension` export (edges = proven co-occurrences; no new truth/causality).
-
-### Repro (Codex run)
-```bash
-python scripts/paradox_field_adapter_v0.py \
-  --transitions-dir ./tests/fixtures/transitions_gate_overlay_tension_v0 \
-  --out ./out/case_study_gate_overlay/paradox_field_v0.json
-
-python scripts/export_paradox_edges_v0.py \
-  --in ./out/case_study_gate_overlay/paradox_field_v0.json \
-  --out ./out/case_study_gate_overlay/paradox_edges_v0.jsonl
-
-python scripts/check_paradox_field_v0_contract.py \
-  --in ./out/case_study_gate_overlay/paradox_field_v0.json
-
-python scripts/check_paradox_edges_v0_contract.py \
-  --in ./out/case_study_gate_overlay/paradox_edges_v0.jsonl \
-  --atoms ./out/case_study_gate_overlay/paradox_field_v0.json
-
-python scripts/check_paradox_edges_v0_acceptance_v0.py \
-  --in ./out/case_study_gate_overlay/paradox_edges_v0.jsonl \
-  --atoms ./out/case_study_gate_overlay/paradox_field_v0.json \
-  --type gate_overlay_tension \
-  --min-count 1
-
-```
-
-```text
-
-```
-
-
----
-
-### Evidence (atoms)
-- gate_flip atom_id: `<gate_flip_atom_id>`
-- overlay_change atom_id: `<overlay_change_atom_id>`
-- gate_overlay_tension atom_id: `<gate_overlay_tension_atom_id>`
-  - gate_atom_id: `<gate_flip_atom_id>`
-  - overlay_atom_id: `<overlay_change_atom_id>`
-
-### Evidence (edges)
-- edge_id: `<edge_id>`
-- type: `gate_overlay_tension`
-- src_atom_id: `<gate_flip_atom_id>`
-- dst_atom_id: `<overlay_change_atom_id>`
-- rule: `<rule>`
-
-### Why it helped
-- Downstream-friendly: quickly surfaces “gate flip + overlay drift” co-occurrence without re-diffing runs.
-- Evidence-first: edge is only a proven co-occurrence in the same run-pair drift output (no explanation/causality).
-
-### Follow-up
-- Add 1–2 real (non-fixture) case studies before deeper “content enrichment” (C.4).
-
----
+Path: docs/paradox_edges_case_studies.md
 
 # Paradox edges case studies (v0)
 
 Edges are **proven co-occurrences** derived from atoms; they do **not** introduce new truth or causality.
-Nodes remain atoms. Edges are a downstream-friendly index layer.
+Nodes remain atoms. Edges are a downstream-friendly index layer exported as JSONL.
 
 ---
 
@@ -104,9 +14,35 @@ Nodes remain atoms. Edges are a downstream-friendly index layer.
 - transitions-dir: `tests/fixtures/transitions_gate_metric_tension_v0`
 - Goal: Verify deterministic “edges = proven co-occurrences” export (no new truth, no causality).
 
+### Repro (Codex / local)
+```bash
+python scripts/paradox_field_adapter_v0.py \
+  --transitions-dir ./tests/fixtures/transitions_gate_metric_tension_v0 \
+  --out ./out/paradox_field_v0.json
+
+python scripts/export_paradox_edges_v0.py \
+  --in ./out/paradox_field_v0.json \
+  --out ./out/paradox_edges_v0.jsonl
+
+python scripts/check_paradox_field_v0_contract.py \
+  --in ./out/paradox_field_v0.json
+
+python scripts/check_paradox_edges_v0_contract.py \
+  --in ./out/paradox_edges_v0.jsonl \
+  --atoms ./out/paradox_field_v0.json
+
+python scripts/check_paradox_edges_v0_acceptance_v0.py \
+  --in ./out/paradox_edges_v0.jsonl \
+  --atoms ./out/paradox_field_v0.json \
+  --type gate_metric_tension \
+  --min-count 1
+```
+
 ### Evidence (atoms)
 - gate_flip atom_id: `c2fe8b5a2a47`
+  - gate_id/status: see `out/paradox_field_v0.json` → atom evidence for `c2fe8b5a2a47`
 - metric_delta atom_id: `a465b50d4bc6`
+  - metric/delta/severity: see `out/paradox_field_v0.json` → atom evidence for `a465b50d4bc6`
 - gate_metric_tension atom_id: `5e53007e2108`
   - gate_atom_id: `c2fe8b5a2a47`
   - metric_atom_id: `a465b50d4bc6`
@@ -133,31 +69,29 @@ Add 1–2 real (non-fixture) case studies before any deeper “content enrichmen
 - transitions-dir: `tests/fixtures/transitions_gate_overlay_tension_v0`
 - Goal: Verify deterministic “gate flip + overlay drift” co-occurrence export as edges.
 
-### Evidence (atoms)
-- gate_flip atom_id: `<gate_flip_atom_id>`
-- overlay_change atom_id: `<overlay_change_atom_id>`
-- gate_overlay_tension atom_id: `<gate_overlay_tension_atom_id>`
-  - gate_atom_id: `<gate_flip_atom_id>`
-  - overlay_atom_id: `<overlay_change_atom_id>`
+### Repro (Codex / local)
+```bash
+python scripts/paradox_field_adapter_v0.py \
+  --transitions-dir ./tests/fixtures/transitions_gate_overlay_tension_v0 \
+  --out ./out/case_study_gate_overlay/paradox_field_v0.json
 
-### Evidence (edges)
-- edge_id: `<edge_id>`
-- type: `gate_overlay_tension`
-- src_atom_id: `<gate_flip_atom_id>`
-- dst_atom_id: `<overlay_change_atom_id>`
-- rule: `<rule>`
+python scripts/export_paradox_edges_v0.py \
+  --in ./out/case_study_gate_overlay/paradox_field_v0.json \
+  --out ./out/case_study_gate_overlay/paradox_edges_v0.jsonl
 
-### Why it helped
-- Downstream-friendly: quickly surfaces “gate flip + overlay drift” co-occurrence without re-diffing runs.
-- Evidence-first: edge is only a proven co-occurrence in the same run-pair drift output (no explanation/causality).
+python scripts/check_paradox_field_v0_contract.py \
+  --in ./out/case_study_gate_overlay/paradox_field_v0.json
 
----
+python scripts/check_paradox_edges_v0_contract.py \
+  --in ./out/case_study_gate_overlay/paradox_edges_v0.jsonl \
+  --atoms ./out/case_study_gate_overlay/paradox_field_v0.json
 
-## Case study — Fixture: gate_overlay_tension (v0)
-
-### Context
-- transitions-dir: `tests/fixtures/transitions_gate_overlay_tension_v0`
-- Goal: Verify deterministic “gate flip + overlay drift” co-occurrence export as edges.
+python scripts/check_paradox_edges_v0_acceptance_v0.py \
+  --in ./out/case_study_gate_overlay/paradox_edges_v0.jsonl \
+  --atoms ./out/case_study_gate_overlay/paradox_field_v0.json \
+  --type gate_overlay_tension \
+  --min-count 1
+```
 
 ### Evidence (atoms)
 - gate_flip atom_id: `c2fe8b5a2a47`
@@ -185,7 +119,7 @@ Add 1–2 real (non-fixture) case studies before deeper “content enrichment”
 ## Case study — Synthetic e2e: runA vs runB (v0)
 
 ### Context
-- runs: `out/case_study_e2e/runA` vs `out/case_study_e2e/runB`
+- runs: `out/case_study_e2e/runA` vs `out/case_study_e2e/runB` (synthetic; not committed)
 - transitions-dir: `out/case_study_real/transitions_A_vs_B`
 - Goal: Verify deterministic **edges = proven co-occurrences** (no new truth, no causality).
 
@@ -231,10 +165,6 @@ Add 1–2 real (non-fixture) case studies before deeper “content enrichment”
 ### Follow-up
 Add 1–2 real (non-fixture) case studies before any deeper “content enrichment” (C.4).
 
-### Codex run
-**Summary:** No code changes were necessary; the snippet above was generated from the synthetic e2e runs.  
-**Testing:** ✅ `python - <<'PY' ... PY`
 
----
-::contentReference[oaicite:0]{index=0}
+
 


### PR DESCRIPTION
## Summary
Cleans up and consolidates `docs/paradox_edges_case_studies.md` into three canonical v0 case studies with concrete IDs.

## What’s included
- `docs/paradox_edges_case_studies.md`
  - Removes duplicate/placeholder sections and empty fences
  - Keeps:
    - fixture `gate_metric_tension`
    - fixture `gate_overlay_tension`
    - synthetic e2e `runA vs runB`

## Why
The docs should be copy-paste friendly and audit-friendly:
- nodes remain atoms
- edges remain proven co-occurrence signals (no causality)
