### PR TITLE
test(paradox): use schema-valid example input for diagram renderer smoke

### DIFF
--- a/schemas/examples/paradox_diagram_input_v0.example.json
+++ b/schemas/examples/paradox_diagram_input_v0.example.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "v0",
+  "timestamp_utc": "2026-02-06T00:00:00+00:00",
+  "shadow": true,
+  "decision_key": "NORMAL",
+  "decision_raw": "NORMAL",
+  "metrics": {
+    "settle_time_p95_ms": 10.0,
+    "settle_time_budget_ms": 50.0,
+    "downstream_error_rate": 0.02,
+    "paradox_density": 0.1
+  }
+}


### PR DESCRIPTION
## What
- Add `schemas/examples/paradox_diagram_input_v0.example.json` as a canonical v0 input.
- Update renderer smoke test to load this fixture instead of constructing JSON inline.

## Why
Keeps tests aligned with schema/contract and prevents drift that causes N/A diagrams
or confusing contract failures.

## Notes
This is deliberately minimal and non-invasive (no gating changes).
