### PR TITLE
docs(policy): add Unreleased note for pulse_gate_policy_v0 change

### DIFF
--- a/docs/policy/CHANGELOG.md
+++ b/docs/policy/CHANGELOG.md
@@ -20,6 +20,7 @@ This changelog records **semantic** changes that can affect release gating outco
    - Impact / migration notes (if any)
 
 ## Unreleased
+- pulse_gate_policy_v0: Add `core_required` gate set for Core CI consumption (no change to existing required/advisory semantics).
 
 - Q3 fairness: fail-closed when dataset manifest or `dataset_manifest.slices.dimensions` is missing/empty; Q3 gating now FAILs without declared slices (spec `q3_fairness_v0` bumped to 0.1.1). (PR: #936)
 


### PR DESCRIPTION
Summary

Adds an Unreleased changelog entry that explicitly references pulse_gate_policy_v0.

Why

CI fail-closed enforcement requires semantic policy changes to be documented under Unreleased. The workflow checks for the literal token pulse_gate_policy_v0, and the absence of this string blocks the pipeline before pack execution.

Testing

CI rerun.