### PR TITLE
test(paradox): add empty-edges fixture gate drift CSV

### DIFF
--- a/tests/fixtures/transitions_empty_edges_v0/pulse_gate_drift_v0.csv
+++ b/tests/fixtures/transitions_empty_edges_v0/pulse_gate_drift_v0.csv
@@ -1,0 +1,2 @@
+gate_id,group,status_a,status_b,pass_a,pass_b,flip,value_a,value_b,threshold,notes_a,notes_b,present_a,present_b
+example_gate,controls,PASS,PASS,1,1,0,0.0,0.0,0.5,,,1,1


### PR DESCRIPTION
## Summary
Add the gate drift input file for the `transitions_empty_edges_v0` regression fixture:
- `tests/fixtures/transitions_empty_edges_v0/pulse_gate_drift_v0.csv`

This CSV is intentionally constructed to contain no gate flips, so the paradox
exporter can legitimately emit zero edges in the empty-edges scenario.

## Motivation
We want a stable regression fixture for the valid case where:
- paradox_field_v0 contains meta.run_context,
- paradox_edges_v0.jsonl is empty (0 edges),
- contract checks remain compatible.

A no-flip gate drift file is the first building block of that fixture.

## Changes
- Add `tests/fixtures/transitions_empty_edges_v0/pulse_gate_drift_v0.csv`

## Notes
This PR only adds the gate drift input. The remaining fixture inputs (metric/overlay/transitions),
acceptance script, and CI wiring are added in subsequent small PRs.
