### PR TITLE
test(paradox): ensure contract rejects boolean numeric metrics

### DIFF
--- a/tests/test_paradox_diagram_input_v0_contract_rejects_bool.py
+++ b/tests/test_paradox_diagram_input_v0_contract_rejects_bool.py
@@ -1,36 +1,69 @@
+#!/usr/bin/env python3
+"""
+Regression test: paradox diagram input v0 contract must reject booleans for numeric metrics.
+
+Why:
+- In Python, bool is a subclass of int, so naive isinstance(v, (int, float)) checks
+  can accidentally accept JSON true/false as valid numbers.
+- We lock in strict typing: numeric metrics must be real numbers, not booleans.
+"""
+
+from __future__ import annotations
+
 import json
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
-def test_contract_rejects_bool_metric(tmp_path: Path) -> None:
+def _repo_root() -> Path:
+    # tests/... -> repo root
+    return Path(__file__).resolve().parents[1]
+
+
+def _write_json(path: Path, obj: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def test_contract_rejects_bool_metrics() -> None:
+    root = _repo_root()
+    script = root / "scripts" / "check_paradox_diagram_input_v0_contract.py"
+    assert script.exists(), f"missing contract checker script: {script}"
+
+    # Minimal schema-shaped input, but with boolean values for numeric fields
+    # (these MUST be rejected by the contract).
     bad = {
-        "schema_version": "v0",
+        "schema_version": "paradox_diagram_input_v0",
         "timestamp_utc": "2026-02-06T00:00:00+00:00",
         "shadow": True,
         "decision_key": "NORMAL",
         "decision_raw": "NORMAL",
         "metrics": {
-            "settle_time_p95_ms": 10.0,
-            "settle_time_budget_ms": 50.0,
-            "downstream_error_rate": True,   # <-- a lényeg
-            "paradox_density": 0.1,
+            "settle_time_p95_ms": True,
+            "settle_time_budget_ms": False,
+            "downstream_error_rate": True,
+            "paradox_density": False,
         },
     }
 
-    p = tmp_path / "bad.json"
-    p.write_text(json.dumps(bad, indent=2) + "\n", encoding="utf-8")
+    with tempfile.TemporaryDirectory() as d:
+        base = Path(d)
+        inp = base / "paradox_diagram_input_v0.json"
+        _write_json(inp, bad)
 
-    r = subprocess.run(
-        [
-            sys.executable,
-            "scripts/check_paradox_diagram_input_v0_contract.py",
-            "--in",
-            str(p),
-        ],
-        capture_output=True,
-        text=True,
-    )
+        # Use absolute path + run from repo root to avoid CWD-dependent failures.
+        p = subprocess.run(
+            [sys.executable, str(script), "--in", str(inp)],
+            cwd=str(root),
+            capture_output=True,
+            text=True,
+        )
 
-    assert r.returncode != 0, f"expected non-zero exit, got {r.returncode}\nstdout={r.stdout}\nstderr={r.stderr}"
+        # Non-zero is the key invariant: bools must NOT be accepted as numbers.
+        if p.returncode == 0:
+            raise AssertionError(
+                "Expected contract checker to reject bool metrics, but it exited 0.\n"
+                f"stdout:\n{p.stdout}\n\nstderr:\n{p.stderr}\n"
+            )


### PR DESCRIPTION
### Summary
Adds a regression test to prevent booleans from being accepted as numeric metric values in paradox diagram inputs.

### Motivation
JSON true/false can slip through numeric validation because Python treats bool as an int subclass. This weakens the contract by allowing invalid metric types.

### Changes
- New test: tests/test_paradox_diagram_input_v0_contract_rejects_bool.py
  - Writes a minimal schema-shaped input where numeric metrics are booleans
  - Asserts scripts/check_paradox_diagram_input_v0_contract.py exits non-zero

### Notes
This is test-only and does not change runtime behavior; it locks in stricter validation semantics.
