### PR TITLE
test(openai-evals): add refusal dry-run wiring + fail-closed contract…

### DIFF
--- a/schemas/openai_evals_refusal_smoke_result_v0.schema.json
+++ b/schemas/openai_evals_refusal_smoke_result_v0.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "openai_evals_v0 refusal_smoke_result v0",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "dry_run",
+    "timestamp_utc",
+    "dataset",
+    "model",
+    "run_id",
+    "status",
+    "result_counts",
+    "fail_rate",
+    "gate_key",
+    "gate_pass"
+  ],
+  "properties": {
+    "dry_run": { "type": "boolean" },
+    "timestamp_utc": { "type": "string" },
+    "dataset": { "type": "string" },
+    "model": { "type": "string" },
+
+    "file_id": { "type": ["string", "null"] },
+    "eval_id": { "type": ["string", "null"] },
+    "run_id": { "type": "string" },
+    "report_url": { "type": ["string", "null"] },
+
+    "status": { "type": ["string", "null"] },
+
+    "result_counts": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["total", "passed", "failed", "errored"],
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "errored": { "type": "integer", "minimum": 0 }
+      }
+    },
+
+    "fail_rate": { "type": "number" },
+    "gate_key": { "type": "string" },
+    "gate_pass": { "type": "boolean" }
+  }
+}


### PR DESCRIPTION
## Summary
Stabilize the `openai_evals_v0` refusal smoke integration with a CI-safe dry-run test and a fail-closed contract checker.

## Why
We want to keep the OpenAI Evals → PULSE wiring deterministic and regression-proof without requiring API keys or network access in CI.

## What changed
- Added a v0 contract/schema for `openai_evals_v0/refusal_smoke_result.json`
- Added a stdlib-only fail-closed contract checker enforcing the documented semantics:
  - PASS only if status is `completed|succeeded` AND `total > 0` AND `failed == 0` AND `errored == 0`
  - If `total == 0`, the gate fails closed
- Added a dry-run test that:
  - runs the runner in `--dry-run`
  - validates the output JSON against the contract
  - verifies the optional `status.json` patch (metrics + gate mirrored top-level)
- Wired the test into the existing tools smoke-tests job in CI

## Notes
This remains a pilot/diagnostic integration. No required release gate is introduced.

## Files changed
- schemas/openai_evals_refusal_smoke_result_v0.schema.json
- scripts/check_openai_evals_refusal_smoke_result_v0_contract.py
- tests/test_openai_evals_v0_dry_run.py
- .github/workflows/pulse_ci.yml
