### PR TITLE
fix(gates): deduplicate gate registry YAML entries

### DIFF
--- a/pulse_gate_registry_v0.yml
+++ b/pulse_gate_registry_v0.yml
@@ -108,11 +108,6 @@ gates:
     category: controls
     intent: "Refusal-delta meets configured thresholds (computed by refusal_delta_calc and injected during status augmentation)."
     stability: stable
-    
-    refusal_delta_pass:
-    category: controls
-    intent: "Refusal-delta meets configured thresholds (computed by refusal_delta_calc and injected during status augmentation)."
-    stability: stable
 
   external_all_pass:
     category: external
@@ -122,18 +117,6 @@ gates:
   external_summaries_present:
     category: external
     intent: "At least one external detector *_summary.json file is present under artifacts/external (evidence available)."
-    stability: experimental
-    default_normative: false
-
-  external_summaries_present:
-    category: external
-    intent: "External detector summary evidence is present under artifacts/external (diagnostic-only signal; indicates whether external_all_pass is evidence-backed)."
-    stability: experimental
-    default_normative: false
-
-    external_summaries_present:
-    category: external
-    intent: "At least one external detector *_summary.json file is present under artifacts/external (evidence availability signal)."
     stability: experimental
     default_normative: false
 


### PR DESCRIPTION
## Summary
Fix CI failure caused by duplicate YAML keys in pulse_gate_registry_v0.yml.

## What changed
- Removed duplicate definitions of:
  - refusal_delta_pass
  - external_summaries_present (kept a single diagnostic entry)
- Kept external_all_pass in the registry (still emitted by status augmentation).

## Why
YAML duplicate keys silently override earlier values. With the new fail-closed duplicate-key guard,
this must be clean to prevent hidden registry drift.

## Testing
- CI: YAML duplicate-key guard + PULSE CI
