### PR TITLE
ci(paradox): validate diagram outputs in case study bundle workflow (shadow)

### DIFF
--- a/.github/workflows/paradox_core_bundle_case_study_shadow.yml
+++ b/.github/workflows/paradox_core_bundle_case_study_shadow.yml
@@ -80,6 +80,28 @@ jobs:
             --k 12 \
             --metric severity
 
+      - name: "Guardrail: Paradox Diagram outputs (case study bundle)"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # JSON is required (meaning layer)
+          test -s out/paradox_core_bundle_case_study_v0/paradox_diagram_v0.json || {
+            echo "::error::Missing paradox_diagram_v0.json in out/paradox_core_bundle_case_study_v0"
+            ls -la out/paradox_core_bundle_case_study_v0 || true
+            exit 1
+          }
+
+          # SVG is best-effort optional (render layer)
+          if [ -f out/paradox_core_bundle_case_study_v0/paradox_diagram_v0.svg ]; then
+            test -s out/paradox_core_bundle_case_study_v0/paradox_diagram_v0.svg || {
+              echo "::error::paradox_diagram_v0.svg is present but empty"
+              exit 1
+            }
+          else
+            echo "::warning::paradox_diagram_v0.svg missing (best-effort optional)"
+          fi
+
       - name: Step summary
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
Adds case-study bundle guardrails for Paradox Diagram outputs.

## Why
We want fail-closed behavior for the meaning layer (diagram JSON), while keeping the render layer (diagram SVG) best-effort optional to prevent false CI failures.

## What changed
- Require `paradox_diagram_v0.json`
- Treat `paradox_diagram_v0.svg` as optional (warn if missing; fail if empty)

## Testing
CI workflow run
