### PR TITLE
feat(external): make external evidence presence explicit in status augmentation

### DIFF
--- a/PULSE_safe_pack_v0/tools/augment_status.py
+++ b/PULSE_safe_pack_v0/tools/augment_status.py
@@ -130,6 +130,22 @@ else:
 thr: Dict[str, Any] = yload(args.thresholds) or {}
 ext_dir = os.path.abspath(args.external_dir)
 
+# Diagnostic gate: whether any external detector summary evidence exists.
+# We define "present" as: at least one *_summary.json file exists in external_dir.
+try:
+    external_summaries_present = (
+        os.path.isdir(ext_dir)
+        and any(
+            fn.endswith("_summary.json") and os.path.isfile(os.path.join(ext_dir, fn))
+            for fn in os.listdir(ext_dir)
+        )
+    )
+except Exception:
+    external_summaries_present = False
+
+gates["external_summaries_present"] = bool(external_summaries_present)
+status["external_summaries_present"] = bool(external_summaries_present)
+
 # Ensure we start from a clean list
 external["metrics"] = []
 


### PR DESCRIPTION
Summary
- Augment status.json with a new diagnostic gate: external_summaries_present.

Why
- Today CI can warn “No external detector summaries found…”, while
  external_all_pass may still be trivially true (fail-open).
- This change makes the presence/absence of external evidence explicit and
  machine-readable without tightening the external policy prematurely.

What changed
- In PULSE_safe_pack_v0/tools/augment_status.py:
  - Compute external_summaries_present from artifacts/external/*_summary.json
  - Write it to:
    - gates.external_summaries_present
    - top-level status.external_summaries_present (mirror)

Behavior
- external_summaries_present:
  - true  -> at least one *_summary.json exists
  - false -> none exist / directory missing
- external_all_pass:
  - unchanged (still pass when no summaries exist)

Testing
- CI: PULSE run produces status.json with the new gate.
- Verified existing gates/external aggregation remain unchanged.

Notes
- Diagnostic-only (default_normative: false). This is visibility/telemetry,
  not a gating semantic change.
