### PR TITLE
docs(theory): link v0.1 time/protocol specs from theory overlay doc

### DIFF
--- a/docs/theory_overlay_v0.md
+++ b/docs/theory_overlay_v0.md
@@ -194,3 +194,13 @@ not by blocking merges.
 - History ingestion for stable `Xi` / `m_slope` / `ΔlnT` forecasts across runs
 - Promotion path:
   shadow overlay → shadow gate profile → (optional) hard gate
+
+---
+
+## Related theory/protocol specs (probe)
+
+These documents are workshop/probe specifications. They do not change normative PULSE release-gate semantics.
+
+- [Time as Consequence (workshop paper, v0.1)](time_as_consequence_v0_1.md)
+- [Time as Consequence (one-pager, v0.1)](time_as_consequence_one_pager_v0_1.md)
+- [Gravity as a Record Test (appendix, v0.1)](gravity_record_protocol_appendix_v0_1.md)


### PR DESCRIPTION
## Why
The v0.1 time-as-consequence docs pack is now in-repo and indexed from docs/INDEX.md.
For better discoverability, the Theory Overlay v0 documentation should also link to those
probe/spec documents directly.

## What changed
- Add a “Related theory/protocol specs (probe)” section to `docs/theory_overlay_v0.md`
  linking to:
  - `time_as_consequence_v0_1.md`
  - `time_as_consequence_one_pager_v0_1.md`
  - `gravity_record_protocol_appendix_v0_1.md`

## Notes
Docs-only change; no schemas, scripts, workflows, or release-gate semantics are modified.
