### PR TITLE
chore(ci): add scheduled GitHub Pages SEO probe

### DIFF
--- a/.github/workflows/seo_probe.yml
+++ b/.github/workflows/seo_probe.yml
@@ -1,0 +1,267 @@
+name: SEO probe (GitHub Pages)
+
+on:
+  schedule:
+    # Daily probe (UTC). Pick a stable minute to reduce burst collisions.
+    - cron: "17 03 * * *"
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Optional override. Default is https://{owner}.github.io/{repo}"
+        required: false
+        type: string
+      max_retries:
+        description: "Retry count for HTTP fetches"
+        required: false
+        default: "10"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "seo-probe-pages"
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve Pages base URL
+        id: base
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Read optional workflow_dispatch input from the event payload (works for schedule too).
+          INPUT_BASE="$(python3 -c 'import json,os; ev=json.load(open(os.environ["GITHUB_EVENT_PATH"])); print((ev.get("inputs") or {}).get("base_url","").strip())')"
+          INPUT_RETRIES="$(python3 -c 'import json,os; ev=json.load(open(os.environ["GITHUB_EVENT_PATH"])); print((ev.get("inputs") or {}).get("max_retries","").strip())')"
+
+          OWNER="${GITHUB_REPOSITORY%%/*}"
+          OWNER="${OWNER,,}"
+          REPO="${GITHUB_REPOSITORY#*/}"
+
+          DEFAULT_BASE="https://${OWNER}.github.io/${REPO}"
+          BASE="${DEFAULT_BASE}"
+
+          if [ -n "${INPUT_BASE}" ]; then
+            BASE="${INPUT_BASE}"
+          fi
+          BASE="${BASE%/}"
+
+          # retries default
+          RETRIES="${INPUT_RETRIES:-10}"
+          if [ -z "${RETRIES}" ]; then RETRIES="10"; fi
+
+          echo "BASE=${BASE}" >> "$GITHUB_OUTPUT"
+          echo "RETRIES=${RETRIES}" >> "$GITHUB_OUTPUT"
+
+          echo "Resolved BASE: ${BASE}"
+          echo "Retries:       ${RETRIES}"
+
+          echo "## SEO probe" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- base: \`${BASE}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- retries: \`${RETRIES}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fetch Pages endpoints (robots + sitemap + headers)
+        shell: bash
+        env:
+          BASE: ${{ steps.base.outputs.BASE }}
+          RETRIES: ${{ steps.base.outputs.RETRIES }}
+        run: |
+          set -euo pipefail
+
+          fetch () {
+            local url="$1"
+            local out="$2"
+            local i=0
+            while true; do
+              i=$((i+1))
+              if curl -fsSL -L "$url" -o "$out"; then
+                return 0
+              fi
+              if [ "$i" -ge "${RETRIES}" ]; then
+                echo "::error::Failed to fetch $url after $i attempts."
+                return 1
+              fi
+              echo "Retry $i/${RETRIES}: $url"
+              sleep 3
+            done
+          }
+
+          fetch_headers () {
+            local url="$1"
+            local out="$2"
+            local i=0
+            while true; do
+              i=$((i+1))
+              if curl -fsSIL -L -D "$out" -o /dev/null "$url"; then
+                return 0
+              fi
+              if [ "$i" -ge "${RETRIES}" ]; then
+                echo "::error::Failed to fetch headers for $url after $i attempts."
+                return 1
+              fi
+              echo "Retry $i/${RETRIES} (headers): $url"
+              sleep 3
+            done
+          }
+
+          mkdir -p _probe
+
+          fetch "${BASE}/robots.txt" _probe/robots.txt
+          fetch "${BASE}/sitemap.xml" _probe/sitemap.xml
+          fetch_headers "${BASE}/" _probe/headers_home.txt
+          fetch_headers "${BASE}/robots.txt" _probe/headers_robots.txt
+          fetch_headers "${BASE}/sitemap.xml" _probe/headers_sitemap.txt
+
+          # Best-effort: homepage HTML (meta noindex)
+          if curl -fsSL -L "${BASE}/" -o _probe/index.html; then
+            :
+          else
+            echo "::warning::Could not fetch homepage HTML; skipping meta robots check."
+            rm -f _probe/index.html || true
+          fi
+
+          echo "robots.txt (head):"
+          sed -n '1,120p' _probe/robots.txt
+
+          echo "sitemap.xml (head):"
+          sed -n '1,80p' _probe/sitemap.xml
+
+          echo "homepage headers (head):"
+          sed -n '1,80p' _probe/headers_home.txt
+
+      - name: Validate SEO allow-indexing signals (fail-closed)
+        shell: bash
+        env:
+          BASE: ${{ steps.base.outputs.BASE }}
+        run: |
+          set -euo pipefail
+
+          # 1) Hard blocker: X-Robots-Tag noindex
+          check_noindex_header () {
+            local url="$1"
+            local file="$2"
+            if grep -Eqi '^x-robots-tag:\s*.*noindex' "$file"; then
+              echo "::error::X-Robots-Tag: noindex detected for $url. This blocks indexing."
+              echo "::error::Fix: Repo Settings → Pages → Search engine visibility must allow indexing."
+              echo "Headers (head):"
+              sed -n '1,200p' "$file"
+              exit 1
+            fi
+          }
+
+          check_noindex_header "${BASE}/" _probe/headers_home.txt
+          check_noindex_header "${BASE}/robots.txt" _probe/headers_robots.txt
+          check_noindex_header "${BASE}/sitemap.xml" _probe/headers_sitemap.txt
+
+          # 2) robots.txt must explicitly allow crawling + point to the canonical sitemap (no regex footguns)
+          python3 - <<'PY'
+          import os, sys
+          from pathlib import Path
+
+          BASE = os.environ["BASE"].rstrip("/")
+          p = Path("_probe/robots.txt")
+          txt = p.read_text(encoding="utf-8", errors="replace").splitlines()
+          norm = [ln.strip() for ln in txt if ln.strip()]
+          lower = [ln.lower() for ln in norm]
+
+          need = [
+              "user-agent: *",
+              "allow: /",
+              f"sitemap: {BASE}/sitemap.xml".lower(),
+          ]
+
+          missing = [x for x in need if x not in lower]
+          if missing:
+              print("::error::robots.txt missing required directive lines:")
+              for m in missing:
+                  print(" - " + m)
+              sys.exit(1)
+
+          # Defensive: reject obvious global block
+          if any(ln.lower() == "disallow: /" for ln in norm):
+              print("::error::robots.txt contains 'Disallow: /' (global block).")
+              sys.exit(1)
+
+          print("OK: robots.txt directives validated.")
+          PY
+
+          # 3) sitemap.xml must be valid XML, include homepage exactly, and all <loc> under BASE/
+          python3 - <<'PY'
+          import os
+          import xml.etree.ElementTree as ET
+          from pathlib import Path
+
+          BASE = os.environ["BASE"].rstrip("/")
+          home = f"{BASE}/"
+
+          xml_text = Path("_probe/sitemap.xml").read_text(encoding="utf-8", errors="replace")
+
+          try:
+              root = ET.fromstring(xml_text)
+          except Exception as e:
+              raise SystemExit(f"::error::sitemap.xml is not valid XML: {e}")
+
+          locs = [(el.text or "").strip() for el in root.findall(".//{*}loc")]
+          if not locs:
+              raise SystemExit("::error::sitemap.xml contains no <loc> entries.")
+
+          if home not in locs:
+              raise SystemExit(f"::error::sitemap.xml missing homepage <loc>{home}</loc>")
+
+          bad = [u for u in locs if not (u == home or u.startswith(home))]
+          if bad:
+              raise SystemExit(f"::error::sitemap.xml contains <loc> outside BASE={home}: {bad[:10]}")
+
+          print(f"OK: sitemap.xml parsed; loc_count={len(locs)}; homepage_present=yes")
+          PY
+
+          # 4) Best-effort: meta noindex detection in homepage HTML
+          if [ -f _probe/index.html ]; then
+            python3 - <<'PY'
+          import re, sys
+          from pathlib import Path
+
+          html = Path("_probe/index.html").read_text(encoding="utf-8", errors="ignore")
+          meta_tags = re.findall(r"<meta\b[^>]*>", html, flags=re.I)
+
+          bad = []
+          for tag in meta_tags:
+            t = tag.lower()
+            if "noindex" not in t:
+              continue
+            if re.search(r"\bname\s*=\s*['\"]?(robots|googlebot)['\"]?\b", t) or re.search(r"\bhttp-equiv\s*=\s*['\"]?x-robots-tag['\"]?\b", t):
+              bad.append(tag.strip())
+
+          if bad:
+            print("::error::Found meta noindex directive(s) in homepage HTML (blocks indexing):")
+            for tag in bad[:10]:
+              print(tag)
+            sys.exit(1)
+
+          print("OK: no meta noindex found in homepage HTML.")
+          PY
+          fi
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ no X-Robots-Tag: noindex" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ robots directives OK" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ sitemap XML canonical OK" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ meta noindex not present (best-effort)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload probe artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: seo-probe-artifacts
+          if-no-files-found: warn
+          path: |
+            _probe/robots.txt
+            _probe/sitemap.xml
+            _probe/headers_home.txt
+            _probe/headers_robots.txt
+            _probe/headers_sitemap.txt
+            _probe/index.html


### PR DESCRIPTION
Adds a scheduled + manually runnable workflow that continuously validates the public GitHub Pages indexing surface.

What it checks (fail-closed):

robots.txt is reachable and allows crawling, and references the canonical sitemap URL

sitemap.xml is reachable, valid XML, contains homepage <loc>BASE/</loc>, and all <loc> are under BASE/

No X-Robots-Tag: noindex header is present on /, /robots.txt, or /sitemap.xml

Best-effort: homepage HTML does not include a meta noindex directive

Why:
Prevents “green CI, dead outside world” regressions by keeping a continuous link between the deployed public surface and the repo.

Artifacts:
Uploads fetched robots/sitemap/headers to simplify debugging when the probe fails.