### PR TITLE
docs(examples): add overlay-only transitions descriptor

### DIFF
--- a/docs/examples/transitions_case_study_v0_overlay_only/pulse_transitions_v0.json
+++ b/docs/examples/transitions_case_study_v0_overlay_only/pulse_transitions_v0.json
@@ -1,0 +1,9 @@
+{
+  "run_a": {
+    "status_sha1": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "run_b": {
+    "status_sha1": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "notes": "overlay-only example: gate flip + allowlisted overlay drift; metrics stay below warn thresholds"
+}


### PR DESCRIPTION
## Summary
Add `pulse_transitions_v0.json` for `docs/examples/transitions_case_study_v0_overlay_only/`.

## Notes
- Minimal run_a/run_b status_sha1 placeholders.
- Supports stable meta.run_context derivation.

## Testing
Not run (input-only change).
