### PR TITLE
fix(pages): avoid regex $BASE matches in sitemap smoke checks

### DIFF
--- a/.github/workflows/publish_report_pages.yml
+++ b/.github/workflows/publish_report_pages.yml
@@ -464,7 +464,8 @@ jobs:
           PY
 
           # sitemap should at least include something under the base URL
-          grep -q "<loc>$BASE/" sitemap.xml
+          # (fixed-string match: avoid treating BASE as a regex where '.' would be a wildcard)
+          grep -Fq "<loc>${BASE}/" sitemap.xml
 
           # Validate sitemap is well-formed XML and locs match BASE (defensive)
           python3 - <<'PY'


### PR DESCRIPTION
PR body

Fix Codex finding: $BASE was used inside a grep pattern interpreted as a regex.

Switch sitemap <loc> smoke check to fixed-string matching (grep -F) so dots in BASE (github.io, 0.1) are not treated as wildcards.

Keeps the SEO guardrail strict (prevents false-positive PASS when URLs are wrong).