### PR TITLE
docs(examples): format examples index README

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -4,21 +4,22 @@ This directory contains small, repo-local example inputs intended to be reproduc
 
 ## Available examples
 
-### 1) transitions_case_study_v0
+### 1) `transitions_case_study_v0`
 
-Path:
+**Path**
 - `docs/examples/transitions_case_study_v0/`
 
-What it covers:
-- transitions drift inputs (gate/metric/overlay)
+**What it covers**
+- transitions drift inputs (gate / metric / overlay)
 - end-to-end run: transitions → paradox_field_v0.json → paradox_edges_v0.jsonl → contract checks
-- run_context present on field meta and edges (useful for downstream correlation)
+- `run_context` present on field meta and edges (useful for downstream correlation)
 
-How to run:
-- See `docs/examples/transitions_case_study_v0/README.md`
+**How to run**
+- See: `docs/examples/transitions_case_study_v0/README.md`
 
 ## Notes
 
 - Do not commit generated outputs under `out/**`.
 - Example input filenames are intentionally fixed (e.g. `pulse_overlay_drift_v0.json`) because the adapters expect those names.
 - CI smoke runs these examples to prevent drift and catch missing/renamed inputs early.
+


### PR DESCRIPTION
## Summary
Reformat `docs/examples/README.md` to use stable markdown structure (headers, lists, inline code).

## Why
The content is correct but currently easy to “run together” in rendering. This keeps it readable and consistent with other docs.

## Scope
- Docs-only: `docs/examples/README.md`

## Testing
N/A (docs-only).
