### PR TITLE
ci: harden repo-hygiene workflow permissions (contents: read)

### DIFF
--- a/.github/workflows/repo_hygiene.yml
+++ b/.github/workflows/repo_hygiene.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   hygiene_guardrails:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
Add explicit minimal `permissions` to `.github/workflows/repo_hygiene.yml`:
- contents: read

## Why
Repo-hygiene only checks tracked paths and should not run with broader token permissions.
This reduces blast radius and looks better in external security reviews.

## Files changed
- .github/workflows/repo_hygiene.yml

## Testing
CI-only change (validated by the workflow run).
