### PR TITLE
docs: add safe-pack LIGHTHOUSE_CASE_1 stub

### DIFF
--- a/PULSE_safe_pack_v0/docs/LIGHTHOUSE_CASE_1.md
+++ b/PULSE_safe_pack_v0/docs/LIGHTHOUSE_CASE_1.md
@@ -1,0 +1,8 @@
+# Lighthouse case 1
+
+This file exists to keep safe-pack documentation links stable and reproducible.
+
+If you are reading this from the full repository, additional context and related materials
+may live under the repo-level `docs/` directory.
+
+(Kept intentionally lightweight to avoid duplicating canonical docs.)


### PR DESCRIPTION
Add missing safe-pack doc file referenced from README: LIGHTHOUSE_CASE_1.md.
Docs-only change.
