### PR TITLE
docs: add external detectors policy and modes

### DIFF
--- a/PULSE_safe_pack_v0/docs/EXTERNAL_DETECTORS.md
+++ b/PULSE_safe_pack_v0/docs/EXTERNAL_DETECTORS.md
@@ -1,62 +1,57 @@
 # External detectors
 
-# External detectors
+> **Implementation guide (schemas, examples, integration patterns):**
+> [`docs/external_detector_summaries.md`](external_detector_summaries.md)
 
-> **Implementation guide (repo-level):** [docs/external_detector_summaries.md](../../docs/external_detector_summaries.md)  
-> (schemas, examples, integration patterns)
+PULSE supports an external detector layer that can enrich run artefacts (e.g. `status.json`)
+with additional safety and quality signals (for example: external alignment scanners,
+safety classifiers, jailbreak probes).
 
+The PULSE safe-pack does **not** hard-wire any single detector implementation. Instead, it defines
+an interface and expects integrations to:
 
-
-PULSE supports an external detector layer that can enrich the status
-with additional safety and quality signals (for example: external
-alignment or safety scanners).
-
-The PULSE safe-pack itself does **not** hard-wire any specific external
-detector implementation. Instead, it defines an interface and expects
-integrations to:
-
-- run external tools (e.g. model scanners, policy checkers),
-- write their findings into an extended status structure,
-- respect the policy encoded in the profile (thresholds, risk limits,
-  and whether external results are gating or advisory).
+- run external tools (e.g., model scanners, policy checkers),
+- write their findings into a structured summary (JSON / JSONL),
+- augment the PULSE status artefacts with those findings (merge/attach + optional composite gates),
+- respect the policy encoded in the active profile (thresholds, risk limits, and whether external results
+  are gating or advisory).
 
 ## Gating vs advisory modes
 
 There are two conceptual ways to use external detectors:
 
-1. **Gating mode (this repository’s default)**  
-   In the main pipeline, external summaries are combined into a
-   composite gate such as `external_all_pass`. The CI workflow
-   (`.github/workflows/pulse_ci.yml`) includes this gate in the enforced
-   gate list, and `tools/augment_status.py` computes the flag from
-   external metrics and thresholds.
-
-   When external detectors are enabled and any metric crosses the
-   configured threshold, `external_all_pass` becomes `FAIL`, and CI will
-   **fail** as part of the deterministic gating. In other words, in this
-   configuration external detectors *do* contribute to pass/fail outcomes.
+1. **Gating mode (often the default for “ship/no-ship”)**  
+   External summaries are combined into a composite gate such as `external_all_pass`.
+   The CI workflow enforces that gate as *required*, so any failing external check can block the release
+   (fail-closed).
 
 2. **Advisory / shadow mode**  
-   The same interface can be used in a purely advisory way (for example
-   in shadow workflows or research runs), where external findings are
-   logged for analysis, reporting and governance but are **not** wired
-   into any required gate. In that setup, external detectors are
-   CI-neutral and do not change the release decision.
+   External findings are ingested for reporting and governance, but are **not** wired into any required
+   gate. In this setup, external detectors are CI-neutral and do not change the release decision.
 
-This repository currently ships the **gating** configuration by default
-for the main PULSE CI, while still allowing downstream users to wire
-external detectors in advisory-only mode in their own workflows or
-profiles if desired.
+Downstream users can choose either mode by adjusting their required gate set and/or profile policy.
 
-For the full, up-to-date top-level documentation in this repository:
+## External Detectors Policy (v0.1)
 
-For the full, up-to-date top-level documentation in this repository:
+This policy captures recommended hardening when external detectors are enabled.
 
-- Policy (gating vs advisory, defaults): [docs/EXTERNAL_DETECTORS.md](../../docs/EXTERNAL_DETECTORS.md)
-- External detector summaries (schemas, examples, integration patterns): [docs/external_detector_summaries.md](../../docs/external_detector_summaries.md)
+- **Allow-list:** only call detectors hosted on domains listed under `profiles/*` →
+  `external_detectors.allow_domains`.
+- **Timeouts:** enforce `timeout_ms_per_call` and `timeout_ms_overall`; on timeout/network error →
+  deterministic `FAIL` (fail-closed).
+- **Versioning:** record each detector as `name@sha256:...` inside `status.json`.
+- **Audit:** include number/status of calls and total wall time in the Quality Ledger notes.
 
+> Note: if your integration does **not** “call” remote detectors (i.e., you only ingest offline summaries),
+> the allow-list/timeout points still apply to the workflow step that produces those summaries.
 
+## Determinism note (important)
 
-If you archive this pack (e.g. via Zenodo/DOI), consider including this file plus the two top-level documents above
-so that external detector behavior remains transparent and reproducible for downstream users.
+To preserve deterministic release semantics, treat external detector outputs as **immutable artefacts**:
+pin tool versions, archive outputs, and have PULSE consume the archived summaries.
+If a required external artefact is missing, it must never be silently interpreted as `PASS`.
 
+## References
+
+- Safe-pack overview (external detectors): `PULSE_safe_pack_v0/docs/EXTERNAL_DETECTORS.md`
+- Implementation guide: `docs/external_detector_summaries.md`


### PR DESCRIPTION
## What
Introduce docs/EXTERNAL_DETECTORS.md as the repo-level policy/modes doc for external detectors.

## Why
The safe-pack documentation references repo-level external detector docs. This adds the
top-level policy/modes entrypoint so downstream users have a stable reference.

## Notes
Docs-only change. No changes to gating logic, status generation, or workflows.

## Follow-ups
Add the implementation guide (docs/external_detector_summaries.md) and clean up minor
duplications in the safe-pack EXTERNAL_DETECTORS.md.
