### PR TITLE
ci: align link-check triggers with scan scope

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -6,6 +6,8 @@ on:
       - "**/*.md"
       - "docs/**"
       - "examples/**"
+      - "CITATION.cff"
+      - "schemas/**"
       - ".github/workflows/link-check.yml"
       - ".lycheeignore"
       - "lychee.toml"
@@ -16,6 +18,8 @@ on:
       - "**/*.md"
       - "docs/**"
       - "examples/**"
+      - "CITATION.cff"
+      - "schemas/**"
       - ".github/workflows/link-check.yml"
       - ".lycheeignore"
       - "lychee.toml"
@@ -55,7 +59,7 @@ jobs:
             --max-retries 2
             --retry-wait-time 2
             --max-concurrency 8
-            .
+            README.md docs examples CITATION.cff schemas
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Summary
- Link-check now runs when non-Markdown link sources change (CITATION.cff, schemas/**).
- Lychee scan scope is narrowed to the same set of paths to keep the guardrail consistent and avoid repo-wide noise.

Testing
⚠️ Not run (workflow-only change).
