### PR TITLE
ci(pages): make separation phase diagnostics directory URL work

### DIFF
--- a/scripts/validate_overlays.py
+++ b/scripts/validate_overlays.py
@@ -126,6 +126,21 @@ def main() -> None:
                 sp("gpt_external_detection_v0.json"),
             ],
         ),
+        OverlayConfig(
+            name="separation_phase_v0",
+            schema_candidates=[
+                sp("schemas", "separation_phase_v0.schema.json"),
+                sp("schemas", "schemas", "separation_phase_v0.schema.json"),
+            ],
+            data_candidates=[
+                sp(
+                    "PULSE_safe_pack_v0",
+                    "artifacts",
+                    "separation_phase_v0.json",
+                ),
+                sp("separation_phase_v0.json"),
+            ],
+        ),
     ]
 
     all_ok = True


### PR DESCRIPTION
## Summary
Ensure the Separation Phase diagnostics directory URL works on GitHub Pages.

## Change
- If `separation_phase_overlay.html` is published under:
  - `_site/diagnostics/separation_phase/v0/`
  also publish:
  - `_site/diagnostics/separation_phase/v0/index.html`
  as a copy of the overlay HTML.

## Why
GitHub Pages serves `/…/v0/` via `index.html`. Without it, the diagnostics landing page link can 404.

## Safety
Publishing-only. No changes to site-root selection or normative PULSE CI gating.

## Test plan
- Run Pages publish and verify (best-effort):
  - `/diagnostics/separation_phase/v0/` loads the overlay
  - direct file URLs still work
