### PR TITLE
feat(external): surface external evidence presence as a diagnostic gate

### DIFF
--- a/pulse_gate_registry_v0.yml
+++ b/pulse_gate_registry_v0.yml
@@ -108,6 +108,12 @@ gates:
     category: controls
     intent: "Refusal-delta meets configured thresholds (computed by refusal_delta_calc and injected during status augmentation)."
     stability: stable
+  
+  external_summaries_present:
+    category: external
+    intent: "External detector summary evidence is present under artifacts/external (diagnostic-only signal; indicates whether external_all_pass is evidence-backed)."
+    stability: experimental
+    default_normative: false
 
   external_all_pass:
     category: external


### PR DESCRIPTION
## Summary
Adds a diagnostic gate `external_summaries_present` during status augmentation to explicitly indicate whether any external detector summaries were found.

## Why
Today CI warns that `external_all_pass` may be trivially true when no external summaries exist (fail-open). This change makes the evidence state explicit and auditable without tightening policy yet.

## What changed
- `PULSE_safe_pack_v0/tools/augment_status.py`: writes `external_summaries_present` into `status.gates`
- `pulse_gate_registry_v0.yml`: registers the new gate as experimental, default_normative=false

## Behavior
- No policy changes (nothing becomes required yet)
- CI remains green, but the evidence state becomes visible and trackable
