### PR TITLE
docs(readme): link reproducible transitions case study example

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,11 @@ Reproducible non-fixture example inputs:
 - docs/examples/README.md (includes docs/examples/transitions_case_study_v0/)
 - docs/paradox_edges_case_studies.md
 
+Reproducible non-fixture example (recommended)
+- See: `docs/examples/transitions_case_study_v0/README.md`
+- Repo-local + CI-friendly inputs; do not commit generated outputs under `out/**`.
+- CI runs this example via `paradox_examples_smoke` to catch missing/renamed inputs early.
+
 Notes:
 - Do not commit generated outputs under out/**.
 


### PR DESCRIPTION
## Summary
Add a short README pointer to the reproducible, repo-local non-fixture example:
`docs/examples/transitions_case_study_v0/README.md`.

## Why
The paradox section currently shows fixture-based commands; this makes it harder
for external readers to quickly reproduce an end-to-end run on a small, stable
input set.

## Changes
- Main README: add a "Reproducible non-fixture example" pointer under the
  Paradox field v0 section.
- Document policy reminder: do not commit generated outputs under `out/**`.

## Testing
N/A (docs-only). CI will still run the docs examples smoke where applicable.
