### PR TITLE
feat(openai-evals): mark refusal smoke status trace as diagnostic

### DIFF
--- a/openai_evals_v0/run_refusal_smoke_to_pulse.py
+++ b/openai_evals_v0/run_refusal_smoke_to_pulse.py
@@ -301,6 +301,7 @@ def main() -> int:
 
         if args.status_json:
             trace = {
+                "kind": "diagnostic",
                 "dry_run": True,
                 "eval_id": result["eval_id"],
                 "run_id": result["run_id"],
@@ -482,6 +483,7 @@ def main() -> int:
 
     if args.status_json:
         trace = {
+            "kind": "diagnostic",
             "dry_run": False,
             "eval_id": eval_id,
             "run_id": run_id,


### PR DESCRIPTION
## Summary
Add a machine-readable marker to the status.json trace for the OpenAI evals refusal smoke pilot.

## Why
We run multiple shadow/diagnostic workflows. A small, explicit marker reduces ambiguity and helps future tooling
distinguish non-gating diagnostics from required release gates.

## Changes
- status.json openai_evals_v0.refusal_smoke trace includes `kind: diagnostic` (shadow output)
- No functional change to gating/contract logic
