### PR TITLE
fix(contract): relax run_pair_id format in edges run_context

### DIFF
--- a/scripts/check_paradox_edges_v0_contract.py
+++ b/scripts/check_paradox_edges_v0_contract.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python3
 """
 check_paradox_edges_v0_contract.py — fail-closed contract checker for paradox_edges_v0.jsonl.
@@ -112,7 +113,7 @@ def _validate_run_context(run_ctx: Any, line_no: int) -> Optional[str]:
     - run_context may be omitted (legacy outputs)
     - if present, must be a dict
     - keys + values must be non-empty strings
-    - run_pair_id is required and must be 12-hex
+    - run_pair_id is required and must be a non-empty string (format is intentionally NOT constrained)
     - sha1 fields (if present) must be 40-hex sha1
     """
     if run_ctx is None:
@@ -131,8 +132,6 @@ def _validate_run_context(run_ctx: Any, line_no: int) -> Optional[str]:
     if not isinstance(rpid, str) or not rpid.strip():
         die(f"line {line_no}: run_context.run_pair_id must be a non-empty string if run_context is present")
     rpid = rpid.strip()
-    if not _is_hex(rpid, 12):
-        die(f"line {line_no}: run_context.run_pair_id must be a 12-hex string (got {rpid!r})")
 
     # Optional sha1s should look like sha1.
     def _opt_sha1(k: str) -> None:
@@ -306,4 +305,3 @@ if __name__ == "__main__":
     except BrokenPipeError:
         # allow piping to head etc.
         raise SystemExit(0)
-


### PR DESCRIPTION
## Summary
Relax `run_context.run_pair_id` validation in `scripts/check_paradox_edges_v0_contract.py` to require a non-empty string (no 12-hex constraint).

## Why
Upstream contracts (field contract + edges export) allow any non-empty `run_pair_id`. Requiring 12-hex in the edges contract introduces a cross-contract regression for existing pipelines that use non-hex identifiers.

## Scope
- One-file change: `scripts/check_paradox_edges_v0_contract.py`

## Testing
✅ python scripts/paradox_field_adapter_v0.py --transitions-dir docs/examples/transitions_case_study_v0 --out out/paradox_field_v0.json  
✅ python scripts/export_paradox_edges_v0.py --in out/paradox_field_v0.json --out out/paradox_edges_v0.jsonl  
✅ python scripts/check_paradox_edges_v0_contract.py --in out/paradox_edges_v0.jsonl  
