### PR TITLE
ci(docs): add docs link check workflow

### DIFF
--- a/.github/workflows/docs_link_check.yml
+++ b/.github/workflows/docs_link_check.yml
@@ -7,11 +7,12 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   docs-link-check:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## What
Add .github/workflows/docs_link_check.yml to run scripts/check_markdown_links.py on PRs and main.

## Why
Prevents broken doc-map links (404) and common path mistakes (docs/docs), and catches case-only
filename collisions that can break on Windows/macOS.

## Scope
CI only; no product/gate behavior changes.
