### PR TITLE
fix(paradox): make Paradox Diagram SVG optional in Pages publish

### DIFF
--- a/scripts/pages_publish_paradox_core_bundle_v0.py
+++ b/scripts/pages_publish_paradox_core_bundle_v0.py
@@ -14,9 +14,11 @@ Copies (fail-closed if missing):
   - paradox_core_v0.json
   - paradox_core_summary_v0.md
   - paradox_core_v0.svg
-  - paradox_diagram_v0.json
-  - paradox_diagram_v0.svg
   - paradox_core_reviewer_card_v0.html
+  - paradox_diagram_v0.json
+
+Copies (best-effort if present):
+  - paradox_diagram_v0.svg
 
 Design goals:
   - CI-neutral (pure publish helper; does not compute semantics)
@@ -34,13 +36,20 @@ from pathlib import Path, PurePosixPath
 from typing import List
 
 
+# Required artifacts: publishing must fail-closed if any of these are missing.
 REQUIRED_FILES: List[str] = [
     "paradox_core_v0.json",
     "paradox_core_summary_v0.md",
     "paradox_core_v0.svg",
-    "paradox_diagram_v0.json",
-    "paradox_diagram_v0.svg",
     "paradox_core_reviewer_card_v0.html",
+    "paradox_diagram_v0.json",
+]
+
+# Best-effort artifacts: copy if present, do not fail if absent.
+# Rationale: the reviewer bundle may skip diagram SVG generation in valid invocations
+# (e.g., legacy renderer requiring --edges when none are provided).
+OPTIONAL_FILES: List[str] = [
+    "paradox_diagram_v0.svg",
 ]
 
 
@@ -171,9 +180,15 @@ def main() -> int:
     if missing:
         _fail(f"Missing required bundle files in {bundle_dir}: {', '.join(missing)}")
 
-    # Copy files deterministically
+    # Copy required files deterministically
     for name in REQUIRED_FILES:
         _copy_bytes(bundle_dir / name, target_dir / name)
+
+    # Copy optional files deterministically (best-effort)
+    for name in OPTIONAL_FILES:
+        src = bundle_dir / name
+        if src.exists():
+            _copy_bytes(src, target_dir / name)
 
     if args.write_index:
         _write_index(target_dir, "paradox_core_reviewer_card_v0.html")


### PR DESCRIPTION
## Summary
Make Pages publishing robust when the Paradox Diagram SVG is not produced.

## Why
The reviewer bundle treats the diagram SVG as best-effort and may skip rendering
in valid invocations (e.g., legacy renderer requires `--edges` but edges are not provided).
Requiring `paradox_diagram_v0.svg` in the publisher causes a regression for such bundles.

## What changed
- `scripts/pages_publish_paradox_core_bundle_v0.py`
  - Keep `paradox_diagram_v0.json` required (fail-closed).
  - Make `paradox_diagram_v0.svg` optional (copy if present, do not fail if absent).

## Testing
Not run (script change only). CI Pages workflows cover publish behavior.
