### PR TITLE
feat(theory-overlay): add theory overlay inputs bundle (v0)

### DIFF
--- a/PULSE_safe_pack_v0/artifacts/theory_overlay_inputs_v0.json
+++ b/PULSE_safe_pack_v0/artifacts/theory_overlay_inputs_v0.json
@@ -1,0 +1,24 @@
+{
+  "meta": {
+    "kind": "theory_overlay_inputs_v0",
+    "source": "demo_fixture",
+    "note": "Demo inputs for shadow overlay wiring. Replace with real pipeline values when available."
+  },
+  "inputs": {
+    "u": 1.0,
+    "T": 0.01,
+    "v_L": 0.1,
+    "lambda_eff": 1.0
+  },
+  "params": {
+    "eta": 1.0,
+    "chi": 10.0,
+    "ell_0": 1.0,
+    "M_infty": 2e-14,
+    "b0_A_bits": 1024,
+    "epsilon_budget": 0.2,
+    "rho_coding": 0.2,
+    "c_m_per_s": 299792458.0,
+    "G_m3_per_kg_s2": 6.6743e-11
+  }
+}


### PR DESCRIPTION
## Summary
Add a v0 inputs bundle artifact consumed by the theory overlay generator.

## What
- Adds `PULSE_safe_pack_v0/artifacts/theory_overlay_inputs_v0.json` with complete demo inputs/params.

## Why
The workflow runs the generator with `--require-inputs`; providing a bundle enables real computation and a meaningful shadow overlay summary.

## Notes
This is a demo fixture intended for wiring validation; replace values with real pipeline inputs when available.
