### PR TITLE
feat(schema): add paradox Pages provenance source_v0 schema

### DIFF
--- a/schemas/PULSE_paradox_pages_source_v0.schema.json
+++ b/schemas/PULSE_paradox_pages_source_v0.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hkati.github.io/pulse-release-gates-0.1/schemas/PULSE_paradox_pages_source_v0.schema.json",
+  "title": "PULSE Paradox Pages provenance (source_v0)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "version",
+    "upstream_run_id",
+    "source",
+    "transitions_dir"
+  ],
+  "properties": {
+    "schema": {
+      "const": "PULSE_paradox_pages_source_v0"
+    },
+    "version": {
+      "const": "v0"
+    },
+    "upstream_run_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "GitHub Actions run id of the upstream PULSE CI run used to publish Pages."
+    },
+    "source": {
+      "type": "string",
+      "enum": [
+        "artifact_drift",
+        "case_study"
+      ],
+      "description": "Which input source was used to build the Paradox Core Pages surface."
+    },
+    "transitions_dir": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path (within the workflow workspace) that provided the pulse_*_drift_v0 inputs."
+    }
+  }
+}


### PR DESCRIPTION
### Summary
Add a strict JSON Schema for the Paradox Core Pages provenance manifest (`source_v0.json`).

### Why
`/paradox/core/v0/source_v0.json` is a public audit/provenance surface. A versioned schema makes the contract explicit and prevents silent shape drift.

### Contract (v0)
Required fields (fail-closed):
- schema = PULSE_paradox_pages_source_v0
- version = v0
- upstream_run_id (non-empty string)
- source ∈ {artifact_drift, case_study}
- transitions_dir (non-empty string)

### Testing
Not run (schema-only change).
