### PR TITLE
fix(policy): restore external_all_pass and refusal_delta_pass in required set

### DIFF
--- a/pulse_gate_policy_v0.yml
+++ b/pulse_gate_policy_v0.yml
@@ -30,7 +30,9 @@ enforcement:
 gates:
   required:
     - pass_controls_refusal
+    - refusal_delta_pass
     - effect_present
+    - external_all_pass
     - psf_monotonicity_ok
     - psf_mono_shift_resilient
     - pass_controls_comm


### PR DESCRIPTION
## Summary
Restore `external_all_pass` and `refusal_delta_pass` in `pulse_gate_policy_v0.yml`
under `gates.required`.

## Why
CI enforcement now sources the required gate list from `pulse_gate_policy_v0.yml`.
The current policy omitted two gates that were previously required and are still
referenced as CI-gating signals in repo docs/profiles. This unintentionally weakens
release gating under the new policy-driven flow.

## What changed
- Add `refusal_delta_pass` to `gates.required`
- Add `external_all_pass` to `gates.required`

## Impact
This brings policy-driven CI enforcement back in line with the previously enforced
(and documented) gate set.
