### PR TITLE
fix(pages): add report_card.htm redirect alias for canonical report card

### DIFF
--- a/docs/report_card.htm
+++ b/docs/report_card.htm
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="https://hkati.github.io/pulse-release-gates-0.1/report_card.html" />
+    <meta http-equiv="refresh" content="0; url=report_card.html" />
+    <title>Redirecting…</title>
+  </head>
+  <body>
+    <p>Redirecting to <a href="report_card.html">report_card.html</a>…</p>
+  </body>
+</html>


### PR DESCRIPTION
### Summary
Add `report_card.htm` as a small redirect page to preserve legacy URLs and point to the canonical `report_card.html`.

### Why
Some links and/or previously indexed URLs may still reference `/report_card.htm`. A 404 can degrade crawl quality and delay re-indexing. This change restores a stable entry point and sets a canonical target.

### Changes
- Add `docs/report_card.htm` redirecting to `report_card.html`
- Set canonical link to the `.html` report card
