### PR TITLE
ci(paradox): add case study shadow workflow for core reviewer bundle

### DIFF
--- a/.github/workflows/paradox_core_bundle_case_study_shadow.yml
+++ b/.github/workflows/paradox_core_bundle_case_study_shadow.yml
@@ -1,0 +1,102 @@
+name: Paradox Core bundle (case study, shadow)
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  paradox_core_bundle_case_study_shadow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: "3.11"
+
+      - name: Locate case study transitions dir (fail-closed)
+        shell: bash
+        run: |
+          set -euo pipefail
+          CASE_DIR="docs/examples/transitions_case_study_v0"
+          test -d "$CASE_DIR" || { echo "Missing case study dir: $CASE_DIR"; exit 1; }
+
+          # Prefer explicit well-known paths if present; otherwise deterministically pick the first transitions* dir.
+          if [ -d "$CASE_DIR/transitions" ]; then
+            TRANSITIONS_DIR="$CASE_DIR/transitions"
+          elif [ -d "$CASE_DIR/transitions_gate_metric_tension_v0" ]; then
+            TRANSITIONS_DIR="$CASE_DIR/transitions_gate_metric_tension_v0"
+          else
+            TRANSITIONS_DIR="$(find "$CASE_DIR" -maxdepth 2 -type d -name 'transitions*' | sort | head -n 1 || true)"
+          fi
+
+          test -n "${TRANSITIONS_DIR:-}" || { echo "No transitions dir found under: $CASE_DIR"; exit 1; }
+          test -d "$TRANSITIONS_DIR" || { echo "Transitions dir not a directory: $TRANSITIONS_DIR"; exit 1; }
+
+          echo "TRANSITIONS_DIR=$TRANSITIONS_DIR" >> "$GITHUB_ENV"
+          echo "Using transitions dir: $TRANSITIONS_DIR"
+
+      - name: Build paradox_field_v0 + edges (case study)
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf out
+          mkdir -p out
+
+          python scripts/paradox_field_adapter_v0.py \
+            --transitions-dir "$TRANSITIONS_DIR" \
+            --out out/paradox_field_v0.json
+
+          python scripts/check_paradox_field_v0_contract.py \
+            --in out/paradox_field_v0.json
+
+          python scripts/export_paradox_edges_v0.py \
+            --in out/paradox_field_v0.json \
+            --out out/paradox_edges_v0.jsonl
+
+          python scripts/check_paradox_edges_v0_contract.py \
+            --in out/paradox_edges_v0.jsonl \
+            --atoms out/paradox_field_v0.json
+
+      - name: Build Paradox Core reviewer bundle (from case study)
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf out/paradox_core_bundle_case_study_v0
+
+          python scripts/paradox_core_reviewer_bundle_v0.py \
+            --field out/paradox_field_v0.json \
+            --edges out/paradox_edges_v0.jsonl \
+            --out-dir out/paradox_core_bundle_case_study_v0 \
+            --k 12 \
+            --metric severity
+
+      - name: Step summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "## Paradox Core bundle (case study, shadow)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- transitions_dir: \`$TRANSITIONS_DIR\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- field: \`out/paradox_field_v0.json\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- edges: \`out/paradox_edges_v0.jsonl\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- bundle: \`out/paradox_core_bundle_case_study_v0\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Bundle files" >> "$GITHUB_STEP_SUMMARY"
+          ls -lah out/paradox_core_bundle_case_study_v0 | sed 's/^/    /' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifact (case study bundle)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: paradox-core-bundle-case-study-v0
+          path: out/paradox_core_bundle_case_study_v0
+          if-no-files-found: error


### PR DESCRIPTION
### Summary
Add a shadow workflow that builds the Paradox Core reviewer bundle from the repo’s reproducible non-fixture case study.

### Why
We want to exit the “fixture-only” world and validate the full chain:
transitions → paradox field/edges → core projection → reviewer bundle.
This gives a real integration signal while remaining CI-neutral.

### What
- New workflow: `.github/workflows/paradox_core_bundle_case_study_shadow.yml`
- Produces an artifact: `paradox-core-bundle-case-study-v0`
- Uses pinned Actions SHAs
- Fail-closed transitions-dir discovery (deterministic selection)

### Scope
CI-neutral diagnostic workflow only; does not affect release gates or enforcement.
