### PR TITLE
docs(examples): add g_field_v0 overlay drift to transitions_case_stud…

### DIFF
--- a/docs/examples/transitions_case_study_v0/pulse_overlay_drift_v0.json
+++ b/docs/examples/transitions_case_study_v0/pulse_overlay_drift_v0.json
@@ -1,4 +1,22 @@
 {
+  "g_field_v0": {
+    "path_a": "artifacts/g_field_v0.json",
+    "path_b": "artifacts/g_field_v0.json",
+    "present_a": true,
+    "present_b": true,
+    "sha1_a": "cccccccccccccccccccccccccccccccccccccccc",
+    "sha1_b": "dddddddddddddddddddddddddddddddddddddddd",
+    "top_level_diff": {
+      "added_keys": [],
+      "changed_keys": [
+        "nodes",
+        "edges",
+        "providers"
+      ],
+      "note": "Example: G-field overlay drift",
+      "removed_keys": []
+    }
+  },
   "paradox_field_v0": {
     "path_a": "artifacts/paradox_field_v0.json",
     "path_b": "artifacts/paradox_field_v0.json",
@@ -19,3 +37,4 @@
     }
   }
 }
+


### PR DESCRIPTION
## Summary
Add a `g_field_v0` overlay drift block to the docs/examples transitions_case_study_v0 input.

## Why
This makes the e2e example cover the G-field integration path in the paradox layer:
overlay drift → overlay_change atom → gate_overlay_tension edge (allowlisted).

## Testing
CI: paradox_examples_smoke / docs_examples_smoke
