### PR TITLE
docs: document where to look when shadow CI warns/fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ python PULSE_safe_pack_v0/tools/check_gates.py \
 
 ```
 
+### Debugging (when CI warns/fails)
+If the OpenAI evals refusal smoke shadow workflow warns or fails, start here:
+- Workflow: `.github/workflows/openai_evals_refusal_smoke_shadow.yml`
+- Inspect the Step Summary and download artifacts from the run:
+  - `openai_evals_v0/refusal_smoke_result.json`
+  - `PULSE_safe_pack_v0/artifacts/status.json`
+
+More details: see `openai_evals_v0/README.md` → “Debugging / triage (shadow)”.
+
+---
+
 **See the latest Quality Ledger (live):** https://hkati.github.io/pulse-release-gates-0.1/
 
 **Artifacts**


### PR DESCRIPTION
### Summary
Add a minimal debugging pointer in the root README so contributors know where to look when the OpenAI evals shadow workflow warns or fails.

### Why
- Main README is the entry point.
- The shadow wiring is discoverable, but the triage steps should be one click away.

### Changes
- Root README: short “Debugging” section after Quickstart pointing to:
  - workflow file
  - Step Summary + artifacts
  - detailed triage section in openai_evals_v0/README.md
