### PR TITLE
docs: add safe-pack COMPETITOR_RADAR_2025 stub

### DIFF
--- a/PULSE_safe_pack_v0/docs/COMPETITOR_RADAR_2025.md
+++ b/PULSE_safe_pack_v0/docs/COMPETITOR_RADAR_2025.md
@@ -1,0 +1,8 @@
+# Competitor radar 2025
+
+This file exists to keep safe-pack documentation links stable and reproducible.
+
+If you are reading this from the full repository, additional context and related materials
+may live under the repo-level `docs/` directory.
+
+(Kept intentionally lightweight to avoid duplicating canonical docs.)


### PR DESCRIPTION
Add missing safe-pack doc file referenced from README: COMPETITOR_RADAR_2025.md.
Docs-only change.
