### PR TITLE
ci(paradox): add shadow workflow for core reviewer bundle

### DIFF
--- a/.github/workflows/paradox_core_bundle_shadow.yml
+++ b/.github/workflows/paradox_core_bundle_shadow.yml
@@ -14,10 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: "3.11"
 
@@ -39,8 +41,9 @@ jobs:
           echo "Artifact: paradox-core-bundle-v0" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: paradox-core-bundle-v0
           path: out/paradox_core_bundle_v0
           if-no-files-found: error
+


### PR DESCRIPTION
### Summary
Add a shadow GitHub Actions workflow that produces the Paradox Core reviewer bundle v0 and uploads it as an artifact.

### Why
We now have deterministic Core projection + Markdown summary + SVG rendering (with golden regression tests).
This workflow makes the reviewer bundle available in CI as a downloadable artifact, without affecting release gating.

### What
- New workflow: `.github/workflows/paradox_core_bundle_shadow.yml`
- Triggers:
  - workflow_dispatch
  - pull_request
  - push to main
- Output artifact:
  - name: `paradox-core-bundle-v0`
  - path: `out/paradox_core_bundle_v0`
- Adds a small `GITHUB_STEP_SUMMARY` listing of the produced files.

### Scope
CI-neutral diagnostic layer only; no changes to release gates or enforcement.
