### PR TITLE
fix: correct gates schema $id URL

### DIFF
--- a/schemas/gates.schema.json
+++ b/schemas/gates.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://hkatilab.github.io/pulse-release-gates-0.1/schemas/gates.schema.json",
+  "$id": "https://hkati.github.io/pulse-release-gates-0.1/schemas/gates.schema.json",
   "title": "PULSE gates.yaml schema (v1)",
   "type": "object",
   "required": ["schemaVersion", "run", "invariants", "quality", "decision"],
@@ -108,3 +108,4 @@
   },
   "additionalProperties": false
 }
+


### PR DESCRIPTION
Summary
- Fixes a typo in schemas/gates.schema.json $id URL (hkatilab -> hkati).

Testing
⚠️ Not run (schema metadata-only change).
