### PR TITLE
test(paradox): add core projection edges fixture v0

### DIFF
--- a/tests/fixtures/paradox_core_projection_v0/edges_v0.jsonl
+++ b/tests/fixtures/paradox_core_projection_v0/edges_v0.jsonl
@@ -1,0 +1,2 @@
+{"edge_id":"e1","src_atom_id":"a_01","dst_atom_id":"a_02","edge_type":"co_occurs","weight":1.0}
+{"edge_id":"e2","src_atom_id":"a_01","dst_atom_id":"a_03","edge_type":"co_occurs","weight":1.0}


### PR DESCRIPTION
### Summary
Add `tests/fixtures/paradox_core_projection_v0/edges_v0.jsonl` for Paradox core projection testing.

### Why
We need a minimal, reproducible edges fixture to validate the induced-subgraph rule:
- edges between selected core atoms are kept,
- edges touching non-core atoms are dropped when selecting top‑K.

### What
- New fixture: `tests/fixtures/paradox_core_projection_v0/edges_v0.jsonl`

### Scope
Test fixture only. No changes to release gates, schemas, or CI enforcement.
