### PR TITLE
docs(readme): add Paradox Core reviewer surface link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@
 
 Releases: https://github.com/HKati/pulse-release-gates-0.1/releases
 
+Paradox Core (shadow reviewer surface): https://hkati.github.io/pulse-release-gates-0.1/paradox/core/v0/
+- Deterministic, CI-neutral by default (diagnostic overlay).
+- Edges are non-causal (co-occurrence/association only).
+- Provenance (source selection): https://hkati.github.io/pulse-release-gates-0.1/paradox/core/v0/source_v0.json
 
 
 # PULSE — Release Gates for Safe & Useful AI


### PR DESCRIPTION
### Summary
Expose the Paradox Core v0 reviewer surface as an official README entrypoint.

### Why
Paradox Core is now published as a static Pages surface under `/paradox/core/v0/`.
Without a single canonical README link, reviewers may use inconsistent URLs (or miss the surface entirely).

### Notes
- CI-neutral by default (diagnostic overlay; does not change PASS/FAIL).
- Edges are non-causal (co-occurrence/association only).
- Provenance is available via `/paradox/core/v0/source_v0.json`.
