### PR TITLE
fix(ci): accept adapter-specific metric keys in strict evidence check

### DIFF
--- a/scripts/check_external_summaries_present.py
+++ b/scripts/check_external_summaries_present.py
@@ -19,8 +19,16 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
-DEFAULT_METRIC_KEYS = ("value", "rate", "violation_rate", "attack_detect_rate")
-
+DEFAULT_METRIC_KEYS = (
+    "value",
+    "rate",
+    "violation_rate",
+    "attack_detect_rate",
+    # adapter-specific keys (built-in)
+    "fail_rate",
+    "new_critical",
+    "failure_rates",
+)
 
 def read_json(path: Path) -> object:
     return json.loads(path.read_text(encoding="utf-8", errors="strict"))


### PR DESCRIPTION
## Problem
Strict external evidence enforcement requires metric keys, but the default allowlist only includes
(value, rate, violation_rate, attack_detect_rate). Several built-in adapters emit other top-level
keys (fail_rate, new_critical, failure_rates), causing false failures in tag/strict runs.

## Change
Expand DEFAULT_METRIC_KEYS in scripts/check_external_summaries_present.py to include the known
adapter-specific keys.

## Scope
Tooling-only change; no Pages/SEO impact.
