### PR TITLE
feat(paradox-field): add src/dst atom id aliases to tension evidence

### DIFF
--- a/scripts/paradox_field_adapter_v0.py
+++ b/scripts/paradox_field_adapter_v0.py
@@ -509,6 +509,8 @@ def main() -> None:
                     "refs": {"gates": [gid], "metrics": [metric_name], "overlays": []},
                     "evidence": {
                         "rule": "gate_flip × metric_delta(warn|crit)",
+                        "src_atom_id": gate_atom_id,
+                        "dst_atom_id": metric_atom_id,
                         "gate_atom_id": gate_atom_id,
                         "metric_atom_id": metric_atom_id,
                         # Optional summaries (downstream-friendly)
@@ -569,6 +571,8 @@ def main() -> None:
                     "refs": {"gates": [gid], "metrics": [], "overlays": [oname]},
                     "evidence": {
                         "rule": "gate_flip × overlay_change",
+                        "src_atom_id": gate_atom_id,
+                        "dst_atom_id": overlay_atom_id,
                         "gate_atom_id": gate_atom_id,
                         "overlay_atom_id": overlay_atom_id,
                         # Optional summaries (downstream-friendly)


### PR DESCRIPTION
## Summary
- Add `evidence.src_atom_id` and `evidence.dst_atom_id` aliases to all tension atoms emitted by the field adapter.
- Keep existing specific link fields (`gate_atom_id`, `metric_atom_id`, `overlay_atom_id`) unchanged.

## Why
Downstream consumers can treat all tension types uniformly by reading `src_atom_id`/`dst_atom_id` regardless of tension subtype, while preserving existing keys for backward compatibility.

## Scope
- Only change: `scripts/paradox_field_adapter_v0.py`

## Testing
✅ python scripts/paradox_field_adapter_v0.py --transitions-dir tests/fixtures/transitions_gate_metric_tension_v0 --out out/paradox_field_v0.json  
✅ python scripts/check_paradox_field_v0_contract.py --in out/paradox_field_v0.json  
✅ python scripts/export_paradox_edges_v0.py --in out/paradox_field_v0.json --out out/paradox_edges_v0.jsonl  
✅ python scripts/check_paradox_edges_v0_contract.py --in out/paradox_edges_v0.jsonl  
✅ python scripts/check_paradox_edges_v0_acceptance_v0.py --in out/paradox_edges_v0.jsonl  

## Notes
- No generated artifacts committed (`out/**`).
- This is additive only (non-breaking).
