### PR TITLE
ci(pulse): tighten strict external evidence (require metric keys)

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -379,7 +379,7 @@ jobs:
         run: |
           set -euo pipefail
           EXT_DIR="${{ env.PACK_DIR }}/artifacts/external"
-          python scripts/check_external_summaries_present.py --external_dir "$EXT_DIR"
+          python scripts/check_external_summaries_present.py --external_dir "$EXT_DIR" --require_metric_key
 
       - name: Augment status (external + top-level flags)
         shell: bash


### PR DESCRIPTION
## Problem
Strict mode currently checks for presence + parseability of *_summary.json/.jsonl files,
but a parseable summary with no expected metric keys can still lead to “no metrics” and a
trivially passing external_all_pass (fail-open loophole).

## Change
Run the strict pre-augment checker with --require_metric_key so strict evidence implies
at least one extractable metric signal.

## Scope
Workflow-only change (pulse_ci.yml). No Pages/SEO impact.
