### PR TITLE
ci(openai-evals): harden shadow workflow with dry-run smoke test

### DIFF
--- a/.github/workflows/openai_evals_refusal_smoke_shadow.yml
+++ b/.github/workflows/openai_evals_refusal_smoke_shadow.yml
@@ -145,6 +145,13 @@ jobs:
           set -euo pipefail
           python scripts/check_openai_evals_refusal_smoke_result_v0_contract.py \
             --in openai_evals_v0/refusal_smoke_result.json
+      
+      - name: Run dry-run smoke test script
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.mode == 'dry-run' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python tests/test_openai_evals_refusal_smoke_dry_run_smoke.py
 
       - name: Workflow summary
         if: always()


### PR DESCRIPTION
### Summary
Run the existing dry-run smoke test script as part of the OpenAI evals shadow workflow.

### Why
- Runner+contract check validates the primary artifact shape.
- The smoke test also validates status.json patching + fail-closed behavior (empty dataset) + trace wiring.
- This keeps main-only iteration safer: regressions show up immediately in Actions.

### Changes
- Add a step to run `python tests/test_openai_evals_refusal_smoke_dry_run_smoke.py`
  - on push/PR
  - and on workflow_dispatch when `mode=dry-run`

### Notes
- No secrets required; no network calls.
- The test runs in temp directories and does not modify repo files.
