### PR TITLE
ci(openai-evals): harden shadow workflow best-effort steps

### DIFF
--- a/.github/workflows/openai_evals_refusal_smoke_shadow.yml
+++ b/.github/workflows/openai_evals_refusal_smoke_shadow.yml
@@ -258,6 +258,13 @@ jobs:
               print(f"::warning::status.json is not valid JSON: {e}")
               raise SystemExit(0)
 
+          if not isinstance(d, dict):
+              print(
+                  "::warning::status.json top-level is not an object "
+                  f"(type={type(d).__name__}); skipping sanity-check"
+              )
+              raise SystemExit(0)
+
           metrics = d.get("metrics")
           gates = d.get("gates")
 


### PR DESCRIPTION
## Summary
Make the OpenAI Evals refusal smoke shadow workflow diagnostics truly best-effort.

## Why
Shadow/sanity steps are informational and should not fail the job due to malformed or unexpected JSON.
This reduces CI noise and prevents false red checks.

## Changes
- status.json sanity check: guard JSON parsing and types; warn-only behavior (exit 0)
- No change to contract enforcement or gate logic
