### PR TITLE
test(paradox): add core projection determinism test v0

### DIFF
--- a/tests/test_paradox_core_projection_v0.py
+++ b/tests/test_paradox_core_projection_v0.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _run(cmd: list[str]) -> None:
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    assert r.returncode == 0, f"Command failed:\n{' '.join(cmd)}\nSTDOUT:\n{r.stdout}\nSTDERR:\n{r.stderr}"
+
+
+def test_paradox_core_projection_is_deterministic(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+
+    field = repo_root / "tests" / "fixtures" / "paradox_core_projection_v0" / "field_v0.json"
+    edges = repo_root / "tests" / "fixtures" / "paradox_core_projection_v0" / "edges_v0.jsonl"
+
+    out1 = tmp_path / "core1.json"
+    out2 = tmp_path / "core2.json"
+
+    _run(["python", str(repo_root / "scripts" / "paradox_core_projection_v0.py"),
+          "--field", str(field),
+          "--edges", str(edges),
+          "--out", str(out1),
+          "--k", "2",
+          "--metric", "severity"])
+
+    _run(["python", str(repo_root / "scripts" / "paradox_core_projection_v0.py"),
+          "--field", str(field),
+          "--edges", str(edges),
+          "--out", str(out2),
+          "--k", "2",
+          "--metric", "severity"])
+
+    b1 = out1.read_bytes()
+    b2 = out2.read_bytes()
+    assert b1 == b2, "Core projection output must be byte-identical across reruns"
+
+    _run(["python", str(repo_root / "scripts" / "check_paradox_core_v0_contract.py"),
+          "--in", str(out1)])


### PR DESCRIPTION
### Summary
Add `tests/test_paradox_core_projection_v0.py` to validate deterministic Paradox core projection output.

### Why
Paradox reviewer surfaces must be stable and audit-friendly. This regression test ensures:
- the core projection builder produces byte-identical JSON across reruns,
- the output satisfies the strict contract checker (ordering + integrity).

### What
- New test: `tests/test_paradox_core_projection_v0.py`
  - Uses the existing fixtures under `tests/fixtures/paradox_core_projection_v0/`
  - Invokes:
    - `scripts/paradox_core_projection_v0.py`
    - `scripts/check_paradox_core_v0_contract.py`

### Scope
Tests only. No changes to schemas, core gates, or CI enforcement.
