### PR TITLE
chore(contract): validate optional meta.run_context in paradox_field_v0

### DIFF
--- a/scripts/check_paradox_field_v0_contract.py
+++ b/scripts/check_paradox_field_v0_contract.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python3
 # scripts/check_paradox_field_v0_contract.py
 
@@ -124,6 +125,19 @@ def main() -> int:
     if "paradox_field_v0" in root and isinstance(root.get("paradox_field_v0"), dict):
         root = as_dict(root.get("paradox_field_v0"), "$.paradox_field_v0")
 
+    # C4.2: Optional run_context checks (non-breaking, fail-closed if present)
+    meta_any = root.get("meta")
+    if meta_any is not None:
+        meta = as_dict(meta_any, "$.meta")
+        rc_any = meta.get("run_context")
+        if rc_any is not None:
+            rc = as_dict(rc_any, "$.meta.run_context")
+            for k, v in rc.items():
+                if not isinstance(k, str) or not k.strip():
+                    die("$.meta.run_context keys must be non-empty strings")
+                if not isinstance(v, str) or not v.strip():
+                    die(f"$.meta.run_context.{k} must be a non-empty string")
+
     atoms_any = root.get("atoms")
     if atoms_any is None:
         die("$.atoms is missing")
@@ -217,4 +231,3 @@ if __name__ == "__main__":
     except BrokenPipeError:
         # allow piping into head, etc.
         sys.exit(0)
-


### PR DESCRIPTION
## Summary
- Add optional (non-breaking) contract validation for `meta.run_context` in `paradox_field_v0`.
- Fail-closed behavior: if `meta.run_context` is present, it must be an object with non-empty string keys and values.

## Why
`meta.run_context` is now emitted by the field artifact for downstream correlation. This PR ensures the contract checker enforces the expected structure when present, without requiring it for older outputs.

## Scope
- Only changes: `scripts/check_paradox_field_v0_contract.py`
- No changes to adapters, exporters, fixtures, or workflows.

## Testing
✅ python scripts/paradox_field_adapter_v0.py --transitions-dir tests/fixtures/transitions_gate_metric_tension_v0 --out out/paradox_field_v0.json  
✅ python scripts/check_paradox_field_v0_contract.py --in out/paradox_field_v0.json  
✅ python scripts/export_paradox_edges_v0.py --in out/paradox_field_v0.json --out out/paradox_edges_v0.jsonl  
✅ python scripts/check_paradox_edges_v0_contract.py --in out/paradox_edges_v0.jsonl  
✅ python scripts/check_paradox_edges_v0_acceptance_v0.py --in out/paradox_edges_v0.jsonl  

## Notes
- `meta.run_context` remains optional (no breaking changes).
- No generated artifacts committed (`out/**`).
