### PR TITLE
fix(metrics): require declared slices for Q3 fairness gating

### DIFF
--- a/docs/policy/CHANGELOG.md
+++ b/docs/policy/CHANGELOG.md
@@ -21,7 +21,7 @@ This changelog records **semantic** changes that can affect release gating outco
 
 ## Unreleased
 
-- None.
+- Q3 fairness: require non-empty `dataset_manifest.slices.dimensions`; missing/empty slices now FAIL Q3 gating (spec `q3_fairness_v0` bumped to 0.1.1).
 
 ## 0.1.0 — Initial baseline
 


### PR DESCRIPTION
## Summary
Make Q3 fairness fail-closed if no slice dimensions are declared in the dataset manifest,
and record the semantic change in the changelog.

## Why
Without declared slice dimensions, slice-based parity checks can be skipped and Q3 can
appear to pass without meaningful fairness evaluation.

## What changed
- Update Q3 fairness spec (0.1.1) to fail when dataset_manifest.slices.dimensions is missing/empty
- Update docs/policy/CHANGELOG.md under **Unreleased** to record the semantic change
