### PR TITLE
test(examples): validate transitions_case_study_v0 via field↔edges join

### DIFF
--- a/scripts/scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py
+++ b/scripts/scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py
@@ -2,16 +2,15 @@
 """
 check_paradox_examples_transitions_case_study_v0_acceptance.py
 
-Acceptance check for the non-fixture example under:
-  docs/examples/transitions_case_study_v0/
+Acceptance check for docs/examples/transitions_case_study_v0 outputs.
 
-This script is intentionally strict and pins a small set of invariants so the
-example remains reproducible and CI-friendly.
+Goal:
+- Validate the example stays reproducible and CI-friendly.
+- Validate field ↔ edges correlation using run_context equality.
+- Validate a few semantic invariants (metrics + allowlisted overlay tensions).
 
-It validates:
-- edges JSONL is readable and non-empty
-- run_context contains expected sha1 keys and expected run_pair_id
-- must-contain tension edges by tension_atom_id + type
+This is intentionally strict where it matters (join integrity + semantics),
+and intentionally NOT hard-pinning file sha1 values (to avoid brittle churn).
 
 Usage:
   python scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py \
@@ -24,27 +23,20 @@ import argparse
 import json
 import os
 import sys
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 
-EXPECTED_RUN_CONTEXT: Dict[str, str] = {
-    "run_pair_id": "3171fcc1fc47",
-    "transitions_gate_csv_sha1": "0b23b3f9f7c0327484afe9d5ca36f7a482eafd84",
-    "transitions_metric_csv_sha1": "78d179ec69c3ba506efc467b36c46513270110fe",
-    "transitions_overlay_json_sha1": "fa475eb7fe00a607c4b510b7dbbda944ed9c742c",
-    "transitions_json_sha1": "f8ed75d20643814c6bf7c1a6ce7b7af90cae0e1f",
-}
-
-# Must-contain tension edges for the docs example.
-EXPECTED_TENSION_EDGES: List[Dict[str, str]] = [
-    {"type": "gate_metric_tension", "tension_atom_id": "f5c720a2599a"},
-    {"type": "gate_metric_tension", "tension_atom_id": "621a91f73ac2"},
-    {"type": "gate_overlay_tension", "tension_atom_id": "64306cf439b0"},
-]
+EXPECTED_METRICS: Set[str] = {"p99_latency", "cpu_util"}
+OVERLAY_ALLOWLIST: Set[str] = {"g_field_v0", "paradox_field_v0"}
 
 
 def die(msg: str, code: int = 2) -> None:
     raise SystemExit(f"[examples-acceptance] {msg}")
+
+
+def _read_json(path: str) -> Any:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 def _read_jsonl(path: str) -> List[Dict[str, Any]]:
@@ -64,6 +56,18 @@ def _read_jsonl(path: str) -> List[Dict[str, Any]]:
     return out
 
 
+def _as_dict(x: Any, path: str) -> Dict[str, Any]:
+    if not isinstance(x, dict):
+        die(f"{path} must be an object/dict")
+    return x
+
+
+def _as_list(x: Any, path: str) -> List[Any]:
+    if not isinstance(x, list):
+        die(f"{path} must be an array/list")
+    return x
+
+
 def _req_str(d: Dict[str, Any], k: str, path: str) -> str:
     v = d.get(k)
     if not isinstance(v, str) or not v.strip():
@@ -71,59 +75,177 @@ def _req_str(d: Dict[str, Any], k: str, path: str) -> str:
     return v.strip()
 
 
+def _load_field_atoms(atoms_path: str) -> Tuple[Dict[str, Any], Dict[str, Dict[str, Any]], List[Dict[str, Any]]]:
+    data = _read_json(atoms_path)
+    root = data.get("paradox_field_v0", data) if isinstance(data, dict) else data
+    root = _as_dict(root, "$")
+
+    meta = root.get("meta")
+    meta = meta if isinstance(meta, dict) else {}
+    atoms_any = root.get("atoms")
+    atoms_list = _as_list(atoms_any, "$.atoms")
+
+    atoms: List[Dict[str, Any]] = []
+    id_to_atom: Dict[str, Dict[str, Any]] = {}
+    for i, a in enumerate(atoms_list):
+        if not isinstance(a, dict):
+            die(f"$.atoms[{i}] must be an object/dict")
+        aid = _req_str(a, "atom_id", f"$.atoms[{i}]")
+        id_to_atom[aid] = a
+        atoms.append(a)
+
+    return meta, id_to_atom, atoms
+
+
+def _extract_overlay_changes(atoms: List[Dict[str, Any]]) -> Set[str]:
+    changed: Set[str] = set()
+    for a in atoms:
+        if not isinstance(a, dict):
+            continue
+        if a.get("type") != "overlay_change":
+            continue
+        refs = a.get("refs")
+        if not isinstance(refs, dict):
+            continue
+        overs = refs.get("overlays")
+        if not isinstance(overs, list):
+            continue
+        for o in overs:
+            if isinstance(o, str) and o.strip():
+                changed.add(o.strip())
+    return changed
+
+
+def _tension_metric_name(tension_atom: Dict[str, Any]) -> str:
+    # Prefer evidence.metric.name; fallback to refs.metrics[0]
+    ev = tension_atom.get("evidence")
+    if isinstance(ev, dict):
+        mm = ev.get("metric")
+        if isinstance(mm, dict) and isinstance(mm.get("name"), str) and mm.get("name").strip():
+            return mm.get("name").strip()
+
+    refs = tension_atom.get("refs")
+    if isinstance(refs, dict):
+        ms = refs.get("metrics")
+        if isinstance(ms, list) and ms and isinstance(ms[0], str) and ms[0].strip():
+            return ms[0].strip()
+
+    return ""
+
+
+def _tension_overlay_name(tension_atom: Dict[str, Any]) -> str:
+    # Prefer evidence.overlay.name; fallback to refs.overlays[0]
+    ev = tension_atom.get("evidence")
+    if isinstance(ev, dict):
+        oo = ev.get("overlay")
+        if isinstance(oo, dict) and isinstance(oo.get("name"), str) and oo.get("name").strip():
+            return oo.get("name").strip()
+
+    refs = tension_atom.get("refs")
+    if isinstance(refs, dict):
+        os_ = refs.get("overlays")
+        if isinstance(os_, list) and os_ and isinstance(os_[0], str) and os_[0].strip():
+            return os_[0].strip()
+
+    return ""
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(
-        description="Acceptance check for docs/examples/transitions_case_study_v0 edges output (JSONL)."
+        description="Acceptance check for docs/examples/transitions_case_study_v0 outputs (field ↔ edges join + semantics)."
     )
-    ap.add_argument("--in", dest="in_path", required=True, help="Path to paradox_edges_v0.jsonl")
+    ap.add_argument("--in", dest="edges_path", required=True, help="Path to paradox_edges_v0.jsonl")
+    ap.add_argument(
+        "--atoms",
+        dest="atoms_path",
+        default="",
+        help="Optional path to paradox_field_v0.json (default: derive from edges path directory).",
+    )
     args = ap.parse_args()
 
-    if not os.path.isfile(args.in_path):
-        die(f"file not found: {args.in_path}")
+    if not os.path.isfile(args.edges_path):
+        die(f"edges file not found: {args.edges_path}")
 
-    edges = _read_jsonl(args.in_path)
+    # Default atoms path: same dir as edges file
+    atoms_path = args.atoms_path.strip() if isinstance(args.atoms_path, str) else ""
+    if not atoms_path:
+        atoms_path = os.path.join(os.path.dirname(os.path.abspath(args.edges_path)), "paradox_field_v0.json")
+
+    if not os.path.isfile(atoms_path):
+        die(f"atoms file not found (expected next to edges): {atoms_path}")
+
+    meta, id_to_atom, atoms = _load_field_atoms(atoms_path)
+
+    # Require meta.run_context (the example is meant to exercise C4.2)
+    rc = meta.get("run_context")
+    if not isinstance(rc, dict):
+        die("$.meta.run_context must be an object/dict (example expects run_context present)")
+    _ = _req_str(rc, "run_pair_id", "$.meta.run_context")
+
+    edges = _read_jsonl(args.edges_path)
     if not edges:
         die("edges JSONL is empty")
 
-    # Validate run_context and pin expected keys/values.
+    # 1) Field ↔ edges correlation: require exact run_context equality per edge
     for i, e in enumerate(edges):
-        path = f"edges[{i}]"
-        _req_str(e, "edge_id", path)
-        _req_str(e, "type", path)
-        _req_str(e, "severity", path)
-        _req_str(e, "src_atom_id", path)
-        _req_str(e, "dst_atom_id", path)
-        _req_str(e, "tension_atom_id", path)
-        _req_str(e, "rule", path)
+        if not isinstance(e, dict):
+            die(f"edges[{i}] must be an object/dict")
+        erc = e.get("run_context")
+        if not isinstance(erc, dict):
+            die(f"edges[{i}].run_context must be an object/dict")
+        if erc != rc:
+            die(f"edges[{i}].run_context does not match field meta.run_context")
 
-        rc = e.get("run_context")
-        if not isinstance(rc, dict):
-            die(f"{path}.run_context must be an object/dict")
+    # 2) Semantic invariants: map edges → tension atoms → metric/overlay names
+    metric_tensions: Set[str] = set()
+    overlay_tensions: Set[str] = set()
 
-        # Ensure expected run_context fields exist and match.
-        for k, expected in EXPECTED_RUN_CONTEXT.items():
-            got = rc.get(k)
-            if not isinstance(got, str) or not got.strip():
-                die(f"{path}.run_context.{k} missing or not a non-empty string")
-            if got.strip() != expected:
-                die(
-                    f"{path}.run_context.{k} mismatch: expected {expected!r}, got {got.strip()!r}"
-                )
+    for i, e in enumerate(edges):
+        typ = e.get("type")
+        if not isinstance(typ, str) or not typ.strip():
+            continue
+        tid = e.get("tension_atom_id")
+        if not isinstance(tid, str) or not tid.strip():
+            die(f"edges[{i}].tension_atom_id must be a non-empty string")
+        tid = tid.strip()
 
-    # Must-contain expected tension edges
-    def _has_edge(expect: Dict[str, str]) -> bool:
-        et = expect["type"]
-        tid = expect["tension_atom_id"]
-        for e in edges:
-            if e.get("type") == et and e.get("tension_atom_id") == tid:
-                return True
-        return False
+        t_atom = id_to_atom.get(tid)
+        if not isinstance(t_atom, dict):
+            die(f"edges[{i}] tension_atom_id not found in atoms: {tid}")
 
-    for ex in EXPECTED_TENSION_EDGES:
-        if not _has_edge(ex):
-            die(f"missing expected edge: type={ex['type']!r} tension_atom_id={ex['tension_atom_id']!r}")
+        # sanity: edge.type should match the tension atom type
+        t_type = t_atom.get("type")
+        if isinstance(t_type, str) and t_type.strip() and t_type.strip() != typ.strip():
+            die(f"edges[{i}] edge.type != tension atom type for tension_atom_id={tid}")
 
-    print(f"[examples-acceptance] OK (edges={len(edges)})")
+        if typ.strip() == "gate_metric_tension":
+            name = _tension_metric_name(t_atom)
+            if name:
+                metric_tensions.add(name)
+
+        if typ.strip() == "gate_overlay_tension":
+            oname = _tension_overlay_name(t_atom)
+            if oname:
+                overlay_tensions.add(oname)
+
+    missing_metrics = sorted(EXPECTED_METRICS - metric_tensions)
+    if missing_metrics:
+        die(f"missing expected gate_metric_tension metrics: {missing_metrics}")
+
+    # 3) Overlay invariants:
+    # If an allowlisted overlay has an overlay_change atom, we expect a corresponding gate_overlay_tension edge.
+    overlays_changed = _extract_overlay_changes(atoms) & OVERLAY_ALLOWLIST
+    if not overlays_changed:
+        die(f"expected at least one allowlisted overlay_change in field (allowlist={sorted(OVERLAY_ALLOWLIST)})")
+
+    for o in sorted(overlays_changed):
+        if o not in overlay_tensions:
+            die(f"missing gate_overlay_tension for allowlisted changed overlay: {o!r}")
+
+    print(
+        f"[examples-acceptance] OK (edges={len(edges)}, "
+        f"metric_tensions={sorted(metric_tensions)}, overlay_tensions={sorted(overlay_tensions)})"
+    )
     return 0
 
 
@@ -132,3 +254,4 @@ if __name__ == "__main__":
         raise SystemExit(main())
     except BrokenPipeError:
         sys.exit(0)
+


### PR DESCRIPTION
## Summary
Make the docs example acceptance check semantic and robust by validating outputs via the generated paradox_field atoms.

## Why
Hard-pinning sha1/run_pair_id values is brittle (formatting churn) and does not add much signal.
This acceptance focuses on the intended invariants:
- field↔edges run_context integrity
- expected metric tensions
- allowlisted overlay tensions when overlay_change atoms are present

## Testing
CI: paradox_examples_smoke / docs_examples_smoke
