### PR TITLE
feat(pages): add Paradox Core Pages preview mount (shadow)

### DIFF
--- a/.github/workflows/paradox_core_pages_preview_shadow.yml
+++ b/.github/workflows/paradox_core_pages_preview_shadow.yml
@@ -1,0 +1,132 @@
+name: Paradox Core Pages preview mount (shadow)
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  paradox_core_pages_preview_shadow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: "3.11"
+
+      - name: Locate case study transitions dir (fail-closed)
+        shell: bash
+        run: |
+          set -euo pipefail
+          CASE_DIR="docs/examples/transitions_case_study_v0"
+          test -d "$CASE_DIR" || { echo "Missing case study dir: $CASE_DIR"; exit 1; }
+
+          # Priority order (deterministic):
+          # 1) explicit transitions/ subdir
+          # 2) explicit transitions_gate_metric_tension_v0/ subdir
+          # 3) CASE_DIR itself if it contains pulse_*_drift_v0* files
+          # 4) otherwise, deterministically pick the first transitions* dir (sorted)
+          if [ -d "$CASE_DIR/transitions" ]; then
+            TRANSITIONS_DIR="$CASE_DIR/transitions"
+          elif [ -d "$CASE_DIR/transitions_gate_metric_tension_v0" ]; then
+            TRANSITIONS_DIR="$CASE_DIR/transitions_gate_metric_tension_v0"
+          elif ls "$CASE_DIR"/pulse_*_drift_v0* >/dev/null 2>&1; then
+            TRANSITIONS_DIR="$CASE_DIR"
+          else
+            TRANSITIONS_DIR="$(find "$CASE_DIR" -maxdepth 2 -type d -name 'transitions*' | sort | head -n 1 || true)"
+          fi
+
+          test -n "${TRANSITIONS_DIR:-}" || { echo "No transitions dir found under: $CASE_DIR"; exit 1; }
+          test -d "$TRANSITIONS_DIR" || { echo "Transitions dir not a directory: $TRANSITIONS_DIR"; exit 1; }
+
+          echo "TRANSITIONS_DIR=$TRANSITIONS_DIR" >> "$GITHUB_ENV"
+          echo "Using transitions dir: $TRANSITIONS_DIR"
+
+      - name: Build paradox_field_v0 + edges (case study)
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf out
+          mkdir -p out
+
+          python scripts/paradox_field_adapter_v0.py \
+            --transitions-dir "$TRANSITIONS_DIR" \
+            --out out/paradox_field_v0.json
+
+          python scripts/check_paradox_field_v0_contract.py \
+            --in out/paradox_field_v0.json
+
+          python scripts/export_paradox_edges_v0.py \
+            --in out/paradox_field_v0.json \
+            --out out/paradox_edges_v0.jsonl
+
+          python scripts/check_paradox_edges_v0_contract.py \
+            --in out/paradox_edges_v0.jsonl \
+            --atoms out/paradox_field_v0.json
+
+      - name: Build Paradox Core reviewer bundle (case study)
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf out/paradox_core_bundle_case_study_v0
+
+          python scripts/paradox_core_reviewer_bundle_v0.py \
+            --field out/paradox_field_v0.json \
+            --edges out/paradox_edges_v0.jsonl \
+            --out-dir out/paradox_core_bundle_case_study_v0 \
+            --k 12 \
+            --metric severity
+
+      - name: Mount bundle into Pages-like site preview (fail-closed)
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf out/site_preview_v0
+          mkdir -p out/site_preview_v0
+
+          # Minimal deterministic root index for the preview bundle.
+          cat > out/site_preview_v0/index.html << 'EOF'
+          <!doctype html>
+          <meta charset="utf-8">
+          <title>PULSE Pages preview (shadow)</title>
+          <h1>PULSE Pages preview (shadow)</h1>
+          <ul>
+            <li><a href="paradox/core/v0/">Paradox Core v0</a></li>
+          </ul>
+          EOF
+
+          python scripts/pages_publish_paradox_core_bundle_v0.py \
+            --bundle-dir out/paradox_core_bundle_case_study_v0 \
+            --site-dir out/site_preview_v0 \
+            --mount paradox/core/v0
+
+      - name: Step summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "## Paradox Core Pages preview (shadow)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- transitions_dir: \`$TRANSITIONS_DIR\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- field: \`out/paradox_field_v0.json\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- edges: \`out/paradox_edges_v0.jsonl\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- bundle: \`out/paradox_core_bundle_case_study_v0\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- site preview: \`out/site_preview_v0\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Site preview tree (top)" >> "$GITHUB_STEP_SUMMARY"
+          find out/site_preview_v0 -maxdepth 4 -type f | sort | sed 's/^/    /' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifact (Pages preview)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: paradox-core-pages-preview-v0
+          path: out/site_preview_v0
+          if-no-files-found: error


### PR DESCRIPTION
What

Add a shadow workflow that generates a Pages-like “site preview” for Paradox Core v0.

The workflow:

builds paradox_field_v0.json + paradox_edges_v0.jsonl from the case study,

builds the Paradox Core reviewer bundle,

mounts it into out/site_preview_v0/paradox/core/v0/ using the publisher script,

uploads out/site_preview_v0/ as an artifact.

Why

Stabilises reviewer-facing output structure before promoting to live Pages.

Keeps Pages semantics “read-only”: the mount step only copies deterministic artifacts.

Non-goals

No Pages deploy in this PR.

No release gating changes.

How to run

Trigger manually via workflow_dispatch, or observe it on PR/push runs.

Download artifact: paradox-core-pages-preview-v0.