### PR TITLE
fix(seo): expand sitemap.xml to include diagnostics + paradox core

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,5 +6,10 @@
   <url>
     <loc>https://hkati.github.io/pulse-release-gates-0.1/report_card.html</loc>
   </url>
+  <url>
+    <loc>https://hkati.github.io/pulse-release-gates-0.1/diagnostics/</loc>
+  </url>
+  <url>
+    <loc>https://hkati.github.io/pulse-release-gates-0.1/paradox/core/v0/</loc>
+  </url>
 </urlset>
-


### PR DESCRIPTION
## What
Expand repo-root sitemap.xml with stable, always-present entry pages:
- /diagnostics/
- /paradox/core/v0/

## Why
Robots/sitemap are now deterministic; this improves discoverability of the main audit surfaces without relying on deep link crawling.

## Verify
After Pages deploy:
- /pulse-release-gates-0.1/sitemap.xml contains the new URLs and is valid XML.
