### PR TITLE
ci(theory-overlay): allow bundle-driven inputs for theory overlay generation

### DIFF
--- a/.github/workflows/theory_overlay_v0.yml
+++ b/.github/workflows/theory_overlay_v0.yml
@@ -8,6 +8,7 @@ on:
       - "scripts/check_theory_overlay_v0_contract.py"
       - "scripts/render_theory_overlay_v0_md.py"
       - "PULSE_safe_pack_v0/artifacts/theory_overlay_v0.json"
+      - "PULSE_safe_pack_v0/artifacts/theory_overlay_inputs_v0.json"
   push:
     branches: ["main"]
     paths:
@@ -16,6 +17,7 @@ on:
       - "scripts/check_theory_overlay_v0_contract.py"
       - "scripts/render_theory_overlay_v0_md.py"
       - "PULSE_safe_pack_v0/artifacts/theory_overlay_v0.json"
+      - "PULSE_safe_pack_v0/artifacts/theory_overlay_inputs_v0.json"
   workflow_dispatch:
 
 concurrency:
@@ -52,13 +54,6 @@ jobs:
           echo "found=true" >> "$GITHUB_OUTPUT"
           echo "overlay=$overlay" >> "$GITHUB_OUTPUT"
           echo "overlay_md=PULSE_safe_pack_v0/artifacts/theory_overlay_v0.md" >> "$GITHUB_OUTPUT"
-          bundle="PULSE_safe_pack_v0/artifacts/theory_overlay_inputs_v0.json"
-          echo "bundle=$bundle" >> "$GITHUB_OUTPUT"
-          if [ -f "$bundle" ]; then
-            echo "bundle_found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "bundle_found=false" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Contract check (pre) - committed overlay must already be valid
         if: ${{ steps.locate_overlay.outputs.found == 'true' }}
@@ -70,17 +65,10 @@ jobs:
         if: ${{ steps.locate_overlay.outputs.found == 'true' }}
         shell: bash
         run: |
-          cmd=(python scripts/generate_theory_overlay_v0.py
-            --in  "${{ steps.locate_overlay.outputs.overlay }}"
-            --out "${{ steps.locate_overlay.outputs.overlay }}"
+          python scripts/generate_theory_overlay_v0.py \
+            --in  "${{ steps.locate_overlay.outputs.overlay }}" \
+            --out "${{ steps.locate_overlay.outputs.overlay }}" \
             --require-inputs
-          )
-
-          if [ "${{ steps.locate_overlay.outputs.bundle_found }}" = "true" ]; then
-            cmd+=(--bundle "${{ steps.locate_overlay.outputs.bundle }}")
-          fi
-
-          "${cmd[@]}"
 
       - name: Contract check (post) - generated overlay must be valid
         if: ${{ steps.locate_overlay.outputs.found == 'true' }}


### PR DESCRIPTION
## Summary
Allow the theory overlay generator to consume an optional inputs bundle artifact.

## Change
- Detect `PULSE_safe_pack_v0/artifacts/theory_overlay_inputs_v0.json` in the workflow
- If present, pass it to `scripts/generate_theory_overlay_v0.py` via `--bundle`

## Notes
No change to gating semantics; this only enables a clean data path for future wiring.
