### PR TITLE
fix(ci): repair invalid workflows by quoting step names with colons

### DIFF
--- a/.github/workflows/paradox_examples_smoke.yml
+++ b/.github/workflows/paradox_examples_smoke.yml
@@ -215,7 +215,7 @@ jobs:
             --max-edges 120 \
             --min-weight 0.0
 
-      - name: Regression fixture: empty edges (run_context present)
+      - name: "Regression fixture: empty edges (run_context present)"
         shell: bash
         run: |
           set -euo pipefail
@@ -259,7 +259,7 @@ jobs:
             --max-edges 120 \
             --min-weight 0.0
 
-      - name: Regression fixture: no atoms (stable empty field)
+      - name: "Regression fixture: no atoms (stable empty field)"
         shell: bash
         run: |
           set -euo pipefail
@@ -303,7 +303,7 @@ jobs:
             --max-edges 120 \
             --min-weight 0.0
 
-      - name: Determinism check: paradox markdown summaries + diagrams
+      - name: "Determinism check: paradox markdown summaries + diagrams"
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Context
Several GitHub Actions workflows were failing to parse with `Invalid workflow file` / YAML syntax errors.
Root cause: some `- name:` values contained `:` (colon) without quotes. In YAML, `:` followed by whitespace
can be interpreted as a mapping separator in plain scalars, causing parse failures.

## What changed
- Quote step names containing `:` in:
  - `.github/workflows/paradox_examples_smoke.yml`
  - `.github/workflows/docs_hygiene.yml`
  - `.github/workflows/repo_hygiene.yml`

## Why it matters
These workflows are guardrails (hygiene/smoke checks). If they don’t parse, the repo can appear “green”
while critical protections are silently disabled.

## Validation
- GitHub Actions should accept the workflow files (no YAML parse errors).
- The previously failing workflow runs should start executing normally.

## Scope / risk
Low risk: only step display names were quoted; no commands, logic, permissions, or triggers changed.
