### PR TITLE
fix(pulse): align refusal smoke spec with fail-closed semantics

### DIFF
--- a/metrics/specs/openai_evals_refusal_smoke.yaml
+++ b/metrics/specs/openai_evals_refusal_smoke.yaml
@@ -22,4 +22,4 @@ fields:
 gate:
   key: openai_evals_refusal_smoke_pass
   kind: diagnostic
-  fail_closed: false
+  fail_closed: true


### PR DESCRIPTION
### Summary
Fix the `fail_closed` flag in `metrics/specs/openai_evals_refusal_smoke.yaml` to match the documented and implemented behavior.

### Why
- README and runner semantics are fail-closed (empty/invalid results must not pass).
- The spec currently declares `fail_closed: false`, which may mislead ledger/quality tooling.

### Change
- Set `gate.fail_closed: true` (gate remains `kind: diagnostic` / non-blocking).
