### PR TITLE
ci(examples): run transitions_case_study_v0 acceptance in smoke

### DIFF
--- a/.github/workflows/paradox_examples_smoke.yml
+++ b/.github/workflows/paradox_examples_smoke.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Debug docs example inputs (fail-fast)
+      - name: Debug workflow context
         shell: bash
         run: |
           set -euo pipefail
@@ -40,16 +40,28 @@ jobs:
           echo "github.ref:  ${{ github.ref }}"
           echo "github.sha:  ${{ github.sha }}"
           echo "HEAD:        $(git rev-parse HEAD)"
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "PR head sha: ${{ github.event.pull_request.head.sha }}"
-            echo "PR base sha: ${{ github.event.pull_request.base.sha }}"
-          fi
-          echo ""
+
+      - name: Debug PR context
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "PR head sha: ${{ github.event.pull_request.head.sha }}"
+          echo "PR base sha: ${{ github.event.pull_request.base.sha }}"
+
+      - name: Debug docs example inputs (fail-fast)
+        shell: bash
+        run: |
+          set -euo pipefail
           echo "Listing docs/examples/transitions_case_study_v0:"
           ls -la docs/examples/transitions_case_study_v0
           echo ""
           echo "Checking required overlay input exists:"
           test -f docs/examples/transitions_case_study_v0/pulse_overlay_drift_v0.json
+          echo ""
+          echo "Acceptance script candidates:"
+          ls -la scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py 2>/dev/null || true
+          ls -la scripts/scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py 2>/dev/null || true
 
       - name: Run docs/examples transitions_case_study_v0
         shell: bash
@@ -73,6 +85,17 @@ jobs:
             --in out/paradox_edges_v0.jsonl \
             --atoms out/paradox_field_v0.json
 
-          python scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py \
-            --in out/paradox_edges_v0.jsonl
-
+          ACCEPT="scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py"
+          if [ -f "$ACCEPT" ]; then
+            python "$ACCEPT" --in out/paradox_edges_v0.jsonl
+          elif [ -f "scripts/scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py" ]; then
+            python "scripts/scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py" \
+              --in out/paradox_edges_v0.jsonl
+          else
+            echo "[docs_examples_smoke] acceptance script not found in scripts/ or scripts/scripts/"
+            echo "ls -la scripts:"
+            ls -la scripts
+            echo "ls -la scripts/scripts (if exists):"
+            ls -la scripts/scripts || true
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
Run the transitions_case_study_v0 acceptance script as the final step in the docs/examples smoke workflow.

## Why
Contract checks validate structure and ordering, but the example should also be pinned to a few stable invariants:
- expected run_context (run_pair_id + sha1 keys)
- a small must-contain set of tension edges

This catches drift early and keeps CI failures clear.

## Changes
- Add a final workflow step to run:
  `scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py`

## Testing
CI: `paradox_examples_smoke` (docs_examples_smoke job)
