### PR TITLE
fix(paradox): align diagram input schema with contract (require decision_raw)

### DIFF
--- a/schemas/paradox_diagram_input_v0.schema.json
+++ b/schemas/paradox_diagram_input_v0.schema.json
@@ -3,7 +3,14 @@
   "$id": "paradox_diagram_input_v0.schema.json",
   "title": "PULSE Paradox diagram input (v0)",
   "type": "object",
-  "required": ["schema_version", "timestamp_utc", "shadow", "decision_key", "metrics"],
+  "required": [
+    "schema_version",
+    "timestamp_utc",
+    "shadow",
+    "decision_key",
+    "decision_raw",
+    "metrics"
+  ],
   "properties": {
     "schema_version": { "const": "v0" },
     "timestamp_utc": { "type": "string", "minLength": 1 },


### PR DESCRIPTION
## What
- Require `decision_raw` in `schemas/paradox_diagram_input_v0.schema.json`
  (and define it if missing).

## Why
The contract checker (`check_paradox_diagram_input_v0_contract.py`) treats
`decision_raw` as mandatory, but the schema did not. This mismatch breaks the
schema-derived minimal input path and causes the new regression test to fail.

## Impact
No behavioral change beyond making the schema reflect the already-enforced
contract requirement. Prevents future schema/contract drift.
