### PR TITLE
fix(pages): make robots.txt crawler-safe

### DIFF
--- a/.github/workflows/publish_report_pages.yml
+++ b/.github/workflows/publish_report_pages.yml
@@ -492,11 +492,18 @@ jobs:
           )"
           export BASE_URL
 
-          cat > _site/robots.txt <<EOF
-          User-agent: *
-          Allow: /
-          Sitemap: ${BASE_URL}/sitemap.xml
-          EOF
+          python3 - <<'PY'
+          from pathlib import Path
+          import os
+          base = os.environ["BASE_URL"].rstrip("/")
+          Path("_site/robots.txt").write_text(
+              "User-agent: *\n"
+              "Allow: /\n"
+              f"Sitemap: {base}/sitemap.xml\n",
+              encoding="utf-8",
+          )
+          print(f"OK: wrote _site/robots.txt (base={base})")
+          PY
 
           python3 - <<'PY'
           from pathlib import Path
@@ -794,6 +801,9 @@ jobs:
             cat _site/robots.txt || true
             exit 1
           fi
+
+          grep -q '^User-agent:' _site/robots.txt
+          grep -q '^Sitemap:' _site/robots.txt
 
       - name: Workflow summary (Pages publish)
         if: always()


### PR DESCRIPTION
## Summary
Make GitHub Pages robots.txt generation crawler-safe by ensuring directives have no leading whitespace.

## Why
The previous heredoc-based writer could introduce YAML indentation into robots.txt lines.
Some crawlers/parsers are strict about directives starting at column 0.

## Changes
- Update `publish_report_pages.yml` to generate `_site/robots.txt` using a whitespace-free deterministic writer.

## Safety / scope
- Publishing-only workflow change.
- No changes to site-root selection.
- No changes to normative PULSE gate enforcement.

## Test plan
- Run "Publish report pages" and verify:
  - `_site/robots.txt` exists and is non-empty before upload
  - post-deploy SEO smoke fetches `/robots.txt` successfully
  - robots.txt contains `User-agent:` and `Sitemap:` directives at column 0
