### PR TITLE
ci: harden overlay schema validation shadow workflow

### DIFF
--- a/.github/workflows/overlay_schema_validation_shadow.yml
+++ b/.github/workflows/overlay_schema_validation_shadow.yml
@@ -1,34 +1,48 @@
 name: Overlay schema validation (shadow)
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: {}
   push:
     paths:
-      - 'schemas/**'
-      - 'schemas/schemas/**'
-      - 'scripts/validate_overlays.py'
-      - 'PULSE_safe_pack_v0/artifacts/**'
-      - '*.json'
-      - '.github/workflows/overlay_schema_validation_shadow.yml'
+      - "schemas/**"
+      - "scripts/validate_overlays.py"
+      - "PULSE_safe_pack_v0/artifacts/**"
+      - "*.json"
+      - ".github/workflows/overlay_schema_validation_shadow.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: overlay-schema-shadow-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   overlay-schema-validation-shadow:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
-          python-version: '3.x'
+          python-version: "3.11"
 
       - name: Install jsonschema
+        shell: bash
         run: |
+          set -euo pipefail
           python -m pip install --upgrade pip
-          pip install jsonschema
+          python -m pip install 'jsonschema>=4,<5'
 
       - name: Validate overlays against JSON Schemas
+        shell: bash
         run: |
+          set -euo pipefail
           python scripts/validate_overlays.py --root .
+


### PR DESCRIPTION
Summary
- Pinned checkout/setup-python actions to immutable commit SHAs.
- Reduced permissions to contents: read and disabled persisted credentials.
- Fixed python version to 3.11 and pinned jsonschema to <5.
- Added concurrency + timeout for stable, non-blocking shadow validation.

Testing
⚠️ Not run (workflow-only change).
