### PR TITLE
ci(openai-evals): standardize shadow workflow triggers + outputs (main-safe)

### DIFF
--- a/.github/workflows/openai_evals_refusal_smoke_shadow.yml
+++ b/.github/workflows/openai_evals_refusal_smoke_shadow.yml
@@ -89,14 +89,10 @@ jobs:
             # For push/PR/dry-run: keep it light and deterministic.
             # Ensure the file exists so the runner can patch it.
             if [[ ! -f PULSE_safe_pack_v0/artifacts/status.json ]]; then
-              python - <<'PY'
-              import json
-              from pathlib import Path
-              p = Path("PULSE_safe_pack_v0/artifacts/status.json")
-              p.write_text(json.dumps({"metrics": {}, "gates": {}}, indent=2) + "\n", encoding="utf-8")
-              PY
+              python -c 'import json; from pathlib import Path; p=Path("PULSE_safe_pack_v0/artifacts/status.json"); p.parent.mkdir(parents=True, exist_ok=True); p.write_text(json.dumps({"metrics": {}, "gates": {}}, indent=2) + "\n", encoding="utf-8")'
             fi
           fi
+
 
       - name: Run refusal smoke (OpenAI Evals v0)
         shell: bash


### PR DESCRIPTION
### Summary
Make the OpenAI evals refusal smoke shadow workflow main-only friendly by running on pushes to `main` and producing stable artifacts with contract validation.

### Why
- Main-only iteration needs push triggers; workflow_dispatch alone is not enough.
- Push/PR should be deterministic and not depend on secrets or network calls.
- Contract + artifacts provide a reliable audit/debug trail.

### Changes
- Added push-to-main + PR triggers with paths filtering.
- Defaulted non-dispatch runs to dry-run mode (no key required).
- Kept workflow_dispatch inputs for real mode.
- Added lightweight status.json preparation for non-real runs.
- Ensured Step Summary is written to GITHUB_STEP_SUMMARY and artifacts are uploaded always.
