### PR TITLE
feat(paradox): introduce v0 schema for diagram input artifact

### DIFF
--- a/schemas/paradox_diagram_input_v0.schema.json
+++ b/schemas/paradox_diagram_input_v0.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "paradox_diagram_input_v0.schema.json",
+  "title": "PULSE Paradox diagram input (v0)",
+  "type": "object",
+  "required": ["schema_version", "timestamp_utc", "shadow", "decision_key", "metrics"],
+  "properties": {
+    "schema_version": { "const": "v0" },
+    "timestamp_utc": { "type": "string", "minLength": 1 },
+
+    "shadow": { "type": "boolean" },
+
+    "decision_key": {
+      "type": "string",
+      "enum": ["NORMAL", "WARN", "FAIL", "UNKNOWN"]
+    },
+    "decision_raw": { "type": ["string", "null"] },
+
+    "source": { "type": ["string", "null"] },
+    "notes": { "type": ["string", "null"] },
+
+    "metrics": {
+      "type": "object",
+      "required": [
+        "settle_time_p95_ms",
+        "settle_time_budget_ms",
+        "downstream_error_rate",
+        "paradox_density"
+      ],
+      "properties": {
+        "settle_time_p95_ms": { "type": "number", "minimum": 0 },
+        "settle_time_budget_ms": { "type": "number", "minimum": 0 },
+        "downstream_error_rate": { "type": "number", "minimum": 0, "maximum": 1 },
+        "paradox_density": { "type": "number", "minimum": 0, "maximum": 1 }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary
Add a v0 JSON Schema for the Paradox diagram input artifact.

## Why
We want to generate a deterministic Paradox diagram from a stable, contract-defined input.
The schema makes the expected fields/types explicit and prevents accidental shape drift.

## Scope
- Adds: `schemas/paradox_diagram_input_v0.schema.json`
- No changes to gate logic or merge requirements (shadow/diagnostic only).
