### PR TITLE
ci(core): check core_required set against gate registry

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -351,7 +351,8 @@ jobs:
           python tools/tools/check_policy_registry_consistency.py \
             --registry pulse_gate_registry_v0.yml \
             --policy pulse_gate_policy_v0.yml \
-            --sets required
+            --sets required core_required
+            
 
       - name: Enforce external evidence presence (strict manual mode)
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true' }}


### PR DESCRIPTION
## Summary
Validate both `required` and `core_required` gate sets against the gate registry.

## Why
PR runs now enforce `core_required`. Without this change, core_required can drift away from the registry without being caught by governance checks.

## Change
- .github/workflows/pulse_ci.yml: run policy↔registry consistency check for `required` and `core_required`.
