### PR TITLE
docs(policy): document q3_fairness_v0 spec 0.1.1 semantic change

### DIFF
--- a/docs/policy/CHANGELOG.md
+++ b/docs/policy/CHANGELOG.md
@@ -23,6 +23,7 @@ This changelog records **semantic** changes that can affect release gating outco
 
 - Q3 fairness: fail-closed when dataset manifest or `dataset_manifest.slices.dimensions` is missing/empty; Q3 gating now FAILs without declared slices (spec `q3_fairness_v0` bumped to 0.1.1). (PR: #936)
 
+- q3_fairness_v0 (spec 0.1.1): Require non-empty dataset slice dimensions; fail-closed when missing/empty to prevent fairness checks from being skipped.
 
 ## 0.1.0 — Initial baseline
 


### PR DESCRIPTION
## Summary
Add an Unreleased changelog entry describing the Q3 fairness spec semantic change for `q3_fairness_v0` (spec 0.1.1).

## Why
We enforce changelog coverage for semantic policy/spec changes. This entry records the new fail-closed behavior so release-gating meaning remains auditable and stable.

## What changed
- `docs/policy/CHANGELOG.md`:
  - Added Unreleased entry:
    - Q3 fairness fails closed when dataset manifest or `dataset_manifest.slices.dimensions` is missing/empty
    - Notes spec bump: `q3_fairness_v0` → 0.1.1
    - References PR: #936

## Notes
Docs-only change (no code or gate semantics changed here); this is documentation for the semantic spec update.
