### PR TITLE
test(paradox): add empty-edges fixture metric drift CSV

### DIFF
--- a/tests/fixtures/transitions_empty_edges_v0/pulse_metric_drift_v0.csv
+++ b/tests/fixtures/transitions_empty_edges_v0/pulse_metric_drift_v0.csv
@@ -1,0 +1,2 @@
+metric,a,b,delta,rel_delta,present_a,present_b
+example_metric,0.500,0.501,0.001,0.002,1,1


### PR DESCRIPTION
## Summary
Add the metric drift input file for the transitions_empty_edges_v0 regression fixture:
- tests/fixtures/transitions_empty_edges_v0/pulse_metric_drift_v0.csv

The values are intentionally kept below warn/crit thresholds so metric_delta atoms
(if generated) remain info-level.

## Motivation
This fixture is designed to protect the valid case where the paradox exporter can
legitimately emit 0 edges. Keeping metric drift below thresholds prevents accidental
warn/crit tension formation in future adjustments.

## Changes
- Add tests/fixtures/transitions_empty_edges_v0/pulse_metric_drift_v0.csv

## Notes
This PR only adds one fixture input file. Additional fixture inputs, acceptance checks,
and CI wiring are added in subsequent small PRs.
