### PR TITLE
ci(examples): call canonical acceptance checker in paradox_examples_s…

### DIFF
--- a/.github/workflows/paradox_examples_smoke.yml
+++ b/.github/workflows/paradox_examples_smoke.yml
@@ -19,9 +19,6 @@ jobs:
   docs_examples_smoke:
     runs-on: ubuntu-latest
     steps:
-      # Default checkout:
-      # - pull_request: checks out refs/pull/<id>/merge (merged result)
-      # - push: checks out the pushed commit
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -36,16 +33,26 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          echo "event_name: ${{ github.event_name }}"
+          echo "github.ref:  ${{ github.ref }}"
+          echo "github.sha:  ${{ github.sha }}"
+          echo "HEAD:        $(git rev-parse HEAD)"
+
+          echo ""
           echo "Listing docs/examples/transitions_case_study_v0:"
           ls -la docs/examples/transitions_case_study_v0
+
+          # Required example inputs (fixed filenames expected by adapters)
+          test -f docs/examples/transitions_case_study_v0/README.md
           test -f docs/examples/transitions_case_study_v0/pulse_gate_drift_v0.csv
           test -f docs/examples/transitions_case_study_v0/pulse_metric_drift_v0.csv
           test -f docs/examples/transitions_case_study_v0/pulse_overlay_drift_v0.json
           test -f docs/examples/transitions_case_study_v0/pulse_transitions_v0.json
 
           echo ""
-          echo "Acceptance entrypoint:"
-          ls -la scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py
+          echo "Checking canonical acceptance entrypoint exists:"
+          test -f scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py
 
       - name: Run docs/examples transitions_case_study_v0
         shell: bash


### PR DESCRIPTION
## Summary
Make paradox_examples_smoke call the canonical transitions_case_study_v0 acceptance checker from `scripts/` using python.

## Why
Directly invoking scripts under `scripts/scripts/` can fail due to execution permissions and path drift. The repository now provides a stable wrapper entrypoint, so CI should consistently call it.

## Changes
- Fail-fast: verify required example inputs exist with fixed filenames
- Run acceptance via:
  `python scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py --in out/paradox_edges_v0.jsonl`

## Testing
CI: paradox_examples_smoke / docs_examples_smoke
