### PR TITLE
ci: simplify paradox_examples_smoke (dedupe guardrails, narrower triggers)

### DIFF
--- a/.github/workflows/paradox_examples_smoke.yml
+++ b/.github/workflows/paradox_examples_smoke.yml
@@ -7,8 +7,7 @@ on:
       - "docs/examples/**"
       - "docs/paradox_edges_case_studies.md"
       - "tests/fixtures/**"
-      - ".github/workflows/**"
-      - "github/workflows/**"   # guardrail trigger: ignored workflows placed here
+      - ".github/workflows/paradox_examples_smoke.yml"
   push:
     branches: ["main"]
     paths:
@@ -16,8 +15,10 @@ on:
       - "docs/examples/**"
       - "docs/paradox_edges_case_studies.md"
       - "tests/fixtures/**"
-      - ".github/workflows/**"
-      - "github/workflows/**"   # guardrail trigger: ignored workflows placed here
+      - ".github/workflows/paradox_examples_smoke.yml"
+
+permissions:
+  contents: read
 
 jobs:
   docs_examples_smoke:
@@ -27,18 +28,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Repo hygiene: forbid nested fixtures
-        shell: bash
-        run: |
-          set -euo pipefail
-          bad="$(git ls-files | grep -E '^tests/fixtures/.*/tests/fixtures/' || true)"
-          if [ -n "$bad" ]; then
-            echo "::error::Nested fixture path detected (tests/fixtures/**/tests/fixtures/**)."
-            echo "$bad" | sed 's/^/ - /'
-            exit 1
-          fi
-          echo "OK: no nested fixtures detected."
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -160,17 +149,6 @@ jobs:
             echo "Listing scripts/:"
             ls -la scripts || true
             exit 1
-          fi
-
-          echo ""
-          echo "Checking for ignored workflows under github/workflows/:"
-          if [ -d github/workflows ]; then
-            if find github/workflows -type f \( -name "*.yml" -o -name "*.yaml" \) | grep -q .; then
-              echo "[docs_examples_smoke] found workflow files under github/workflows/ (ignored by GitHub Actions)."
-              echo "Move these files under .github/workflows/:"
-              find github/workflows -type f \( -name "*.yml" -o -name "*.yaml" \) -print
-              exit 1
-            fi
           fi
 
       - name: Prepare out/


### PR DESCRIPTION
## What
Update `.github/workflows/paradox_examples_smoke.yml` to:
- drop duplicated guardrails now enforced repo-wide by `repo-hygiene`
- narrow path triggers to avoid running on unrelated workflow changes
- set minimal token permissions (`contents: read`)

## Why
Reduce duplication and CI noise while keeping the paradox smoke focused on its actual inputs.

## Files changed
- .github/workflows/paradox_examples_smoke.yml

## Testing
CI-only change (validated by workflow run).
