### PR TITLE
ci(openai-evals): warn on gate_pass=false in shadow workflow (optional hard-fail on dispatch)

### DIFF
--- a/.github/workflows/openai_evals_refusal_smoke_shadow.yml
+++ b/.github/workflows/openai_evals_refusal_smoke_shadow.yml
@@ -146,6 +146,17 @@ jobs:
           python scripts/check_openai_evals_refusal_smoke_result_v0_contract.py \
             --in openai_evals_v0/refusal_smoke_result.json
       
+      - name: Gate monitor (warn on false; optionally fail on dispatch)
+        if: ${{ always() }}
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          FAIL_ON_FALSE: ${{ github.event.inputs.fail_on_false }}
+        run: |
+          set -euo pipefail
+
+          python -c $'import json, os, sys\nfrom pathlib import Path\np=Path("openai_evals_v0/refusal_smoke_result.json")\nif not p.exists():\n  print("::warning::missing openai_evals_v0/refusal_smoke_result.json")\n  sys.exit(0)\ntry:\n  d=json.loads(p.read_text(encoding="utf-8"))\nexcept Exception as e:\n  print(f"::warning::unable to parse refusal_smoke_result.json: {e}")\n  sys.exit(0)\n\ngp=d.get("gate_pass")\nst=d.get("status")\nif gp is not True:\n  print(f"::warning::openai_evals_refusal_smoke_pass is not passing (gate_pass={gp}, status={st})")\n\nevent=os.getenv("EVENT_NAME","")\nfof=os.getenv("FAIL_ON_FALSE","false").lower()=="true"\nif event=="workflow_dispatch" and fof and gp is not True:\n  print("::error::fail_on_false=true and gate_pass!=true")\n  sys.exit(2)\n'
+
       - name: Run dry-run smoke test script
         if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.mode == 'dry-run' }}
         shell: bash


### PR DESCRIPTION
### Summary
Add a gate monitor step to the shadow workflow that warns when `gate_pass` is false and can optionally fail in manual dispatch runs.

### Why
- Push/PR runs should stay deterministic and non-blocking, but we still want a visible signal when the smoke gate does not pass.
- Manual dispatch runs may want strict behavior (`fail_on_false=true`) without changing default CI behavior.

### Changes
- Added an `if: always()` step that reads `openai_evals_v0/refusal_smoke_result.json`:
  - emits `::warning::` when `gate_pass != true`
  - fails only for `workflow_dispatch` when `fail_on_false=true`
- Uses `python -c $'...'` to avoid heredoc EOF/indentation issues.
