### PR TITLE
ci: pin paradox_edges_smoke actions to SHAs

### DIFF
--- a/.github/workflows/paradox_edges_smoke.yml
+++ b/.github/workflows/paradox_edges_smoke.yml
@@ -12,16 +12,19 @@ on:
       - "tests/fixtures/**"
       - ".github/workflows/paradox_edges_smoke.yml"
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.11"
 
@@ -86,7 +89,7 @@ jobs:
 
       - name: Upload artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: paradox-edges-smoke-out
           path: out


### PR DESCRIPTION
## What
Pin external GitHub Actions used by `.github/workflows/paradox_edges_smoke.yml`
to full commit SHAs (checkout/setup-python/upload-artifact).

## Why
Avoid moving tags and make CI runs deterministic and easier to audit
(supply-chain hardening).

## Files changed
- .github/workflows/paradox_edges_smoke.yml

## Testing
CI-only change (validated by workflow run).
