### PR TITLE
chore(paradox-edges): allow empty edges when field run_context exists

### DIFF
--- a/scripts/check_paradox_edges_v0_contract.py
+++ b/scripts/check_paradox_edges_v0_contract.py
@@ -16,7 +16,8 @@ Guarantees (v0):
   - edge.severity must match the linked tension atom severity
   - edge endpoints must match the linked IDs inside the tension atom evidence
     (prevents swapped/misaligned endpoints)
-  - if atoms meta.run_context is present, edges must carry run_context and it must match
+  - if atoms meta.run_context is present and edges are non-empty, edges must carry
+    run_context and it must match
 
 Usage:
   python scripts/check_paradox_edges_v0_contract.py \
@@ -431,7 +432,9 @@ def main() -> int:
         die("mixed presence of run_context within one edges file is not allowed")
 
     # If the atoms file provides meta.run_context, enforce edges carry it and match it (C4.2).
-    if field_ctx_norm is not None:
+    # Allow empty edges files: exporter may legitimately emit zero edges, and there is no
+    # per-edge run_context to compare in that scenario.
+    if field_ctx_norm is not None and edges_count > 0:
         if first_ctx_norm is None:
             die("atoms meta.run_context is present but edges are missing run_context (expected propagation)")
         if first_ctx_norm != field_ctx_norm:


### PR DESCRIPTION
## Summary
Fix a false-negative in `scripts/check_paradox_edges_v0_contract.py` when validating
field↔edges run_context parity in `--atoms` mode.

If the field contains `meta.run_context` but the exported edges JSONL is empty
(0 edges), the contract should pass: there is no per-edge run_context to compare.

This PR updates the parity check to run only when `edges_count > 0`.

## Motivation
The exporter can legitimately emit an empty `paradox_edges_v0.jsonl` (no tension edges).
In that case:
- there is no JSONL header to carry run_context
- there are no edges to compare
- the dataset is valid and should not fail contract checks

Codex review highlighted that the previous behavior incorrectly failed this scenario.

## Changes
- `scripts/check_paradox_edges_v0_contract.py`:
  - when `--atoms` provides `meta.run_context`, enforce run_context parity only if
    the edges file contains at least one edge (`edges_count > 0`)

## How to test
- Generate a field with `meta.run_context` but no tension edges and export edges.
- Validate:
  - `python scripts/check_paradox_edges_v0_contract.py --in out/paradox_edges_v0.jsonl --atoms out/paradox_field_v0.json`

## Notes
- This is a contract hardening bugfix (not a behavior relaxation for non-empty edges).
- Non-empty edges still require run_context propagation and parity when field meta.run_context exists.
