### PR TITLE
feat(tools): enable core_required parsing for Core CI gate materialization

### DIFF
--- a/tools/policy_to_require_args.py
+++ b/tools/policy_to_require_args.py
@@ -11,12 +11,15 @@ Behavior
 --------
 - `--set required`:
     - missing set OR empty set => error (non-zero)
+- `--set core_required`:
+    - missing set OR empty set => error (non-zero)
 - `--set advisory`:
     - missing set OR empty set => valid (exit 0, print nothing)
 
 Supports inline list forms:
   advisory: []
   required: [a, b, c]
+  core_required: [a, b, c]
 
 Design constraints
 ------------------
@@ -24,6 +27,7 @@ Design constraints
 - Minimal parsing tailored to the policy layout under:
     gates:
       required: ...
+      core_required: ...
       advisory: ...
 """
 
@@ -164,7 +168,7 @@ def main() -> int:
     ap.add_argument(
         "--set",
         default="required",
-        choices=["required", "advisory"],
+        choices=["required", "core_required", "advisory"],
         help="Which gate set to print (default: required)",
     )
     ap.add_argument(
@@ -188,7 +192,7 @@ def main() -> int:
         if not found_set or not gates:
             return 0
 
-    # Required must exist and must be non-empty.
+    # Required-like sets must exist and must be non-empty.
     if not found_set:
         print(f"[policy_to_require_args] Gate set not found: {args.set}", file=sys.stderr)
         return 3


### PR DESCRIPTION
Summary

Extend tools/policy_to_require_args.py to accept --set core_required in addition to required and advisory.

Why

The policy YAML can define a minimal gates.core_required set for “Core CI”, but the canonical helper previously rejected that set name. This would prevent CI and tooling from consuming the policy as intended.

What changed

Added core_required to --set choices.

Enforced required-like semantics for core_required (fail-closed on missing/empty).

Kept advisory semantics unchanged (optional, empty OK).

Testing

CI: relies on existing smoke tests / workflow execution.

Manual:

python tools/policy_to_require_args.py --set core_required

python tools/policy_to_require_args.py --set advisory