### PR TITLE
docs(examples): add pulse_transitions_v0.json

### DIFF
--- a/docs/examples/transitions_case_study_v0/pulse_transitions_v0.json
+++ b/docs/examples/transitions_case_study_v0/pulse_transitions_v0.json
@@ -1,0 +1,9 @@
+{
+  "note": "Docs example run-pair for paradox_field_v0 / paradox_edges_v0",
+  "run_a": {
+    "status_sha1": "1111111111111111111111111111111111111111"
+  },
+  "run_b": {
+    "status_sha1": "2222222222222222222222222222222222222222"
+  }
+}


### PR DESCRIPTION
## Summary
Add `docs/examples/transitions_case_study_v0/pulse_transitions_v0.json` as repo-local input for the non-fixture C4.4 transitions example.

## Why
This file provides the `run_a` / `run_b` block used by the transitions/paradox adapters for deterministic run-pair context in the example pipeline.

## Scope
- Adds a single JSON file only.

## Testing
```bash
python -m json.tool docs/examples/transitions_case_study_v0/pulse_transitions_v0.json > /dev/null
