### PR TITLE
docs(separation-phase): add separation phase overlay to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,21 @@ All of these are **fail‑closed only for their own job** (they never block the
 main PULSE gates) and are meant as a safe playground for the internal G‑field
 and GPT diagnostics.
 
+  * Separation Phase overlay (`separation_phase_v0.json`)
+Snapshot-style diagnostic overlay that classifies the run into:
+`FIELD_STABLE` / `FIELD_STRAINED` / `FIELD_COLLAPSED` / `UNKNOWN`
+based on separation-style invariants (order stability, separation integrity, phase dependency).
+
+    * Schema: `schemas/separation_phase_v0.schema.json`
+    * Adapter: `scripts/separation_phase_adapter_v0.py`
+    * Contract check (fail-closed within the overlay): `scripts/check_separation_phase_v0_contract.py`
+    * Renderer (human summary): `scripts/render_separation_phase_overlay_v0_md.py`
+    * Workflow: `.github/workflows/separation_phase_overlay.yml`
+    * Output artifacts:
+      - `PULSE_safe_pack_v0/artifacts/separation_phase_v0.json`
+      - `PULSE_safe_pack_v0/artifacts/separation_phase_overlay_v0.md`
+
+Note: this is a CI-neutral diagnostic layer. It must not change core release gate semantics.
 
 ---
 


### PR DESCRIPTION
## Summary
Document the new Separation Phase diagnostic overlay (v0) in README so contributors can quickly find:
- schema + contract check
- adapter + renderer scripts
- shadow workflow wiring
- produced artifacts (JSON + MD)

## Why
The overlay introduces a new “separation-phase” diagnostic axis (order stability / separation integrity / phase dependency).
Without a README entry, it’s easy to miss or confuse it with the normative PULSE gate layer.

## Scope
Docs-only:
- README: add a dedicated bullet under the shadow overlays section.

## Non-goals
- No changes to core PULSE gating semantics.
- No changes to required CI gates.

## Test plan
N/A (documentation change only).
