### PR TITLE
docs(ambiguity): resolve field-first terms via glossary

### DIFF
--- a/docs/AMBIGUITY_REGISTER_v0.md
+++ b/docs/AMBIGUITY_REGISTER_v0.md
@@ -30,11 +30,11 @@ To resolve a `blocking` item, a PR must include:
 
 | Term | 1‑line meaning | Layer | Canonical doc link | Status | Notes |
 |------|-----------------|-------|--------------------|--------|------|
-| Anchor | Reference frame for decision-relative interpretation (baseline / cut / run context) | Diagnostic | docs/GLOSSARY_v0.md#anchor | resolved | Canonical, non-causal framing; requires explicit anchor for orientation |
-| Atom | Minimal audit-carrying evidence unit in the decision-relative field | Diagnostic | docs/GLOSSARY_v0.md#atom | resolved | Evidence-first; traceable to artefacts; not a narrative belief |
-| Edge | Typed relationship between atoms; co-occurrence/association in v0 (no causality) | Diagnostic | docs/GLOSSARY_v0.md#edge | resolved | Direction/weight are decision-relative aids; no causal semantics in v0 |
-| Orientation | Decision-relative reading direction w.r.t. an Anchor (push PASS/FAIL) | Diagnostic | docs/GLOSSARY_v0.md#orientation | resolved | Meaningless without Anchor; deterministic computation required |
-| Core | Deterministic minimal sub-structure for reviewer readability (projection) | Diagnostic | docs/GLOSSARY_v0.md#core-field-core | resolved | Must be deterministic + explainable; not “Core profile” nor “Core gates” |
+| Anchor | Reference frame for decision-relative interpretation (baseline / cut / run context) | Diagnostic | [docs/GLOSSARY_v0.md#anchor](docs/GLOSSARY_v0.md#anchor) | resolved | Requires explicit anchor for orientation |
+| Atom | Minimal audit-carrying evidence unit in the decision-relative field | Diagnostic | [docs/GLOSSARY_v0.md#atom](docs/GLOSSARY_v0.md#atom) | resolved | Evidence-first; traceable to artefacts; not a narrative belief |
+| Edge | Typed relationship between atoms; co-occurrence/association in v0 (no causality) | Diagnostic | [docs/GLOSSARY_v0.md#edge](docs/GLOSSARY_v0.md#edge) | resolved | Direction/weight are decision-relative aids; non-causal in v0 |
+| Orientation | Decision-relative reading direction w.r.t. an Anchor (push PASS/FAIL) | Diagnostic | [docs/GLOSSARY_v0.md#orientation](docs/GLOSSARY_v0.md#orientation) | resolved | Meaningless without Anchor; must be deterministic |
+| Core | Deterministic minimal sub-structure for reviewer readability (projection) | Diagnostic | [docs/GLOSSARY_v0.md#core-field-core](docs/GLOSSARY_v0.md#core-field-core) | resolved | Not “Core profile” nor “Core gates”; deterministic tie-breaks required |
 | EPF | Shadow-only stability/diagnostic layer; never flips CI outcomes | Diagnostic | docs/PULSE_epf_shadow_quickstart_v0.md | review | Clarify “missing EPF” vs “schema drift” semantics |
 | RDSI | Release decision stability signal; diagnostic only | Diagnostic | PULSE_safe_pack_v0/docs/METHODS_RDSI_QLEDGER.md | review | Clarify reporting vs enforcement usage |
 | Drift | Compare/history output; useful only with stable, indexable artefacts/surfaces | Diagnostic | docs/STATE_v0.md | review | Define minimal URL + artefact naming contract |


### PR DESCRIPTION
### Summary
Update `docs/AMBIGUITY_REGISTER_v0.md` to mark the core field-first terms as `resolved`:
Anchor, Atom, Edge, Orientation, Core.

### Why
These terms were previously tracked as high-risk ambiguities for Paradox/field semantics.
They are now canonically defined in `docs/GLOSSARY_v0.md`, so we can proceed without semantic ambiguity.

### Scope
Docs-only. No changes to CI behaviour, release gates, schemas, or tooling.
