### PR TITLE
docs(index): link paradox diagram v0 guide

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -30,6 +30,7 @@ If you add/rename a doc under `docs/`, please update this index.
 - [Pulse_paradox_edges_v0_status.md](Pulse_paradox_edges_v0_status.md) — Status/roadmap for `paradox_edges_v0.jsonl`.
 - [paradox_edges_case_studies.md](paradox_edges_case_studies.md) — Case studies (fixture + non-fixture).
 - [PARADOX_RUNBOOK.md](PARADOX_RUNBOOK.md) — What to do when EPF shadow disagrees with baseline.
+- [Paradox diagram v0](paradox_diagram_v0.md) — how to generate and read the Mermaid topology view.
 
 ## EPF shadow & hazard diagnostics
 - [PULSE_epf_shadow_quickstart_v0.md](PULSE_epf_shadow_quickstart_v0.md) — Command-level EPF shadow quickstart.


### PR DESCRIPTION
## Summary
Add an entry in `docs/INDEX.md` linking to `docs/paradox_diagram_v0.md`.

## Why
The Paradox diagram guide is now merged, but without an index link it’s hard to discover.
This makes reviewer onboarding and navigation faster.

## Changes
- `docs/INDEX.md`: add link to `paradox_diagram_v0.md`

## Testing
⚠️ Not run (docs-only change).
