### PR TITLE
docs: align Paradox Gate triage SVG v0 page naming and scope

### DIFF
--- a/docs/paradox_gate_triage_svg_v0.md
+++ b/docs/paradox_gate_triage_svg_v0.md
@@ -1,7 +1,11 @@
-# Paradox diagram v0 (shadow)
+# Paradox Gate triage SVG v0 (shadow)
 
 This repo produces a small **diagnostic (shadow-only)** SVG (“Paradox diagram v0”) from the Paradox Gate triage summary.
 It is **not a release gate** and **does not block merges**.
+
+> Canonical doc filename: `docs/paradox_gate_triage_svg_v0.md`.
+>
+> This page documents the shadow SVG triage flow (`paradox_diagram_input_v0.json` → `paradox_diagram_v0.svg`) used by Paradox Gate diagnostics.
 
 ## What it is
 - A compact visualization of key Paradox Gate metrics:


### PR DESCRIPTION
## Summary
- Updated `docs/paradox_gate_triage_svg_v0.md` with a clear, canonical title.
- Added an explicit canonical filename note:
  - `docs/paradox_gate_triage_svg_v0.md`
- Clarified that this page documents the shadow SVG triage path and remains non-gating.

## Motivation
- Remove ambiguity between the generic “Paradox diagram v0” wording and the dedicated
  Paradox Gate triage SVG documentation page.

## Scope
- Documentation only (`docs/paradox_gate_triage_svg_v0.md`).
- No CI gate logic or runtime behavior changes.

## Validation
- Verified markdown content and references in the updated page.
