### PR TITLE
ci(governance): run policy-registry consistency check

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -338,6 +338,15 @@ jobs:
             --registry pulse_gate_registry_v0.yml \
             --emit-stubs
 
+      - name: Policy ↔ registry consistency check
+        shell: bash
+        run: |
+          set -euo pipefail
+          python tools/tools/check_policy_registry_consistency.py \
+            --registry pulse_gate_registry_v0.yml \
+            --policy pulse_gate_policy_v0.yml \
+            --sets required
+
       - name: Enforce external evidence presence (strict manual mode)
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true' }}
         shell: bash


### PR DESCRIPTION
Summary
- Run the policy↔registry consistency checker in CI to prevent policy drift and accidental promotion of diagnostic gates.

Why
- Gate IDs are stable core: policy must not reference undefined IDs.
- Gates marked default_normative:false must not become required unintentionally.

What changed
- pulse_ci.yml: added policy↔registry check for the required policy set
- pulse_core_ci.yml: added registry check for the hardcoded Core required gate list

Behavior
- Fails closed (exit 2) with GitHub Actions annotations when violations are found.
