### PR TITLE
docs(readme): replace broken Kaggle baseline DOI with direct dataset …

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@
 - **Live Quality Ledger:** https://hkati.github.io/pulse-release-gates-0.1/
 
 - **Kaggle Dataset (EPF A/B artifacts, seeded) — DOI:** https://doi.org/10.34740/kaggle/dsv/13571702
-- **Kaggle Dataset (baseline demo; deterministic, fail‑closed) — DOI:** https://doi.org/10.34740/kaggle/dsv/13571927
+- Kaggle Dataset (baseline demo; deterministic, fail‑closed): https://www.kaggle.com/datasets/horvathkatalin/pulse-baseline-demo-deterministic-fail-closed
+
 
 - **Kaggle Notebook (repro figures — EPF A/B, seeded):**
   https://www.kaggle.com/code/horvathkatalin/pulse-epf-shadow-a-b-reproduce-figures-seeded


### PR DESCRIPTION
### What changed
- Replaced the broken Kaggle baseline demo DOI link with a direct Kaggle dataset URL in README.

### Why
- The previous `doi.org/10.34740/kaggle/dsv/13571927` baseline entry resolves to a 404, which creates confusion and link-check noise.
- A direct Kaggle dataset URL is a clearer “mirror/demo surface” pointer, while Zenodo remains the stable DOI path.

### Notes
- No changes to PULSE gating, policies, or CI behavior.
- Docs-only change.
