### PR TITLE
test(paradox): document empty-edges transitions fixture

### DIFF
--- a/tests/fixtures/transitions_empty_edges_v0/README.md
+++ b/tests/fixtures/transitions_empty_edges_v0/README.md
@@ -1,0 +1,17 @@
+# transitions_empty_edges_v0
+
+Regression fixture for the paradox layer.
+
+Goal:
+- field meta.run_context is present (stable fingerprint),
+- exporter emits **zero** paradox edges (no tension atoms),
+- edges contract must still pass in `--atoms` mode.
+
+Inputs are intentionally "no-tension":
+- gate drift: no flips
+- metric drift: deltas below warn/crit thresholds
+- overlay drift: empty
+
+Expected outcome:
+- paradox_field_v0.json contains meta.run_context
+- paradox_edges_v0.jsonl is empty (0 lines / 0 edges)


### PR DESCRIPTION
## Summary
Add `tests/fixtures/transitions_empty_edges_v0/README.md` documenting the purpose
and expected outcomes of the empty-edges regression fixture.

## Motivation
We want to lock in a valid pipeline behavior:
- field meta.run_context may exist,
- edges JSONL may legitimately be empty (0 edges),
- contracts should remain compatible with this case.

A fixture README makes the intent explicit and keeps future edits aligned.

## Changes
- Add `tests/fixtures/transitions_empty_edges_v0/README.md`

## Notes
This PR adds documentation only; the fixture data files and CI wiring follow in
subsequent PRs (kept separate for small, reviewable changes).
