### PR TITLE
test: run external evidence smoke checks under pytest

### DIFF
--- a/tests/test_check_external_summaries_present.py
+++ b/tests/test_check_external_summaries_present.py
@@ -105,6 +105,9 @@ def main() -> int:
     print("OK: check_external_summaries_present smoke tests passed")
     return 0
 
+def test_smoke() -> None:
+    # Pytest entrypoint: run the same smoke scenarios as the script.
+    assert main() == 0
 
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
## Problem
The repo documents `pytest -q` as the standard test command, but the external evidence
smoke checks were only executed via a __main__ block, so pytest would run 0 checks.

## Change
Add a pytest-discoverable `test_smoke()` that invokes `main()`.

## Scope
Tests-only change. No workflow, gate, or Pages/SEO impact.
