### PR TITLE
ci(paradox): publish diagram input artifact from paradox gate workflow

### DIFF
--- a/.github/workflows/pulse-paradox-gate.yml
+++ b/.github/workflows/pulse-paradox-gate.yml
@@ -237,6 +237,28 @@ jobs:
             --summary artifacts/pulse_paradox_gate_summary.json \
             --out "$out"
 
+      - name: Contract check (paradox diagram input v0)
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          f="PULSE_safe_pack_v0/artifacts/paradox_diagram_input_v0.json"
+          if [[ ! -f "$f" ]]; then
+            echo "::warning::missing $f (triage did not produce diagram input)"
+            exit 0
+          fi
+          python scripts/check_paradox_diagram_input_v0_contract.py --in "$f" || \
+            echo "::warning::paradox diagram input contract check failed (shadow; non-gating)"
+
+      - name: Upload paradox diagram input (v0)
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # pinned
+        with:
+          name: paradox-diagram-input-v0
+          if-no-files-found: warn
+          path: |
+            PULSE_safe_pack_v0/artifacts/paradox_diagram_input_v0.json
+
       - name: Post or update PR comment
         continue-on-error: true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0


### PR DESCRIPTION
## Summary
Update `.github/workflows/pulse-paradox-gate.yml` to upload the Paradox diagram input v0
JSON produced by `tools/gh_pr_comment_triage.py`.

## Why
We want deterministic diagram generation without parsing PR comment markdown.
Publishing the input artifact makes the workflow auditable and makes it easy to iterate
on diagram tooling.

## Changes
- Upload artifact:
  - `PULSE_safe_pack_v0/artifacts/paradox_diagram_input_v0.json`
- Keep triage as shadow/diagnostic and best-effort:
  - do not fail the job because of optional artifacts or summary steps.

## Notes
This does not change core gate enforcement or required status checks.
