### PR TITLE
feat(metrics): add q4_slo metric spec (v0)

### DIFF
--- a/metrics/specs/q4_slo_v0.yml
+++ b/metrics/specs/q4_slo_v0.yml
@@ -1,0 +1,149 @@
+# q4_slo_v0.yml
+# Metric specification (human + governance contract).
+#
+# Q4 SLO is defined as "performance + efficiency budgets":
+# - latency must stay within a p95 budget
+# - cost must stay within a budget (mean by default; p95 optional)
+#
+# This file is intentionally "spec-first":
+# - It documents the meaning of q4_slo and the q4_slo_ok gate.
+# - It does not change runtime behavior by itself.
+# - If semantics change, bump spec.version and update canonical contract docs together.
+
+spec:
+  id: q4_slo_v0
+  version: "0.1.0"
+  category: "Q"
+  metric_id: "q4_slo"
+  gate_signal: "q4_slo_ok"
+  title: "Q4 SLO (Latency + Cost)"
+  intent: "Ensure p95 latency and cost budgets are met for the evaluated slice."
+
+references:
+  canonical_gate_set: "pulse_gate_policy_v0.yml"
+  status_artifact_hint: "PULSE_safe_pack_v0/artifacts/status.json"
+  dataset_manifest_schema: "schemas/dataset_manifest.schema.json"
+  dataset_manifest_example: "examples/dataset_manifest.example.json"
+
+data_contract:
+  dataset_manifest:
+    required: true
+    rule: "Runs SHOULD carry a dataset manifest to remove ambiguity about slice/time/source/sampling."
+
+  measurement_unit:
+    name: "request"
+    description: "A single model invocation / completion, measured end-to-end at a defined boundary."
+
+  required_fields_per_request:
+    - "request_id"
+    - "t_start_ms"        # integer epoch ms at request start (or monotonic-to-epoch mapped)
+    - "t_end_ms"          # integer epoch ms at request end
+    - "input_tokens"      # integer >= 0
+    - "output_tokens"     # integer >= 0
+    - "model_id"          # string identifier used for cost attribution
+    - "pricing_table_id"  # versioned pricing table identifier
+
+  optional_fields_per_request:
+    - "cost_usd"          # if already computed deterministically upstream
+    - "region"
+    - "endpoint"
+    - "cache_hit"
+    - "metadata"
+
+  boundary_definition:
+    latency:
+      definition: "t_end_ms - t_start_ms"
+      scope: "Measured at the chosen boundary (server-side preferred)."
+      note: "If client-side is used, it must be explicitly documented and stable."
+
+normalization:
+  latency_ms:
+    computation: "max(0, t_end_ms - t_start_ms)"
+    invalid_handling: "EXCLUDE_IF_MISSING_FIELDS"
+
+  token_total:
+    computation: "input_tokens + output_tokens"
+
+  cost_usd:
+    computation:
+      primary: "use cost_usd if provided"
+      fallback: "compute from (input_tokens, output_tokens, model_id, pricing_table_id)"
+    requirements:
+      - "pricing_table_id must be versioned and stable (no floating live pricing)."
+      - "cost computation must be deterministic and reproducible."
+
+exclusions:
+  warmup:
+    enabled: true
+    rule: "Exclude first N requests as warmup if present in the run metadata."
+    default_n: 0
+    note: "If warmup exclusion is used, N must be recorded to preserve reproducibility."
+
+scoring:
+  per_request:
+    eligibility:
+      - "All required fields present"
+      - "latency_ms computable"
+      - "cost_usd computable (directly or via deterministic pricing)"
+    outputs:
+      - "latency_ms"
+      - "cost_usd"
+      - "token_total"
+
+aggregation:
+  latency_p95_ms:
+    definition: "95th percentile of latency_ms over eligible requests."
+    quantile_method: "nearest_rank"
+    rationale: "Deterministic quantile selection (no interpolation ambiguity)."
+
+  cost_mean_usd_per_request:
+    definition: "Mean cost_usd over eligible requests."
+    rationale: "Budget control for average efficiency."
+
+  # Optional secondary metric (diagnostic unless explicitly promoted)
+  cost_p95_usd_per_request:
+    definition: "95th percentile of cost_usd over eligible requests."
+    quantile_method: "nearest_rank"
+    ci_neutral_by_default: true
+
+statistics:
+  sampling_notes:
+    - "If the slice is sampled, the sampling strategy and seed must be recorded in the dataset manifest."
+  confidence:
+    note: >
+      SLO gating is typically deterministic (no CI needed). If confidence bounds are introduced later,
+      they must be deterministic and documented in this spec.
+
+gating:
+  # IMPORTANT:
+  # Thresholds here are documented to prevent ambiguity.
+  # If these values differ from the executing policy today, align them intentionally and bump spec.version.
+  threshold:
+    latency_p95_ms: 1500
+    cost_mean_usd_per_request: 0.005
+
+  decision_rule:
+    - "Compute latency_p95_ms using nearest_rank quantile."
+    - "Compute cost_mean_usd_per_request."
+    - "PASS iff latency_p95_ms <= threshold.latency_p95_ms AND cost_mean_usd_per_request <= threshold.cost_mean_usd_per_request."
+    - "FAIL otherwise."
+
+  missing_data_handling:
+    required_field_missing: "FAIL"
+    insufficient_evidence: "FAIL"
+
+  evidence_requirements:
+    min_n_eligible_requests:
+      value: 200
+      rule: "If n_eligible_requests < min_n_eligible_requests => FAIL (insufficient evidence)."
+
+    max_excluded_fraction:
+      value: 0.02
+      rule: "If >2% of requests are excluded due to missing required fields => FAIL (measurement quality issue)."
+
+determinism:
+  requirements:
+    - "Quantile method must be fixed (nearest_rank)."
+    - "Timestamps must be recorded at a consistent boundary."
+    - "Pricing must be versioned (pricing_table_id) and deterministic."
+    - "If sampling is used, record seed and sampling strategy in the dataset manifest."


### PR DESCRIPTION
## Summary
Add `metrics/specs/q4_slo_v0.yml` defining the v0 contract for Q4 SLO (latency + cost)
and the `q4_slo_ok` gate semantics.

## Why
SLO gates can become ambiguous without explicit units, quantile method, measurement boundary,
and pricing/versioning assumptions. A spec file makes the SLO definition reviewable and
reduces disagreements and silent drift.

## What changed
- Add `metrics/specs/q4_slo_v0.yml` (spec-only; no runtime wiring)

## Scope / Non-goals
- ✅ Define the SLO measurement contract and gating rule
- ✅ Require deterministic quantile selection and versioned pricing
- ❌ Do not change CI behavior or safe-pack code in this PR

## Notes
If thresholds, measurement boundary, or cost attribution assumptions change, treat it as a
semantic change: bump `spec.version` and update canonical contract docs together.
