### PR TITLE
ci(workflows): add workflow-lint guardrail for Actions YAML

### DIFF
--- a/.github/workflows/workflow_lint.yml
+++ b/.github/workflows/workflow_lint.yml
@@ -1,0 +1,104 @@
+name: workflow-lint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/*.yml"
+      - ".github/workflows/*.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint_workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: "3.11"
+
+      - name: Install PyYAML (for workflow parsing)
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check "pyyaml==6.0.2"
+
+      - name: Validate workflow YAML (parse + guardrails)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python3 - <<'PY'
+          import re
+          import sys
+          import pathlib
+
+          import yaml
+
+          root = pathlib.Path(".github/workflows")
+          files = sorted(list(root.glob("*.yml")) + list(root.glob("*.yaml")))
+
+          if not files:
+              print("::warning::No workflow files found under .github/workflows/")
+              sys.exit(0)
+
+          # Guardrail: this is the exact failure mode you hit.
+          # Unquoted ':' followed by whitespace inside a step name can break YAML parsing in GitHub Actions.
+          colon_name_re = re.compile(r'^\s*-\s*name:\s+[^"\'].*:\s+.*$', re.MULTILINE)
+
+          ok = True
+
+          for f in files:
+              text = f.read_text(encoding="utf-8", errors="replace")
+
+              # Extra explicit check for the known footgun (even if parsing succeeds locally).
+              m = colon_name_re.search(text)
+              if m:
+                  line_no = text[:m.start()].count("\n") + 1
+                  print(f"::error file={f},line={line_no}::Unquoted ':' in step name. Quote the value of - name: ...")
+                  ok = False
+
+              try:
+                  obj = yaml.safe_load(text)
+              except yaml.YAMLError as e:
+                  # Best-effort line extraction
+                  line = None
+                  col = None
+                  mark = getattr(e, "problem_mark", None)
+                  if mark is not None:
+                      line = mark.line + 1
+                      col = mark.column + 1
+                  loc = f",line={line},col={col}" if line is not None and col is not None else ""
+                  msg = str(e).replace("\n", " | ")
+                  print(f"::error file={f}{loc}::YAML parse error: {msg}")
+                  ok = False
+                  continue
+
+              if obj is None:
+                  print(f"::error file={f}::Workflow YAML is empty (safe_load returned None).")
+                  ok = False
+                  continue
+
+              if not isinstance(obj, dict):
+                  print(f"::error file={f}::Workflow YAML must be a mapping at top-level (got {type(obj).__name__}).")
+                  ok = False
+                  continue
+
+              # Minimal sanity: expect at least one of the canonical keys
+              if not any(k in obj for k in ("on", "name", "jobs")):
+                  print(f"::warning file={f}::Top-level keys look unusual (missing 'on'/'jobs').")
+
+          if not ok:
+              sys.exit(1)
+
+          print(f"OK: validated {len(files)} workflow file(s).")
+          PY


### PR DESCRIPTION
## What
Add a `workflow-lint` guardrail that validates GitHub Actions workflow YAML files when they change.

## Why
We recently hit a failure mode where workflows became invalid due to YAML parsing issues
(e.g. unquoted ':' in step names), which can silently disable guardrails and still make the repo look “green”.

This PR adds a small safety net:
- YAML parse validation for `.github/workflows/*.yml` / `*.yaml`
- A targeted check for the known unquoted-colon step-name footgun

## Validation
- The new workflow runs on PRs/pushes that modify workflow files.
- Invalid YAML is rejected with actionable file/line error annotations.

## Scope / risk
Low risk: adds a new guardrail workflow only; no changes to existing CI logic or release gating.
