### PR TITLE
chore(overlay): add placeholder theory_overlay_v0 artifact

### DIFF
--- a/PULSE_safe_pack_v0/artifacts/theory_overlay_v0.json
+++ b/PULSE_safe_pack_v0/artifacts/theory_overlay_v0.json
@@ -1,0 +1,15 @@
+{
+  "schema": "theory_overlay_v0",
+  "inputs_digest": "0000000000000000000000000000000000000000000000000000000000000000",
+  "gates_shadow": {
+    "theory_overlay_stub_ok": {
+      "status": "MISSING",
+      "reason": "Placeholder overlay artifact (generation not wired yet)."
+    }
+  },
+  "cases": [],
+  "evidence": {
+    "overlay_source": "manual_stub",
+    "note": "This file exists to exercise the shadow workflow contract check."
+  }
+}


### PR DESCRIPTION
### What
Add `PULSE_safe_pack_v0/artifacts/theory_overlay_v0.json` as a minimal placeholder overlay artifact.

### Why
The `theory_overlay_v0` shadow workflow only runs the contract check when this artifact exists.
This stub ensures the contract checker is exercised in CI (instead of always skipping).

### Notes
- This is a placeholder only (`gates_shadow` marked MISSING with reason).
- Does not affect required release gating; workflow remains shadow/diagnostic.
