### PR TITLE
ci: pin paradox_examples_smoke actions to commit SHAs

### DIFF
--- a/.github/workflows/paradox_examples_smoke.yml
+++ b/.github/workflows/paradox_examples_smoke.yml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.11"
 
@@ -340,7 +340,7 @@ jobs:
 
       - name: Upload paradox artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: paradox-artifacts
           if-no-files-found: warn


### PR DESCRIPTION
## What
Pin GitHub Actions used by `.github/workflows/paradox_examples_smoke.yml` to full commit SHAs:
- actions/checkout (v4.3.0)
- actions/setup-python (v5.4.0)
- actions/upload-artifact (v4.6.2)

## Why
Avoid moving tags and make CI runs deterministic and easier to audit (supply-chain hardening).

## Files changed
- .github/workflows/paradox_examples_smoke.yml

## Testing
CI-only change (validated by workflow run).
