### PR TITLE
fix(paradox): require non-empty decision_raw in diagram input contract

### DIFF
--- a/scripts/check_paradox_diagram_input_v0_contract.py
+++ b/scripts/check_paradox_diagram_input_v0_contract.py
@@ -104,7 +104,10 @@ def validate(d: Dict[str, Any]) -> None:
         _die(f"Invalid decision_key: {decision_key}")
 
     decision_raw = _require_key(d, "decision_raw")
-    _expect_str("decision_raw", decision_raw)
+    _expect_str_or_none("decision_raw", decision_raw)
+    # Align with schema (string|null): if present as string, require non-empty.
+    if decision_raw is not None:
+        _expect_str("decision_raw", decision_raw)
 
     # Optional metadata
     if "source" in d:


### PR DESCRIPTION
Why
decision_raw is used for provenance/debug, but contract previously allowed null via _expect_str_or_none, which can mask missing decisions and drift from schema intent.

What changed

Contract now requires decision_raw to be a non-empty string (_expect_str).

Impact

Invalid inputs with decision_raw: null or empty string now fail the contract check (exit code 2), making missing provenance explicit.