### PR TITLE
docs(readme): add Paradox quick inspect (projection view) snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,10 @@ The smoke workflow generates a deterministic Markdown summary for reviewers:
 
 Both are uploaded as the `paradox-artifacts` CI artifact.
 
+Notes:
+- Projection view only; does not affect CI gating.
+- Edges are co-occurrence only (no causality).
+
 Local quick inspect:
 
 ```bash


### PR DESCRIPTION
## What
Adds a short “Paradox quick inspect (projection view)” entrypoint to the README:
- points reviewers to the generated deterministic Markdown summaries
- clarifies the summary is a projection (CI gating unchanged)
- clarifies edges are co-occurrence (no causality claim)
- includes a local quick-inspect command

## Why
Make the paradox layer reviewer-friendly without simplifying the underlying field/edges source of truth.

## Test plan
- [ ] README renders correctly (no broken Markdown / code blocks)
- [ ] Smoke workflow still uploads `paradox-artifacts` including the summary markdown files
- [ ] Local command runs and produces `out/paradox_summary_v0.md` from `out/paradox_field_v0.json` + `out/paradox_edges_v0.jsonl`

## Notes
No runtime / gate behavior changes; documentation-only.
