### PR TITLE
docs(paradox): document Paradox Gate triage SVG v0 (shadow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ More details: see `openai_evals_v0/README.md` → “Debugging / triage (shadow)
 
 **Artifacts**
 
-**Report Card** → [`PULSE_safe_pack_v0/artifacts/report_card.html`](PULSE_safe_pack_v0/artifacts/report_card.html)  
-**Status JSON** → [`PULSE_safe_pack_v0/artifacts/status.json`](PULSE_safe_pack_v0/artifacts/status.json)  
-**Paradox Gate triage SVG (shadow)** → [`PULSE_safe_pack_v0/artifacts/paradox_diagram_v0.svg`](PULSE_safe_pack_v0/artifacts/paradox_diagram_v0.svg)  (Docs: [`docs/paradox_gate_triage_svg_v0.md`](docs/paradox_gate_triage_svg_v0.md))
+**Report Card** → `PULSE_safe_pack_v0/artifacts/report_card.html`  
+**Status JSON** → `PULSE_safe_pack_v0/artifacts/status.json`  
+**Paradox Gate triage SVG (shadow)** → `PULSE_safe_pack_v0/artifacts/paradox_diagram_v0.svg` (Docs: [`docs/paradox_gate_triage_svg_v0.md`](docs/paradox_gate_triage_svg_v0.md))
+
 
 
 ### Developer tools (optional)


### PR DESCRIPTION
## Context
We now generate a shadow-only Paradox Gate triage SVG for quick PR review. This is a diagnostic overlay and must not gate merges.

## Change
- Add a focused doc page for the Paradox Gate triage SVG v0 (shadow):
  - `docs/paradox_gate_triage_svg_v0.md`
- Add a README pointer under **Artifacts** to the SVG output and doc page.

## Notes
- Shadow-only: does not affect PASS/FAIL release semantics.
- Contract-first: rendering is best-effort and runs only when the input contract check succeeds.

## Future improvements (non-blocking)
- Legend + clearer budget delta labels
- Explicit “MISSING” markers for absent metrics
- Link PR triage comment → uploaded SVG + input JSON
- Golden SVG regression tests
