### PR TITLE
fix(ci): use PACK_DIR for gate enforcement paths

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -319,8 +319,8 @@ jobs:
           REQ="$(python tools/policy_to_require_args.py --policy pulse_gate_policy_v0.yml --set required)"
           echo "Required gates (from policy): $REQ"
 
-          python PULSE_safe_pack_v0/tools/check_gates.py \
-            --status PULSE_safe_pack_v0/artifacts/status.json \
+          python "${{ env.PACK_DIR }}/tools/check_gates.py" \
+            --status "${{ env.PACK_DIR }}/artifacts/status.json" \
             --require $REQ
 
       - name: Export JUnit & SARIF


### PR DESCRIPTION
## Summary
Make the required-gates enforcement step use the resolved `PACK_DIR` when calling
`check_gates.py` and reading `status.json`.

## Why
The workflow already resolves a pack location dynamically (`PACK_DIR`) to support
cases where the safe-pack is nested or extracted into a non-root directory. The
gate enforcement step previously used hardcoded `PULSE_safe_pack_v0/...` paths,
which could break when `PACK_DIR` is not the repo root pack path.

## What changed
- Replace hardcoded safe-pack paths in the enforcement step with `PACK_DIR`-based paths:
  - `check_gates.py` path now comes from the resolved pack directory
  - `status.json` path now comes from the resolved pack directory

## Impact
Improves robustness and consistency with pack discovery logic without changing
the actual required gate set or enforcement semantics.

## How to test
- Run the CI workflow and confirm the enforcement step successfully locates:
  - `check_gates.py` under the resolved `PACK_DIR`
  - `artifacts/status.json` under the resolved `PACK_DIR`
