### PR TITLE
docs(pr-template): add Security Intake (v0) section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,6 +38,75 @@ jobs:
 - Performance / SLO impact:
 - Security considerations:
 
+What’s included
+ Code
+ Docs
+ CI / workflow
+
+Paths / files touched:
+
+CI usage
+
+# Minimal snippet — how this change runs in CI
+name: PULSE CI (minimal)
+on: [push, pull_request]
+jobs:
+  pulse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: python PULSE_safe_pack_v0/tools/run_all.py
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pulse-report
+          path: |
+            PULSE_safe_pack_v0/artifacts/**
+            reports/*.xml
+            reports/*.json
+
+Impact
+Additive / backwards-compatible
+
+Breaking change — details:
+
+Performance / SLO impact:
+
+Security considerations:
+
+### Security Intake (v0) — dependency / external code (if applicable)
+**Intake v0:** PASS | REVIEW | HARD STOP  
+**Isolation used (if REVIEW):** yes / no  
+
+**Reasons (1–3 bullets):**
+- 
+- 
+- 
+
+**Checks**
+- [ ] No password-protected ZIP / random binary download involved
+- [ ] Repo age ≥ 12 months and maintainer history looks real
+- [ ] No postinstall/preinstall scripts (or justified + reviewed)
+- [ ] No obfuscation / base64 blobs / runtime-downloaded binaries
+- [ ] No instructions like “disable Defender/AV”
+- [ ] First run done in VM/container (if REVIEW)
+
+> If any HIGH-risk signal appears → mark **HARD STOP** and do not merge.
+
+Notes
+
+Follow-ups:
+
+Risks / mitigations:
+
+PULSE checklist (governance)
+ PULSE CI is green on this PR
+ Quality Ledger link (if enabled)
+ Badges updated (PASS / RDSI / Q-Ledger)
+
+
 ## Notes
 - Follow-ups:
 - Risks / mitigations:


### PR DESCRIPTION
## What
Adds a “Security Intake (v0)” section to `.github/PULL_REQUEST_TEMPLATE.md` under
“Security considerations” to standardize quick triage for new dependencies / external code.

## Why
Recent supply-chain waves increasingly hide behind polished repos/packages.
A small, repeatable intake gate reduces accidental execution/merge risk.

## Included
- Docs: PR template updated with:
  - PASS / REVIEW / HARD STOP
  - isolation flag
  - compact checklist + hard-stop rule

## Scope
- Additive / backwards-compatible
- No runtime or CI behavior change

## How to use
- If PR introduces new dependency / external code / PoC: fill the section.
- Otherwise: mark as N/A or leave minimal (PASS + short reason).

## Risks / mitigations
- Risk: extra PR friction  
  Mitigation: section is “if applicable” and designed to be short.

## Follow-ups (optional)
- Add a minimal CI guard that enforces presence of “Intake v0:” when dependency files change.
