### PR TITLE
test(paradox): add overlay drift input for transitions_no_atoms_v0

### DIFF
--- a/tests/fixtures/transitions_no_atoms_v0/pulse_overlay_drift_v0.json
+++ b/tests/fixtures/transitions_no_atoms_v0/pulse_overlay_drift_v0.json
@@ -1,0 +1,16 @@
+{
+  "paradox_field_v0": {
+    "present_a": true,
+    "present_b": true,
+    "sha1_a": "",
+    "sha1_b": "",
+    "path_a": "",
+    "path_b": "",
+    "top_level_diff": {
+      "added_keys": [],
+      "removed_keys": [],
+      "changed_keys": [],
+      "note": "No overlay changes in this fixture."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add `pulse_overlay_drift_v0.json` for the `transitions_no_atoms_v0` fixture.

## Motivation
The no-atoms fixture should produce no overlay_change atoms. An overlay diff with
empty changed_keys validates the “no overlay drift” path.

## Changes
- Add `tests/fixtures/transitions_no_atoms_v0/pulse_overlay_drift_v0.json`

## Testing
Not run (fixture input only).
