### PR TITLE
test(pages): add regression test for paradox core Pages mount contract

### DIFF
--- a/scripts/pages_publish_paradox_core_bundle_v0.py
+++ b/scripts/pages_publish_paradox_core_bundle_v0.py
@@ -1,132 +1,184 @@
+#!/usr/bin/env python3
+"""
+pages_publish_paradox_core_bundle_v0.py
 
-# tests/test_pages_publish_paradox_core_bundle_v0.py
-import subprocess
-import sys
-import tempfile
-import unittest
-from pathlib import Path
+Deterministic publisher for the Paradox Core reviewer bundle into a Pages site directory.
+
+Inputs:
+  --bundle-dir   Directory produced by scripts/paradox_core_reviewer_bundle_v0.py
+  --site-dir     Pages site build output directory (the directory that will be deployed)
+  --mount        Mount path within the site (default: paradox/core/v0)
+  --write-index  If set, write a tiny index.html redirect to the reviewer card
+
+Copies (fail-closed if missing):
+  - paradox_core_v0.json
+  - paradox_core_summary_v0.md
+  - paradox_core_v0.svg
+  - paradox_core_reviewer_card_v0.html
+
+Design goals:
+  - CI-neutral (pure publish helper; does not compute semantics)
+  - deterministic outputs (stable index.html content; no timestamps)
+  - fail-closed if required inputs are missing
+  - byte-for-byte copying (no metadata preservation)
+  - prevent mount path traversal / escaping site_dir
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path, PurePosixPath
+from typing import List
 
 
-def _run(cmd, cwd: Path | None = None) -> subprocess.CompletedProcess:
-    """
-    Run a command and capture stdout/stderr for deterministic debugging.
-    We do not use shell=True and we do not rely on wall-clock timestamps.
-    """
-    return subprocess.run(
-        cmd,
-        cwd=str(cwd) if cwd else None,
-        text=True,
-        capture_output=True,
-        check=False,
+REQUIRED_FILES: List[str] = [
+    "paradox_core_v0.json",
+    "paradox_core_summary_v0.md",
+    "paradox_core_v0.svg",
+    "paradox_core_reviewer_card_v0.html",
+]
+
+
+def _fail(msg: str) -> None:
+    raise SystemExit(msg)
+
+
+def _copy_bytes(src: Path, dst: Path) -> None:
+    # Copy content only (no mtime/metadata) for deterministic publish behavior.
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+
+
+def _write_index(dst_dir: Path, target_html: str) -> None:
+    # Deterministic redirect page; no timestamps, no dynamic content.
+    content = (
+        "<!doctype html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '  <meta charset="utf-8" />\n'
+        '  <meta name="viewport" content="width=device-width,initial-scale=1" />\n'
+        f'  <meta http-equiv="refresh" content="0; url={target_html}" />\n'
+        f'  <link rel="canonical" href="{target_html}" />\n'
+        "  <title>Paradox Core Reviewer Card v0</title>\n"
+        "</head>\n"
+        "<body>\n"
+        f'  <p>Redirecting to <a href="{target_html}">{target_html}</a>…</p>\n'
+        "</body>\n"
+        "</html>\n"
     )
+    (dst_dir / "index.html").write_text(content, encoding="utf-8")
 
 
-def _check_ok(cmd, cwd: Path | None = None) -> None:
-    proc = _run(cmd, cwd=cwd)
-    if proc.returncode != 0:
-        raise AssertionError(
-            "Command failed (expected success)\n"
-            f"cmd: {cmd}\n"
-            f"returncode: {proc.returncode}\n"
-            f"stdout:\n{proc.stdout}\n"
-            f"stderr:\n{proc.stderr}\n"
-        )
+def _safe_mount_parts(mount: str) -> List[str]:
+    """
+    Convert a user-provided mount string into safe path parts.
+
+    Reject:
+      - empty mounts
+      - backslashes
+      - absolute mounts
+      - '.' or '..' segments
+    """
+    m = str(mount).strip()
+    if not m:
+        _fail("Mount must be non-empty")
+
+    # Enforce forward-slash semantics to avoid platform surprises.
+    if "\\" in m:
+        _fail("Mount must use forward slashes ('/'), not backslashes ('\\')")
+
+    m = m.strip("/")
+    if not m:
+        _fail("Mount must not be '/' only")
+
+    p = PurePosixPath(m)
+    if p.is_absolute():
+        _fail(f"Mount must be relative, got absolute mount: {mount!r}")
+
+    parts = [seg for seg in p.parts if seg]
+    for seg in parts:
+        if seg in (".", ".."):
+            _fail(f"Mount contains forbidden path segment {seg!r}: {mount!r}")
+    return parts
 
 
-class TestPagesPublishParadoxCoreBundleV0(unittest.TestCase):
-    def test_mount_contract_rejects_path_traversal(self) -> None:
-        repo_root = Path(__file__).resolve().parents[1]
+def _ensure_within_site(site_dir: Path, target_dir: Path) -> None:
+    """
+    Fail-closed if target_dir resolves outside site_dir.
 
-        fixture_field = repo_root / "tests" / "fixtures" / "paradox_core_projection_v0" / "field_v0.json"
-        fixture_edges = repo_root / "tests" / "fixtures" / "paradox_core_projection_v0" / "edges_v0.jsonl"
+    Uses resolve(strict=False) to normalize and follow symlinks if present.
+    This prevents publishing outside the intended Pages output directory.
+    """
+    site_res = site_dir.resolve(strict=False)
+    target_res = target_dir.resolve(strict=False)
+    try:
+        target_res.relative_to(site_res)
+    except ValueError:
+        _fail(f"Mount escapes site-dir: target={target_res} site={site_res}")
 
-        bundle_tool = repo_root / "scripts" / "paradox_core_reviewer_bundle_v0.py"
-        publish_tool = repo_root / "scripts" / "pages_publish_paradox_core_bundle_v0.py"
 
-        self.assertTrue(fixture_field.exists(), f"Missing fixture field: {fixture_field}")
-        self.assertTrue(fixture_edges.exists(), f"Missing fixture edges: {fixture_edges}")
-        self.assertTrue(bundle_tool.exists(), f"Missing bundle tool: {bundle_tool}")
-        self.assertTrue(publish_tool.exists(), f"Missing pages publish tool: {publish_tool}")
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--bundle-dir",
+        default="out/paradox_core_bundle_v0",
+        help="Input bundle directory (default: out/paradox_core_bundle_v0)",
+    )
+    ap.add_argument(
+        "--site-dir",
+        required=True,
+        help="Pages site build output directory (the directory to be deployed)",
+    )
+    ap.add_argument(
+        "--mount",
+        default="paradox/core/v0",
+        help="Mount path within the site (default: paradox/core/v0)",
+    )
+    ap.add_argument(
+        "--write-index",
+        action="store_true",
+        help="Write index.html redirect to paradox_core_reviewer_card_v0.html",
+    )
+    args = ap.parse_args()
 
-        with tempfile.TemporaryDirectory(prefix="pulse_test_pages_publish_") as td:
-            td = Path(td)
-            bundle_dir = td / "bundle"
-            site_dir = td / "site"
+    bundle_dir = Path(args.bundle_dir)
+    site_dir = Path(args.site_dir)
 
-            # 1) Build a deterministic reviewer bundle from fixtures.
-            _check_ok(
-                [
-                    sys.executable,
-                    str(bundle_tool),
-                    "--field",
-                    str(fixture_field),
-                    "--edges",
-                    str(fixture_edges),
-                    "--out-dir",
-                    str(bundle_dir),
-                    "--k",
-                    "2",
-                    "--metric",
-                    "severity",
-                ]
-            )
+    if not bundle_dir.exists() or not bundle_dir.is_dir():
+        _fail(f"Bundle dir not found: {bundle_dir}")
 
-            # 2) Publish into a safe mount (should succeed).
-            _check_ok(
-                [
-                    sys.executable,
-                    str(publish_tool),
-                    "--bundle-dir",
-                    str(bundle_dir),
-                    "--site-dir",
-                    str(site_dir),
-                    "--mount",
-                    "paradox/core/v0",
-                ]
-            )
+    # Ensure site-dir exists before resolving containment.
+    site_dir.mkdir(parents=True, exist_ok=True)
 
-            mounted = site_dir / "paradox" / "core" / "v0"
-            self.assertTrue(mounted.exists(), f"Expected mount dir to exist: {mounted}")
+    parts = _safe_mount_parts(args.mount)
+    target_dir = site_dir.joinpath(*parts)
 
-            # Expect at least one known artifact in the mount directory.
-            # (We don't hardcode the full list here; we only need evidence of publish.)
-            expected_any = ["paradox_core_v0.json", "paradox_core_summary_v0.md", "paradox_core_k2.svg", "index.html"]
-            self.assertTrue(
-                any((mounted / name).exists() for name in expected_any),
-                f"Expected at least one known artifact under mount. Found: {[p.name for p in mounted.glob('*')]}",
-            )
+    # Fail-closed: do not allow mount to escape the site directory.
+    _ensure_within_site(site_dir, target_dir)
 
-            # 3) Path traversal attempts must fail-closed.
-            bad_mounts = [
-                "../evil",
-                "../../evil",
-                "paradox/../evil",
-                "paradox/core/v0/../../evil",
-                "paradox/core/v0/../..",
-            ]
+    target_dir.mkdir(parents=True, exist_ok=True)
 
-            for bad in bad_mounts:
-                proc = _run(
-                    [
-                        sys.executable,
-                        str(publish_tool),
-                        "--bundle-dir",
-                        str(bundle_dir),
-                        "--site-dir",
-                        str(site_dir),
-                        "--mount",
-                        bad,
-                    ]
-                )
-                self.assertNotEqual(
-                    proc.returncode,
-                    0,
-                    "Bad mount unexpectedly succeeded (must fail-closed)\n"
-                    f"mount: {bad}\n"
-                    f"stdout:\n{proc.stdout}\n"
-                    f"stderr:\n{proc.stderr}\n",
-                )
+    # Fail-closed: all required files must exist.
+    missing: List[str] = []
+    for name in REQUIRED_FILES:
+        if not (bundle_dir / name).exists():
+            missing.append(name)
+    if missing:
+        _fail(f"Missing required bundle files in {bundle_dir}: {', '.join(missing)}")
+
+    # Copy files deterministically
+    for name in REQUIRED_FILES:
+        _copy_bytes(bundle_dir / name, target_dir / name)
+
+    if args.write_index:
+        _write_index(target_dir, "paradox_core_reviewer_card_v0.html")
+
+    # Minimal stdout; stable, no timestamps.
+    print(f"Published Paradox Core bundle v0 → {target_dir}")
+    return 0
 
 
 if __name__ == "__main__":
-    unittest.main()
+    raise SystemExit(main())
+


### PR DESCRIPTION
Why

We fixed a mount path traversal risk in pages_publish_paradox_core_bundle_v0.py.

This PR freezes the contract in CI so the fix can’t silently regress.

What

Adds tests/test_pages_publish_paradox_core_bundle_v0.py.

The test:

generates a small deterministic bundle from existing fixtures (k=2),

publishes it to paradox/core/v0,

asserts that traversal-style mounts (e.g. ../evil) fail-closed.

Notes

CI-neutral: does not affect Core gates or release decisions.

Deterministic: no timestamps, no external calls, fixture-driven inputs.