### PR TITLE
docs(openai-evals): clarify real-run guardrails for refusal smoke runner

### DIFF
--- a/openai_evals_v0/README.md
+++ b/openai_evals_v0/README.md
@@ -43,12 +43,25 @@ python openai_evals_v0/run_refusal_smoke_to_pulse.py \
 ```
 
 ### 3) Real run (experimental; requires API key)
-
-```bash
 export OPENAI_API_KEY="..."   # do not commit
+
+# Real runs are intentionally guarded to avoid accidental paid calls:
+# - --confirm-real is required
+# - --max-dataset-lines enforces a budget (default is 200)
 python openai_evals_v0/run_refusal_smoke_to_pulse.py \
+  --confirm-real \
+  --max-dataset-lines 200 \
   --status-json PULSE_safe_pack_v0/artifacts/status.json
-```
+
+### Real-run guardrails (why real mode may refuse to start)
+
+Real runs are intentionally protected to avoid accidental paid/flaky executions:
+
+- `--confirm-real` is required for real runs (otherwise the runner exits non-zero).
+- `--max-dataset-lines N` enforces a dataset budget (default: `200`).
+- In GitHub Actions `workflow_dispatch`, set `mode=real` **and** `confirm_real=yes`
+  (and optionally raise/lower `max_dataset_lines`).
+
 
 ## Outputs
 


### PR DESCRIPTION
## Summary
Document the real-run safety latches for the OpenAI evals refusal smoke runner.

## Why
Real runs are paid/flaky and are intentionally protected. This PR makes the expected flags
and workflow_dispatch requirements explicit in the openai_evals_v0 README.

## Changes
- Update Quickstart real-run command to include --confirm-real and --max-dataset-lines
- Add a "Real-run guardrails" section for triage and operator clarity
