### PR TITLE
docs(scripts): clarify canonical acceptance entrypoint wrapper

### DIFF
--- a/scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py
+++ b/scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py
@@ -9,6 +9,11 @@ The real implementation currently lives here:
 
 This wrapper stabilizes the call site for CI and local runs and avoids
 "Permission denied" issues (always run via `python ...`).
+
+NOTE (canonical entrypoint):
+- This file is the stable CI entrypoint for the docs example acceptance check.
+- Always invoke via `python ...` (do not rely on executable permissions).
+- Keep this path stable even if the implementation moves (it may delegate internally).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
Clarify the canonical acceptance entrypoint by folding the NOTE into the module docstring.

## Why
- Avoids a stray top-level string literal.
- Makes it obvious that the stable CI/local entrypoint is `scripts/...` and should be invoked via `python ...`.
- Preserves the intended contract: entrypoint stays stable even if the implementation path moves.

## Changes
- `scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py`: docstring cleanup + canonical-entrypoint note placement.

## Testing
Not run (docs-only change).
