### PR TITLE
fix(adapters): add canonical rate to garak summary

### DIFF
--- a/PULSE_safe_pack_v0/tools/adapters/garak_ingest.py
+++ b/PULSE_safe_pack_v0/tools/adapters/garak_ingest.py
@@ -1,27 +1,69 @@
 #!/usr/bin/env python3
 """
-Ingest Garak scan results (JSON).
-Expected input JSON: {"findings":[{"severity":"critical|high|...", "rule":"...", "new": true/false}, ...]}
-If you have CSV -> convert to JSON first.
+Ingest Garak run summary (JSON) and produce a compact summary (JSON).
+
+Expected input JSON (approx):
+  {
+    "findings": [
+      {"severity": "critical|high|medium|low|...", "new": true/false, ...},
+      ...
+    ]
+  }
+
 Usage:
-  python tools/adapters/garak_ingest.py --in garak_report.json --out PULSE_safe_pack_v0/artifacts/external/garak_summary.json
+  python tools/adapters/garak_ingest.py \
+    --in garak_results.json \
+    --out PULSE_safe_pack_v0/artifacts/external/garak_summary.json
+
+Notes:
+- Keeps rich detail (by severity, new_critical)
+- Also emits canonical `rate` so augment_status.py can fold metrics deterministically
+  (value/rate/violation_rate fallbacks).
+- Current rate semantics (conservative + deterministic):
+    new_critical > 0 => rate = 1.0
+    else            => rate = 0.0
 """
-import json, argparse
-ap = argparse.ArgumentParser()
-ap.add_argument('--in', dest='inp', required=True)
-ap.add_argument('--out', required=True)
-a = ap.parse_args()
+import argparse
+import json
 
-data = json.load(open(a.inp, encoding='utf-8'))
-findings = data.get('findings') or []
-tot = len(findings)
-sev = {}; new_crit = 0
-for f in findings:
-    s = (f.get('severity') or 'unknown').lower()
-    sev[s] = sev.get(s,0)+1
-    if f.get('new') and s=='critical':
-        new_crit += 1
 
-summary = {"tool":"garak","total_findings":tot,"by_severity":sev,"new_critical":new_crit}
-open(a.out,'w',encoding='utf-8').write(json.dumps(summary,indent=2))
-print("Wrote", a.out)
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True)
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+
+    with open(a.inp, encoding="utf-8") as f:
+        data = json.load(f)
+
+    findings = data.get("findings") or []
+    tot = len(findings)
+
+    sev = {}
+    new_crit = 0
+    for fnd in findings:
+        s = (fnd.get("severity") or "unknown").lower()
+        sev[s] = sev.get(s, 0) + 1
+        if fnd.get("new") and s == "critical":
+            new_crit += 1
+
+    # Canonical key expected by fold_external fallbacks.
+    # Deterministic + conservative: any new critical finding should fail typical thresholds.
+    rate = 1.0 if new_crit else 0.0
+
+    summary = {
+        "tool": "garak",
+        "total_findings": tot,
+        "by_severity": sev,
+        "new_critical": new_crit,
+        "rate": rate,
+    }
+
+    with open(a.out, "w", encoding="utf-8") as f:
+        f.write(json.dumps(summary, indent=2))
+
+    print("Wrote", a.out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Why
augment_status.py folds external summaries using value/rate/violation_rate (or an explicit key).
Garak summaries did not include any of these keys, which could cause fold_external() to fall back to
defaults and incorrectly pass thresholds.

### What changed
- garak_summary.json now includes canonical `rate`
  - derived deterministically from `new_critical` (new critical finding => rate=1.0, else 0.0)
- existing fields preserved: total_findings, by_severity, new_critical

### Risk
Low. Additive output change only.

### Validation
- Run garak_ingest.py and confirm output contains `rate`
- Run augment_status.py and confirm Garak metric reflects the adapter-emitted rate
