### PR TITLE
feat(schemas): add theory_overlay_v0 schema

### DIFF
--- a/schemas/theory_overlay_v0.schema.json
+++ b/schemas/theory_overlay_v0.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "cases": {
+      "type": "array"
+    },
+    "evidence": {
+      "type": "object"
+    },
+    "gates_shadow": {
+      "type": "object"
+    },
+    "inputs_digest": {
+      "type": "string"
+    },
+    "notes": {
+      "type": "array"
+    },
+    "schema": {
+      "const": "theory_overlay_v0",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema",
+    "inputs_digest",
+    "gates_shadow",
+    "cases",
+    "evidence"
+  ],
+  "title": "theory_overlay_v0",
+  "type": "object"
+}


### PR DESCRIPTION
What: Introduce schemas/theory_overlay_v0.schema.json (draft 2020-12) for the theory overlay.

Why: Enables consistent validation/documentation of the overlay artifact structure without coupling to “authority” assumptions — only the observable contract shape.

Notes: Minimal schema on purpose; semantic correctness stays in check_theory_overlay_v0_contract.py.

Risk: None (new file, shadow-only).