### PR TITLE
docs: remove stale README link to external_detectors.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ Curated entrypoints (repo-level docs under `docs/`):
 ### Status, ledger & external signals
 - [docs/quality_ledger.md](docs/quality_ledger.md) — Quality Ledger layout and purpose.
 - [docs/refusal_delta_gate.md](docs/refusal_delta_gate.md) — Refusal-delta summary format + fail-closed semantics.
--  [docs/EXTERNAL_DETECTORS.md](docs/EXTERNAL_DETECTORS.md) — External detectors policy & modes (gating vs advisory).
+- [docs/EXTERNAL_DETECTORS.md](docs/EXTERNAL_DETECTORS.md) — External detectors policy & modes (gating vs advisory).
 - [docs/external_detector_summaries.md](docs/external_detector_summaries.md) — Folding external detector summaries into status/ledger.
 
 


### PR DESCRIPTION
## Problem
README references docs/external_detectors.md, which is missing and causes the docs link
checker to fail (404 / fail-closed).

## Change
Replace the stale link with:
- docs/EXTERNAL_DETECTORS.md (policy & modes)
- docs/external_detector_summaries.md (implementation guide)

## Scope
Docs-only; no CI/gate behavior changes.
