### PR TITLE
test(ci): execute augment_status smoke test during tools smoke tests

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -878,5 +878,7 @@ jobs:
           subprocess.check_call([sys.executable, "tests/test_exporters.py"])
           subprocess.check_call([sys.executable, "tests/test_tools_governance_smoke.py"])
           subprocess.check_call([sys.executable, "tests/test_check_external_summaries_present.py"])
+          subprocess.check_call([sys.executable, "tests/test_augment_status_smoke.py"])
+
           print("Exporter + governance smoke tests OK")
           PY


### PR DESCRIPTION
## What
Run tests/test_augment_status_smoke.py as part of the existing Tools smoke tests
in PULSE CI.

## Why
We recently hit CI failures from augment_status.py regressions (indent/parse issues).
This adds a fast guardrail to catch similar breaks immediately.

## Scope
CI/test wiring only. No changes to pack logic or release gate semantics.
