### PR TITLE
ci: harden link-check workflow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,25 +1,61 @@
 name: Link check
+
 on:
   pull_request:
+    paths:
+      - "**/*.md"
+      - "docs/**"
+      - "examples/**"
+      - ".github/workflows/link-check.yml"
+      - ".lycheeignore"
+      - "lychee.toml"
+      - ".github/config/lychee.toml"
   push:
-  workflow_dispatch:
+    branches: [ main ]
+    paths:
+      - "**/*.md"
+      - "docs/**"
+      - "examples/**"
+      - ".github/workflows/link-check.yml"
+      - ".lycheeignore"
+      - "lychee.toml"
+      - ".github/config/lychee.toml"
+  workflow_dispatch: {}
   schedule:
     - cron: "0 3 * * 1"  # every Monday 03:00 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: link-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lychee:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
       - name: Run Lychee link checker
-        uses: lycheeverse/lychee-action@v1
+        uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621 # v1.10.0
         with:
           args: >-
             --verbose --no-progress
             --accept 200,206,301,302,303,307,308,429
-            --exclude "https://www.kaggle.com/*"
-            --exclude "mailto:*"
+            --exclude "https://www\.kaggle\.com/.*"
+            --exclude "^mailto:"
             --timeout 20
             --max-redirects 10
+            --max-retries 2
+            --retry-wait-time 2
+            --max-concurrency 8
             .
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Summary
- Hardened link-check workflow by pinning actions to commit SHAs.
- Reduced CI noise with minimal permissions + concurrency.
- Improved lychee stability (retries/concurrency) and fixed exclude patterns.

Why
- Makes the workflow deterministic and supply-chain safer.
- Keeps link checking useful without slowing down unrelated development.

Testing
⚠️ Not run (CI/workflow-only change).
