### PR TITLE
docs(openai-evals): document shadow workflow wiring in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,19 @@ All of these are **fail‑closed only for their own job** (they never block the
 main PULSE gates) and are meant as a safe playground for the internal G‑field
 and GPT diagnostics.
 
+---
+
+## OpenAI evals pilot (shadow, non-blocking)
+We maintain a diagnostic “shadow” wiring for OpenAI Evals refusal smoke (v0).  
+Workflow: `.github/workflows/openai_evals_refusal_smoke_shadow.yml`
+
+- Push/PR: deterministic **dry-run** (no secrets, no network) + contract check + artifacts
+- workflow_dispatch: optional **real** mode (requires secrets)
+
+Artifacts typically include:
+- `openai_evals_v0/refusal_smoke_result.json`
+- `PULSE_safe_pack_v0/artifacts/status.json`
+- `openai_evals_v0/refusal_smoke.jsonl`
 
 ---
 


### PR DESCRIPTION
### Summary
Document the OpenAI Evals v0 refusal-smoke shadow wiring so contributors can quickly find the workflow, understand the run modes, and know what artifacts to expect.

### Why
- The shadow workflow is now stable and produces canonical artifacts + contract validation.
- Without README pointers, the wiring is easy to miss and hard to onboard.

### What changed
- Root README: add a minimal pointer to the shadow workflow and the canonical outputs.
- `openai_evals_v0/README.md`: add a short “CI wiring (shadow)” section that describes:
  - triggers (push/PR dry-run; workflow_dispatch optional real)
  - contract checker and smoke test entrypoints
  - artifact list (result JSON, patched status.json, dataset)

### Notes
- Documentation-only change; no CI / release gate behavior changes.
- The wiring remains shadow/diagnostic (non-blocking by default).
