### PR TITLE
ci: pin docs-hygiene actions to commit SHAs

### DIFF
--- a/.github/workflows/docs_hygiene.yml
+++ b/.github/workflows/docs_hygiene.yml
@@ -14,7 +14,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Repo hygiene: forbid case-insensitive path collisions
         shell: bash
@@ -40,7 +40,7 @@ jobs:
           print("OK: no case-insensitive collisions.")
           PY
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## What
Pin external GitHub Actions used by `.github/workflows/docs_hygiene.yml` to full commit SHAs:
- actions/checkout -> v6.0.1
- actions/setup-python -> v6.1.0

## Why
Avoids moving tags and makes CI runs reproducible/audit-friendly (supply-chain hardening).

## Files changed
- .github/workflows/docs_hygiene.yml

## Testing
CI-only change (validated by workflow run).
