### PR TITLE
fix(paradox): harden diagram contract numeric checks (reject bools)

### DIFF
--- a/scripts/check_paradox_diagram_input_v0_contract.py
+++ b/scripts/check_paradox_diagram_input_v0_contract.py
@@ -64,10 +64,7 @@ def _expect_str_or_none(name: str, v: Any) -> None:
 
 
 def _expect_number_ge0(name: str, v: Any) -> float:
-    # Important: bool is a subclass of int in Python → reject explicitly.
-    if isinstance(v, bool):
-        _die(f"Expected '{name}' to be number, got bool")
-    if not isinstance(v, (int, float)):
+    if isinstance(v, bool) or not isinstance(v, (int, float)):
         _die(f"Expected '{name}' to be number, got {type(v).__name__}")
     fv = float(v)
     if fv < 0:
@@ -76,10 +73,7 @@ def _expect_number_ge0(name: str, v: Any) -> float:
 
 
 def _expect_number_0_1(name: str, v: Any) -> float:
-    # Important: bool is a subclass of int in Python → reject explicitly.
-    if isinstance(v, bool):
-        _die(f"Expected '{name}' to be number, got bool")
-    if not isinstance(v, (int, float)):
+    if isinstance(v, bool) or not isinstance(v, (int, float)):
         _die(f"Expected '{name}' to be number, got {type(v).__name__}")
     fv = float(v)
     if not (0.0 <= fv <= 1.0):


### PR DESCRIPTION
## What
Reject boolean values for numeric metrics in `check_paradox_diagram_input_v0_contract.py`.

## Why
Python treats `bool` as a subtype of `int`, so `true/false` can incorrectly pass
as numeric values. This weakens the contract and can silently corrupt diagram inputs.

## Notes
Fail-closed behavior is preserved: invalid numeric types now correctly fail validation.
