### PR TITLE
ci(tools): include external evidence checker in smoke tests

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -790,6 +790,6 @@ jobs:
 
           subprocess.check_call([sys.executable, "tests/test_exporters.py"])
           subprocess.check_call([sys.executable, "tests/test_tools_governance_smoke.py"])
-
+          subprocess.check_call([sys.executable, "tests/test_check_external_summaries_present.py"])
           print("Exporter + governance smoke tests OK")
           PY


### PR DESCRIPTION
## What
Run tests/test_check_external_summaries_present.py as part of the existing tools-tests job
in pulse_ci.yml.

## Why
We added a smoke test for the strict external evidence checker; it should be executed in CI
to prevent regressions (e.g. syntax/indentation errors or overly-permissive presence logic).

## Scope
Workflow-only wiring. No changes to PULSE pack tools, gates, or Pages/SEO.
