### PR TITLE
test(paradox): add golden core SVG fixture k2

### DIFF
--- a/tests/fixtures/paradox_core_render_v0/golden_core_k2.svg
+++ b/tests/fixtures/paradox_core_render_v0/golden_core_k2.svg
@@ -1,0 +1,10 @@
+python scripts/paradox_core_projection_v0.py \
+  --field tests/fixtures/paradox_core_projection_v0/field_v0.json \
+  --edges tests/fixtures/paradox_core_projection_v0/edges_v0.jsonl \
+  --out out/core_k2.json \
+  --k 2 \
+  --metric severity
+
+python scripts/render_paradox_core_svg_v0.py \
+  --in out/core_k2.json \
+  --out tests/fixtures/paradox_core_render_v0/golden_core_k2.svg


### PR DESCRIPTION
### Summary
Add a golden SVG fixture for the deterministic Core → SVG renderer: `golden_core_k2.svg`.

### Why
We want a canonical “reviewer visual” baseline for SVG rendering so that future
renderer changes can be caught via golden-file regression tests.

### How this file was generated
```bash
python scripts/paradox_core_projection_v0.py \
  --field tests/fixtures/paradox_core_projection_v0/field_v0.json \
  --edges tests/fixtures/paradox_core_projection_v0/edges_v0.jsonl \
  --out out/core_k2.json \
  --k 2 \
  --metric severity

python scripts/render_paradox_core_svg_v0.py \
  --in out/core_k2.json \
  --out tests/fixtures/paradox_core_render_v0/golden_core_k2.svg
