### PR TITLE
ci(examples): validate edges against atoms in smoke

### DIFF
--- a/.github/workflows/paradox_examples_smoke.yml
+++ b/.github/workflows/paradox_examples_smoke.yml
@@ -66,5 +66,6 @@ jobs:
             --in out/paradox_field_v0.json \
             --out out/paradox_edges_v0.jsonl
 
-          python scripts/check_paradox_edges_v0_contract.py --in out/paradox_edges_v0.jsonl
-
+          python scripts/check_paradox_edges_v0_contract.py \
+           --in out/paradox_edges_v0.jsonl \
+           --atoms out/paradox_field_v0.json


### PR DESCRIPTION
## Summary
Update the docs/examples smoke workflow to validate edges against the atoms source.

## Why
`check_paradox_edges_v0_contract.py` supports `--atoms` for link/type integrity checks.
Running it in CI catches regressions where exported edges have wrong src/dst ids or type mismatches.

## Scope
- One-file change: `.github/workflows/paradox_examples_smoke.yml`

## Testing
CI smoke workflow will run on PR.
