### PR TITLE
docs(openai-evals): add openai_evals_v0 scaffold

### DIFF
--- a/openai_evals_v0/README.md
+++ b/openai_evals_v0/README.md
@@ -1,0 +1,3 @@
+# openai_evals_v0
+
+Pilot / smoke integráció OpenAI Evals ↔ PULSE-hoz.


### PR DESCRIPTION
## Mi változott
- Létrejött a `openai_evals_v0/` verziózott mappa
- Hozzáadtam a `openai_evals_v0/README.md` fájlt, ami a pilot / smoke integráció helye lesz

## Miért
A cél, hogy az OpenAI Evals (online) bekötése elkülönüljön a PULSE determinisztikus, offline “core” gate logikájától, és verziózottan auditálható maradjon.

## Teszt / hatás
- Dokumentációs/szerkezeti változás, futtatási viselkedést nem módosít.
- CI / release gate logikához nem nyúltam.

## Következő lépések
- `refusal_smoke.jsonl` hozzáadása ebbe a mappába
- smoke runner script, ami Evals run → összegző → PULSE `status.json` external gate (először shadow módban)
