### PR TITLE
ci(paradox): add empty-edges regression run to smoke workflow

### DIFF
--- a/.github/workflows/paradox_examples_smoke.yml
+++ b/.github/workflows/paradox_examples_smoke.yml
@@ -6,6 +6,7 @@ on:
       - "scripts/**"
       - "docs/examples/**"
       - "docs/paradox_edges_case_studies.md"
+      - "tests/fixtures/**"
       - ".github/workflows/**"
   push:
     branches: ["main"]
@@ -13,6 +14,7 @@ on:
       - "scripts/**"
       - "docs/examples/**"
       - "docs/paradox_edges_case_studies.md"
+      - "tests/fixtures/**"
       - ".github/workflows/**"
 
 jobs:
@@ -123,6 +125,37 @@ jobs:
             --edges out/paradox_edges_v0.jsonl \
             --out out/paradox_summary_v0.md
 
+      - name: Regression fixture: empty edges (run_context present)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p out/empty_edges
+
+          python scripts/paradox_field_adapter_v0.py \
+            --transitions-dir tests/fixtures/transitions_empty_edges_v0 \
+            --out out/empty_edges/paradox_field_v0.json
+
+          python scripts/check_paradox_field_v0_contract.py \
+            --in out/empty_edges/paradox_field_v0.json
+
+          python scripts/export_paradox_edges_v0.py \
+            --in out/empty_edges/paradox_field_v0.json \
+            --out out/empty_edges/paradox_edges_v0.jsonl
+
+          python scripts/check_paradox_edges_v0_contract.py \
+            --in out/empty_edges/paradox_edges_v0.jsonl \
+            --atoms out/empty_edges/paradox_field_v0.json
+
+          python scripts/inspect_paradox_v0.py \
+            --field out/empty_edges/paradox_field_v0.json \
+            --edges out/empty_edges/paradox_edges_v0.jsonl \
+            --out out/empty_edges/paradox_summary_v0.md
+
+          python scripts/check_paradox_empty_edges_v0_acceptance.py \
+            --field out/empty_edges/paradox_field_v0.json \
+            --edges out/empty_edges/paradox_edges_v0.jsonl
+
       - name: Acceptance (canonical wrapper)
         shell: bash
         run: |
@@ -141,10 +174,19 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
           if [ -f out/paradox_summary_v0.md ]; then
-            # Keep the UI glanceable: omit the machine-readable JSON index block.
             awk 'BEGIN{p=1} /^## Summary index/ {p=0} p{print}' out/paradox_summary_v0.md >> "$GITHUB_STEP_SUMMARY"
           else
             echo "_No paradox_summary_v0.md generated._" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Paradox empty-edges fixture (excerpt)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -f out/empty_edges/paradox_summary_v0.md ]; then
+            awk 'BEGIN{p=1} /^## Summary index/ {p=0} p{print}' out/empty_edges/paradox_summary_v0.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "_No empty-edges paradox summary generated._" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload paradox artifacts
@@ -157,4 +199,7 @@ jobs:
             out/paradox_field_v0.json
             out/paradox_edges_v0.jsonl
             out/paradox_summary_v0.md
+            out/empty_edges/paradox_field_v0.json
+            out/empty_edges/paradox_edges_v0.jsonl
+            out/empty_edges/paradox_summary_v0.md
 


### PR DESCRIPTION
## Summary
Extend `paradox_examples_smoke` to execute the empty-edges regression fixture and
publish its artifacts + a short excerpt in the Actions run summary.

The fixture covers a valid case:
- paradox_field_v0 has meta.run_context
- exporter emits 0 edges (empty JSONL)
- edges contract in --atoms mode remains compatible

## Motivation
We recently hardened run_context parity enforcement and fixed the valid empty-edges
scenario. This workflow update locks the behavior in CI to prevent regressions.

## Changes
- `.github/workflows/paradox_examples_smoke.yml`
  - Add `tests/fixtures/**` to path filters
  - Add a new pipeline block under `out/empty_edges/`:
    - generate field
    - validate field contract
    - export edges (expected empty)
    - validate edges contract with --atoms
    - generate markdown summary
    - run empty-edges acceptance
  - Upload empty-edges artifacts
  - Add Actions summary excerpt for the empty-edges summary (omits machine JSON index)

## How to test
CI:
- Trigger the workflow on a PR touching scripts/ or tests/fixtures/.
- Confirm:
  - main docs example still runs
  - empty-edges regression pipeline runs
  - artifacts include both the normal and empty-edges outputs
  - Actions run Summary shows both excerpts

Local (manual equivalent):
```bash
mkdir -p out/empty_edges
python scripts/paradox_field_adapter_v0.py --transitions-dir tests/fixtures/transitions_empty_edges_v0 --out out/empty_edges/paradox_field_v0.json
python scripts/check_paradox_field_v0_contract.py --in out/empty_edges/paradox_field_v0.json
python scripts/export_paradox_edges_v0.py --in out/empty_edges/paradox_field_v0.json --out out/empty_edges/paradox_edges_v0.jsonl
python scripts/check_paradox_edges_v0_contract.py --in out/empty_edges/paradox_edges_v0.jsonl --atoms out/empty_edges/paradox_field_v0.json
python scripts/inspect_paradox_v0.py --field out/empty_edges/paradox_field_v0.json --edges out/empty_edges/paradox_edges_v0.jsonl --out out/empty_edges/paradox_summary_v0.md
python scripts/check_paradox_empty_edges_v0_acceptance.py --field out/empty_edges/paradox_field_v0.json --edges out/empty_edges/paradox_edges_v0.jsonl
