### PR TITLE
fix(adapters): emit canonical rate in external summaries

### DIFF
--- a/PULSE_safe_pack_v0/tools/adapters/promptfoo_ingest.py
+++ b/PULSE_safe_pack_v0/tools/adapters/promptfoo_ingest.py
@@ -1,20 +1,52 @@
 #!/usr/bin/env python3
 """
 Ingest Promptfoo run summary (JSON).
-Expected input JSON: {"results":[{"pass":true/false, "name":"...", ...}, ...]}
-Usage:
-  python tools/adapters/promptfoo_ingest.py --in promptfoo_results.json --out PULSE_safe_pack_v0/artifacts/external/promptfoo_summary.json
-"""
-import json, argparse
-ap = argparse.ArgumentParser()
-ap.add_argument('--in', dest='inp', required=True)
-ap.add_argument('--out', required=True)
-a = ap.parse_args()
 
-data = json.load(open(a.inp, encoding='utf-8'))
-res = data.get('results') or []
-n = len(res); fails = sum(1 for r in res if not r.get('pass', False))
-rate = (fails/n) if n else 0.0
-summary = {"tool":"promptfoo","n":n,"fails":fails,"fail_rate":rate}
-open(a.out,'w',encoding='utf-8').write(json.dumps(summary,indent=2))
-print("Wrote", a.out)
+Expected input JSON:
+  {"results":[{"pass":true/false, "name":"...", ...}, ...]}
+
+Usage:
+  python tools/adapters/promptfoo_ingest.py \
+    --in promptfoo_results.json \
+    --out PULSE_safe_pack_v0/artifacts/external/promptfoo_summary.json
+
+Notes:
+- Writes both tool-specific `fail_rate` and canonical `rate` so augment_status.py can fold
+  metrics deterministically without default fallbacks.
+"""
+import argparse
+import json
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True)
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+
+    with open(a.inp, encoding="utf-8") as f:
+        data = json.load(f)
+
+    res = data.get("results") or []
+    n = len(res)
+    fails = sum(1 for r in res if not r.get("pass", False))
+    rate = (fails / n) if n else 0.0
+
+    summary = {
+        "tool": "promptfoo",
+        "n": n,
+        "fails": fails,
+        # Keep tool-specific key (backward compatibility)
+        "fail_rate": rate,
+        # Canonical key expected by fold_external fallbacks
+        "rate": rate,
+    }
+
+    with open(a.out, "w", encoding="utf-8") as f:
+        f.write(json.dumps(summary, indent=2))
+
+    print("Wrote", a.out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Why
augment_status.py folds external summaries using `value` / `rate` / `violation_rate` (or an explicit key).
Some adapters currently only emit tool-specific keys (e.g. fail_rate, failure_rates) which can cause
fold_external() to fall back to default values and incorrectly pass thresholds.

### What changed
- promptfoo summary now includes `rate` (mirrors `fail_rate`)
- azure_eval summary now includes `rate` (overall failure rate), keeps per-category `failure_rates`
- garak summary now includes `rate` derived deterministically from `new_critical`

### Risk
Low. Output JSON adds one additional key (`rate`) and keeps existing keys unchanged.

### Validation
- Run each adapter and verify the produced *_summary.json contains `rate`
- Run augment_status.py and confirm external metrics reflect the adapter-produced rates
