### PR TITLE
feat(pages): publish Paradox Diagram v0 artifacts under /paradox/core/v0

### DIFF
--- a/scripts/pages_publish_paradox_core_bundle_v0.py
+++ b/scripts/pages_publish_paradox_core_bundle_v0.py
@@ -14,6 +14,8 @@ Copies (fail-closed if missing):
   - paradox_core_v0.json
   - paradox_core_summary_v0.md
   - paradox_core_v0.svg
+  - paradox_diagram_v0.json
+  - paradox_diagram_v0.svg
   - paradox_core_reviewer_card_v0.html
 
 Design goals:
@@ -36,6 +38,8 @@ REQUIRED_FILES: List[str] = [
     "paradox_core_v0.json",
     "paradox_core_summary_v0.md",
     "paradox_core_v0.svg",
+    "paradox_diagram_v0.json",
+    "paradox_diagram_v0.svg",
     "paradox_core_reviewer_card_v0.html",
 ]
 
@@ -181,4 +185,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-


### PR DESCRIPTION
## Summary
Publishes Paradox Diagram v0 outputs (JSON + SVG) alongside the existing Paradox Core reviewer bundle artifacts on Pages.

## Why
The reviewer bundle now deterministically produces Paradox Diagram v0 artifacts. Pages should expose them as static, audit-friendly outputs (Pages computes no semantics).

## What changed
- scripts/pages_publish_paradox_core_bundle_v0.py
  - added required publish files:
    - paradox_diagram_v0.json
    - paradox_diagram_v0.svg

## Guardrails
- Pages remains static publish only
- Deterministic copy (no timestamps/metadata)
- Fail-closed if expected bundle artifacts are missing

## Testing
Not run locally (CI workflows cover publish/mount behavior).
