### PR TITLE
docs(readme): use policy-driven required gate list in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,7 @@ python PULSE_safe_pack_v0/tools/run_all.py
 
 python PULSE_safe_pack_v0/tools/check_gates.py \
   --status PULSE_safe_pack_v0/artifacts/status.json \
-  --require pass_controls_refusal effect_present psf_monotonicity_ok psf_mono_shift_resilient \
-    pass_controls_comm psf_commutativity_ok psf_comm_shift_resilient pass_controls_sanit \
-    sanitization_effective sanit_shift_resilient psf_action_monotonicity_ok psf_idempotence_ok \
-    psf_path_independence_ok psf_pii_monotonicity_ok q1_grounded_ok q2_consistency_ok \
-    q3_fairness_ok q4_slo_ok
+  --require $(python tools/policy_to_require_args.py --policy pulse_gate_policy_v0.yml --set required)
 
 
 


### PR DESCRIPTION
## Summary
Update `README.md` to use a policy-driven required gate list via
`tools/policy_to_require_args.py`, replacing any hardcoded `--require ...` lists.

## Why
CI enforcement already sources required gates from `pulse_gate_policy_v0.yml`.
Keeping README policy-driven prevents CI/docs drift and copy/paste errors.

## What changed
- Replace hardcoded `--require <long list>` with:
  - `--require $(python tools/policy_to_require_args.py --policy pulse_gate_policy_v0.yml --set required)`
- Add a short note that the canonical required gate set is defined in `pulse_gate_policy_v0.yml`.

## How to test
N/A (documentation-only change)
