### PR TITLE
docs(readme): add "Start here" to Documentation map

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,7 +569,14 @@ python scripts/inspect_paradox_v0.py \
 
 ## Documentation map
 
+Start here:
+
+- Running PULSE in CI: [docs/QUICKSTART_CORE_v0.md](docs/QUICKSTART_CORE_v0.md) — Minimal steps to run the core pipeline.
+- Understanding the source of truth (`status.json`): [docs/status_json.md](docs/status_json.md) — How to read `status.json` (metrics, gates, consumers).
+- When things fail (triage): [docs/RUNBOOK.md](docs/RUNBOOK.md) — Operational runbook for triage and reruns.
+
 Curated entrypoints (repo-level docs under `docs/`):
+
 
 ### Orientation & contracts
 - [docs/STATE_v0.md](docs/STATE_v0.md) — Current snapshot of PULSE v0 gates, signals, and tooling.


### PR DESCRIPTION
## What
Adds a short “Start here” section at the top of the README Documentation map.

## Why
Gives a fast entrypoint for two common personas:
- Integrators/MLOps: how to run CI and what the core pipeline is
- Reviewers: how to interpret the source of truth (`status.json`) and how to triage failures

## Changes
- Add 3 curated links above the existing “Curated entrypoints …” section:
  - docs/QUICKSTART_CORE_v0.md
  - docs/status_json.md
  - docs/RUNBOOK.md

## Test plan
- [ ] README renders correctly on GitHub
- [ ] Links resolve to the expected docs pages

Docs-only; no behavior changes.
