### PR TITLE
docs(examples): add overlay-only metric drift input

### DIFF
--- a/docs/examples/transitions_case_study_v0_overlay_only/pulse_metric_drift_v0.csv
+++ b/docs/examples/transitions_case_study_v0_overlay_only/pulse_metric_drift_v0.csv
@@ -1,0 +1,3 @@
+metric,a,b,delta,rel_delta,present_a,present_b
+p99_latency,0.850,0.855,0.005,0.00588,1,1
+cpu_util,0.600,0.605,0.005,0.00833,1,1


### PR DESCRIPTION
## Summary
Add `pulse_metric_drift_v0.csv` for `docs/examples/transitions_case_study_v0_overlay_only/`.

## Notes
- Deltas intentionally < 0.01 (abs and rel) to avoid warn/crit metric tensions.
- Keeps the example focused on overlay-only tension.

## Testing
Not run (input-only change).
