### PR TITLE
docs(examples): add overlay-only gate drift input

### DIFF
--- a/docs/examples/transitions_case_study_v0_overlay_only/pulse_gate_drift_v0.csv
+++ b/docs/examples/transitions_case_study_v0_overlay_only/pulse_gate_drift_v0.csv
@@ -1,0 +1,2 @@
+gate_id,group,status_a,status_b,pass_a,pass_b,flip,value_a,value_b,threshold,notes_a,notes_b,present_a,present_b
+gate_latency_budget,slo,PASS,FAIL,true,false,true,0.85,0.95,0.90,within budget,over budget,1,1


### PR DESCRIPTION
## Summary
Add `pulse_gate_drift_v0.csv` for `docs/examples/transitions_case_study_v0_overlay_only/`.

## Notes
- Single gate flip row (intentionally small).
- Non-fixture, repo-local example input.

## Testing
Not run (input-only change).
