### PR TITLE
feat(paradox-field): add overlay json_pointer provenance 

### DIFF
--- a/scripts/paradox_field_adapter_v0.py
+++ b/scripts/paradox_field_adapter_v0.py
@@ -392,8 +392,14 @@ def main() -> None:
                     "title": title,
                     "refs": {"gates": [], "metrics": [], "overlays": [str(overlay_name)]},
                     "evidence": {
-                        "source": {"overlay_drift_json": os.path.basename(t["overlay_json"])},
-                        "overlay": {
+                        "source": {
+                            "overlay_drift_json": os.path.basename(t["overlay_json"]),
+                            "overlay_name": str(overlay_name),
+                            "json_pointer": f"/{str(overlay_name)}",
+                            "json_pointer_top_level_diff": f"/{str(overlay_name)}/top_level_diff",
+                         }, 
+                          
+                       "overlay": {
                             "name": str(overlay_name),
                             "present_a": bool(overlay_block.get("present_a")),
                             "present_b": bool(overlay_block.get("present_b")),


### PR DESCRIPTION
## Summary
Adds explicit JSON pointer provenance fields to `overlay_change` atom evidence.

## What changed
- `scripts/paradox_field_adapter_v0.py`
  - `overlay_change` atoms now include:
    - `evidence.source.overlay_name`
    - `evidence.source.json_pointer`
    - `evidence.source.json_pointer_top_level_diff`

## Why
Downstream consumers can reliably jump from an atom to the exact location in
`pulse_overlay_drift_v0.json` (evidence-first), without introducing new truth.

## Testing
✅ python -m py_compile scripts/paradox_field_adapter_v0.py  
✅ python scripts/paradox_field_adapter_v0.py --transitions-dir ./tests/fixtures/transitions_gate_overlay_tension_v0 --out ./out/paradox_field_v0.json  
✅ python scripts/check_paradox_field_v0_contract.py --in ./out/paradox_field_v0.json  