### PR TITLE
ci: pin repo-hygiene checkout action to SHA

### DIFF
--- a/.github/workflows/repo_hygiene.yml
+++ b/.github/workflows/repo_hygiene.yml
@@ -12,7 +12,7 @@ jobs:
   hygiene_guardrails:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1 :contentReference[oaicite:1]{index=1}
 
       - name: Repo hygiene: forbid case-insensitive path collisions (file/file + file/dir)
         shell: bash


### PR DESCRIPTION
## What
Pin `actions/checkout` in `.github/workflows/repo_hygiene.yml` to a full commit SHA (v6.0.1).

## Why
Avoids “moving tag” behavior and makes CI runs reproducible and audit-friendly.

## Files changed
- .github/workflows/repo_hygiene.yml

## Testing
CI-only change (validated by the workflow run).
