### PR TITLE
ci: harden secret sweep workflow

### DIFF
--- a/.github/workflows/secret_sweep.yml
+++ b/.github/workflows/secret_sweep.yml
@@ -1,15 +1,26 @@
 name: Secret sweep (working tree)
+
 on:
   workflow_dispatch: {}
 
 permissions:
   contents: read
 
+concurrency:
+  group: secret-sweep-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
 
       # Simple grep across text files (soft warning; never fails the job)
       - name: Grep common secret patterns
@@ -19,3 +30,4 @@ jobs:
           PATTERN='(BEGIN (RSA|OPENSSH) PRIVATE KEY|Authorization: Bearer|api[_-]?key|apikey|token|password|aws_access_key_id|aws_secret_access_key|ghp_[0-9A-Za-z]{36}|xox[baprs]-[0-9A-Za-z-]+)'
           # -r recurse, -n line numbers, -I ignore binary, --exclude-dir skip .git
           grep -rInE --exclude-dir=".git" "$PATTERN" . || echo "No obvious secrets found."
+


### PR DESCRIPTION
Summary
- Hardened secret_sweep workflow by pinning checkout to a commit SHA.
- Added concurrency/timeout and disabled persisted credentials.

Testing
⚠️ Not run (workflow-only change).
