### PR TITLE
docs(readme): surface paradox summary artifact for reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,25 @@ gates:
 **CI:** EPF runs as a **separate, CI‑neutral** workflow (`.github/workflows/epf_experiment.yml`).  
 Deterministic, fail‑closed gates in `check_gates.py` remain the **only** release gates.
 
+---
+
+### Paradox quick inspect (projection view)
+
+The smoke workflow generates a deterministic Markdown summary for reviewers:
+
+- `out/paradox_summary_v0.md` (case study)
+- `out/empty_edges/paradox_summary_v0.md` (regression: empty edges with run_context)
+
+Both are uploaded as the `paradox-artifacts` CI artifact.
+
+Local quick inspect:
+
+```bash
+python scripts/inspect_paradox_v0.py \
+  --field out/paradox_field_v0.json \
+  --edges out/paradox_edges_v0.jsonl \
+  --out out/paradox_summary_v0.md
+```
 
 ---
 


### PR DESCRIPTION
**Summary**
Add a short README note that the paradox smoke workflow produces deterministic Markdown summaries and uploads them as `paradox-artifacts`. Include a local one-liner for generating `out/paradox_summary_v0.md`.

**Why**
Makes the paradox layer immediately glanceable without changing semantics: the Markdown file is a projection view over the evidence-first JSON/JSONL artifacts.

**Testing**
Not run (docs-only change).