### PR TITLE
fix(adapters): emit canonical rate in azure eval summary

### DIFF
--- a/PULSE_safe_pack_v0/tools/adapters/azure_eval_ingest.py
+++ b/PULSE_safe_pack_v0/tools/adapters/azure_eval_ingest.py
@@ -1,30 +1,73 @@
 #!/usr/bin/env python3
 """
-Ingest Azure AI Risk & Safety Evaluations export (JSONL).
-Input JSONL lines example: {"category":"indirect_jailbreak","passed":true/false, ...}
-We compute failure rates for key categories.
+Ingest Azure eval run results (JSONL) and produce a compact summary (JSON).
+
+Expected input (JSONL):
+- one JSON object per line
+- fields used:
+  - "category" (optional; defaults to "unknown")
+  - "passed" (boolean; failures are counted when passed is explicitly False)
+
 Usage:
-  python tools/adapters/azure_eval_ingest.py --in azure_eval.jsonl --out PULSE_safe_pack_v0/artifacts/external/azure_eval_summary.json
+  python tools/adapters/azure_eval_ingest.py \
+    --in azure_eval_results.jsonl \
+    --out PULSE_safe_pack_v0/artifacts/external/azure_eval_summary.json
+
+Notes:
+- Writes per-category failure_rates (tool-specific detail)
+- Also writes canonical `rate` (overall failure rate) so augment_status.py can fold metrics
+  deterministically without default fallbacks.
 """
-import json, argparse
-ap = argparse.ArgumentParser()
-ap.add_argument('--in', dest='inp', required=True)
-ap.add_argument('--out', required=True)
-a = ap.parse_args()
+import argparse
+import json
 
-tot=0; cat_tot={}; cat_fail={}
-with open(a.inp, encoding='utf-8') as f:
-    for line in f:
-        line=line.strip()
-        if not line: continue
-        tot += 1
-        obj = json.loads(line)
-        c = obj.get('category') or 'unknown'
-        cat_tot[c] = cat_tot.get(c,0)+1
-        if obj.get('passed') is False:
-            cat_fail[c] = cat_fail.get(c,0)+1
 
-rates = {c: (cat_fail.get(c,0)/cat_tot.get(c,1)) for c in cat_tot}
-summary = {"tool":"azure_eval","total":tot,"failures_by_category":cat_fail,"failure_rates":rates}
-open(a.out,'w',encoding='utf-8').write(json.dumps(summary,indent=2))
-print("Wrote", a.out)
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True)
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+
+    tot = 0
+    cat_tot = {}
+    cat_fail = {}
+
+    with open(a.inp, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+
+            tot += 1
+            obj = json.loads(line)
+
+            c = obj.get("category") or "unknown"
+            cat_tot[c] = cat_tot.get(c, 0) + 1
+
+            if obj.get("passed") is False:
+                cat_fail[c] = cat_fail.get(c, 0) + 1
+
+    # Per-category failure rates (detail)
+    rates = {c: (cat_fail.get(c, 0) / cat_tot.get(c, 1)) for c in cat_tot}
+
+    # Canonical overall rate for folding into augment_status.py
+    fails_total = sum(cat_fail.values())
+    overall_rate = (fails_total / tot) if tot else 0.0
+
+    summary = {
+        "tool": "azure_eval",
+        "total": tot,
+        "failures_by_category": cat_fail,
+        "failure_rates": rates,
+        # Canonical key expected by fold_external fallbacks
+        "rate": overall_rate,
+    }
+
+    with open(a.out, "w", encoding="utf-8") as f:
+        f.write(json.dumps(summary, indent=2))
+
+    print("Wrote", a.out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Why
augment_status.py consumes external summary metrics via value/rate/violation_rate (or an explicit key).
azure_eval_ingest.py only emitted per-category `failure_rates`, which may lead to default fallback values
and a false PASS in external gating.

### What changed
- Compute overall failure rate from JSONL input and emit it as canonical `rate`
- Preserve existing summary fields: total, failures_by_category, failure_rates

### Risk
Low. Additive summary field only.

### Validation
- Run azure_eval_ingest.py on a sample JSONL and confirm output includes `rate`
- Run augment_status.py and confirm azure eval external metric uses the emitted rate
