### PR TITLE
chore(ci): improve external evidence visibility (summary JSON aware)

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -335,14 +335,25 @@ jobs:
         run: |
           set -euo pipefail
           EXT_DIR="${{ env.PACK_DIR }}/artifacts/external"
+
+          echo "### External evidence" >> "$GITHUB_STEP_SUMMARY"
+
           if [ -d "$EXT_DIR" ]; then
             echo "External summary directory: $EXT_DIR"
             ls -la "$EXT_DIR" || true
-            if ! find "$EXT_DIR" -maxdepth 1 -type f | grep -q .; then
-              echo "::warning::No external detector summaries found. external_all_pass may be trivially true (fail-open)."
+
+            if ! find "$EXT_DIR" -maxdepth 1 -type f -name '*_summary.json' | grep -q .; then
+              echo "::warning::No external *_summary.json summaries found under $EXT_DIR. external_all_pass may be trivially true (fail-open)."
+              echo "- external_summaries_present: false" >> "$GITHUB_STEP_SUMMARY"
+              echo "- note: external_all_pass may be fail-open when no evidence is present" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "Found external summaries:"
+              find "$EXT_DIR" -maxdepth 1 -type f -name '*_summary.json' -print || true
+              echo "- external_summaries_present: true" >> "$GITHUB_STEP_SUMMARY"
             fi
           else
             echo "::warning::External summary directory missing: $EXT_DIR"
+            echo "- external_summaries_present: false (missing directory)" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Show gates snapshot


### PR DESCRIPTION
This PR improves the “External detector summaries (visibility)” CI step:

Detects evidence using *_summary.json (instead of any file),

Emits a clearer warning when evidence is missing (external_all_pass may be fail-open),

Adds a short “External evidence” section to the GitHub run summary.

No changes to gating semantics.