### PR TITLE
ci(pages): restrict publish workflow_run to main

### DIFF
--- a/.github/workflows/publish_report_pages.yml
+++ b/.github/workflows/publish_report_pages.yml
@@ -4,7 +4,8 @@ on:
   workflow_run:
     workflows: ["PULSE CI"]
     types: [completed]
-
+    branches: [main]
+  
   workflow_dispatch:
     inputs:
       run_id:
@@ -39,6 +40,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
+      
 
     steps:
       - name: Resolve upstream run id


### PR DESCRIPTION
## Summary
Reduce Actions noise by preventing the Pages publish workflow from running on PR-triggered PULSE CI completions.

## Why
Publish report pages is triggered via workflow_run and currently creates skipped (neutral) runs on PR activity. This is expected but noisy.

## Changes
- Add workflow_run branch filter: branches: [main]
- (Optional) Gate deploy job on workflow_run.conclusion == success

## Files changed
- .github/workflows/publish_report_pages.yml
