### PR TITLE
chore(gates): add missing emitted gate IDs to registry

### DIFF
--- a/pulse_gate_registry_v0.yml
+++ b/pulse_gate_registry_v0.yml
@@ -36,9 +36,19 @@ gates:
     intent: "Monotonicity invariant holds for the test suite."
     stability: stable
 
+  psf_mono_shift_resilient:
+    category: invariants
+    intent: "Monotonicity invariant remains valid under shift/perturbation tests."
+    stability: stable
+
   psf_commutativity_ok:
     category: invariants
     intent: "Commutativity invariant holds for the test suite."
+    stability: stable
+
+  psf_comm_shift_resilient:
+    category: invariants
+    intent: "Commutativity invariant remains valid under shift/perturbation tests."
     stability: stable
 
   psf_idempotence_ok:
@@ -81,6 +91,11 @@ gates:
   pass_controls_comm:
     category: controls
     intent: "Pack control suite: comm-related control checks pass under the current run_all protocol."
+    stability: stable
+
+  pass_controls_sanit:
+    category: controls
+    intent: "Pack control suite: sanitization-related control checks pass under the current run_all protocol."
     stability: stable
 
   effect_present:


### PR DESCRIPTION
## Summary
Adds missing gate IDs to `pulse_gate_registry_v0.yml` that are already emitted by the pack run.

## Why
The CI registry sync guard fails closed when `status.json` contains undocumented gate IDs. `run_all.py` emits additional stable gates that were not yet registered.

## What changed
- Registered:
  - `psf_mono_shift_resilient`
  - `psf_comm_shift_resilient`
  - `pass_controls_sanit`

## Notes
- No renames or repurposing: existing meanings remain intact.
- Policy vs status alignment is unchanged; this is registry coverage only.
