### PR TITLE
ci(secrets): harden secret full sweep workflow

### DIFF
--- a/.github/workflows/secret_full_sweep.yml
+++ b/.github/workflows/secret_full_sweep.yml
@@ -1,44 +1,234 @@
 name: Secret Full Sweep
+
 on:
   workflow_dispatch: {}
 
 permissions:
   contents: read
 
+concurrency:
+  group: secret-full-sweep-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Pin TruffleHog container by digest (amd64) for reproducibility
+  TRUFFLEHOG_IMAGE: ghcr.io/trufflesecurity/trufflehog@sha256:61f9ac3434c6be5a1af4b42551b41f90d3ee0f9142fe63ec20793b494642f217
+
 jobs:
   sweep:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # full history for TruffleHog
+    timeout-minutes: 15
 
-      # A) Working tree gyors grep (tipikus minták)
-      - name: Grep common secret patterns (working tree)
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Grep common secret patterns (working tree, safe output)
         shell: bash
         run: |
           set -euo pipefail
-          PATTERN='(BEGIN (RSA|OPENSSH) PRIVATE KEY|Authorization: Bearer|api[_-]?key|apikey|token|password|aws_access_key_id|aws_secret_access_key|ghp_[0-9A-Za-z]{36}|xox[baprs]-[0-9A-Za-z-]+|OPENAI_API_KEY|AZURE_OPENAI_KEY|HF_TOKEN)'
-          grep -rInE --exclude-dir=".git" "$PATTERN" . || echo "No obvious secrets found in working tree."
-
-      # B) Teljes git history vizsgálat (TruffleHog)
-      - name: Run TruffleHog (git history)
-        id: th
-        uses: trufflesecurity/trufflehog@v3
-        with:
-          scan: git
-          path: .
-        continue-on-error: true   # ne blokkoljon, csak jelezzen
-
-      - name: Save TruffleHog findings
-        if: always()
-        run: |
           mkdir -p findings
-          echo "${{ steps.th.outputs.result }}" > findings/trufflehog.json || true
 
-      - name: Upload findings
+          # Always create files so artifact upload is stable
+          : > findings/grep_suspects.txt
+          echo "0" > findings/grep_hits_count.txt
+
+          PATTERN='(BEGIN (RSA|OPENSSH) PRIVATE KEY|Authorization: Bearer|api[_-]?key|apikey|token|password|aws_access_key_id|aws_secret_access_key|ghp_[0-9A-Za-z]{36}|xox[baprs]-[0-9A-Za-z-]+|OPENAI_API_KEY|AZURE_OPENAI_KEY|HF_TOKEN)'
+
+          RAW="findings/_grep_raw.txt"
+          # NOTE: grep normally prints full matching lines (could include secrets).
+          # We capture to a file and only keep file:line metadata.
+          grep -rInE -I --exclude-dir=".git" "$PATTERN" . > "$RAW" || true
+
+          if [ -s "$RAW" ]; then
+            echo "::warning::Potential secret-like patterns detected in working tree (file:line only)."
+            cut -d: -f1-2 "$RAW" | sort -u > findings/grep_suspects.txt
+            wc -l < findings/grep_suspects.txt | tr -d ' ' > findings/grep_hits_count.txt
+
+            echo "Sample (first 50 file:line entries):"
+            head -n 50 findings/grep_suspects.txt | sed 's/^/ - /'
+          else
+            echo "No obvious secret patterns found in working tree."
+          fi
+
+          rm -f "$RAW" || true
+
+      - name: TruffleHog (git history -> sanitize -> summary)
+        id: trufflehog
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p findings
+
+          # Base commit for "full history" scan: repo root commit
+          BASE="$(git rev-list --max-parents=0 HEAD | tail -n 1)"
+          echo "base_commit=$BASE" >> "$GITHUB_OUTPUT"
+
+          RAW="findings/trufflehog_raw.jsonl"
+          SAN="findings/trufflehog_sanitized.jsonl"
+          SUMMARY="findings/trufflehog_summary.json"
+          EXIT_CODE_FILE="findings/trufflehog_exit_code.txt"
+
+          # Ensure predictable artifact set
+          : > "$SAN"
+          echo '{}' > "$SUMMARY"
+
+          echo "Running TruffleHog image: ${TRUFFLEHOG_IMAGE}"
+          echo "Scanning from base commit: $BASE"
+
+          # Capture stdout (JSONL) to file; keep stderr out of the workflow log.
+          set +e
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/workdir" \
+            -w /workdir \
+            "${TRUFFLEHOG_IMAGE}" \
+            git file://. \
+              --since-commit "$BASE" \
+              --branch HEAD \
+              --results=verified,unknown \
+              --json \
+              --no-update \
+              --fail \
+            > "$RAW" 2> findings/trufflehog_stderr.log
+          rc=$?
+          set -e
+
+          echo "$rc" > "$EXIT_CODE_FILE"
+          echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
+
+          # Mark findings/errors as warnings (this workflow is non-blocking by design)
+          if [ "$rc" -eq 183 ]; then
+            echo "::warning::TruffleHog: results found (exit code 183 with --fail)."
+          elif [ "$rc" -ne 0 ]; then
+            echo "::warning::TruffleHog: scan returned non-zero exit code: $rc"
+          fi
+
+          export TH_EXIT_CODE="$rc"
+
+          # Sanitize results: remove raw secret material (Raw/RawV2/etc.)
+          python - <<'PY'
+          import json, os, pathlib, sys
+
+          raw = pathlib.Path("findings/trufflehog_raw.jsonl")
+          out = pathlib.Path("findings/trufflehog_sanitized.jsonl")
+          summary = pathlib.Path("findings/trufflehog_summary.json")
+
+          exit_code = int(os.environ.get("TH_EXIT_CODE", "0") or "0")
+
+          out.parent.mkdir(parents=True, exist_ok=True)
+
+          if not raw.exists() or raw.stat().st_size == 0:
+              summary.write_text(
+                  json.dumps(
+                      {"exit_code": exit_code, "total": 0, "verified": 0, "other": 0, "note": "no json output"},
+                      indent=2
+                  ),
+                  encoding="utf-8",
+              )
+              out.write_text("", encoding="utf-8")
+              print("No findings (or no JSON output).")
+              sys.exit(0)
+
+          def pick(d, path):
+              cur = d
+              for key in path:
+                  if not isinstance(cur, dict):
+                      return None
+                  cur = cur.get(key)
+              return cur
+
+          total = verified = other = 0
+
+          with raw.open("r", encoding="utf-8", errors="replace") as f_in, out.open("w", encoding="utf-8") as f_out:
+              for line in f_in:
+                  line = line.strip()
+                  if not line:
+                      continue
+                  try:
+                      obj = json.loads(line)
+                  except Exception:
+                      continue
+
+                  sm = obj.get("SourceMetadata") if isinstance(obj, dict) else None
+                  git = pick(sm, ["Data", "Git"]) if isinstance(sm, dict) else None
+                  if not isinstance(git, dict):
+                      git = {}
+
+                  # Keep only non-sensitive fields useful for triage.
+                  rec = {
+                      "DetectorName": obj.get("DetectorName"),
+                      "DetectorType": obj.get("DetectorType"),
+                      "Verified": obj.get("Verified"),
+                      # Redacted may still be long depending on detector; keep a short prefix only.
+                      "RedactedPrefix": (obj.get("Redacted") or "")[:20] if isinstance(obj.get("Redacted"), str) else None,
+                      "Source": {
+                          "commit": git.get("commit"),
+                          "file": git.get("file"),
+                          "line": git.get("line"),
+                          "repository": git.get("repository"),
+                          "timestamp": git.get("timestamp"),
+                      },
+                  }
+
+                  total += 1
+                  if rec["Verified"] is True:
+                      verified += 1
+                  else:
+                      other += 1
+
+                  f_out.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+          summary.write_text(
+              json.dumps(
+                  {"exit_code": exit_code, "total": total, "verified": verified, "other": other},
+                  indent=2,
+                  ensure_ascii=False,
+              ),
+              encoding="utf-8",
+          )
+          print(f"Sanitized findings: total={total} verified={verified} other={other}")
+          PY
+
+          # Remove raw outputs to avoid leaving secrets on the runner
+          rm -f "$RAW" findings/trufflehog_stderr.log || true
+
+      - name: Workflow summary
         if: always()
-        uses: actions/upload-artifact@v4
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "## Secret Full Sweep" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          c="$(tr -d '[:space:]' < findings/grep_hits_count.txt 2>/dev/null || echo 0)"
+          echo "- Working tree grep suspects: **${c}** (file:line only; see artifact)" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -f findings/trufflehog_summary.json ]; then
+            total="$(python -c 'import json; d=json.load(open("findings/trufflehog_summary.json")); print(d.get("total",0))')"
+            ver="$(python -c 'import json; d=json.load(open("findings/trufflehog_summary.json")); print(d.get("verified",0))')"
+            other="$(python -c 'import json; d=json.load(open("findings/trufflehog_summary.json")); print(d.get("other",0))')"
+            rc="$(python -c 'import json; d=json.load(open("findings/trufflehog_summary.json")); print(d.get("exit_code",""))')"
+            echo "- TruffleHog (history) findings: **${total}** (verified: ${ver}, other: ${other})" >> "$GITHUB_STEP_SUMMARY"
+            echo "- TruffleHog exit code: \`${rc}\` (0=clean, 183=results found with --fail)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "_Artifacts contain only sanitized outputs (no raw secret values)._ " >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload findings artifact (sanitized)
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: secret-findings
-          path: findings/
+          name: secret-full-sweep-findings
+          if-no-files-found: warn
+          path: |
+            findings/grep_suspects.txt
+            findings/grep_hits_count.txt
+            findings/trufflehog_sanitized.jsonl
+            findings/trufflehog_summary.json
+            findings/trufflehog_exit_code.txt
+


### PR DESCRIPTION
Summary
- Hardened the manual “Secret Full Sweep” workflow to avoid leaking secret material into CI logs/artifacts.
- Pinned actions and the TruffleHog container image for reproducibility.

Changes
- Grep step now records only file:line suspects (no matched line content).
- TruffleHog history scan writes JSONL to a file, sanitizes it, and uploads only sanitized results.
- Raw TruffleHog output is deleted on-runner after sanitization.

Testing
⚠️ Not run (workflow-only change).
