### PR TITLE
ci(workflow): upload theory_overlay_v0 artifacts for PR debugging

### DIFF
--- a/.github/workflows/theory_overlay_v0.yml
+++ b/.github/workflows/theory_overlay_v0.yml
@@ -223,3 +223,14 @@ jobs:
           else
             echo "theory_overlay_v0.md not found; nothing to publish." >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - name: Upload theory overlay v0 artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: theory-overlay-v0
+          if-no-files-found: warn
+          path: |
+            PULSE_safe_pack_v0/artifacts/theory_overlay_inputs_v0.json
+            PULSE_safe_pack_v0/artifacts/theory_overlay_v0.json
+            PULSE_safe_pack_v0/artifacts/theory_overlay_v0.md


### PR DESCRIPTION
## Why
The theory overlay v0 pipeline produces useful outputs (inputs bundle, overlay JSON, rendered markdown).
Uploading them as workflow artifacts makes PR review, debugging, and audit trails significantly easier.

## What changed
- Update `.github/workflows/theory_overlay_v0.yml` to upload overlay outputs via `actions/upload-artifact@v4`.

## Artifacts uploaded
- `PULSE_safe_pack_v0/artifacts/theory_overlay_inputs_v0.json`
- `PULSE_safe_pack_v0/artifacts/theory_overlay_v0.json`
- `PULSE_safe_pack_v0/artifacts/theory_overlay_v0.md`

## Notes
Artifacts are uploaded with `if: always()` and `if-no-files-found: warn` to avoid introducing new failure modes.
