### PR TITLE
docs(readme): document strict evidence on version tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,9 @@ In addition to running the pack, CI enforces repo‑level governance guards:
 - **Gate registry sync:** every gate emitted in `status.json` must be registered in `pulse_gate_registry_v0.yml`.
 - **Policy ↔ registry consistency:** every gate required by policy must exist in the registry.
 
-Manual strict mode: workflow dispatch input `strict_external_evidence=true` additionally requires `external_summaries_present` (and `external_all_pass`).
+Strict external evidence mode: workflow dispatch input strict_external_evidence=true or version tag pushes (v*/V*) additionally require external_summaries_present (and external_all_pass).
+Policy set selection: pull_request runs enforce core_required; main and version tag runs enforce required (policy-driven).
+
 
 > Tip: after making the repo **public**, add a **Branch protection rule** (Settings → Branches) and mark **PULSE CI** as a **required status check**.
 


### PR DESCRIPTION
## Summary
Update the README governance preflight section to match current CI behavior.

## Changes
- Document that strict external evidence is enforced on workflow_dispatch strict=true and on version tag pushes (v*/V*)
- Document policy set selection: PR uses core_required; main/tag uses required

## Files changed
- README.md
