### PR TITLE
ci(tools-tests): run governance smoke tests

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -651,7 +651,14 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Run exporter smoke tests
+      - name: Install minimal Python deps
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install pyyaml
+
+      - name: Run exporter + governance smoke tests
         shell: bash
         run: |
           set -euo pipefail
@@ -662,5 +669,7 @@ jobs:
           (root / "tests" / "out").mkdir(parents=True, exist_ok=True)
 
           subprocess.check_call([sys.executable, "tests/test_exporters.py"])
-          print("Exporter smoke tests OK")
+          subprocess.check_call([sys.executable, "tests/test_tools_governance_smoke.py"])
+
+          print("Exporter + governance smoke tests OK")
           PY


### PR DESCRIPTION
## Summary
Extend the Tools smoke tests job to run governance smoke tests in addition to exporter smoke tests.

## Why
Governance checks (registry sync, policy↔registry consistency, duplicate YAML key guard) are part of the stable core and must not silently regress. Running the governance smoke test in CI keeps these tools continuously validated.

## What changed
- tools-tests job now installs minimal deps (pyyaml)
- tools-tests job runs:
  - tests/test_exporters.py
  - tests/test_tools_governance_smoke.py

## Notes
No gate semantics or policy meaning changes. CI coverage only.
