### PR TITLE
ci(release): add release_check workflow for Zenodo metadata

### DIFF
--- a/.github/workflows/release_check.yml
+++ b/.github/workflows/release_check.yml
@@ -1,0 +1,46 @@
+name: Release check
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  zenodo-release-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout (release tag)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Validate Zenodo metadata JSON
+        run: python -m json.tool .zenodo.json > /dev/null
+
+      - name: Check release status (draft/prerelease) and print release URL
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_DRAFT: ${{ github.event.release.draft }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          python - <<'PY'
+          import os
+          tag = os.environ.get("RELEASE_TAG", "")
+          url = os.environ.get("RELEASE_URL", "")
+          draft = os.environ.get("RELEASE_DRAFT", "false").lower() == "true"
+          prerelease = os.environ.get("RELEASE_PRERELEASE", "false").lower() == "true"
+
+          print(f"Release tag: {tag}")
+          print(f"Release URL: {url}")
+
+          if draft:
+              raise SystemExit("ERROR: release is draft (should not happen on 'published').")
+          if prerelease:
+              raise SystemExit("ERROR: release is prerelease; publish a final release for Zenodo archiving.")
+
+          print("OK: release is published and not prerelease.")
+          PY


### PR DESCRIPTION
## Summary
Add `.github/workflows/release_check.yml` to validate Zenodo metadata and release conditions on **published** GitHub releases.

## Why
We lost release-time visibility during the Zenodo indexing regression. This workflow provides a deterministic, quick diagnostic:
- confirms `.zenodo.json` is valid JSON
- surfaces the release URL and draft/prerelease status
- checks the **release tag snapshot** (not default branch HEAD)

## Changes
- New workflow: `.github/workflows/release_check.yml`

## Testing
⚠️ Not run (workflow-only change). Will execute automatically on the next **published** GitHub release.
