### PR TITLE
ci(secrets): preserve secret_history scan errors

### DIFF
--- a/.github/workflows/secret_history.yml
+++ b/.github/workflows/secret_history.yml
@@ -5,11 +5,13 @@ on:
 
 permissions:
   contents: read
-  actions: write
+
+concurrency:
+  group: secret-history-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
-  # Pinned image (linux/amd64) for reproducible, supply-chain-safe runs
-  # Source: GHCR package page shows digests per arch
+  # Pinned image digest for reproducible runs (amd64)
   TRUFFLEHOG_IMAGE: ghcr.io/trufflesecurity/trufflehog:3.92.4@sha256:61f9ac3434c6be5a1af4b42551b41f90d3ee0f9142fe63ec20793b494642f217
   TRUFFLEHOG_RESULTS: verified,unknown
 
@@ -20,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout (full history)
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -33,12 +35,17 @@ jobs:
           set -euo pipefail
           mkdir -p findings
 
+          RAW="findings/trufflehog_raw.ndjson"
+          ERR="findings/trufflehog_stderr.log"
+          EXIT="findings/trufflehog_exit_code.txt"
+
+          rm -f "$RAW" "$ERR" "$EXIT" || true
+
           echo "Using image: $TRUFFLEHOG_IMAGE"
           echo "Results mode: $TRUFFLEHOG_RESULTS"
 
-          # IMPORTANT:
-          # - We redirect stdout to a file to avoid leaking secrets into Actions logs.
-          # - TruffleHog JSON output can include raw secret material; we sanitize later.
+          # Capture exit code explicitly (do NOT mask with || true).
+          set +e
           docker run --rm \
             -v "$PWD:/workdir" \
             -w /workdir \
@@ -48,7 +55,28 @@ jobs:
               --json \
               --fail \
               --quiet \
-            > findings/trufflehog_raw.ndjson || true
+              --no-update \
+            > "$RAW" 2> "$ERR"
+          rc=$?
+          set -e
+
+          echo "$rc" > "$EXIT"
+          echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
+
+          if [ "$rc" -eq 0 ]; then
+            echo "TruffleHog: clean."
+            exit 0
+          fi
+
+          if [ "$rc" -eq 183 ]; then
+            # Findings detected with --fail. Keep non-blocking, but visible via warning + summary.
+            echo "::warning::TruffleHog: findings detected (exit 183 with --fail)."
+            exit 0
+          fi
+
+          # Real scan failure: keep the step red (continue-on-error keeps the job running).
+          echo "::warning::TruffleHog: scan error (exit $rc). See findings/trufflehog_stderr.log"
+          exit "$rc"
 
       - name: Sanitize findings (remove secret material)
         if: always()
@@ -61,13 +89,21 @@ jobs:
           from pathlib import Path
 
           raw = Path("findings/trufflehog_raw.ndjson")
+          err = Path("findings/trufflehog_stderr.log")
+          exit_path = Path("findings/trufflehog_exit_code.txt")
+
           safe = Path("findings/trufflehog_findings_sanitized.ndjson")
           summary = Path("findings/trufflehog_summary.md")
 
           safe.parent.mkdir(parents=True, exist_ok=True)
 
-          count_total = 0
-          count_verified = 0
+          try:
+              rc = int(exit_path.read_text(encoding="utf-8").strip())
+          except Exception:
+              rc = 0
+
+          total = 0
+          verified = 0
           examples = []
 
           def pick_git(obj: dict) -> dict:
@@ -89,16 +125,14 @@ jobs:
                       try:
                           obj = json.loads(line)
                       except Exception:
-                          # If any non-JSON sneaks into stdout, skip it.
                           continue
 
-                      count_total += 1
+                      total += 1
                       if obj.get("Verified") is True:
-                          count_verified += 1
+                          verified += 1
 
                       git = pick_git(obj)
 
-                      # Store ONLY safe triage fields (no Raw / Redacted / ExtraData).
                       item = {
                           "detector_name": obj.get("DetectorName"),
                           "detector_type": obj.get("DetectorType"),
@@ -110,36 +144,46 @@ jobs:
                       if len(examples) < 10:
                           examples.append(item)
           else:
-              # Ensure artifact paths exist even when empty
               safe.write_text("", encoding="utf-8")
 
-          # Delete raw output to avoid accidental artifact/log exposure
+          # Always delete raw output to avoid leaving any secret material on runner
           try:
               raw.unlink()
           except FileNotFoundError:
               pass
 
           lines = []
-          lines.append("# TruffleHog history scan (sanitized)")
+          lines.append("## TruffleHog history scan (sanitized)")
           lines.append("")
-          lines.append(f"- Findings: **{count_total}**")
-          lines.append(f"- Verified findings: **{count_verified}**")
+          lines.append(f"- Exit code: `{rc}` (0=clean, 183=findings with --fail, other=scan error)")
+          lines.append(f"- Findings (sanitized): **{total}** (verified: {verified})")
           lines.append("")
 
-          if count_total == 0:
-              lines.append("No findings detected.")
+          if rc not in (0, 183):
+              lines.append("⚠️ Scan error detected — this is not a clean scan.")
+              if err.exists() and err.stat().st_size > 0:
+                  lines.append("")
+                  lines.append("### Error excerpt (stderr, first 80 lines)")
+                  lines.append("")
+                  lines.append("```")
+                  excerpt = err.read_text(encoding="utf-8", errors="replace").splitlines()[:80]
+                  lines.extend(excerpt)
+                  lines.append("```")
           else:
-              lines.append("## Examples (first 10, sanitized)")
-              lines.append("")
-              for it in examples:
-                  name = it.get("detector_name") or it.get("detector_type") or "unknown-detector"
-                  verdict = "VERIFIED" if it.get("verified") else "unverified"
-                  loc = f"{it.get('file')}:{it.get('line')}"
-                  commit = it.get("commit")
-                  lines.append(f"- {name}: {verdict} — {loc} @ {commit}")
+              if total == 0:
+                  lines.append("No findings detected (or no JSON output produced).")
+              else:
+                  lines.append("### Examples (first 10, sanitized)")
+                  lines.append("")
+                  for it in examples:
+                      name = it.get("detector_name") or it.get("detector_type") or "unknown-detector"
+                      verdict = "VERIFIED" if it.get("verified") else "unverified"
+                      loc = f"{it.get('file')}:{it.get('line')}"
+                      commit = it.get("commit")
+                      lines.append(f"- {name}: {verdict} — {loc} @ {commit}")
 
           summary.write_text("\n".join(lines) + "\n", encoding="utf-8")
-          print(f"Wrote {safe} and {summary}")
+          print("Wrote:", safe, summary)
           PY
 
       - name: Workflow summary (sanitized)
@@ -153,13 +197,15 @@ jobs:
             echo "No TruffleHog summary produced." >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Upload sanitized findings artifact
+      - name: Upload findings artifact (sanitized)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: trufflehog-history-findings
           if-no-files-found: warn
           path: |
             findings/trufflehog_findings_sanitized.ndjson
             findings/trufflehog_summary.md
+            findings/trufflehog_exit_code.txt
+            findings/trufflehog_stderr.log
 


### PR DESCRIPTION
Summary
- Secret history scan now preserves real TruffleHog errors instead of masking them as a clean run.
- Findings remain non-blocking, but scan failures become visible (red step + summary).

Testing
⚠️ Not run (workflow-only change).
