### PR TITLE
ci(theory-overlay): add pre-check to avoid silent normalization of committed overlay

### DIFF
--- a/.github/workflows/theory_overlay_v0.yml
+++ b/.github/workflows/theory_overlay_v0.yml
@@ -51,6 +51,7 @@ jobs:
           fi
           echo "found=true" >> "$GITHUB_OUTPUT"
           echo "overlay=$overlay" >> "$GITHUB_OUTPUT"
+          echo "overlay_md=PULSE_safe_pack_v0/artifacts/theory_overlay_v0.md" >> "$GITHUB_OUTPUT"
 
       - name: Contract check (pre) - committed overlay must already be valid
         if: ${{ steps.locate_overlay.outputs.found == 'true' }}
@@ -79,4 +80,4 @@ jobs:
         run: |
           python scripts/render_theory_overlay_v0_md.py \
             --in  "${{ steps.locate_overlay.outputs.overlay }}" \
-            --out PULSE_safe_pack_v0/artifacts/theory_overlay_v0.md
+            --out "${{ steps.locate_overlay.outputs.overlay_md }}"


### PR DESCRIPTION
## Summary
Add a pre-generation contract check so in-place overlay generation cannot mask committed contract violations.

## Why
The generator can add missing top-level keys via its skeleton logic. Without a pre-check, a malformed committed overlay could be normalized and then pass CI.

## Change
Run `check_theory_overlay_v0_contract.py` before the generator step, then keep the existing post-generation check and markdown render.
