### PR TITLE
ci(zenodo): add .zenodo.json lint workflow

### DIFF
--- a/.github/workflows/zenodo-jsonlint.yml
+++ b/.github/workflows/zenodo-jsonlint.yml
@@ -1,0 +1,17 @@
+name: zenodo-jsonlint
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate .zenodo.json
+        run: python -m json.tool .zenodo.json > /dev/null


### PR DESCRIPTION
Add a minimal CI check to ensure `.zenodo.json` is always valid JSON.
Prevents Zenodo ingestion from breaking due to malformed metadata.
