### PR TITLE
ci(examples): call canonical acceptance entrypoint in paradox_example…

### DIFF
--- a/.github/workflows/paradox_examples_smoke.yml
+++ b/.github/workflows/paradox_examples_smoke.yml
@@ -32,39 +32,20 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Debug workflow context
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "event_name: ${{ github.event_name }}"
-          echo "github.ref:  ${{ github.ref }}"
-          echo "github.sha:  ${{ github.sha }}"
-          echo "HEAD:        $(git rev-parse HEAD)"
-          python -V
-
-      - name: Debug PR context
-        if: github.event_name == 'pull_request'
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "PR head sha: ${{ github.event.pull_request.head.sha }}"
-          echo "PR base sha: ${{ github.event.pull_request.base.sha }}"
-
-      - name: Debug docs example inputs (fail-fast)
+      - name: Verify docs example inputs exist (fail-fast)
         shell: bash
         run: |
           set -euo pipefail
           echo "Listing docs/examples/transitions_case_study_v0:"
           ls -la docs/examples/transitions_case_study_v0
-          echo ""
-          echo "Checking required overlay input exists:"
+          test -f docs/examples/transitions_case_study_v0/pulse_gate_drift_v0.csv
+          test -f docs/examples/transitions_case_study_v0/pulse_metric_drift_v0.csv
           test -f docs/examples/transitions_case_study_v0/pulse_overlay_drift_v0.json
+          test -f docs/examples/transitions_case_study_v0/pulse_transitions_v0.json
+
           echo ""
-          echo "Checking canonical acceptance entrypoint exists:"
-          test -f scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py
-          echo ""
-          echo "Listing acceptance implementation (for debugging):"
-          ls -la scripts/scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py 2>/dev/null || true
+          echo "Acceptance entrypoint:"
+          ls -la scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py
 
       - name: Run docs/examples transitions_case_study_v0
         shell: bash


### PR DESCRIPTION
## Summary
Make the docs examples smoke workflow call the canonical acceptance entrypoint under `scripts/`.

## Why
We now have a stable wrapper at:
- `scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py`

Calling `scripts/scripts/...` (or probing multiple locations) adds ambiguity and can fail due to execute-bit/permission issues. The CI should invoke the entrypoint deterministically via `python`.

## Changes
- Fail-fast check for required example inputs
- Run `paradox_field_adapter_v0.py` → field contract → edges export → edges contract
- Run acceptance via the canonical wrapper (python)

## Testing
- CI: `paradox_examples_smoke / docs_examples_smoke`
