### PR TITLE
ci: harden publish report pages workflow

### DIFF
--- a/.github/workflows/publish_report_pages.yml
+++ b/.github/workflows/publish_report_pages.yml
@@ -32,8 +32,6 @@ jobs:
          github.event.workflow_run.head_branch == 'main')
       }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
@@ -46,13 +44,12 @@ jobs:
           set -euo pipefail
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            run_id="${{ inputs.run_id }}"
+            echo "run_id=${{ inputs.run_id }}" >> "$GITHUB_OUTPUT"
           else
-            run_id="${{ github.event.workflow_run.id }}"
+            echo "run_id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
           fi
 
-          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
-          echo "Using run_id: $run_id"
+          echo "Using run_id: ${{ steps.runid.outputs.run_id }}"
 
       - name: Download pulse-report artifact (from upstream run)
         uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
@@ -64,14 +61,16 @@ jobs:
           if_no_artifact_found: fail
 
       - name: Prepare Pages site
+        id: prepare
         shell: bash
-        env:
-          RUN_ID: ${{ steps.runid.outputs.run_id }}
         run: |
           set -euo pipefail
 
           rm -rf _site
           mkdir -p _site
+
+          # Disable Jekyll processing (safer for arbitrary static assets/layouts).
+          touch _site/.nojekyll
 
           # 1) Prefer a real index.html if present (already a proper site root).
           site_index="$(python3 - <<'PY'
@@ -115,91 +114,48 @@ jobs:
           PY
           )"
 
-          picked_kind=""
-          picked_path=""
-
-          if [ -n "$site_index" ]; then
+          if [ -n "$site_index" ] && [ -f "$site_index" ]; then
             site_root="$(dirname "$site_index")"
             echo "Detected site root (index.html): $site_root"
             cp -a "$site_root"/. _site/
-            picked_kind="index"
-            picked_path="$site_index"
 
-          elif [ -n "$report_card" ]; then
+            echo "mode=index" >> "$GITHUB_OUTPUT"
+            echo "site_root=$site_root" >> "$GITHUB_OUTPUT"
+
+          elif [ -n "$report_card" ] && [ -f "$report_card" ]; then
             card_root="$(dirname "$report_card")"
             echo "Detected report_card.html: $report_card"
             echo "Using report_card directory as site root: $card_root"
 
-            # Copy the directory containing report_card.html to the Pages root
-            # so relative assets (e.g. report_assets/) keep working.
+            # Copy directory containing report_card.html to Pages root so relative assets keep working.
             cp -a "$card_root"/. _site/
 
-            # Promote report_card.html to index.html at the Pages root.
+            # Promote report_card.html to index.html at the Pages root (regression fix).
             cp -a "$report_card" _site/index.html
 
-            picked_kind="report_card"
-            picked_path="$report_card"
+            echo "mode=report_card" >> "$GITHUB_OUTPUT"
+            echo "site_root=$card_root" >> "$GITHUB_OUTPUT"
 
           else
-            echo "::warning::No index.html or report_card.html found in downloaded artifact; publishing raw files with a landing page."
+            echo "::warning::No index.html or report_card.html found in downloaded artifact; publishing raw files with a minimal landing page."
             cp -a _artifact/. _site/
-            picked_kind="landing"
-            picked_path="_artifact/"
 
-            # Build a small landing page that also lists discovered HTML files (if any).
-            python3 - <<'PY'
-            import os
-            import pathlib
-            import html as _html
+            cat > _site/index.html <<'HTML'
+          <!doctype html>
+          <html lang="en">
+            <meta charset="utf-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <title>PULSE report artifact</title>
+            <body>
+              <h1>PULSE report artifact</h1>
+              <p>This Pages site was generated from the <code>pulse-report</code> workflow artifact.</p>
+              <p>If you expected an HTML report, ensure the upstream workflow produces a <code>report_card.html</code> or <code>index.html</code>.</p>
+            </body>
+          </html>
+          HTML
 
-            root = pathlib.Path("_artifact")
-            out = pathlib.Path("_site/index.html")
-
-            repo = os.environ.get("GITHUB_REPOSITORY", "")
-            run_id = os.environ.get("RUN_ID", "")
-
-            html_files = []
-            for p in root.rglob("*.html"):
-              s = p.as_posix()
-              if "/node_modules/" in s:
-                continue
-              try:
-                rel = p.relative_to(root).as_posix()
-              except Exception:
-                continue
-              html_files.append(rel)
-
-            html_files = sorted(set(html_files))[:200]
-
-            run_url = f"https://github.com/{repo}/actions/runs/{run_id}" if repo and run_id else ""
-
-            parts = []
-            parts.append("<!doctype html>")
-            parts.append("<html lang='en'>")
-            parts.append("<meta charset='utf-8' />")
-            parts.append("<meta name='viewport' content='width=device-width, initial-scale=1' />")
-            parts.append("<title>PULSE report artifact</title>")
-            parts.append("<body style='font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif;'>")
-            parts.append("<h1>PULSE report artifact</h1>")
-            parts.append("<p>This Pages site was generated from the <code>pulse-report</code> workflow artifact.</p>")
-            if run_url:
-              parts.append(f"<p>Upstream run: <a href='{_html.escape(run_url)}'>{_html.escape(run_url)}</a></p>")
-            parts.append("<p>If you expected an HTML report at the root, ensure the upstream workflow produces a <code>report_card.html</code> or <code>index.html</code>.</p>")
-
-            if html_files:
-              parts.append("<h2>HTML files found in artifact</h2>")
-              parts.append("<ul>")
-              for rel in html_files:
-                href = _html.escape(rel, quote=True)
-                label = _html.escape(rel)
-                parts.append(f"<li><a href='{href}'>{label}</a></li>")
-              parts.append("</ul>")
-            else:
-              parts.append("<p><em>No HTML files found in artifact.</em></p>")
-
-            parts.append("</body></html>")
-            out.write_text("\n".join(parts) + "\n", encoding="utf-8")
-            PY
+            echo "mode=raw" >> "$GITHUB_OUTPUT"
+            echo "site_root=_artifact" >> "$GITHUB_OUTPUT"
           fi
 
           # Optional: also surface top-level extras if present in the artifact bundle.
@@ -210,18 +166,34 @@ jobs:
             cp -a "_artifact/reports" "_site/"
           fi
 
-          # Drop a tiny meta file for auditing/debugging (safe, no secrets).
-          cat > _site/_publish_meta.json <<JSON
-          {
-            "run_id": "${RUN_ID}",
-            "picked_kind": "${picked_kind}",
-            "picked_path": "${picked_path}"
-          }
-          JSON
-
           echo ""
           echo "Top-level in _site:"
           ls -la _site | sed 's/^/  /'
+
+      - name: Workflow summary (Pages publish)
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "## Publish report pages" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- upstream run_id: \`${{ steps.runid.outputs.run_id }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- publish mode: \`${{ steps.prepare.outputs.mode }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- site root used: \`${{ steps.prepare.outputs.site_root }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -f "_site/index.html" ]; then
+            echo "- ✅ \`_site/index.html\` present" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- ❌ \`_site/index.html\` missing" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### _site top-level" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          ls -la _site >> "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0


### PR DESCRIPTION
Summary
- Improves GitHub Pages publish robustness and outside-review clarity.
- Adds .nojekyll and a concise Actions Summary (mode + root + index.html check).
- Keeps the report_card.html -> index.html fallback behavior.

Testing
⚠️ Not run (workflow-only change).
