### PR TITLE
ci: pin semantic pr action to sha

### DIFF
--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -2,22 +2,21 @@ name: Semantic PR Title
 on:
   pull_request:
     branches: [ main ]
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   pull-requests: read
 
 jobs:
   semantic:
-    # UGORJA ÁT a Dependabot PR-okat VAGY ha "dependencies" a címke
+    # skip Dependabot PRs OR if labeled "dependencies"
     if: ${{ github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # engedjük a tipikus típusokat
           types: |
             feat
             fix
@@ -29,6 +28,6 @@ jobs:
             build
             ci
             revert
-          # opcionális: ha van "dependencies" címke, akkor eleve ignorálja
           ignoreLabels: |
             dependencies
+


### PR DESCRIPTION
## Summary
Pin PR title lint action to a fixed commit SHA and set least-privilege permissions.

## Changes
- Pin amannn/action-semantic-pull-request to an immutable SHA.
- Ensure permissions are limited to `pull-requests: read`.

## Why
- Deterministic CI (no moving tags).
- Cleaner security posture for a required PR title guardrail.

## Testing
CI-only change (validated by workflow run).
