### PR TITLE
fix(pages): publish sitemap.xml + robots.txt to prevent crawler 404

### DIFF
--- a/.github/workflows/publish_report_pages.yml
+++ b/.github/workflows/publish_report_pages.yml
@@ -37,6 +37,10 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
 
     steps:
+      # Needed so repo-root assets (sitemap.xml, robots.txt) are available for publishing.
+      - name: Checkout repository (for crawler assets)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Resolve upstream run id
         id: runid
         shell: bash
@@ -166,9 +170,42 @@ jobs:
             cp -a "_artifact/reports" "_site/"
           fi
 
+          # --- Crawler assets (fix: prevent /sitemap.xml 404 regression) ---
+          # Publish repo-root sitemap.xml + robots.txt into the Pages site root.
+          if [ -f "sitemap.xml" ]; then
+            cp -a "sitemap.xml" "_site/sitemap.xml"
+          else
+            echo "::error::Missing repo-root sitemap.xml; cannot publish sitemap to Pages."
+            exit 1
+          fi
+
+          if [ -f "robots.txt" ]; then
+            cp -a "robots.txt" "_site/robots.txt"
+          else
+            echo "::error::Missing repo-root robots.txt; cannot publish robots file to Pages."
+            exit 1
+          fi
+
           echo ""
           echo "Top-level in _site:"
           ls -la _site | sed 's/^/  /'
+
+      - name: Verify crawler assets present before upload
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ ! -s "_site/sitemap.xml" ]; then
+            echo "::error::Expected _site/sitemap.xml to exist and be non-empty before publish."
+            ls -la _site || true
+            exit 1
+          fi
+
+          if [ ! -s "_site/robots.txt" ]; then
+            echo "::error::Expected _site/robots.txt to exist and be non-empty before publish."
+            ls -la _site || true
+            exit 1
+          fi
 
       - name: Workflow summary (Pages publish)
         if: always()
@@ -187,6 +224,18 @@ jobs:
             echo "- ✅ \`_site/index.html\` present" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- ❌ \`_site/index.html\` missing" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ -f "_site/sitemap.xml" ]; then
+            echo "- ✅ \`_site/sitemap.xml\` present" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- ❌ \`_site/sitemap.xml\` missing" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [ -f "_site/robots.txt" ]; then
+            echo "- ✅ \`_site/robots.txt\` present" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- ❌ \`_site/robots.txt\` missing" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           echo "" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
The Pages workflow was deploying the report artifact but **not publishing repo-root crawler assets**.
As a result, the live site served **/robots.txt OK** but **/sitemap.xml 404**, which can stop/slow crawlers.

This PR fixes the Pages deploy by:
- checking out the repo in the Pages workflow
- copying `sitemap.xml` + `robots.txt` into the published `_site/` root
- failing fast before upload if the sitemap/robots files are missing or empty

## Why
- Crawlers rely on stable entrypoints:
  - `/robots.txt` → may reference `Sitemap: .../sitemap.xml`
  - `/sitemap.xml` → enumerates canonical URLs
- If `/sitemap.xml` disappears from the published Pages output, crawlers will drop/stop revisiting.

## Verification
After merge + next Pages deploy, these must return **200 OK**:
- https://hkati.github.io/pulse-release-gates-0.1/robots.txt
- https://hkati.github.io/pulse-release-gates-0.1/sitemap.xml

The workflow will also fail-fast if `_site/sitemap.xml` or `_site/robots.txt` is missing/empty.

## Scope
- `.github/workflows/publish_report_pages.yml` (workflow-only change)

## Testing
⚠️ Not run (workflow change only).
