### PR TITLE
ci(core): use core_required gate set on pull requests

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -9,7 +9,7 @@ on:
       - "badges/**"
       - "reports/**"
       - "!docs/policy/CHANGELOG.md"
-  
+
   pull_request:
     branches: [main]
 
@@ -23,7 +23,6 @@ on:
         options:
           - "false"
           - "true"
-
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -589,6 +588,7 @@ jobs:
           fi
           if [ -f sarif.json ]; then
             mv sarif.json reports/sarif.json
+          fi
 
       - name: Generate badges (artifact only)
         if: always()
@@ -631,6 +631,7 @@ jobs:
             echo '```' >> "$GITHUB_STEP_SUMMARY"
           else
             echo "_No status.json produced (or jq missing)._ " >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload artifacts
         if: always()


### PR DESCRIPTION
## Summary
Use policy-defined `core_required` gates for pull_request runs while keeping `required` on main and other run types.

## Why
- Faster PR signal with minimal deterministic enforcement
- No change to release enforcement on main (still full `required`)

## What changed
- .github/workflows/pulse_ci.yml: select require set based on event type and pass it to policy_to_require_args.py

## Behavior
- PRs enforce: core_required
- main/dispatch/schedule enforce: required
