### PR TITLE
chore(contract): require run_pair_id and consistent run_context in edges

### DIFF
--- a/scripts/check_paradox_edges_v0_contract.py
+++ b/scripts/check_paradox_edges_v0_contract.py
@@ -2,23 +2,14 @@
 """
 check_paradox_edges_v0_contract.py — fail-closed contract checker for paradox_edges_v0.jsonl.
 
-This validator is for the *edges* layer (JSONL), and optionally checks link integrity
-against paradox_field_v0.json (atoms) when `--atoms` is provided.
-
-Why this exists:
-- docs + CI reference `paradox_edges_v0.jsonl`
-- edges are JSONL (1 JSON object per line), not a single JSON object
-- we must preserve:
-  - JSONL parsing robustness
-  - deterministic ordering checks
-  - uniqueness checks
-  - link/type validation against atoms when `--atoms` is provided
-  - cross-check: edge src/dst must match the linked tension atom evidence (when `--atoms` is provided)
-
-Usage:
-  python scripts/check_paradox_edges_v0_contract.py \
-    --in out/paradox_edges_v0.jsonl \
-    --atoms out/paradox_field_v0.json
+Validates:
+- JSONL parse robustness
+- deterministic ordering (severity, type, edge_id)
+- uniqueness of edge_id
+- required fields
+- optional run_context validation + file-level consistency
+- optional link/type validation against atoms when --atoms is provided
+- cross-check: edge src/dst must match linked tension atom evidence when --atoms is provided
 """
 
 from __future__ import annotations
@@ -32,7 +23,6 @@ from typing import Any, Dict, Optional, Tuple
 
 SEVERITY_ORDER = {"crit": 0, "warn": 1, "info": 2}
 
-# v0 edge types and their expected atom link types
 EDGE_TYPE_SPECS: Dict[str, Dict[str, str]] = {
     "gate_metric_tension": {
         "src_atom_type": "gate_flip",
@@ -85,7 +75,7 @@ def _load_atoms(atoms_path: str) -> Dict[str, Dict[str, Any]]:
         die(f"atoms file malformed: expected list at paradox_field_v0.atoms: {atoms_path}")
 
     by_id: Dict[str, Dict[str, Any]] = {}
-    for i, a in enumerate(atoms):
+    for a in atoms:
         if not isinstance(a, dict):
             continue
         aid = a.get("atom_id")
@@ -94,7 +84,6 @@ def _load_atoms(atoms_path: str) -> Dict[str, Dict[str, Any]]:
             continue
         if not isinstance(atype, str) or not atype.strip():
             continue
-        # last wins, but should be unique anyway
         by_id[aid] = a
     return by_id
 
@@ -106,49 +95,50 @@ def _edge_key(edge: Dict[str, Any]) -> Tuple[int, str, str]:
     return (sev, str(et or ""), str(eid or ""))
 
 
-def _validate_run_context(run_ctx: Any, line_no: int) -> None:
+def _normalize_run_context(run_ctx: Any, line_no: int) -> Optional[Dict[str, str]]:
+    """
+    run_context is optional. If present:
+      - must be dict
+      - must contain run_pair_id as non-empty string
+      - known sha1 fields, if present, must be 40-hex sha1
+      - returns a normalized dict of stable keys for file-level consistency checks
+    """
     if run_ctx is None:
-        return
+        return None
     if not isinstance(run_ctx, dict):
-        die(f"line {line_no}: run_context must be an object if present")
+        die(f"line {line_no}: run_context must be an object/dict when present")
 
-    # Optional but if present must be strings; sha1s should look like sha1.
-    def _opt_sha1(k: str) -> None:
+    rpid = run_ctx.get("run_pair_id")
+    if not isinstance(rpid, str) or not rpid.strip():
+        die(f"line {line_no}: run_context.run_pair_id must be a non-empty string when run_context is present")
+    rpid = rpid.strip()
+
+    sha1_keys = [
+        "status_sha1",
+        "g_field_sha1",
+        "transitions_gate_csv_sha1",
+        "transitions_metric_csv_sha1",
+        "transitions_overlay_json_sha1",
+        "transitions_json_sha1",
+    ]
+
+    norm: Dict[str, str] = {"run_pair_id": rpid}
+
+    for k in sha1_keys:
         v = run_ctx.get(k)
         if v is None:
-            return
-        if not isinstance(v, str) or not _is_hex(v, 40):
-            die(f"line {line_no}: run_context.{k} must be a 40-hex sha1 if present")
-
-    def _opt_str(k: str) -> None:
-        v = run_ctx.get(k)
-        if v is None:
-            return
+            continue
         if not isinstance(v, str) or not v.strip():
             die(f"line {line_no}: run_context.{k} must be a non-empty string if present")
+        vv = v.strip()
+        if not _is_hex(vv, 40):
+            die(f"line {line_no}: run_context.{k} must be a 40-hex sha1 if present")
+        norm[k] = vv
 
-    _opt_str("run_pair_id")
-    _opt_sha1("transitions_gate_csv_sha1")
-    _opt_sha1("transitions_metric_csv_sha1")
-    _opt_sha1("transitions_overlay_json_sha1")
-    _opt_sha1("transitions_json_sha1")
-    _opt_sha1("status_sha1")
-    _opt_sha1("g_field_sha1")
+    return norm
 
 
 def _tension_expected_src_dst(edge_type: str, tension_atom: Dict[str, Any], line_no: int) -> Tuple[str, str]:
-    """
-    Derive the expected (src_atom_id, dst_atom_id) from the linked tension atom.
-
-    Prefer C4.3 aliases on the tension atom evidence:
-      - evidence.src_atom_id / evidence.dst_atom_id
-
-    If either alias key exists, require both to be non-empty strings (fail-closed).
-
-    Fallback to legacy per-type keys:
-      - gate_metric_tension: evidence.gate_atom_id + evidence.metric_atom_id
-      - gate_overlay_tension: evidence.gate_atom_id + evidence.overlay_atom_id
-    """
     ev = tension_atom.get("evidence")
     if not isinstance(ev, dict):
         die(f"line {line_no}: tension atom evidence must be an object/dict")
@@ -182,7 +172,7 @@ def _tension_expected_src_dst(edge_type: str, tension_atom: Dict[str, Any], line
         return gate_id, over_id.strip()
 
     die(f"line {line_no}: unsupported edge type for tension cross-check: {edge_type}")
-    raise SystemExit(2)  # unreachable (for type checkers)
+    raise SystemExit(2)
 
 
 def main() -> int:
@@ -205,6 +195,11 @@ def main() -> int:
     prev_key: Optional[Tuple[int, str, str]] = None
     edges_count = 0
 
+    # run_context consistency (file-level)
+    expected_run_context: Optional[Dict[str, str]] = None
+    saw_run_context = False
+    saw_missing_run_context = False
+
     with open(args.in_path, "r", encoding="utf-8") as f:
         for line_no, raw in enumerate(f, start=1):
             line = raw.strip()
@@ -219,7 +214,6 @@ def main() -> int:
             if not isinstance(edge, dict):
                 die(f"line {line_no}: edge must be a JSON object")
 
-            # ---- Required fields
             edge_id = edge.get("edge_id")
             edge_type = edge.get("type")
             src_atom_id = edge.get("src_atom_id")
@@ -236,15 +230,18 @@ def main() -> int:
 
             if not isinstance(edge_type, str) or not edge_type.strip():
                 die(f"line {line_no}: type must be a non-empty string")
+            edge_type = edge_type.strip()
 
             if edge_type not in EDGE_TYPE_SPECS:
                 die(f"line {line_no}: unknown edge type '{edge_type}' (v0 allowlist: {sorted(EDGE_TYPE_SPECS)})")
 
             if not isinstance(src_atom_id, str) or not src_atom_id.strip():
                 die(f"line {line_no}: src_atom_id must be a non-empty string")
+            src_atom_id = src_atom_id.strip()
 
             if not isinstance(dst_atom_id, str) or not dst_atom_id.strip():
                 die(f"line {line_no}: dst_atom_id must be a non-empty string")
+            dst_atom_id = dst_atom_id.strip()
 
             if not isinstance(severity, str) or severity not in SEVERITY_ORDER:
                 die(f"line {line_no}: severity must be one of {sorted(SEVERITY_ORDER)}")
@@ -252,14 +249,14 @@ def main() -> int:
             if not isinstance(rule, str) or not rule.strip():
                 die(f"line {line_no}: rule must be a non-empty string")
 
-            # ---- Required for v0 tension edges
             tension_atom_id = edge.get("tension_atom_id")
             if tension_atom_id is None:
                 die(f"line {line_no}: missing tension_atom_id (required for v0 tension edges)")
             if not isinstance(tension_atom_id, str) or not _is_hex(tension_atom_id, 12):
                 die(f"line {line_no}: tension_atom_id must be 12-hex string")
+            tension_atom_id = tension_atom_id.strip()
 
-            # ---- Deterministic ordering
+            # Deterministic ordering
             k = _edge_key(edge)
             if prev_key is not None and k < prev_key:
                 die(
@@ -268,10 +265,21 @@ def main() -> int:
                 )
             prev_key = k
 
-            # ---- Optional run_context validation
-            _validate_run_context(edge.get("run_context"), line_no)
+            # run_context validation + file-level consistency
+            rc_norm = _normalize_run_context(edge.get("run_context"), line_no)
+            if rc_norm is None:
+                saw_missing_run_context = True
+            else:
+                saw_run_context = True
+                if expected_run_context is None:
+                    expected_run_context = rc_norm
+                elif rc_norm != expected_run_context:
+                    die(
+                        f"line {line_no}: run_context mismatch across edges; "
+                        f"expected {expected_run_context!r}, got {rc_norm!r}"
+                    )
 
-            # ---- Link/type validation against atoms (if provided)
+            # If atoms provided: link/type validation + cross-check vs tension evidence
             if atoms_by_id:
                 spec = EDGE_TYPE_SPECS[edge_type]
 
@@ -281,9 +289,9 @@ def main() -> int:
                         die(f"line {line_no}: {what} atom_id not found in atoms: {aid}")
                     return a
 
-                src_atom = _must_atom(src_atom_id.strip(), "src")
-                dst_atom = _must_atom(dst_atom_id.strip(), "dst")
-                tens_atom = _must_atom(tension_atom_id.strip(), "tension")
+                src_atom = _must_atom(src_atom_id, "src")
+                dst_atom = _must_atom(dst_atom_id, "dst")
+                tens_atom = _must_atom(tension_atom_id, "tension")
 
                 src_type = src_atom.get("type")
                 dst_type = dst_atom.get("type")
@@ -307,15 +315,18 @@ def main() -> int:
                         f"expected '{spec['tension_atom_type']}', got '{tens_type}'"
                     )
 
-                # ---- Cross-check: edge endpoints must match tension atom evidence links
                 exp_src, exp_dst = _tension_expected_src_dst(edge_type, tens_atom, line_no)
-                if exp_src != src_atom_id.strip() or exp_dst != dst_atom_id.strip():
+                if exp_src != src_atom_id or exp_dst != dst_atom_id:
                     die(
                         f"line {line_no}: edge src/dst mismatch vs tension_atom_id evidence; "
-                        f"expected ({exp_src},{exp_dst}), got ({src_atom_id.strip()},{dst_atom_id.strip()})"
+                        f"expected ({exp_src},{exp_dst}), got ({src_atom_id},{dst_atom_id})"
                     )
 
             edges_count += 1
+
+    # Mixed presence is not allowed: either all edges have run_context or none do.
+    if saw_run_context and saw_missing_run_context:
+        die("mixed run_context presence across edges; include run_context on all edges or none")
 
     print(f"[edges-contract] OK (edges={edges_count})")
     return 0
@@ -325,6 +336,5 @@ if __name__ == "__main__":
     try:
         raise SystemExit(main())
     except BrokenPipeError:
-        # allow piping to head etc.
         raise SystemExit(0)
 


### PR DESCRIPTION
## Summary
Make `run_pair_id` required when `run_context` is present in edges, and enforce file-level consistency.

## Why
Field contract (C4.2) requires `meta.run_context.run_pair_id` when run_context exists. Allowing edges to have mixed/missing run_pair_id undermines field↔edges correlation and edge_id reproducibility.

## Behavior
- Backward compatible: edges with no run_context still pass.
- If any edge has run_context:
  - run_pair_id is required
  - run_context must be present on all edges
  - normalized run_context must match across all edges

## Testing
✅ python scripts/check_paradox_edges_v0_contract.py --in out/paradox_edges_v0.jsonl --atoms out/paradox_field_v0.json
