### PR TITLE
feat(external): emit external_summaries_present diagnostic gate

### DIFF
--- a/PULSE_safe_pack_v0/tools/augment_status.py
+++ b/PULSE_safe_pack_v0/tools/augment_status.py
@@ -130,24 +130,17 @@ else:
 thr: Dict[str, Any] = yload(args.thresholds) or {}
 ext_dir = os.path.abspath(args.external_dir)
 
-# Diagnostic gate: whether any external detector summary evidence exists.
-# We define "present" as: at least one *_summary.json file exists in external_dir.
+# Ensure we start from a clean list
+external["metrics"] = []
+
+# Diagnostic: do we have any external *_summary.json evidence at all?
 try:
-    external_summaries_present = (
-        os.path.isdir(ext_dir)
-        and any(
-            fn.endswith("_summary.json") and os.path.isfile(os.path.join(ext_dir, fn))
-            for fn in os.listdir(ext_dir)
-        )
+    external_summaries_present = any(
+        fn.endswith("_summary.json") and os.path.isfile(os.path.join(ext_dir, fn))
+        for fn in os.listdir(ext_dir)
     )
 except Exception:
     external_summaries_present = False
-
-gates["external_summaries_present"] = bool(external_summaries_present)
-status["external_summaries_present"] = bool(external_summaries_present)
-
-# Ensure we start from a clean list
-external["metrics"] = []
 
 
 def fold_external(
@@ -290,6 +283,10 @@ external["all_pass"] = ext_all
 # Mirror to gates + top-level, so check_gates.py can consume it
 gates["external_all_pass"] = ext_all
 status["external_all_pass"] = ext_all
+
+external["summaries_present"] = external_summaries_present  # optional mirror
+gates["external_summaries_present"] = external_summaries_present
+status["external_summaries_present"] = external_summaries_present
 
 # ---------------------------------------------------------------------------
 # 3) Write back


### PR DESCRIPTION
This PR emits a new non-normative diagnostic gate external_summaries_present during
status augmentation.

external_summaries_present=true when at least one *_summary.json exists under artifacts/external

false otherwise

external_all_pass behavior is unchanged; this PR only makes fail-open evidence gaps explicit.

Squash merge title

feat(external): surface external_summaries_present diagnostic gate