### PR TITLE
docs(readme): reference workflow_lint for workflow YAML guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ In addition to running the pack, CI enforces repo‑level governance guards:
 - **Policy ↔ registry consistency:** every gate required by policy must exist in the registry (including `core_required`).
 - **Policy set selection:** `pull_request` runs enforce `core_required`; main branch pushes and version tag pushes (`v*`/`V*`) enforce `required` (policy-driven).
 - **Strict external evidence:** workflow dispatch input `strict_external_evidence=true` **or** version tag pushes (`v*`/`V*`) additionally require `external_summaries_present` (and `external_all_pass`).
-- **Workflow YAML guard:** fail‑closed validation of `.github/workflows/*.yml` to prevent broken workflow YAML (e.g., unquoted `:` in step names).
+- **Workflow YAML guard (workflow_lint.yml):** fail‑closed validation of `.github/workflows/*.yml` to prevent broken workflow YAML (e.g., unquoted `:` in step names).
 
 > Tip: after making the repo **public**, add a **Branch protection rule** (Settings → Branches) and mark **PULSE CI** as a **required status check**.
 


### PR DESCRIPTION
## Summary
Clarify the README governance bullet by referencing the existing workflow YAML guard implementation.

## Change
- Mention `workflow_lint.yml` as the workflow that enforces the workflow YAML guard (fail-closed)

## Files changed
- README.md
