### PR TITLE
chore(examples): add canonical acceptance entrypoint wrapper

### DIFF
--- a/scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py
+++ b/scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py
@@ -2,13 +2,13 @@
 """
 check_paradox_examples_transitions_case_study_v0_acceptance.py
 
-Thin wrapper to keep the acceptance checker discoverable at:
-  scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py
+Canonical entrypoint for the docs example acceptance checker.
 
-The real implementation currently lives under:
+The real implementation currently lives here:
   scripts/scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py
 
-This wrapper avoids CI "Permission denied" issues and stabilizes the call site.
+This wrapper stabilizes the call site for CI and local runs and avoids
+"Permission denied" issues (always run via `python ...`).
 """
 
 from __future__ import annotations
@@ -27,9 +27,16 @@ def main() -> int:
 
     # Make argparse/help output refer to the real script path
     sys.argv[0] = target
+
+    # Ensure the target directory is importable (defensive)
+    target_dir = os.path.dirname(target)
+    if target_dir and target_dir not in sys.path:
+        sys.path.insert(0, target_dir)
+
     runpy.run_path(target, run_name="__main__")
     return 0
 
 
 if __name__ == "__main__":
     raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
Add a canonical acceptance checker entrypoint at:
- `scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py`

The wrapper delegates to the existing implementation under:
- `scripts/scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py`

## Why
This removes CI brittleness around nested paths and avoids direct-execution permission issues by standardizing on `python scripts/...`.

## Testing
Covered by the `paradox_examples_smoke` workflow after the follow-up workflow PR.
