### PR TITLE
test(paradox): add metric drift input for transitions_no_atoms_v0

### DIFF
--- a/tests/fixtures/transitions_no_atoms_v0/tests/fixtures/transitions_no_atoms_v0/pulse_metric_drift_v0.csv
+++ b/tests/fixtures/transitions_no_atoms_v0/tests/fixtures/transitions_no_atoms_v0/pulse_metric_drift_v0.csv
@@ -1,0 +1,2 @@
+metric,a,b,delta,rel_delta,present_a,present_b
+metric_noop,0.5,0.5,,,1,1


### PR DESCRIPTION
## Summary
Add `pulse_metric_drift_v0.csv` for the `transitions_no_atoms_v0` fixture.

## Motivation
The no-atoms fixture should produce an empty paradox field. Omitting numeric delta
values ensures the adapter does not create metric_delta atoms.

## Changes
- Add `tests/fixtures/transitions_no_atoms_v0/pulse_metric_drift_v0.csv`

## Testing
Not run (fixture input only).
