### PR TITLE
docs(runbook): fix GOV-007 heading level and formatting

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -127,23 +127,27 @@ Rule:
 - “Present but broken” must never be treated as PASS.
 
 
-GOV‑007 — Workflow YAML parse failure (unquoted ':' in step name)
+### GOV‑007 — Workflow YAML parse failure (unquoted ':' in step name)
+
 Meaning:
 
-A GitHub Actions workflow YAML file failed to parse. A common footgun is an unquoted ':' followed by whitespace inside a step name.
+- A GitHub Actions workflow YAML file failed to parse. A common footgun is an unquoted `:` followed by whitespace inside a step name.
 
 Typical symptoms:
 
-- "Unquoted ':' in step name. Quote the value of - name: ..."
-- "YAML parse error: mapping values are not allowed here"
+- `Unquoted ':' in step name. Quote the value of - name: ...`
+- `YAML parse error: mapping values are not allowed here`
 
 Fix:
 
-- Prefer avoiding ':' in step names, or quote the entire step name using ASCII quotes.
+- Prefer avoiding `:` in step names, or quote the entire step name using plain ASCII quotes (`'` or `"`).
 - If your editor tends to auto-replace quotes, use a block scalar (most robust):
 
+  ```yml
   - name: >-
       Enforce external evidence presence (strict: manual OR version tag)
+
+
 
 Notes:
 


### PR DESCRIPTION
## Summary
Fix GOV-007 formatting in the Runbook so it matches the other GOV-00x sections.

## Why
GOV-007 was rendered with an inconsistent heading level, causing it to appear mismatched compared to GOV-006 and the other governance guard entries.

## Changes
- Adjust GOV-007 heading level to match existing GOV sections
- Improve Markdown formatting for readability (code block + inline error messages)

## Files changed
- docs/RUNBOOK.md
