### PR TITLE
ci(openai-evals): prevent status sanity check from failing the shadow workflow

### DIFF
--- a/.github/workflows/openai_evals_refusal_smoke_shadow.yml
+++ b/.github/workflows/openai_evals_refusal_smoke_shadow.yml
@@ -206,12 +206,64 @@ jobs:
           python scripts/check_openai_evals_refusal_smoke_result_v0_contract.py \
             --in openai_evals_v0/refusal_smoke_result.json
 
-      - name: Status patch sanity check (warning-only)
-        if: ${{ always() }}
+      - name: Status patch sanity check (metrics + gate mirror)
+        if: always()
         shell: bash
         run: |
           set -euo pipefail
-          python -c $'import json,sys\nfrom pathlib import Path\n\ns=Path("PULSE_safe_pack_v0/artifacts/status.json")\nif not s.exists():\n  print("::warning::status.json missing (nothing to sanity-check)")\n  sys.exit(0)\n\ntry:\n  d=json.loads(s.read_text(encoding="utf-8"))\nexcept Exception as e:\n  print(f"::warning::status.json is not valid JSON: {e}")\n  sys.exit(0)\n\nif not isinstance(d, dict):\n  print(f"::warning::status.json top-level is not an object: {type(d).__name__}")\n  sys.exit(0)\n\nmetrics=d.get("metrics")\nif metrics is None:\n  metrics={}\nif not isinstance(metrics, dict):\n  print(f"::warning::status.json metrics is not an object: {type(metrics).__name__}")\n  metrics={}\n\ngates=d.get("gates")\nif gates is None:\n  gates={}\nif not isinstance(gates, dict):\n  print(f"::warning::status.json gates is not an object: {type(gates).__name__}")\n  gates={}\n\nreq=[\n  "openai_evals_refusal_smoke_total",\n  "openai_evals_refusal_smoke_passed",\n  "openai_evals_refusal_smoke_failed",\n  "openai_evals_refusal_smoke_errored",\n  "openai_evals_refusal_smoke_fail_rate",\n]\nmissing=[k for k in req if k not in metrics]\nif missing:\n  print("::warning::missing metrics in status.json: "+", ".join(missing))\n\nkey="openai_evals_refusal_smoke_pass"\nif key not in gates:\n  print("::warning::missing gate "+key+" in status.json gates")\nelse:\n  gp=gates.get(key)\n  if d.get(key) != gp:\n    print("::warning::top-level mirror "+key+" mismatch vs status.gates")\n\nsys.exit(0)\n'
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          s = Path("PULSE_safe_pack_v0/artifacts/status.json")
+          if not s.exists():
+              print("::warning::status.json missing (nothing to sanity-check)")
+              raise SystemExit(0)
+
+          try:
+              d = json.loads(s.read_text(encoding="utf-8"))
+          except Exception as e:
+              print(f"::warning::unable to parse status.json: {e}")
+              raise SystemExit(0)
+
+          if not isinstance(d, dict):
+              print(f"::warning::status.json top-level is {type(d).__name__}, expected object")
+              raise SystemExit(0)
+
+          metrics = d.get("metrics")
+          if not isinstance(metrics, dict):
+              print(f"::warning::status.json metrics is {type(metrics).__name__}, expected object")
+              metrics = {}
+
+          gates = d.get("gates")
+          if not isinstance(gates, dict):
+              print(f"::warning::status.json gates is {type(gates).__name__}, expected object")
+              gates = {}
+
+          req_metrics = [
+              "openai_evals_refusal_smoke_total",
+              "openai_evals_refusal_smoke_passed",
+              "openai_evals_refusal_smoke_failed",
+              "openai_evals_refusal_smoke_errored",
+              "openai_evals_refusal_smoke_fail_rate",
+          ]
+
+          missing = [k for k in req_metrics if k not in metrics]
+          if missing:
+              print("::warning::missing metrics in status.json: " + ", ".join(missing))
+
+          gate_key = "openai_evals_refusal_smoke_pass"
+          if gate_key not in gates:
+              print(f"::warning::missing gate {gate_key} in status.json gates")
+              raise SystemExit(0)
+
+          gp = gates.get(gate_key)
+          if d.get(gate_key) != gp:
+              print(f"::warning::top-level mirror {gate_key} mismatch vs status.gates")
+
+          # warning-only: never fail the job from this sanity check
+          raise SystemExit(0)
+          PY
 
       - name: Gate monitor (warn on false; optionally fail on dispatch)
         if: ${{ always() }}


### PR DESCRIPTION
### Summary
Make the `status.json` sanity check best-effort (warning-only) in the refusal smoke shadow workflow.

### Why
The sanity check is informational. A malformed or partial status.json should not fail the job,
especially under `if: always()`.

### Changes
- Add try/except JSON parsing
- Tolerate unexpected shapes for metrics/gates (warn + continue)
- Ensure the step always exits 0
