### PR TITLE
fix(ci): quote repo-hygiene step names containing colons

### DIFF
--- a/.github/workflows/repo_hygiene.yml
+++ b/.github/workflows/repo_hygiene.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1 :contentReference[oaicite:1]{index=1}
 
-      - name: Repo hygiene: forbid case-insensitive path collisions (file/file + file/dir)
+      - name: "Repo hygiene: forbid case-insensitive path collisions (file/file + file/dir)"
         shell: bash
         run: |
           set -euo pipefail
@@ -76,7 +76,7 @@ jobs:
           sys.exit(1)
           PY
 
-      - name: Repo hygiene: forbid ignored workflows under github/workflows/
+      - name: "Repo hygiene: forbid ignored workflows under github/workflows/"
         shell: bash
         run: |
           set -euo pipefail
@@ -89,7 +89,7 @@ jobs:
           fi
           echo "OK: no ignored workflows under github/workflows/."
 
-      - name: Repo hygiene: forbid nested fixtures
+      - name: "Repo hygiene: forbid nested fixtures"
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Context
`repo-hygiene` workflow was intermittently / consistently rejected by GitHub Actions with YAML parsing errors.
Root cause: several step names contained `:` (colon) without quotes. In YAML, `:` followed by whitespace can
be interpreted as a mapping separator inside plain scalars, which can invalidate the workflow file.

## What changed
- Quote step names containing `:` in:
  - `.github/workflows/repo_hygiene.yml`

## Why it matters
This workflow is a guardrail. If it fails to parse, the repo can appear “green” while hygiene protections
(case-insensitive collisions, ignored workflows, nested fixtures) are silently disabled.

## Validation
- GitHub Actions accepts the workflow file (no `Invalid workflow file` / YAML syntax errors).
- `repo-hygiene` runs normally on PRs and on `main` pushes.

## Scope / risk
Low risk: only YAML quoting of step display names. No command logic, permissions, or triggers changed.
