### PR TITLE
test(paradox): add core projection field fixture v0

### DIFF
--- a/tests/fixtures/paradox_core_projection_v0/field_v0.json
+++ b/tests/fixtures/paradox_core_projection_v0/field_v0.json
@@ -1,0 +1,11 @@
+{
+  "schema": "PULSE_paradox_field_v0",
+  "run_context": {
+    "run_id": "fixture_run_core_projection_v0"
+  },
+  "atoms": [
+    { "atom_id": "a_02", "severity": 0.9, "summary": "equal-severity atom 2" },
+    { "atom_id": "a_01", "severity": 0.9, "summary": "equal-severity atom 1 (tie-break by id)" },
+    { "atom_id": "a_03", "severity": 0.2, "summary": "low-severity atom 3" }
+  ]
+}


### PR DESCRIPTION
### Summary
Add `tests/fixtures/paradox_core_projection_v0/field_v0.json` for Paradox core projection testing.

### Why
We need a minimal, reproducible field fixture to validate:
- deterministic top‑K selection,
- stable tie-break behaviour (equal metric values → atom_id ordering),
- compatibility with the core projection builder.

### What
- New fixture: `tests/fixtures/paradox_core_projection_v0/field_v0.json`

### Scope
Test fixture only. No changes to release gates, schemas, or CI enforcement.
