### PR TITLE
ci: pin paradox gate workflow actions to shas

### DIFF
--- a/.github/workflows/pulse-paradox-gate.yml
+++ b/.github/workflows/pulse-paradox-gate.yml
@@ -25,22 +25,31 @@ jobs:
 
     steps:
       - name: Checkout Pulse repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Checkout gate repo (tag)
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: ${{ env.GATE_REPO }}
           ref: ${{ env.GATE_REF }}
           path: ./.gates
+          fetch-depth: 1
+          persist-credentials: false
 
       - name: Unpack Paradox Gate kit
-        run: unzip -q ./.gates/pulse_paradox_gate_ci_v1.zip -d ./.gates/_ex
+        shell: bash
+        run: |
+          set -euo pipefail
+          unzip -q ./.gates/pulse_paradox_gate_ci_v1.zip -d ./.gates/_ex
 
       - name: Decide metrics source (log vs env fallback)
         id: metrics_src
         shell: bash
         run: |
+          set -euo pipefail
           if [ -f "logs/decision_log.ndjson" ]; then
             echo "src=log" >> "$GITHUB_OUTPUT"
             echo "Using Decision Log at logs/decision_log.ndjson"
@@ -52,7 +61,7 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: "3.11"
 
@@ -60,12 +69,13 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
+          set -euo pipefail
           G=".gates/_ex/pulse_paradox_gate_ci_v1/pulse/gates/paradox"
           python "$G/gate.py" --mode shadow --policy "$G/policy.yaml"
 
       - name: Upload Paradox Gate summary (artifact)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pulse-paradox-gate-summary
           path: artifacts/pulse_paradox_gate_summary.json
@@ -73,12 +83,17 @@ jobs:
 
       - name: Debug list artifacts dir
         if: ${{ always() && github.event_name == 'pull_request' }}
-        run: ls -la artifacts || true
+        shell: bash
+        run: |
+          set -euo pipefail
+          ls -la artifacts || true
 
       - name: Generate PR triage comment (why it failed / what to fix)
         if: ${{ always() && github.event_name == 'pull_request' }}
         continue-on-error: true
+        shell: bash
         run: |
+          set -euo pipefail
           python tools/gh_pr_comment_triage.py \
             --summary artifacts/pulse_paradox_gate_summary.json \
             --out triage_comment.md
@@ -86,7 +101,7 @@ jobs:
       - name: Post or update PR comment
         if: ${{ always() && github.event_name == 'pull_request' }}
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const fs = require('fs');
@@ -101,9 +116,7 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: context.issue.number
               });
-              const existing = comments.find(
-                (c) => c.body && c.body.includes(marker)
-              );
+              const existing = comments.find((c) => c.body && c.body.includes(marker));
               if (existing) {
                 await github.rest.issues.updateComment({
                   owner: context.repo.owner,
@@ -120,3 +133,4 @@ jobs:
                 });
               }
             }
+


### PR DESCRIPTION
Summary
- Pinned all GitHub Actions in the Paradox Gate (shadow) workflow to commit SHAs.
- Disabled persisted credentials on checkout steps.

Why
- Improves CI determinism and supply-chain hygiene for external review/audit.

Testing
⚠️ Not run (workflow-only change).
