### PR TITLE
test(fixtures): add theory_overlay_inputs_v0 raw demo fixture

### DIFF
--- a/PULSE_safe_pack_v0/fixtures/theory_overlay_inputs_v0.raw.demo.json
+++ b/PULSE_safe_pack_v0/fixtures/theory_overlay_inputs_v0.raw.demo.json
@@ -1,0 +1,10 @@
+{
+  "source_kind": "demo",
+  "inputs": {
+    "u": 1.0,
+    "T": 10.0,
+    "v_L": 1.0,
+    "lambda_eff": 0.1
+  }
+}
+


### PR DESCRIPTION
## Why
The theory overlay workflow/build expects a raw demo input file for constructing a
`theory_overlay_inputs_v0` bundle. Without a tracked fixture, the builder ends up
with missing inputs and the inputs-v0 contract check fails closed.

## What changed
- Add `PULSE_safe_pack_v0/fixtures/theory_overlay_inputs_v0.raw.demo.json`

## Notes
The fixture is intentionally minimal and contract-valid:
- Provides numeric **T** (satisfies T-or-lnT requirement)
- Includes required inputs: `u`, `v_L`, `lambda_eff`
