### PR TITLE
fix(metadata): complete Zenodo relations for software and publication

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -3,25 +3,40 @@
   "description": "PULSE provides deterministic, fail-closed release gates across Safety (I2–I7), Utility (Q1–Q4) and SLO dimensions. It produces audit artefacts including a human-readable Quality Ledger and SVG badges that summarise pass/fail states. This software package allows developers to enforce safety invariants, utility budgets and service level objectives prior to shipment.",
   "upload_type": "software",
   "language": "eng",
+
   "creators": [
     {
       "name": "Horvat, Katalin",
       "orcid": "0009-0001-9745-3764",
       "affiliation": "EPLabsAI"
-    },
+    }
+  ],
+
+  "contributors": [
     {
       "name": "EPLabsAI",
+      "type": "ResearchGroup",
       "affiliation": "EPLabsAI"
     }
   ],
+
   "license": "Apache-2.0",
+
   "keywords": [
     "release-governance",
     "ai-safety",
     "evaluations",
     "guardrails",
-    "SLO"
+    "SLO",
+    "deterministic",
+    "fail-closed",
+    "reproducibility",
+    "auditability",
+    "quality-ledger",
+    "badges",
+    "mlops"
   ],
+
   "related_identifiers": [
     {
       "identifier": "10.5281/zenodo.17833583",
@@ -34,11 +49,17 @@
       "scheme": "doi"
     },
     {
+      "identifier": "https://github.com/HKati/pulse-release-gates-0.1",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
       "identifier": "https://github.com/HKati/pulse-guard-pack",
       "relation": "hasPart",
       "resource_type": "software",
       "scheme": "url"
     }
   ],
-  "notes": "Reproducibility instructions are included in the repository README (reproduce section)."
+
+  "notes": "This software release is accompanied by a cs.AI preprint archived as a separate Zenodo publication. Reproducibility instructions and CI/CD integration details are provided in the repository README."
 }


### PR DESCRIPTION
### Summary

This PR completes the Zenodo metadata for the PULSE software record by making
all critical relationships explicit and machine-readable.

### What was added / fixed

- Explicit `isDocumentedBy` relation to the cs.AI preprint (publication DOI)
- Explicit `isVersionOf` relation to the software concept DOI
- Explicit repository URL linkage (`isSupplementTo`)
- Clear separation of human creator and organizational contributor roles

### Why this matters

Zenodo and DataCite no longer guarantee implicit normalization of metadata.
Making these relations explicit prevents silent indexing or discovery issues
and ensures long-term correctness of the software–paper–repository chain.

### Scope

- Metadata only (`.zenodo.json`)
- No changes to code, tests, or release logic
