### PR TITLE
feat(policy): add v0 gate policy (required vs advisory)

### DIFF
--- a/pulse_gate_policy_v0.yml
+++ b/pulse_gate_policy_v0.yml
@@ -1,0 +1,52 @@
+# pulse_gate_policy_v0.yml
+# Canonical required/advisory gate set for CI enforcement.
+#
+# Normative (required) gates are FAIL-closed:
+#   - missing required gate => FAIL
+#   - required gate == false => FAIL
+#
+# Diagnostic (advisory) gates never block shipping:
+#   - missing advisory gate => WARN
+#   - advisory gate == false => WARN
+#
+# This file intentionally defines ONLY:
+#   - the gate set (required vs advisory)
+#   - enforcement semantics around missing/unknown signals
+#
+# Thresholds / measurement details remain elsewhere (safe-pack / profiles).
+
+policy:
+  id: pulse-gate-policy-v0
+  version: "0.1.0"
+
+enforcement:
+  required_missing: FAIL
+  required_false: FAIL
+  advisory_missing: WARN
+  advisory_false: WARN
+  unknown_gate_in_status: WARN
+  external_detectors_default: ADVISORY
+
+gates:
+  required:
+    - pass_controls_refusal
+    - effect_present
+    - psf_monotonicity_ok
+    - psf_mono_shift_resilient
+    - pass_controls_comm
+    - psf_commutativity_ok
+    - psf_comm_shift_resilient
+    - pass_controls_sanit
+    - sanitization_effective
+    - sanit_shift_resilient
+    - psf_action_monotonicity_ok
+    - psf_idempotence_ok
+    - psf_path_independence_ok
+    - psf_pii_monotonicity_ok
+    - q1_grounded_ok
+    - q2_consistency_ok
+    - q3_fairness_ok
+    - q4_slo_ok
+
+  # Start empty; promote signals here only after they are proven stable.
+  advisory: []


### PR DESCRIPTION
## Summary
Add `pulse_gate_policy_v0.yml` as the canonical source-of-truth for:
- which gates are **required** (can block shipping)
- which gates are **advisory** (diagnostic only)
- how to handle missing/unknown signals (fail-closed for required)

## Why
The required `--require ...` gate set is currently easy to duplicate and drift
between README, CI workflow, and local runs. A single policy file makes the
release semantics reviewable and reduces silent semantic drift.

## Scope
- ✅ Add policy file only (no behavior change yet)
- ❌ No workflow changes in this PR
- ❌ No changes to `check_gates.py` semantics

## Follow-ups (next PRs)
1. Wire CI to materialize the `--require` list from this policy file.
2. Update docs/quickstart to reference the policy-driven gate set.

## Notes
This is intentionally minimal: it defines the **gate set** and **enforcement semantics** only.
Thresholds and measurement details remain in the safe-pack/profiles.
