### PR TITLE
feat(schemas): add diagnostics manifest v0 schema

### DIFF
--- a/schemas/PULSE_diagnostics_manifest_v0.schema.json
+++ b/schemas/PULSE_diagnostics_manifest_v0.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PULSE Diagnostics Manifest v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "version", "upstream_run_id", "publish", "items"],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "PULSE_diagnostics_manifest_v0"
+    },
+    "version": {
+      "type": "string",
+      "const": "v0"
+    },
+    "upstream_run_id": {
+      "type": "string"
+    },
+    "publish": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "site_root"],
+      "properties": {
+        "mode": { "type": "string" },
+        "site_root": { "type": "string" }
+      }
+    },
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "present", "paths"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "present": { "type": "boolean" },
+          "paths": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "html": { "type": "string" },
+              "json": { "type": "string" },
+              "md": { "type": "string" }
+            }
+          },
+          "state": { "type": ["string", "null"] },
+          "gate_action": { "type": ["string", "null"] },
+          "notes": { "type": ["string", "null"] }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add a JSON Schema for the published diagnostics manifest so the surface is contract-defined and audit-friendly.

## Changes
- Add `schemas/PULSE_diagnostics_manifest_v0.schema.json`

## Why
`/diagnostics/manifest_v0.json` is a stable, machine-readable inventory of published diagnostic surfaces.
Publishing its schema makes the contract explicit and enables CI-neutral validation and fail-closed publish checks.

## Safety / scope
- Schema-only change.
- No changes to site-root selection.
- No changes to normative PULSE release gate enforcement.

## Test plan
- Confirm the schema file is published to GitHub Pages under `/schemas/`.
- (Optional) Validate a sample `manifest_v0.json` against the schema in a shadow workflow.
