### PR TITLE
fix(zenodo): remove manual version fields from .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,8 +2,6 @@
   "title": "PULSE: Deterministic Release Gates for Safe & Useful AI",
   "description": "PULSE provides deterministic, fail-closed release gates across Safety (I2–I7), Utility (Q1–Q4) and SLO dimensions. It produces audit artefacts including a human-readable Quality Ledger and SVG badges that summarise pass/fail states. This software package allows developers to enforce safety invariants, utility budgets and service level objectives prior to shipment.",
   "upload_type": "software",
-  "version": "1.0.2",
-  "publication_date": "2025-10-16",
   "language": "eng",
   "creators": [
     {


### PR DESCRIPTION
### What
- Remove hand-maintained `version` and `publication_date` from `.zenodo.json`.

### Why
We don’t want Zenodo metadata to require manual updates every release/tag.

### Verification
python -m json.tool .zenodo.json > /dev/null
