### PR TITLE
docs(policy): update changelog for Q3 fairness 0.1.1

### DIFF
--- a/docs/policy/CHANGELOG.md
+++ b/docs/policy/CHANGELOG.md
@@ -21,7 +21,7 @@ This changelog records **semantic** changes that can affect release gating outco
 
 ## Unreleased
 
-- Q3 fairness: fail-closed when dataset manifest or `dataset_manifest.slices.dimensions` is missing/empty; Q3 gating now FAILs without declared slices (spec `q3_fairness_v0` bumped to 0.1.1).
+- Q3 fairness: fail-closed when dataset manifest or `dataset_manifest.slices.dimensions` is missing/empty; Q3 gating now FAILs without declared slices (spec `q3_fairness_v0` bumped to 0.1.1). (PR: #936)
 
 
 ## 0.1.0 — Initial baseline


### PR DESCRIPTION
## Summary
Update `docs/policy/CHANGELOG.md` under **Unreleased** to document the semantic change to
Q3 fairness (`q3_fairness_v0` version `0.1.1`).

## Why
The CI workflow enforces that any semantic changes to policy/spec/contract files (e.g.
`metrics/specs/*`) must be accompanied by a changelog update to prevent silent drift in
release gating meaning.

## What changed
- Adjust the Unreleased changelog entry for Q3 fairness (q3_fairness_v0 0.1.1)

## How to test
- Re-run the PR checks; the "Enforce changelog for policy/spec changes" step should pass
  because this PR includes `docs/policy/CHANGELOG.md`.
