### PR TITLE
ci(workflows): publish markdown report artifact for separation phase overlay

### DIFF
--- a/.github/workflows/separation_phase_overlay.yml
+++ b/.github/workflows/separation_phase_overlay.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.10"
 
@@ -63,15 +63,24 @@ jobs:
           python scripts/check_separation_phase_v0_contract.py \
             --in PULSE_safe_pack_v0/artifacts/separation_phase_v0.json
 
+      - name: Render overlay report (markdown)
+        shell: bash
+        run: |
+          python scripts/render_separation_phase_overlay_v0_md.py \
+            --overlay PULSE_safe_pack_v0/artifacts/separation_phase_v0.json \
+            --status  PULSE_safe_pack_v0/artifacts/status.json \
+            --out     PULSE_safe_pack_v0/artifacts/separation_phase_overlay_v0.md
+
       - name: Summarize overlay (job summary)
         shell: bash
         run: |
           python - <<'PY'
           import json
           from pathlib import Path
+          import os
 
-          p = Path("PULSE_safe_pack_v0/artifacts/separation_phase_v0.json")
-          d = json.loads(p.read_text(encoding="utf-8"))
+          overlay = Path("PULSE_safe_pack_v0/artifacts/separation_phase_v0.json")
+          d = json.loads(overlay.read_text(encoding="utf-8"))
 
           state = d.get("state")
           rec = d.get("recommendation", {}) or {}
@@ -88,7 +97,9 @@ jobs:
           lines.append(f"- Recommendation: **{action}**")
           lines.append(f"- Rationale: {rationale}")
           lines.append("")
-          lines.append(f"- Baseline generation exit code (run_all.py): `{__import__('os').environ.get('PULSE_RUN_ALL_EXIT_CODE','?')}`")
+          lines.append(f"- Baseline generation exit code (run_all.py): `{os.environ.get('PULSE_RUN_ALL_EXIT_CODE','?')}`")
+          lines.append(f"- Overlay JSON: `{overlay.as_posix()}`")
+          lines.append(f"- Overlay report (MD): `PULSE_safe_pack_v0/artifacts/separation_phase_overlay_v0.md`")
           lines.append("")
           lines.append("### Unstable gates (first 10)")
           lines.append("")
@@ -98,14 +109,15 @@ jobs:
           lines.append("")
           lines.extend([f"- `{g}`" for g in thresh[:10]] or ["- (none)"])
 
-          Path(__import__("os").environ["GITHUB_STEP_SUMMARY"]).write_text("\n".join(lines) + "\n", encoding="utf-8")
+          Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text("\n".join(lines) + "\n", encoding="utf-8")
           PY
 
       - name: Upload overlay artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: separation-phase-overlay
           if-no-files-found: error
           path: |
             PULSE_safe_pack_v0/artifacts/separation_phase_v0.json
+            PULSE_safe_pack_v0/artifacts/separation_phase_overlay_v0.md
             PULSE_safe_pack_v0/artifacts/status.json


### PR DESCRIPTION
## Summary
Enhance the Separation Phase Overlay (shadow) workflow to produce and upload a
human-readable Markdown report (`separation_phase_overlay_v0.md`) in addition to the
JSON overlay.

## Why
The JSON overlay is machine-friendly but not ideal for fast human review in PRs/audits.
A deterministic Markdown report provides an audit-friendly surface without altering any
normative gating logic.

## Changes
- Add step to render the Markdown report:
  - `scripts/render_separation_phase_overlay_v0_md.py`
- Upload the report as part of the workflow artifacts bundle
- Reference the report in the GitHub job summary output

## Scope / Safety
CI-neutral / diagnostic-only. No changes to required gate sets or PASS/FAIL enforcement.

## Test plan
- Run the workflow on a PR and confirm artifacts include:
  - `separation_phase_v0.json`
  - `separation_phase_overlay_v0.md`
  - `status.json` (when available)
- Confirm contract check step remains green.
