### PR TITLE
fix(zenodo): repair malformed .zenodo.json metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,37 +1,47 @@
 {
   "title": "PULSE: Deterministic Release Gates for Safe & Useful AI",
-  "description": "PULSE provides deterministic, fail‑closed release gates across Safety (I2–I7), Utility (Q1–Q4) and SLO dimensions. It produces audit artefacts including a human‑readable Quality Ledger and SVG badges that summarise pass/fail states. This software package allows developers to enforce safety invariants, utility budgets and service level objectives prior to shipment.",
-  "upload_type": "software",
-  {
+  "description": "PULSE provides deterministic, fail-closed release gates across Safety (I2–I7), Utility (Q1–Q4) and SLO dimensions. It produces audit artefacts including a human-readable Quality Ledger and SVG badges that summarise pass/fail states. This software package allows developers to enforce safety invariants, utility budgets and service level objectives prior to shipment.",
   "upload_type": "software",
   "version": "1.0.2",
   "publication_date": "2025-10-16",
-  …
-}
- {
-  "upload_type": "software",
-  "publication_date": "2025-10-16",
-  …
-}
-
   "language": "eng",
   "creators": [
-    { "name": "Horvat, Katalin", "orcid": "0009-0001-9745-3764", "affiliation": "EPLabsAI" },
-    { "name": "EPLabsAI", "affiliation": "EPLabsAI" }
+    {
+      "name": "Horvat, Katalin",
+      "orcid": "0009-0001-9745-3764",
+      "affiliation": "EPLabsAI"
+    },
+    {
+      "name": "EPLabsAI",
+      "affiliation": "EPLabsAI"
+    }
   ],
   "license": "Apache-2.0",
-  "keywords": ["release-governance","ai-safety","evaluations","guardrails","SLO"],
+  "keywords": [
+    "release-governance",
+    "ai-safety",
+    "evaluations",
+    "guardrails",
+    "SLO"
+  ],
   "related_identifiers": [
-    { "identifier": "10.5281/zenodo.17214909", "relation": "isDocumentedBy", "scheme": "doi" },
-    { "identifier": "10.5281/zenodo.17214908", "relation": "isVersionOf",   "scheme": "doi" }
-  {
-  "identifier": "https://github.com/HKati/pulse-guard-pack",
-  "relation": "hasPart",
-  "resource_type": "software",
-  "scheme": "url"
+    {
+      "identifier": "10.5281/zenodo.17214909",
+      "relation": "isDocumentedBy",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "10.5281/zenodo.17214908",
+      "relation": "isVersionOf",
+      "scheme": "doi"
+    },
+    {
+      "identifier": "https://github.com/HKati/pulse-guard-pack",
+      "relation": "hasPart",
+      "resource_type": "software",
+      "scheme": "url"
+    }
+  ],
+  "notes": "Reproducibility instructions are included in the repository README (reproduce section)."
 }
 
-  ],
-  "notes": "Reproducibility instructions are included in the repository README (reproduce section).",
-  "communities": []
-}


### PR DESCRIPTION
## Summary
Fix `.zenodo.json` so it is valid JSON again.

## Why
Zenodo uses `.zenodo.json` as the metadata source for GitHub release archiving.
The existing file contained invalid JSON (duplicate/stray `{}` blocks, ellipsis
placeholders, and a malformed `related_identifiers` list), which can break or
skip metadata ingestion when publishing new releases.

## Changes
- `.zenodo.json`: replaced with a single valid JSON object preserving the
  intended metadata fields and identifiers.

## Verification
- `python -m json.tool .zenodo.json` (parses successfully)

## Notes
This PR is metadata-only and does not affect runtime code paths.
