### PR TITLE
ci: harden tools smoke tests (fail-fast compile + clean logs)

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -869,26 +869,21 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python - <<'PY'
-          import subprocess
-          import sys
 
-          tests = [
-              "tests/test_exporters.py",
-              "tests/test_tools_governance_smoke.py",
-              "tests/test_check_external_summaries_present.py",
-              "tests/test_augment_status_smoke.py",
-          ]
+          tests=(
+            "tests/test_exporters.py"
+            "tests/test_tools_governance_smoke.py"
+            "tests/test_check_external_summaries_present.py"
+            "tests/test_augment_status_smoke.py"
+          )
 
-          def run(cmd):
-              print("\n+ " + " ".join(cmd), flush=True)
-              subprocess.check_call(cmd)
+          echo "Fail-fast: py_compile smoke scripts"
+          python -m py_compile "${tests[@]}"
 
-          for f in tests:
-              run([sys.executable, "-m", "py_compile", f])
+          echo "Run smoke scripts (one-by-one for clean logs)"
+          for t in "${tests[@]}"; do
+            echo "==> python $t"
+            python "$t"
+          done
 
-          for f in tests:
-              run([sys.executable, f])
-
-          print("Exporter + governance smoke tests OK")
-          PY
+          echo "Exporter + governance smoke tests OK"


### PR DESCRIPTION
Hardens the Tools smoke tests job to fail fast on syntax/indent errors and provide clearer logs.

Changes:
- Drop CI-time rewriting of test sources (no “indent fixer” behavior)
- Add python -m py_compile for the smoke scripts
- Execute smoke scripts one-by-one so the failing file is explicit in logs

This keeps CI deterministic and avoids masking real source issues.
