### PR TITLE
fix(ci): repair docs-hygiene workflow YAML (quote colon in step name)

### DIFF
--- a/.github/workflows/docs_hygiene.yml
+++ b/.github/workflows/docs_hygiene.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - name: Repo hygiene: forbid case-insensitive path collisions
+      - name: "Repo hygiene: forbid case-insensitive path collisions"
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What
Fix GitHub Actions workflow parsing by quoting a step name that contains `:` in:
- `.github/workflows/docs_hygiene.yml`

## Why
Unquoted `:` in a YAML plain scalar (step name) can break workflow parsing, leading to
`Invalid workflow file` errors and disabling this guardrail silently.

## Scope
Syntax-only change; no behavior changes to the workflow steps.
