### PR TITLE
chore(paradox-edges): normalize atom_id keys in atoms loader

### DIFF
--- a/scripts/check_paradox_edges_v0_contract.py
+++ b/scripts/check_paradox_edges_v0_contract.py
@@ -99,13 +99,28 @@ def _load_atoms(atoms_path: str) -> Dict[str, Dict[str, Any]]:
     for a in atoms:
         if not isinstance(a, dict):
             continue
-        aid = a.get("atom_id")
+
+        aid_raw = a.get("atom_id")
         atype = a.get("type")
-        if not isinstance(aid, str) or not aid.strip():
+
+        if not isinstance(aid_raw, str) or not aid_raw.strip():
             continue
         if not isinstance(atype, str) or not atype.strip():
             continue
+
+        # Normalize atom_id keys to match edge-side normalization (src/dst IDs are stripped).
+        aid = aid_raw.strip()
+
+        # Fail-closed on collisions after normalization (whitespace-only differences).
+        if aid in by_id:
+            prev_raw = by_id[aid].get("atom_id")
+            die(
+                "atoms file has duplicate atom_id after strip-normalization: "
+                f"{aid!r} (examples: {prev_raw!r} vs {aid_raw!r})"
+            )
+
         by_id[aid] = a
+
     return by_id
 
 


### PR DESCRIPTION
## Summary
Hardens the `paradox_edges_v0` contract checker in two ways (fail-closed):
1) When `--atoms` is provided, require `edge.severity` to match the linked tension atom severity.
2) Normalize `atom_id` keys when loading atoms (strip) so atom lookups remain consistent with
   edge-side ID normalization and exporter behavior.

## Motivation
We already validate:
- JSONL robustness + deterministic ordering + unique edge_id
- required tension fields (tension_atom_id)
- optional run_context validation + per-file consistency (when present)
- src/dst/tension atom existence + type checks
- endpoint integrity via tension.evidence links (prevents swapped endpoints)

Two additional integrity rules close common correctness gaps:
- Severity mismatch between an edge and its tension atom can silently break prioritization and downstream triage.
- Atom ID whitespace can lead to a field file passing contract, edges being exported with stripped IDs,
  and then failing `--atoms` lookups in the edges contract checker.

## Changes
- `scripts/check_paradox_edges_v0_contract.py`:
  - (atoms mode) Validate `tension_atom.severity` and enforce `edge.severity == tension_atom.severity`.
  - Normalize `atom_id` keys on load (`strip`) and fail-closed on collisions after normalization.

## How to test
- Run e2e example and contract checks (as CI does):
  - `python scripts/check_paradox_edges_v0_contract.py --in out/paradox_edges_v0.jsonl --atoms out/paradox_field_v0.json`
- CI workflow: `.github/workflows/paradox_examples_smoke.yml`

## Notes
- No behavior change when `--atoms` is not used.
- If any exporter path emits mismatched severities, this PR will surface it immediately (desired).
