### PR TITLE
feat(paradox): add v0 contract checker for paradox diagram input

### DIFF
--- a/scripts/check_paradox_diagram_input_v0_contract.py
+++ b/scripts/check_paradox_diagram_input_v0_contract.py
@@ -64,6 +64,8 @@ def _expect_str_or_none(name: str, v: Any) -> None:
 
 
 def _expect_number_ge0(name: str, v: Any) -> float:
+    if isinstance(v, bool):
+        _die(f"Expected '{name}' to be number, got bool")
     if not isinstance(v, (int, float)):
         _die(f"Expected '{name}' to be number, got {type(v).__name__}")
     fv = float(v)
@@ -73,6 +75,8 @@ def _expect_number_ge0(name: str, v: Any) -> float:
 
 
 def _expect_number_0_1(name: str, v: Any) -> float:
+    if isinstance(v, bool):
+        _die(f"Expected '{name}' to be number, got bool")
     if not isinstance(v, (int, float)):
         _die(f"Expected '{name}' to be number, got {type(v).__name__}")
     fv = float(v)


### PR DESCRIPTION
## Summary
Introduce `scripts/check_paradox_diagram_input_v0_contract.py` to validate the v0 Paradox
diagram input artifact shape.

## Why
We are preparing a deterministic Paradox diagram generator. Before generating visuals, we
need a stable and testable input contract to catch regressions early (missing fields,
type changes, invalid ranges).

## What changed
- Add stdlib-only contract checker:
  - validates `schema_version`, `timestamp_utc`, `shadow`, `decision_key`
  - validates required metrics and numeric ranges
- No changes to Paradox gating logic (shadow/diagnostic tooling only).
