### PR TITLE
ci(pulse): fail-closed on missing external summaries before augment_s…

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -373,7 +373,8 @@ jobs:
           cat "${{ env.PACK_DIR }}/artifacts/refusal_delta_summary.json" || true
           echo "-------------------------------------"
 
-      - name: Strict external evidence: require external summaries present (pre-augment, fail-closed)
+      - name: "Strict external evidence: require external summaries present (pre-augment, fail-closed)"
+
         if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') }}
         shell: bash
         run: |


### PR DESCRIPTION
## What
Add a strict external evidence presence check to pulse_ci.yml that runs before augment_status.py
for tag builds (v*/V*) and when strict_external_evidence=true via workflow_dispatch.

## Why
Fail-closed if external evidence is missing/unparseable, preventing silent release passes.

## Scope
CI-only workflow wiring; no changes to pack tools or gate semantics beyond strict-mode enforcement.
