### PR TITLE
fix(paradox): keep diagram input schema in sync with contract

### DIFF
--- a/schemas/paradox_diagram_input_v0.schema.json
+++ b/schemas/paradox_diagram_input_v0.schema.json
@@ -22,9 +22,11 @@
       "enum": ["NORMAL", "WARN", "FAIL", "UNKNOWN"]
     },
     "decision_raw": {
-      "type": "string",
-      "minLength": 1,
-      "description": "Raw decision string used for provenance/debug (e.g. 'NORMAL')."
+      "anyOf": [
+        { "type": "string", "minLength": 1 },
+        { "type": "null" }
+      ],
+      "description": "Raw decision string used for provenance/debug (e.g. 'NORMAL'). May be null when decision is unavailable."
     },
 
     "source": { "type": ["string", "null"] },


### PR DESCRIPTION
## What
Make `decision_raw` required in `schemas/paradox_diagram_input_v0.schema.json`.

## Why
The contract checker requires `decision_raw`; schema must reflect this so
schema-derived minimal inputs cannot drift from contract expectations.

## Impact
No behavioral change for valid producers (they already must provide `decision_raw`
to pass the contract). This only removes a schema/contract mismatch.
