### PR TITLE
ci: add case-collision guardrail to docs_hygiene workflow

### DIFF
--- a/.github/workflows/docs_hygiene.yml
+++ b/.github/workflows/docs_hygiene.yml
@@ -13,6 +13,30 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Repo hygiene: forbid case-insensitive path collisions
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import sys
+          from collections import defaultdict
+          import subprocess
+
+          files = subprocess.check_output(["git", "ls-files"], text=True).splitlines()
+          m = defaultdict(list)
+          for f in files:
+              m[f.lower()].append(f)
+
+          collisions = {k: v for k, v in m.items() if len(v) > 1}
+          if collisions:
+              print("ERROR: case-insensitive path collisions detected:")
+              for _, v in sorted(collisions.items()):
+                  print(" - " + "  |  ".join(v))
+              sys.exit(1)
+
+          print("OK: no case-insensitive collisions.")
+          PY
+
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
@@ -45,3 +69,4 @@ jobs:
           if ! grep -q "mailto:" README.md; then
             echo "::warning::No 'mailto:' links in README.md"
           fi
+


### PR DESCRIPTION
## What
Add a fail-fast check to `.github/workflows/docs_hygiene.yml` that fails if the repo contains
case-insensitive path collisions (paths differing only by letter case).

## Why
Prevents platform-specific checkout issues (Windows/default macOS) and blocks case-only duplicates
from reappearing.

## Files changed
- .github/workflows/docs_hygiene.yml

## Testing
CI-only change (runs in GitHub Actions).
