### PR TITLE
ci(reproduce): harden workflow and publish checksums as artifact

### DIFF
--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -1,28 +1,66 @@
 name: Reproduce & checksums
-on: { workflow_dispatch: {} }
-permissions: { contents: write }
+
+on:
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege: do NOT write back to the repo from CI.
+permissions:
+  contents: read
+
 jobs:
   reproduce:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with: { python-version: '3.10' }
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: "3.10"
+
       - name: Install deps (best effort)
+        shell: bash
         run: |
+          set -euo pipefail
           python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt || true; fi
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt || true
+          fi
+
       - name: Reproduce (best effort)
+        shell: bash
         run: |
-          if make -v >/dev/null 2>&1; then make reproduce || true; fi
+          set -euo pipefail
+          if make -v >/dev/null 2>&1; then
+            make reproduce || true
+          fi
+
       - name: Create checksums
+        shell: bash
         run: |
+          set -euo pipefail
           python tools/compute_checksums.py dist artifacts > checksums.txt || echo "# WARN: no artifacts" > checksums.txt
+          echo "---- checksums.txt (head) ----"
           head -n 20 checksums.txt || true
-      - name: Commit checksums.txt to the repo
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add checksums.txt
-          git commit -m "build: add checksums.txt from reproduce [skip ci]" || echo "Nothing to commit"
-          git push
+          echo "------------------------------"
+
+      - name: Upload checksums (artifact)
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: reproduce-checksums
+          if-no-files-found: warn
+          path: |
+            checksums.txt
+            dist/**
+            artifacts/**
+


### PR DESCRIPTION
Summary
- Harden reproduce workflow with pinned action SHAs and least-privilege permissions.
- Publish checksums.txt as an artifact instead of committing to the repo.
- Add concurrency + timeout to reduce CI contention.

Testing
CI/workflow-only change (validated by GitHub Actions run).
