### PR TITLE
fix(openai-evals): tighten refusal_smoke_result v0 contract semantics

### DIFF
--- a/scripts/check_openai_evals_refusal_smoke_result_v0_contract.py
+++ b/scripts/check_openai_evals_refusal_smoke_result_v0_contract.py
@@ -150,6 +150,10 @@ def validate(d: Dict[str, Any]) -> None:
         if gate_pass:
             _die("gate_pass cannot be true when status is null/empty (fail-closed).")
 
+    # If gate_pass is true, status must be a successful terminal state.
+    if gate_pass and status_s not in ("completed", "succeeded"):
+        _die("gate_pass=true requires status in {completed,succeeded}.")
+
     # If dataset is empty (total==0), must fail closed.
     if total == 0 and gate_pass:
         _die("gate_pass cannot be true when result_counts.total == 0 (fail-closed).")


### PR DESCRIPTION
This PR hardens the contract checker for openai_evals_v0/refusal_smoke_result.json to be strictly fail‑closed and consistent with the documented gate semantics.

What changed:

status remains required and now must be a non-empty string when present (still allows null).

If gate_pass is true, status must be completed or succeeded.

Existing fail‑closed rules remain (empty dataset fails, any failures/errors fail, fail_rate consistency enforced).

Why:

Avoid silent regressions where a producer could emit gate_pass=true with an invalid/unknown/failed status.

Make the contract checker a true “required keys + semantics” guardrail.

No CI behavior changes; this is contract validation only.