### PR TITLE
feat(pack): stabilize Azure metric folding in augment_status

### DIFF
--- a/PULSE_safe_pack_v0/tools/augment_status.py
+++ b/PULSE_safe_pack_v0/tools/augment_status.py
@@ -312,7 +312,9 @@ def main() -> int:
         "azure_eval_summary.json",
         "azure_indirect_jailbreak_rate_max",
         "azure_indirect_jailbreak_rate",
+        key_in_json="azure_indirect_jailbreak_rate",
     )
+    
     if r is not None:
         oks.append(r)
 


### PR DESCRIPTION
## What
Prefer azure_indirect_jailbreak_rate when folding Azure eval summaries in augment_status.py.

## Why
We now emit a canonical top-level scalar in azure_eval_summary. Using it explicitly reduces
schema ambiguity and stabilizes gating/reporting over time.

## Scope
Tooling change only (augment_status folding). Backward compatible due to fallbacks.
No workflow semantics changes beyond reading a more explicit key.
