### PR TITLE
docs(index): add Paradox Core v0 entry

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,6 +31,7 @@ If you add/rename a doc under `docs/`, please update this index.
 - [paradox_edges_case_studies.md](paradox_edges_case_studies.md) — Case studies (fixture + non-fixture).
 - [PARADOX_RUNBOOK.md](PARADOX_RUNBOOK.md) — What to do when EPF shadow disagrees with baseline.
 - [Paradox diagram v0](paradox_diagram_v0.md) — how to generate and read the Mermaid topology view.
+- [PULSE_paradox_core_v0.md](PULSE_paradox_core_v0.md) — Paradox Core v0 (deterministic core projection + markdown reviewer summary).
 
 ## EPF shadow & hazard diagnostics
 - [PULSE_epf_shadow_quickstart_v0.md](PULSE_epf_shadow_quickstart_v0.md) — Command-level EPF shadow quickstart.


### PR DESCRIPTION
### Summary
Add a clickable link to `PULSE_paradox_core_v0.md` in `docs/INDEX.md`.

### Why
Paradox Core v0 is now part of the documented workflow (core projection + markdown summary).
The full docs index should list it to improve discoverability and keep the Paradox section complete.

### Scope
Docs-only. No changes to release gates, schemas, or CI enforcement.
