### PR TITLE
fix(pages): make sitemap validation regex-safe and fail-closed

### DIFF
--- a/.github/workflows/publish_report_pages.yml
+++ b/.github/workflows/publish_report_pages.yml
@@ -463,17 +463,15 @@ jobs:
           print("OK: robots.txt directives validated.")
           PY
 
-          # sitemap should at least include something under the base URL
-          # (fixed-string match: avoid treating BASE as a regex where '.' would be a wildcard)
-          grep -Fq "<loc>${BASE}/" sitemap.xml
-
-          # Validate sitemap is well-formed XML and locs match BASE (defensive)
+          # Validate sitemap is well-formed XML and locs are canonical (regex-safe, fail-closed)
           python3 - <<'PY'
           import os
           import xml.etree.ElementTree as ET
           from pathlib import Path
 
           BASE = os.environ.get("BASE","").rstrip("/")
+          home = f"{BASE}/"
+
           xml_text = Path("sitemap.xml").read_text(encoding="utf-8", errors="replace")
 
           try:
@@ -485,11 +483,16 @@ jobs:
           if not locs:
             raise SystemExit("::error::sitemap.xml contains no <loc> entries.")
 
-          ok = any(u == f"{BASE}/" or u.startswith(f"{BASE}/") for u in locs)
-          if not ok:
-            raise SystemExit(f"::error::sitemap.xml <loc> entries do not start with BASE={BASE}/")
+          # Must include homepage exactly (canonical).
+          if home not in locs:
+            raise SystemExit(f"::error::sitemap.xml missing homepage <loc>{home}</loc>")
 
-          print(f"OK: sitemap.xml parsed; loc_count={len(locs)}")
+          # Every loc must be under BASE/ (fail closed if any typo slips in).
+          bad = [u for u in locs if not (u == home or u.startswith(home))]
+          if bad:
+            raise SystemExit(f"::error::sitemap.xml contains <loc> outside BASE={home}: {bad[:5]}")
+
+          print(f"OK: sitemap.xml parsed; loc_count={len(locs)}; homepage_present=yes")
           PY
 
           # guardrail: accidental noindex in homepage HTML blocks indexing even if robots is open
@@ -527,7 +530,8 @@ jobs:
           echo "- ✅ robots: \`$BASE/robots.txt\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- ✅ sitemap: \`$BASE/sitemap.xml\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- ✅ no X-Robots-Tag: noindex" >> "$GITHUB_STEP_SUMMARY"
-          echo "- ✅ sitemap XML parse OK" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ robots directives OK" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ sitemap XML parse OK (canonical, fail-closed)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
           echo "OK: post-deploy SEO smoke passed."


### PR DESCRIPTION
Problem
Codex flagged that grep checks using $BASE treat dots as regex wildcards, allowing false-positive “SEO smoke PASS” even when the published URLs are wrong.

Fix

Remove regex grep sitemap assertions.

Validate sitemap via XML parse:

homepage <loc> must exist (BASE/)

every <loc> must be under BASE/… (fail-closed)
This makes the SEO smoke guardrail deterministic and robust.

How to verify
Run “Publish report pages” and confirm “SEO smoke (post-deploy)” logs show:

no X-Robots-Tag: noindex

robots directives OK

sitemap XML parse OK (canonical, fail-closed)