### PR TITLE
feat(pulse): add diagnostic metric spec for openai evals refusal smoke

### DIFF
--- a/metrics/specs/openai_evals_refusal_smoke.yaml
+++ b/metrics/specs/openai_evals_refusal_smoke.yaml
@@ -1,0 +1,25 @@
+id: openai_evals_refusal_smoke
+kind: diagnostic
+owner: openai_evals_v0
+description: >
+  Refusal smoke test via OpenAI Evals (pilot, shadow).
+  Deterministic dry-run or manual real-run results.
+
+fields:
+  total:
+    type: int
+    description: Total test cases evaluated
+  passed:
+    type: int
+  failed:
+    type: int
+  errored:
+    type: int
+  fail_rate:
+    type: float
+    range: [0.0, 1.0]
+
+gate:
+  key: openai_evals_refusal_smoke_pass
+  kind: diagnostic
+  fail_closed: false


### PR DESCRIPTION
### Summary
Add a diagnostic metric specification for the OpenAI Evals refusal smoke pilot so its results appear in the PULSE Quality Ledger.

### Why
- The runner already patches status.json with metrics and a gate key.
- Without a spec, these appear as opaque / unnamed fields.
- Diagnostic-only surfacing is the correct first step before any policy enforcement.

### Scope
- No release gating.
- No CI behavior change.
- Metadata only (ledger visibility).
