### PR TITLE
ci(pages): validate separation phase schema publishing on Pages

### DIFF
--- a/.github/workflows/publish_report_pages.yml
+++ b/.github/workflows/publish_report_pages.yml
@@ -694,6 +694,12 @@ jobs:
             exit 1
           fi
 
+          if [ ! -s "_site/schemas/separation_phase_v0.schema.json" ]; then
+            echo "::error::Expected _site/schemas/separation_phase_v0.schema.json to exist and be non-empty before publish."
+            ls -la _site/schemas || true
+            exit 1
+          fi
+
       - name: Generate diagnostics landing page
         shell: bash
         run: |
@@ -996,6 +1002,7 @@ jobs:
 
           fetch "$BASE/schemas/gates.schema.json" schema_gates.schema.json
           fetch "$BASE/schemas/PULSE_paradox_field_v0.schema.json" schema_paradox_field.schema.json
+          fetch "$BASE/schemas/separation_phase_v0.schema.json" schema_separation_phase.schema.json
 
           fetch "$BASE/paradox/core/v0/" paradox_core_index.html
           fetch "$BASE/paradox/core/v0/paradox_core_reviewer_card_v0.html" paradox_core_card.html


### PR DESCRIPTION
## Summary
Harden the Pages publish pipeline by validating that the Separation Phase schema is published
and publicly reachable.

## Changes
- Add a fail-closed check for:
  - `_site/schemas/separation_phase_v0.schema.json`
  in `Verify schema assets present before upload`.
- Extend post-deploy `SEO smoke` to fetch:
  - `/schemas/separation_phase_v0.schema.json`

## Why
Separation Phase is now a first-class diagnostic overlay. Publishing its schema at a stable URL
is part of the audit/contract surface, similar to gates and paradox schemas.

## Safety
Publishing-only change. Does not affect root selection, does not impact normative gating.

## Test plan
- Run `Publish report pages` and confirm:
  - the workflow fails if the schema is missing
  - the deployed site serves `/schemas/separation_phase_v0.schema.json`
