### PR TITLE
ci(core): run PULSE CI on version tags with strict evidence

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -357,8 +357,7 @@ jobs:
             --sets required core_required
             
 
-      - name:  "Enforce external evidence presence (strict: manual OR version tag)"
-
+      - name: "Enforce external evidence presence (strict: manual OR version tag)"
         if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') }}
         shell: bash
         run: |
@@ -367,6 +366,7 @@ jobs:
           python "${{ env.PACK_DIR }}/tools/check_gates.py" \
             --status "${{ env.PACK_DIR }}/artifacts/status.json" \
             --require external_summaries_present external_all_pass
+
 
 
       - name: External detector summaries (visibility)


### PR DESCRIPTION
## Summary
Run PULSE CI on version tag pushes (v* and V*) and enforce strict external evidence on those runs.

## Why
Release-tag runs should be audit-strong: external detector evidence must be present.
PRs remain lightweight via core_required; main and version tags stay strict.

## Changes
- .github/workflows/pulse_ci.yml: add tag triggers and strict evidence condition for v*/V* tags
