### PR TITLE
ci: harden docs-hygiene workflow permissions (contents: read)

### DIFF
--- a/.github/workflows/docs_hygiene.yml
+++ b/.github/workflows/docs_hygiene.yml
@@ -7,6 +7,9 @@ on:
       - "CITATION.cff"
       - ".github/workflows/*.yml"
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
Add explicit minimal `permissions` to `.github/workflows/docs_hygiene.yml`:
- contents: read

## Why
docs-hygiene only reads repository contents (README/CITATION/workflow linting) and should not run
with broader token permissions. This reduces blast radius and looks better in external reviews.

## Files changed
- .github/workflows/docs_hygiene.yml

## Testing
CI-only change (validated by the workflow run).
