### PR TITLE
chore(gates): add missing baseline gate IDs to gate registry

### DIFF
--- a/pulse_gate_registry_v0.yml
+++ b/pulse_gate_registry_v0.yml
@@ -72,6 +72,33 @@ gates:
     intent: "Sanitization remains effective under small perturbations."
     stability: stable
 
+  # --- Controls / pack-level checks (emitted by run_all.py) ---
+  pass_controls_refusal:
+    category: controls
+    intent: "Pack control suite: refusal-related control checks pass under the current run_all protocol."
+    stability: stable
+
+  pass_controls_comm:
+    category: controls
+    intent: "Pack control suite: comm-related control checks pass under the current run_all protocol."
+    stability: stable
+
+  effect_present:
+    category: controls
+    intent: "Pack control suite: expected control effect is present under the current run_all protocol."
+    stability: stable
+
+  # --- Augmented / derived gates (injected by augment_status.py) ---
+  refusal_delta_pass:
+    category: controls
+    intent: "Refusal-delta meets configured thresholds (computed by refusal_delta_calc and injected during status augmentation)."
+    stability: stable
+
+  external_all_pass:
+    category: external
+    intent: "All external detector summaries meet configured thresholds (injected during status augmentation from artifacts/external)."
+    stability: stable
+
   # --- Diagnostics (must remain non-normative unless explicitly promoted) ---
   epf_hazard_ok:
     category: diagnostics


### PR DESCRIPTION
## Summary
Updates `pulse_gate_registry_v0.yml` with gate IDs that are already emitted by the current CI run.

## Why
The new CI gate registry sync step fails closed when `status.json` contains gate IDs not documented in the registry. The default pack run and `augment_status.py` already emit several IDs that were missing from the registry, causing CI to fail on every run.

## What changed
- Added the following gate IDs to `pulse_gate_registry_v0.yml`:
  - `pass_controls_refusal`
  - `pass_controls_comm`
  - `effect_present`
  - `refusal_delta_pass`
  - `external_all_pass`
- Fixed YAML syntax for `epf_hazard_ok` (`default_normative: false`)

## Notes
- No gate semantics were changed; this PR only documents existing emitted IDs.
- Intents are anchored to the emitting components (pack run_all / augment_status) to minimize meaning drift.
