### PR TITLE
docs: add Paradox Gate triage SVG v0 to documentation index

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,6 +31,7 @@ If you add/rename a doc under `docs/`, please update this index.
 - [Pulse_paradox_edges_v0_status.md](Pulse_paradox_edges_v0_status.md) — Status/roadmap for `paradox_edges_v0.jsonl`.
 - [paradox_edges_case_studies.md](paradox_edges_case_studies.md) — Case studies (fixture + non-fixture).
 - [PARADOX_RUNBOOK.md](PARADOX_RUNBOOK.md) — What to do when EPF shadow disagrees with baseline.
+- [Paradox Gate triage SVG v0](paradox_gate_triage_svg_v0.md) — Shadow-only Paradox Gate triage SVG input/contract/render flow.
 - [Paradox diagram v0](paradox_diagram_v0.md) — how to generate and read the Mermaid topology view.
 - [PULSE_paradox_core_v0.md](PULSE_paradox_core_v0.md) — Paradox Core v0 (deterministic core projection + markdown reviewer summary).
 


### PR DESCRIPTION
## Summary
- Added a new entry in `docs/INDEX.md` under **Paradox field & edges**:
  - `Paradox Gate triage SVG v0` → `paradox_gate_triage_svg_v0.md`

## Motivation
- Make the canonical Paradox Gate triage SVG documentation easier to find from the docs index.

## Scope
- Documentation only (`docs/INDEX.md`).
- No code, schema, or pipeline behavior changes.

## Validation
- Confirmed the index section includes the new link and points to the expected file.
