### PR TITLE
ci(theory-overlay): wire theory overlay generator into workflow

### DIFF
--- a/.github/workflows/theory_overlay_v0.yml
+++ b/.github/workflows/theory_overlay_v0.yml
@@ -4,13 +4,17 @@ on:
   pull_request:
     paths:
       - ".github/workflows/theory_overlay_v0.yml"
+      - "scripts/generate_theory_overlay_v0.py"
       - "scripts/check_theory_overlay_v0_contract.py"
+      - "scripts/render_theory_overlay_v0_md.py"
       - "PULSE_safe_pack_v0/artifacts/theory_overlay_v0.json"
   push:
     branches: ["main"]
     paths:
       - ".github/workflows/theory_overlay_v0.yml"
+      - "scripts/generate_theory_overlay_v0.py"
       - "scripts/check_theory_overlay_v0_contract.py"
+      - "scripts/render_theory_overlay_v0_md.py"
       - "PULSE_safe_pack_v0/artifacts/theory_overlay_v0.json"
   workflow_dispatch:
 
@@ -41,16 +45,32 @@ jobs:
           set -euo pipefail
           overlay="PULSE_safe_pack_v0/artifacts/theory_overlay_v0.json"
           if [ ! -f "$overlay" ]; then
-            echo "::warning::missing $overlay; skipping contract check."
+            echo "::warning::missing $overlay; skipping generate/contract/render."
             echo "found=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           echo "found=true" >> "$GITHUB_OUTPUT"
           echo "overlay=$overlay" >> "$GITHUB_OUTPUT"
 
-      - name: Contract check (fail-closed)
+      - name: Generate theory overlay v0 (record horizon)
         if: ${{ steps.locate_overlay.outputs.found == 'true' }}
         shell: bash
         run: |
-          python scripts/check_theory_overlay_v0_contract.py \
-            --in "${{ steps.locate_overlay.outputs.overlay }}"
+          python scripts/generate_theory_overlay_v0.py \
+            --in  "${{ steps.locate_overlay.outputs.overlay }}" \
+            --out "${{ steps.locate_overlay.outputs.overlay }}" \
+            --require-inputs
+
+      - name: Contract check (theory overlay v0)
+        if: ${{ steps.locate_overlay.outputs.found == 'true' }}
+        shell: bash
+        run: |
+          python scripts/check_theory_overlay_v0_contract.py --in "${{ steps.locate_overlay.outputs.overlay }}"
+
+      - name: Render markdown (theory overlay v0)
+        if: ${{ steps.locate_overlay.outputs.found == 'true' }}
+        shell: bash
+        run: |
+          python scripts/render_theory_overlay_v0_md.py \
+            --in  "${{ steps.locate_overlay.outputs.overlay }}" \
+            --out PULSE_safe_pack_v0/artifacts/theory_overlay_v0.md


### PR DESCRIPTION
## Summary
Wire the theory overlay generator into the CI workflow.

## Change
Run `scripts/generate_theory_overlay_v0.py` before:
- `scripts/check_theory_overlay_v0_contract.py`
- `scripts/render_theory_overlay_v0_md.py`

## Result
The overlay JSON and markdown consistently reflect record-horizon diagnostics when inputs are available.
