### PR TITLE
fix(paradox): reject bools for numeric diagram metrics in contract

### DIFF
--- a/scripts/check_paradox_diagram_input_v0_contract.py
+++ b/scripts/check_paradox_diagram_input_v0_contract.py
@@ -64,6 +64,7 @@ def _expect_str_or_none(name: str, v: Any) -> None:
 
 
 def _expect_number_ge0(name: str, v: Any) -> float:
+    # Important: bool is a subclass of int in Python → reject explicitly.
     if isinstance(v, bool):
         _die(f"Expected '{name}' to be number, got bool")
     if not isinstance(v, (int, float)):
@@ -75,6 +76,7 @@ def _expect_number_ge0(name: str, v: Any) -> float:
 
 
 def _expect_number_0_1(name: str, v: Any) -> float:
+    # Important: bool is a subclass of int in Python → reject explicitly.
     if isinstance(v, bool):
         _die(f"Expected '{name}' to be number, got bool")
     if not isinstance(v, (int, float)):


### PR DESCRIPTION
## What
- Tighten paradox diagram input contract: reject JSON booleans for numeric metrics.

## Why
In Python, `bool` is an `int` subclass, so `isinstance(v, (int,float))` accepts
`true/false` as numbers. This weakens the contract and can let invalid inputs
silently pass, skewing diagram data.

## Scope
- Minimal change: explicit `isinstance(v, bool)` guard before numeric checks.
- No behavior change for valid numeric inputs.
