### PR TITLE
chore(contract): enforce edge severity integrity against tension atoms

### DIFF
--- a/scripts/check_paradox_edges_v0_contract.py
+++ b/scripts/check_paradox_edges_v0_contract.py
@@ -314,6 +314,20 @@ def main() -> int:
                         f"line {line_no}: tension_atom_id type mismatch for '{edge_type}': "
                         f"expected '{spec['tension_atom_type']}', got '{tens_type}'"
                     )
+                
+              # Severity integrity: edge.severity must match the tension atom severity
+                tens_sev = tens_atom.get("severity")
+                if not isinstance(tens_sev, str) or tens_sev not in SEVERITY_ORDER:
+                    die(
+                        f"line {line_no}: tension atom has invalid severity "
+                        f"(tension_atom_id={tension_atom_id!r}, got={tens_sev!r})"
+                    )
+
+                if tens_sev != severity:
+                    die(
+                        f"line {line_no}: edge.severity does not match tension atom severity "
+                        f"(edge={severity!r} != tension={tens_sev!r}, tension_atom_id={tension_atom_id!r})"
+                    )
 
                 # Cross-check: edge endpoints must match tension atom evidence links
                 tens_ev = tens_atom.get("evidence")


### PR DESCRIPTION
## Summary
Tighten the edges v0 contract: when `--atoms` is provided, require `edge.severity` to match the referenced tension atom severity.

## Why
Downstream uses edge severity for ranking/triage. If severity diverges from the tension atom, the edge layer can silently mislead consumers even though all links/types are valid.

## Changes
- `scripts/check_paradox_edges_v0_contract.py`
  - Add fail-closed check: `edge.severity == tension_atom.severity` (when `--atoms` is used)

## Testing
CI:
- `paradox_edges_smoke`
- `paradox_examples_smoke`
