### PR TITLE
fix(metrics): require declared slices for Q3 fairness gating

### DIFF
--- a/docs/policy/CHANGELOG.md
+++ b/docs/policy/CHANGELOG.md
@@ -21,7 +21,8 @@ This changelog records **semantic** changes that can affect release gating outco
 
 ## Unreleased
 
-- Q3 fairness: require non-empty `dataset_manifest.slices.dimensions`; missing/empty slices now FAIL Q3 gating (spec `q3_fairness_v0` bumped to 0.1.1).
+- Q3 fairness: fail-closed when dataset manifest or `dataset_manifest.slices.dimensions` is missing/empty; Q3 gating now FAILs without declared slices (spec `q3_fairness_v0` bumped to 0.1.1).
+
 
 ## 0.1.0 — Initial baseline
 


### PR DESCRIPTION
## Summary
Ensure Q3 fairness changes are auditable by updating docs/policy/CHANGELOG.md under Unreleased.

## Why
CI requires a changelog update whenever semantic policy/spec/contract files change to prevent
silent drift in release gating meaning.

## What changed
- Update docs/policy/CHANGELOG.md to document that Q3 fairness is now fail-closed when
  dataset manifest or declared slice dimensions are missing/empty (q3_fairness_v0 0.1.1).
