### PR TITLE
docs(policy): record pulse_gate_policy_v0 change in Unreleased

### DIFF
--- a/docs/policy/CHANGELOG.md
+++ b/docs/policy/CHANGELOG.md
@@ -20,7 +20,7 @@ This changelog records **semantic** changes that can affect release gating outco
    - Impact / migration notes (if any)
 
 ## Unreleased
-- pulse_gate_policy_v0: Add `core_required` gate set for Core CI consumption (no change to existing required/advisory semantics).
+pulse_gate_policy_v0.yml: add core_required gate set (minimal deterministic Core CI); required/advisory enforcement semantics unchanged.
 
 - Q3 fairness: fail-closed when dataset manifest or `dataset_manifest.slices.dimensions` is missing/empty; Q3 gating now FAILs without declared slices (spec `q3_fairness_v0` bumped to 0.1.1). (PR: #936)
 


### PR DESCRIPTION
## Summary
Add Unreleased changelog coverage for the semantic change in `pulse_gate_policy_v0.yml`.

## Why
CI enforces fail-closed changelog coverage for policy/spec/contract changes.

## Change
- docs/policy/CHANGELOG.md: add Unreleased entry mentioning `pulse_gate_policy_v0.yml` and core_required.
