### PR TITLE
chore(gates): align gate registry with status.json emitted gates

### DIFF
--- a/pulse_gate_registry_v0.yml
+++ b/pulse_gate_registry_v0.yml
@@ -108,7 +108,23 @@ gates:
     category: controls
     intent: "Refusal-delta meets configured thresholds (computed by refusal_delta_calc and injected during status augmentation)."
     stability: stable
-  
+    
+    refusal_delta_pass:
+    category: controls
+    intent: "Refusal-delta meets configured thresholds (computed by refusal_delta_calc and injected during status augmentation)."
+    stability: stable
+
+  external_all_pass:
+    category: external
+    intent: "All external detector summaries meet configured thresholds (computed from artifacts/external by augment_status.py)."
+    stability: stable
+
+  external_summaries_present:
+    category: external
+    intent: "At least one external detector *_summary.json file is present under artifacts/external (evidence available)."
+    stability: experimental
+    default_normative: false
+
   external_summaries_present:
     category: external
     intent: "External detector summary evidence is present under artifacts/external (diagnostic-only signal; indicates whether external_all_pass is evidence-backed)."


### PR DESCRIPTION
Summary
- Refresh pulse_gate_registry_v0.yml so it fully covers gate IDs emitted by the
  pack run and augmentation.

Why
- CI now enforces a registry sync check: every gate ID in status.json must be
  present in the registry under `gates:`.
- Without registry coverage, the sync check fails (fail-closed), blocking merges.

What changed
- Updated/overwrote pulse_gate_registry_v0.yml to include the emitted gate IDs
  with documented meaning:
  - quality gates (q1..q4)
  - invariant gates (psf_*)
  - controls/sanitization gates
  - augmented/derived gates (refusal_delta_pass, external_all_pass)
  - diagnostic-only gates remain non-normative via default_normative: false

Testing
- CI: Gate registry sync check passes once registry and workflow are aligned.

Notes
- Registry is a source-of-truth ledger for gate IDs; this PR documents existing
  emitted IDs, not new semantics.
