### PR TITLE
feat(schema): add gravity record protocol v0.1 schema

### DIFF
--- a/schemas/gravity_record_protocol_v0_1.schema.json
+++ b/schemas/gravity_record_protocol_v0_1.schema.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "gravity_record_protocol_v0_1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "schema_version", "source_kind", "provenance", "cases"],
+  "properties": {
+    "schema": { "const": "gravity_record_protocol_v0_1" },
+    "schema_version": { "type": "integer", "const": 1 },
+
+    "source_kind": {
+      "type": "string",
+      "enum": ["demo", "measurement", "simulation", "pipeline", "manual", "missing"]
+    },
+
+    "provenance": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["generated_at_utc", "generator"],
+      "properties": {
+        "generated_at_utc": { "type": "string" },
+        "generator": { "type": "string" },
+        "git_sha": { "type": ["string", "null"] },
+        "run_id": { "type": ["string", "null"] },
+        "run_url": { "type": ["string", "null"] },
+        "dataset_doi": { "type": ["string", "null"] }
+      }
+    },
+
+    "inputs_digest": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["algo", "sha256", "canonicalization"],
+      "properties": {
+        "algo": { "const": "sha256" },
+        "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "canonicalization": { "type": "string" }
+      }
+    },
+
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/case_v0_1" }
+    },
+
+    "raw_errors": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+
+    "ext": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    }
+  },
+
+  "definitions": {
+    "status_enum": {
+      "type": "string",
+      "enum": ["PASS", "FAIL", "MISSING"]
+    },
+
+    "r_label": {
+      "type": ["number", "string"]
+    },
+
+    "station_v0_1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["station_id"],
+      "properties": {
+        "station_id": { "type": "string", "minLength": 1 },
+        "r_areal": { "type": ["number", "null"] },
+        "r_label": { "type": ["string", "null"] },
+        "location": { "type": ["string", "null"] },
+        "notes": { "type": ["string", "null"] }
+      }
+    },
+
+    "lambda_point_v0_1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["r", "value"],
+      "properties": {
+        "r": { "$ref": "#/definitions/r_label" },
+        "value": { "type": "number", "exclusiveMinimum": 0 },
+        "uncertainty": { "type": ["number", "null"], "minimum": 0 },
+        "n": { "type": ["integer", "null"], "minimum": 0 }
+      }
+    },
+
+    "kappa_point_v0_1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["r", "value"],
+      "properties": {
+        "r": { "$ref": "#/definitions/r_label" },
+        "value": { "type": "number", "minimum": 0, "maximum": 1 },
+        "uncertainty": { "type": ["number", "null"], "minimum": 0 },
+        "n": { "type": ["integer", "null"], "minimum": 0 }
+      }
+    },
+
+    "scalar_point_v0_1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["r", "value"],
+      "properties": {
+        "r": { "$ref": "#/definitions/r_label" },
+        "value": { "type": "number" },
+        "uncertainty": { "type": ["number", "null"], "minimum": 0 },
+        "n": { "type": ["integer", "null"], "minimum": 0 }
+      }
+    },
+
+    "profile_lambda_v0_1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "$ref": "#/definitions/status_enum" },
+        "points": {
+          "type": ["array", "null"],
+          "items": { "$ref": "#/definitions/lambda_point_v0_1" }
+        },
+        "units": { "type": ["string", "null"] },
+        "quality": { "type": ["object", "null"], "additionalProperties": true },
+        "notes": { "type": ["string", "null"] }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "PASS" } }, "required": ["status"] },
+          "then": { "required": ["points"], "properties": { "points": { "type": "array", "minItems": 1 } } }
+        }
+      ]
+    },
+
+    "profile_kappa_v0_1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "$ref": "#/definitions/status_enum" },
+        "points": {
+          "type": ["array", "null"],
+          "items": { "$ref": "#/definitions/kappa_point_v0_1" }
+        },
+        "units": { "type": ["string", "null"] },
+        "quality": { "type": ["object", "null"], "additionalProperties": true },
+        "notes": { "type": ["string", "null"] }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "PASS" } }, "required": ["status"] },
+          "then": { "required": ["points"], "properties": { "points": { "type": "array", "minItems": 1 } } }
+        }
+      ]
+    },
+
+    "profile_scalar_v0_1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "$ref": "#/definitions/status_enum" },
+        "points": {
+          "type": ["array", "null"],
+          "items": { "$ref": "#/definitions/scalar_point_v0_1" }
+        },
+        "units": { "type": ["string", "null"] },
+        "quality": { "type": ["object", "null"], "additionalProperties": true },
+        "notes": { "type": ["string", "null"] }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "PASS" } }, "required": ["status"] },
+          "then": { "required": ["points"], "properties": { "points": { "type": "array", "minItems": 1 } } }
+        }
+      ]
+    },
+
+    "derived_g_vs_lambda_v0_1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "$ref": "#/definitions/status_enum" },
+        "error_norm": { "type": ["number", "null"], "minimum": 0 },
+        "notes": { "type": ["string", "null"] }
+      }
+    },
+
+    "wall_classification_v0_1": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "frequency_wall": { "$ref": "#/definitions/status_enum" },
+        "delay_wall": { "$ref": "#/definitions/status_enum" },
+        "record_wall": { "$ref": "#/definitions/status_enum" },
+        "notes": { "type": ["string", "null"] }
+      }
+    },
+
+    "case_v0_1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["case_id", "stations", "profiles"],
+      "properties": {
+        "case_id": { "type": "string", "minLength": 1 },
+        "description": { "type": ["string", "null"] },
+
+        "stations": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/station_v0_1" }
+        },
+
+        "profiles": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["lambda", "kappa"],
+          "properties": {
+            "lambda": { "$ref": "#/definitions/profile_lambda_v0_1" },
+            "kappa": { "$ref": "#/definitions/profile_kappa_v0_1" },
+            "s": { "$ref": "#/definitions/profile_scalar_v0_1" },
+            "g": { "$ref": "#/definitions/profile_scalar_v0_1" }
+          }
+        },
+
+        "derived": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "g_vs_lambda": { "$ref": "#/definitions/derived_g_vs_lambda_v0_1" }
+          }
+        },
+
+        "wall_classification": { "$ref": "#/definitions/wall_classification_v0_1" },
+
+        "meta": {
+          "type": ["object", "null"],
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Why
We want the v0.1 gravity record protocol (λ/s/κ + optional s/g + wall taxonomy fields) to be contract-shaped
before implementing any computation. A strict schema baseline prevents semantic drift and “rubber models”.

## What changed
- Add `schemas/gravity_record_protocol_v0_1.schema.json`:
  - strict top-level contract
  - PASS/FAIL/MISSING profile statuses
  - `status=PASS` requires non-empty `points`

## Notes
Schema-only baseline step. No scripts, workflows, or release-gate behavior changed.
