### PR TITLE
test(paradox): add gate drift input for transitions_no_atoms_v0

### DIFF
--- a/tests/fixtures/transitions_no_atoms_v0/pulse_gate_drift_v0.csv
+++ b/tests/fixtures/transitions_no_atoms_v0/pulse_gate_drift_v0.csv
@@ -1,0 +1,3 @@
+gate_id,group,status_a,status_b,pass_a,pass_b,flip,value_a,value_b,threshold,notes_a,notes_b,present_a,present_b
+gate_noop,core,pass,pass,1,1,0,,,,,1,1
+


### PR DESCRIPTION
## Summary
Add `pulse_gate_drift_v0.csv` for the `transitions_no_atoms_v0` fixture.

## Motivation
This fixture represents the stable “no drift” case. Setting flip=0 ensures the
adapter does not emit gate_flip atoms, keeping the paradox field empty.

## Changes
- Add `tests/fixtures/transitions_no_atoms_v0/pulse_gate_drift_v0.csv`

## Testing
Not run (fixture input only).
