### PR TITLE
docs: clarify shadow diagnostic signals in Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,20 +119,32 @@ UI and Pages surfaces must be pure readers/renderers of immutable run artefacts.
 
 ```console
 python PULSE_safe_pack_v0/tools/run_all.py
+```
 
-# Optional (diagnostic): OpenAI evals refusal smoke v0 dry-run (no network / no API key)
+### Optional diagnostics (shadow)
+
+Some checks run as *diagnostic/shadow* signals (they may warn but should not block merges):
+
+- **OpenAI Evals • Refusal smoke (shadow)**: on PR/push it runs **dry-run by policy** (secrets are not exposed).
+  The canonical output is written to: `openai_evals_v0/refusal_smoke_result.json`
+  and uploaded as a workflow artifact in GitHub Actions.
+- **Real runs** are only available via `workflow_dispatch` and require explicit confirmation/budget
+  (see `openai_evals_v0/README.md`).
+
+```console
 python openai_evals_v0/run_refusal_smoke_to_pulse.py \
   --dry-run \
   --dataset openai_evals_v0/refusal_smoke.jsonl \
   --out openai_evals_v0/refusal_smoke_result.json \
   --status-json PULSE_safe_pack_v0/artifacts/status.json
+```
 
+```console
 python PULSE_safe_pack_v0/tools/check_gates.py \
   --status PULSE_safe_pack_v0/artifacts/status.json \
   --require $(python tools/policy_to_require_args.py --policy pulse_gate_policy_v0.yml --set required)
-
-
 ```
+
 
 ### Debugging (when CI warns/fails)
 If the OpenAI evals refusal smoke shadow workflow warns or fails, start here:


### PR DESCRIPTION
## Summary
Add a tiny Quickstart note about optional diagnostic/shadow checks.

## Why
Reduces “false alarm” triage time (e.g., dry-run policy warnings and long-running shadow jobs),
without changing gating behavior.

## Changes
- Document where the refusal smoke result JSON is produced
- Clarify PR/push = dry-run policy, real runs only via workflow_dispatch
