### PR TITLE
docs(examples): add pulse_overlay_drift_v0.json

### DIFF
--- a/docs/examples/transitions_case_study_v0/pulse_overlay_drift_v0.jso
+++ b/docs/examples/transitions_case_study_v0/pulse_overlay_drift_v0.jso
@@ -1,0 +1,21 @@
+{
+  "paradox_field_v0": {
+    "path_a": "artifacts/paradox_field_v0.json",
+    "path_b": "artifacts/paradox_field_v0.json",
+    "present_a": true,
+    "present_b": true,
+    "sha1_a": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "sha1_b": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "top_level_diff": {
+      "added_keys": [
+        "meta.run_context"
+      ],
+      "changed_keys": [
+        "meta.contract.metric_thresholds.abs_warn",
+        "meta.contract.metric_thresholds.abs_crit"
+      ],
+      "note": "Example: thresholds tuned",
+      "removed_keys": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add `docs/examples/transitions_case_study_v0/pulse_overlay_drift_v0.json` as repo-local input for the non-fixture C4.4 transitions example.

## Why
Provides an overlay drift input that exercises overlay_change atoms (and downstream tensions) in a reproducible pipeline without committing generated outputs.

## Scope
- Adds a single JSON file only.

## Testing
```bash
python -m json.tool docs/examples/transitions_case_study_v0/pulse_overlay_drift_v0.json > /dev/null
