### PR TITLE
ci(paradox): publish paradox summary excerpt in workflow run

### DIFF
--- a/.github/workflows/paradox_examples_smoke.yml
+++ b/.github/workflows/paradox_examples_smoke.yml
@@ -131,6 +131,22 @@ jobs:
           python scripts/check_paradox_examples_transitions_case_study_v0_acceptance.py \
             --in out/paradox_edges_v0.jsonl
 
+      - name: Workflow summary (paradox excerpt)
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "## Paradox summary (excerpt)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -f out/paradox_summary_v0.md ]; then
+            # Keep the UI glanceable: omit the machine-readable JSON index block.
+            awk 'BEGIN{p=1} /^## Summary index/ {p=0} p{print}' out/paradox_summary_v0.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "_No paradox_summary_v0.md generated._" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Upload paradox artifacts
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Make the paradox smoke run more glanceable by publishing an excerpt of
`out/paradox_summary_v0.md` into the GitHub Actions run summary
(`$GITHUB_STEP_SUMMARY`).

The full Markdown summary and JSON/JSONL artifacts remain uploaded as build
artifacts; this change only improves the review UX.

## Motivation
We already generate a deterministic Markdown summary via `scripts/inspect_paradox_v0.py`
and upload it as an artifact. Reviewers still need to download artifacts to read it.

Publishing an excerpt directly in the Actions run summary makes the paradox layer
immediately visible while keeping the evidence-first drilldown available via the
uploaded artifacts.

## Changes
- `.github/workflows/paradox_examples_smoke.yml`
  - Add a step: "Workflow summary (paradox excerpt)"
  - Uses `awk` to omit the "Summary index (machine-readable)" section so the UI stays
    compact and readable
  - Step runs with `if: always()` so the summary is available even if acceptance fails

## How to test
- Run the workflow on a PR or push and open the workflow run.
- Confirm the "Summary" tab includes the paradox excerpt.
- Confirm the full artifacts are still uploaded:
  - `out/paradox_field_v0.json`
  - `out/paradox_edges_v0.jsonl`
  - `out/paradox_summary_v0.md`

## Notes
- This does not change any gate logic or contract checks.
- The excerpt is a presentation layer only; the underlying artifacts remain the source of truth.
