### PR TITLE
fix(zenodo): update .zenodo.json preprint DOI reference

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -26,7 +26,7 @@
   ],
   "related_identifiers": [
     {
-      "identifier": "10.5281/zenodo.17214909",
+      "identifier": "10.5281/zenodo.17833583",
       "relation": "isDocumentedBy",
       "scheme": "doi"
     },


### PR DESCRIPTION
## Summary
Fix `.zenodo.json` to reference the current PULSE preprint DOI in `related_identifiers`.

## Why
The repository currently references two different preprint DOIs across docs and citation files.
Zenodo uses `.zenodo.json` for GitHub release metadata; keeping the `isDocumentedBy` DOI aligned
reduces metadata ambiguity and prevents future confusion.

## Changes
- `.zenodo.json`: update `related_identifiers` entry with `relation: isDocumentedBy`
  from `10.5281/zenodo.17214909` to `10.5281/zenodo.17833583`.

## Verification
- ✅ `python -m json.tool .zenodo.json > /dev/null`

## Notes
Metadata-only change; no runtime / CI gate logic modified.
