### PR TITLE
feat(adapters): canonicalize deepeval summary metric keys

### DIFF
--- a/PULSE_safe_pack_v0/tools/adapters/deepeval_ingest.py
+++ b/PULSE_safe_pack_v0/tools/adapters/deepeval_ingest.py
@@ -7,6 +7,7 @@ Usage:
   python tools/adapters/deepeval_ingest.py --in deepeval.jsonl --out PULSE_safe_pack_v0/artifacts/external/deepeval_summary.json
 """
 import json, argparse, os
+
 ap = argparse.ArgumentParser()
 ap.add_argument('--in', dest='inp', required=True)
 ap.add_argument('--out', required=True)
@@ -16,18 +17,32 @@ items = []
 with open(a.inp, encoding='utf-8') as f:
     txt = f.read().strip()
     if txt.startswith('{'):
-        data = json.loads(txt); items = data.get('results', [])
+        data = json.loads(txt)
+        items = data.get('results', [])
     else:
         for line in txt.splitlines():
-            if line.strip(): items.append(json.loads(line))
+            if line.strip():
+                items.append(json.loads(line))
 
-n = len(items); fails = sum(1 for it in items if not it.get('passed', False))
-rate = (fails/n) if n else 0.0
+n = len(items)
+fails = sum(1 for it in items if not it.get('passed', False))
+rate = (fails / n) if n else 0.0
+
 by_metric = {}
 for it in items:
     m = it.get('metric') or 'unknown'
-    by_metric[m] = by_metric.get(m,0) + (0 if it.get('passed', False) else 1)
+    by_metric[m] = by_metric.get(m, 0) + (0 if it.get('passed', False) else 1)
 
-summary = {"tool":"deepeval","n":n,"fails":fails,"fail_rate":rate,"fails_by_metric":by_metric}
-open(a.out,'w',encoding='utf-8').write(json.dumps(summary,indent=2))
+summary = {
+    "tool": "deepeval",
+    "n": n,
+    "fails": fails,
+    "fail_rate": rate,
+    # Canonical keys (mirror fail_rate) for downstream consumers
+    "rate": rate,
+    "value": rate,
+    "fails_by_metric": by_metric,
+}
+
+open(a.out, 'w', encoding='utf-8').write(json.dumps(summary, indent=2))
 print("Wrote", a.out)


### PR DESCRIPTION
## What
Update PULSE_safe_pack_v0/tools/adapters/deepeval_ingest.py so deepeval_summary output includes
canonical metric fields (rate/value) alongside the existing fail_rate.

## Why
External summary consumers benefit from a stable canonical key. This reduces key-mismatch risk
in strict evidence checks and status augmentation.

## Scope
Adapter output only (backward compatible). No workflow or gate semantics change.
