### PR TITLE
ci(smoke): call example acceptance via canonical scripts entrypoint

### DIFF
--- a/.github/workflows/paradox_examples_smoke.yml
+++ b/.github/workflows/paradox_examples_smoke.yml
@@ -40,6 +40,7 @@ jobs:
           echo "github.ref:  ${{ github.ref }}"
           echo "github.sha:  ${{ github.sha }}"
           echo "HEAD:        $(git rev-parse HEAD)"
+          python -V
 
       - name: Debug PR context
         if: github.event_name == 'pull_request'
@@ -59,8 +60,10 @@ jobs:
           echo "Checking required overlay input exists:"
           test -f docs/examples/transitions_case_study_v0/pulse_overlay_drift_v0.json
           echo ""
-          echo "Acceptance script candidates:"
-          ls -la scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py 2>/dev/null || true
+          echo "Checking canonical acceptance entrypoint exists:"
+          test -f scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py
+          echo ""
+          echo "Listing acceptance implementation (for debugging):"
           ls -la scripts/scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py 2>/dev/null || true
 
       - name: Run docs/examples transitions_case_study_v0
@@ -85,17 +88,6 @@ jobs:
             --in out/paradox_edges_v0.jsonl \
             --atoms out/paradox_field_v0.json
 
-          ACCEPT="scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py"
-          if [ -f "$ACCEPT" ]; then
-            python "$ACCEPT" --in out/paradox_edges_v0.jsonl
-          elif [ -f "scripts/scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py" ]; then
-            python "scripts/scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py" \
-              --in out/paradox_edges_v0.jsonl
-          else
-            echo "[docs_examples_smoke] acceptance script not found in scripts/ or scripts/scripts/"
-            echo "ls -la scripts:"
-            ls -la scripts
-            echo "ls -la scripts/scripts (if exists):"
-            ls -la scripts/scripts || true
-            exit 1
-          fi
+          python scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py \
+            --in out/paradox_edges_v0.jsonl
+


### PR DESCRIPTION
## Summary
Switch the paradox examples smoke workflow to call the acceptance checker via the canonical scripts entrypoint:
- `python scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py`

## Why
Keeps CI stable by removing nested-path ambiguity and prevents direct execution permission issues.

## Testing
- GitHub Actions: `paradox_examples_smoke`
