### PR TITLE
feat(theory-overlay): scaffold record-horizon (G) overlay fields in theory_overlay_v0

### DIFF
--- a/PULSE_safe_pack_v0/artifacts/theory_overlay_v0.json
+++ b/PULSE_safe_pack_v0/artifacts/theory_overlay_v0.json
@@ -5,11 +5,56 @@
     "theory_overlay_stub_ok": {
       "status": "MISSING",
       "reason": "Placeholder overlay artifact (generation not wired yet)."
+    },
+    "g_record_horizon_v0": {
+      "status": "MISSING",
+      "reason": "Record-horizon (G/tidality) overlay not wired yet. This is a schema-compatible stub.",
+      "zone": "UNKNOWN",
+      "mode": "UNKNOWN"
     }
   },
-  "cases": [],
+  "cases": [
+    {
+      "id": "contract_smoke",
+      "status": "PASS",
+      "message": "theory_overlay_v0 artifact present and schema-valid"
+    }
+  ],
   "evidence": {
     "overlay_source": "manual_stub",
-    "note": "This file exists to exercise the shadow workflow contract check."
+    "note": "This file exists to exercise the shadow workflow contract check.",
+    "record_horizon_v0": {
+      "status": "MISSING",
+      "expected_inputs": ["u", "T|lnT", "v_L", "lambda_eff"],
+      "expected_params": ["eta", "chi", "ell_0", "M_infty", "b0_A_bits", "epsilon_budget", "rho_coding"],
+      "thresholds": {
+        "Btilde_green": 100,
+        "Btilde_yellow": 10,
+        "Btilde_red": 1,
+        "sharp_Xi": 8,
+        "sharp_F": 10
+      },
+      "formulas": {
+        "alpha0": "alpha0 = eta * (ell_0/c^2) * T",
+        "B_rem_bits": "B_rem ≈ (M_infty * lambda_eff * exp(-u)) / (alpha0 * v_L * (1 + chi*u))",
+        "B_eff_payload_bits": "B_eff_payload = (1-epsilon_budget)*(1-rho_coding)*B_rem",
+        "Btilde_core_units": "Btilde = B_eff_payload / b0_A_bits",
+        "zone": "GREEN if Btilde>=100; YELLOW if 10<=Btilde<100; RED if 1<=Btilde<10; POST if Btilde<1"
+      },
+      "computed": {
+        "B_rem_bits": null,
+        "B_eff_payload_bits": null,
+        "Btilde_core_units": null,
+        "x_ln_Btilde": null,
+        "zone": "UNKNOWN",
+        "mode": "UNKNOWN",
+        "feedback_F": null,
+        "Xi": null,
+        "m_slope": null,
+        "delta_lnT_to_100": null,
+        "delta_lnT_to_10": null,
+        "delta_lnT_to_1": null
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
Scaffolds a G/tidality-based record-horizon diagnostic overlay inside `theory_overlay_v0`.
This change is schema-compatible and keeps the overlay CI-neutral (v0).

## Details
- Adds `evidence.record_horizon_v0` with:
  - expected inputs/params
  - thresholds (100/10/1 core-units; SHARP heuristics)
  - formulas reference
  - placeholder `computed` fields (nulls / UNKNOWN)
- Adds `gates_shadow.g_record_horizon_v0` as a stub gate (status=MISSING) to surface the overlay in reports.

## Why
We want to ship the contract + report surface now, then wire generation once input signals are available,
without changing the v0 schema again.

## Next steps
- Wire generation to populate:
  - B_rem_bits, B_eff_payload_bits, Btilde_core_units, x
  - zone/mode + (optional) ΔlnT predictions when history is available
- Switch g_record_horizon_v0 from MISSING → PASS/FAIL/FAIL_CLOSED at runtime
