### PR TITLE
ci(pulse): include separation phase overlay artifacts in pulse-report

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -186,6 +186,110 @@ jobs:
           fi
           echo "--------------------------------"
 
+      - name: Generate Separation Phase overlay artifacts (diagnostic, for Pages)
+        if: always()
+        continue-on-error: true
+        shell: bash
+        env:
+          OUT_JSON: ${{ env.PACK_DIR }}/artifacts/separation_phase_v0.json
+          OUT_MD: ${{ env.PACK_DIR }}/artifacts/separation_phase_overlay_v0.md
+          OUT_HTML: ${{ env.PACK_DIR }}/artifacts/separation_phase_overlay.html
+        run: |
+          set -euo pipefail
+
+          STATUS="${{ env.PACK_DIR }}/artifacts/status.json"
+
+          # 1) Overlay JSON (adapter is fail-closed: emits UNKNOWN/CLOSED if status missing)
+          python scripts/separation_phase_adapter_v0.py \
+            --status "$STATUS" \
+            --out "$OUT_JSON" \
+            --commit "${GITHUB_SHA}"
+
+          # 2) Contract check (diagnostic-only; do not block main gates)
+          python scripts/check_separation_phase_v0_contract.py --in "$OUT_JSON"
+
+          # 3) Human summary (Markdown)
+          python scripts/render_separation_phase_overlay_v0_md.py \
+            --overlay "$OUT_JSON" \
+            --status "$STATUS" \
+            --out "$OUT_MD"
+
+          # 4) Tiny static HTML viewer (no deps) – good for Pages browsing
+          python - <<'PY'
+          import json, html, os
+          from pathlib import Path
+
+          out_json = Path(os.environ["OUT_JSON"])
+          out_html = Path(os.environ["OUT_HTML"])
+
+          d = json.loads(out_json.read_text(encoding="utf-8"))
+
+          state = d.get("state", "UNKNOWN")
+          rec = d.get("recommendation") or {}
+          action = rec.get("gate_action", "CLOSED")
+          rationale = rec.get("rationale", "")
+
+          inv = d.get("invariants") or {}
+          os_ = inv.get("order_stability") or {}
+          score = os_.get("score")
+          n_runs = os_.get("n_runs")
+          unstable = (os_.get("unstable_gates") or [])[:50]
+
+          ts = inv.get("threshold_sensitivity") or {}
+          thresh = (ts.get("threshold_like_gates") or [])[:50]
+
+          def esc(x):
+            return html.escape("" if x is None else str(x))
+
+          body = f"""<!doctype html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <title>Separation Phase Overlay (v0)</title>
+            <style>
+              body {{ font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+                     margin: 24px; max-width: 980px; }}
+              code, pre {{ font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }}
+              .k {{ color: #555; }}
+              .box {{ padding: 12px 14px; border: 1px solid #ddd; border-radius: 8px; background: #fafafa; }}
+              pre {{ padding: 10px 12px; border: 1px solid #eee; border-radius: 8px; background: #fff; overflow-x: auto; }}
+            </style>
+          </head>
+          <body>
+            <h1>Separation Phase Overlay (v0)</h1>
+
+            <div class="box">
+              <p><span class="k">State:</span> <strong>{esc(state)}</strong></p>
+              <p><span class="k">Recommendation:</span> <strong>{esc(action)}</strong></p>
+              <p><span class="k">Rationale:</span> {esc(rationale)}</p>
+              <p><span class="k">Order-stability score:</span> <strong>{esc(score)}</strong>
+                 <span class="k">(n_runs={esc(n_runs)})</span></p>
+            </div>
+
+            <h2>Artifacts</h2>
+            <ul>
+              <li><a href="separation_phase_v0.json">separation_phase_v0.json</a></li>
+              <li><a href="separation_phase_overlay_v0.md">separation_phase_overlay_v0.md</a></li>
+              <li><a href="status.json">status.json</a></li>
+            </ul>
+
+            <h2>Unstable gates (first 50)</h2>
+            <pre>{esc("\\n".join(map(str, unstable)) if unstable else "(none)")}</pre>
+
+            <h2>Threshold-like gates (first 50)</h2>
+            <pre>{esc("\\n".join(map(str, thresh)) if thresh else "(none)")}</pre>
+
+            <p class="k">
+              Diagnostic-only surface. Must not redefine normative PULSE gating semantics.
+            </p>
+          </body>
+          </html>
+          """
+          out_html.write_text(body + "\n", encoding="utf-8")
+          print(f"OK: wrote {out_html}")
+          PY
+
       - name: Enforce gates (fail-closed)
         shell: bash
         run: |
@@ -320,4 +424,3 @@ jobs:
           subprocess.check_call([sys.executable, 'tests/test_exporters.py'])
           print('Exporter smoke tests OK')
           PY
-


### PR DESCRIPTION
## Summary
Extend `.github/workflows/pulse_ci.yml` to generate and publish Separation Phase overlay artifacts
from the main PULSE CI run.

## What changes
Adds a best-effort diagnostic step (runs even on failures, non-blocking) that:
1) Generates `separation_phase_v0.json` from the augmented `status.json`
2) Runs the overlay contract check (diagnostic-only)
3) Renders a deterministic Markdown summary (`separation_phase_overlay_v0.md`)
4) Generates a tiny static HTML viewer (`separation_phase_overlay.html`)

All outputs are written under `${PACK_DIR}/artifacts/` so they are included in the existing
`pulse-report` artifact upload.

## Why
We want a GitHub Pages–friendly diagnostic surface for Separation Phase without mixing it into
normative PASS/FAIL gate enforcement. Publishing via the `pulse-report` artifact keeps the
Pages pipeline simple and audit-friendly.

## Output artifacts
- `${PACK_DIR}/artifacts/separation_phase_v0.json`
- `${PACK_DIR}/artifacts/separation_phase_overlay_v0.md`
- `${PACK_DIR}/artifacts/separation_phase_overlay.html`

## Safety / Non-goals
- CI-neutral: `continue-on-error: true` so this cannot break core gate enforcement.
- Does not modify or reinterpret normative gate decisions; diagnostic overlay only.

## Test plan
- Run PULSE CI on a PR
- Confirm artifacts contain the 3 Separation Phase files above
- Confirm “Enforce gates (fail-closed)” behavior is unchanged
