### PR TITLE
feat(schemas): introduce separation_phase_v0 contract

### DIFF
--- a/schemas/separation_phase_v0.schema.json
+++ b/schemas/separation_phase_v0.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hkati.github.io/pulse-release-gates-0.1/schemas/separation_phase_v0.schema.json",
+  "title": "PULSE Separation Phase Overlay v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "invariants", "state", "recommendation"],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "separation_phase_v0"
+    },
+    "meta": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "run_id": { "type": "string" },
+        "commit": { "type": "string" },
+        "generator": { "type": "string" },
+        "source_date_epoch": { "type": ["integer", "null"], "minimum": 0 }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "status_path": { "type": "string" },
+        "permutation_status_paths": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "invariants": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["order_stability", "separation_integrity", "phase_dependency", "threshold_sensitivity"],
+      "properties": {
+        "order_stability": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["method", "score", "n_runs", "unstable_gates"],
+          "properties": {
+            "method": { "type": "string", "enum": ["permutations", "rdsi_proxy", "unknown"] },
+            "score": { "type": ["number", "null"], "minimum": 0.0, "maximum": 1.0 },
+            "n_runs": { "type": "integer", "minimum": 0 },
+            "unstable_gates": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        },
+        "separation_integrity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["decision_stable", "notes"],
+          "properties": {
+            "decision_stable": { "type": ["boolean", "null"] },
+            "notes": { "type": "string" }
+          }
+        },
+        "phase_dependency": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["critical_global_phase"],
+          "properties": {
+            "critical_global_phase": { "type": ["boolean", "null"] }
+          }
+        },
+        "threshold_sensitivity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["threshold_like_gates"],
+          "properties": {
+            "threshold_like_gates": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "state": {
+      "type": "string",
+      "enum": ["FIELD_STABLE", "FIELD_STRAINED", "FIELD_COLLAPSED", "UNKNOWN"]
+    },
+    "recommendation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["gate_action", "rationale"],
+      "properties": {
+        "gate_action": { "type": "string", "enum": ["OPEN", "SLOW", "CLOSED"] },
+        "rationale": { "type": "string" }
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "message"],
+        "properties": {
+          "kind": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds `schemas/separation_phase_v0.schema.json`, introducing a spec-first JSON Schema
for representing the “separation phase” axis (time as an event-separation phase, not as a
primary parameter).

## Motivation / Context
We want to make the time–QKD–PULSE framing operational inside PULSE:
- PULSE gates should reason about *meaningful separation*, not raw timing.
- The first step is to define a deterministic, CI-checkable contract that future overlays
  (e.g. `separation_phase_v0.json`) can adhere to.

## What’s included
- New schema: `schemas/separation_phase_v0.schema.json`
  - Core signals (0..1 normalized):
    - `order_stability` (permutation invariance)
    - `separation_integrity` (local validity + global consistency)
    - `time_phase_dependency` (global time-phase criticality)
  - Decision surface:
    - `FIELD_STABLE` / `FIELD_STRAINED` / `FIELD_COLLAPSED`
  - Audit hooks (optional): run metadata + evidence blocks (for future CI / Pages surfacing)

## Impact / Risk
- No change to core PULSE deterministic PASS/FAIL gates.
- No change to CI behaviour (schema only).
- Low risk: purely additive contract.

## How to test (optional)
If using `jsonschema` locally:
- Validate a future overlay against the schema:
  - `python -m jsonschema -i <overlay.json> schemas/separation_phase_v0.schema.json`

## Follow-ups (next PRs)
- Add a minimal example overlay JSON (seeded) + a validator step in the “overlay schema validation (shadow)” workflow.
- Wire the overlay into Pages under `/schemas/` and/or the report-card surface (read-only, CI-neutral).
