### PR TITLE
docs(readme): refresh documentation map

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,28 +565,43 @@ python scripts/inspect_paradox_v0.py \
 
 ## Documentation map
 
-In addition to this README, the following documents describe how the PULSE v0 stack is wired in this repository:
+Curated entrypoints (repo-level docs under `docs/`):
 
-- **Orientation (what runs / what is source of truth)**
-  - `docs/STATE_v0.md` — Current snapshot of PULSE v0 gates, signals, and tooling.
-  - `docs/status_json.md` — Overview of the `status.json` artefact (metrics, gates, consumers).
+### Orientation & contracts
+- [docs/STATE_v0.md](docs/STATE_v0.md) — Current snapshot of PULSE v0 gates, signals, and tooling.
+- [docs/QUICKSTART_CORE_v0.md](docs/QUICKSTART_CORE_v0.md) — Minimal steps to run the core pipeline.
+- [docs/RUNBOOK.md](docs/RUNBOOK.md) — Operational runbook for triage and reruns.
+- [docs/STATUS_CONTRACT.md](docs/STATUS_CONTRACT.md) — Contract for `status.json` shape and semantics.
+- [docs/GLOSSARY_v0.md](docs/GLOSSARY_v0.md) — Canonical term definitions used across docs.
 
-- **Stability & drift**
-  - `docs/RDSI_STABILITY_NOTES.md` — How to read RDSI and what it does *not* cover.
-  - `docs/DRIFT_OVERVIEW.md` — How artefacts (gates, ledger, RDSI, EPF, detectors) support drift/governance.
+### Status, ledger & external signals
+- [docs/status_json.md](docs/status_json.md) — How to read `status.json` (metrics, gates, consumers).
+- [docs/quality_ledger.md](docs/quality_ledger.md) — Quality Ledger layout and purpose.
+- [docs/refusal_delta_gate.md](docs/refusal_delta_gate.md) — Refusal-delta summary format + fail-closed semantics.
+- [docs/external_detectors.md](docs/external_detectors.md) — Folding external detector summaries into status/ledger.
 
-- **Paradox field & edges (evidence-first)**
-  - `docs/FIELD_FIRST_INTERPRETATION.md` — Field-first interpretation; queries are projections (not triggers).
-  - `docs/paradox_edges_case_studies.md` — Evidence-first edge case studies (co-occurrence only).
-  - `docs/PARADOX_RUNBOOK.md` — What to do when EPF shadow conflicts with deterministic baseline gates.
+### Paradox field & edges
+- [docs/PULSE_paradox_field_v0_walkthrough.md](docs/PULSE_paradox_field_v0_walkthrough.md) — How to read `paradox_field_v0`.
+- [docs/Pulse_paradox_edges_v0_status.md](docs/Pulse_paradox_edges_v0_status.md) — Status/roadmap for `paradox_edges_v0.jsonl`.
+- [docs/paradox_edges_case_studies.md](docs/paradox_edges_case_studies.md) — Case studies (fixture + non-fixture).
+- [docs/PARADOX_RUNBOOK.md](docs/PARADOX_RUNBOOK.md) — What to do when EPF shadow disagrees with baseline.
 
-- **Reproducible examples**
-  - `docs/examples/README.md` — Index of reproducible examples.
-  - `docs/examples/transitions_case_study_v0/README.md` — Transitions → paradox field/edges case study.
+### EPF shadow & hazard diagnostics
+- [docs/PULSE_epf_shadow_quickstart_v0.md](docs/PULSE_epf_shadow_quickstart_v0.md) — Command-level EPF shadow quickstart.
+- [docs/epf_relational_grail.md](docs/epf_relational_grail.md) — Relational hazard overview + calibration/CLI examples.
+- [docs/epf_hazard_inspect.md](docs/epf_hazard_inspect.md) — Inspect `epf_hazard_log.jsonl` from the CLI.
 
-- **Contribution & PR tooling**
-  - `docs/PR_SUMMARY_TOOLS.md` — Canonical PR summary tooling references.
-  - `CONTRIBUTING.md` — Contribution rules, DCO, and review workflow.
+### Topology & field-first interpretation
+- [docs/PULSE_topology_overview_v0.md](docs/PULSE_topology_overview_v0.md) — Topology layer overview (diagnostic overlay).
+- [docs/PULSE_decision_field_v0_overview.md](docs/PULSE_decision_field_v0_overview.md) — Decision field v0 overview.
+- [docs/PULSE_decision_engine_v0.md](docs/PULSE_decision_engine_v0.md) — Decision Engine v0 outputs and semantics.
+- [docs/FIELD_FIRST_INTERPRETATION.md](docs/FIELD_FIRST_INTERPRETATION.md) — Field-first interpretation (question as projection).
+
+### Examples & contributing
+- [docs/examples/README.md](docs/examples/README.md) — Reproducible examples index.
+- [docs/examples/transitions_case_study_v0/README.md](docs/examples/transitions_case_study_v0/README.md) — Transitions → paradox field/edges case study.
+- [docs/PR_SUMMARY_TOOLS.md](docs/PR_SUMMARY_TOOLS.md) — PR summary tooling (canonical scripts).
+- [CONTRIBUTING.md](CONTRIBUTING.md) — Conventions, DCO, and review workflow.
 
 ... 
 


### PR DESCRIPTION
Summary
Refresh the README Documentation map into a grouped, concise index and add links for the newest repo docs (field-first, paradox edges, examples).

What’s included

Replace the flat doc list with themed entrypoints.

Add links to new/updated docs (field-first interpretation, paradox edges status + case studies, transitions case study, status/ledger docs).

Testing
Not run (documentation-only change).