### PR TITLE
ci(shadow): add gravity record protocol v0.1 contract workflow

### DIFF
--- a/.github/workflows/gravity_record_protocol_v0_1_shadow.yml
+++ b/.github/workflows/gravity_record_protocol_v0_1_shadow.yml
@@ -1,0 +1,72 @@
+name: Gravity Record Protocol v0.1 (shadow)
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/gravity_record_protocol_v0_1_shadow.yml"
+      - "scripts/check_gravity_record_protocol_v0_1_contract.py"
+      - "schemas/gravity_record_protocol_v0_1.schema.json"
+      - "PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.demo.json"
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/gravity_record_protocol_v0_1_shadow.yml"
+      - "scripts/check_gravity_record_protocol_v0_1_contract.py"
+      - "schemas/gravity_record_protocol_v0_1.schema.json"
+      - "PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.demo.json"
+  workflow_dispatch:
+
+concurrency:
+  group: gravity-record-protocol-v0-1-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  gravity-record-protocol:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Contract check (demo fixture)
+        shell: bash
+        run: |
+          python scripts/check_gravity_record_protocol_v0_1_contract.py \
+            --in PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.demo.json
+
+      - name: Publish summary
+        if: always()
+        shell: bash
+        run: |
+          echo "## Gravity Record Protocol v0.1 (shadow)" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "- contract: ✅ PASS" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- contract: ❌ FAIL" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Validated inputs:" >> "$GITHUB_STEP_SUMMARY"
+          echo "- fixture: \`PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.demo.json\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- schema:  \`schemas/gravity_record_protocol_v0_1.schema.json\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- checker: \`scripts/check_gravity_record_protocol_v0_1_contract.py\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: gravity-record-protocol-v0-1
+          if-no-files-found: error
+          path: |
+            PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.demo.json
+            schemas/gravity_record_protocol_v0_1.schema.json
+            scripts/check_gravity_record_protocol_v0_1_contract.py


### PR DESCRIPTION
## Why
We now have a schema, a fail-closed contract checker, and a tracked demo fixture for
`gravity_record_protocol_v0_1`. This PR wires them into a CI-neutral shadow workflow to prevent
silent drift and make failures easy to triage.

## What changed
- Add `.github/workflows/gravity_record_protocol_v0_1_shadow.yml`
  - Validates `PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.demo.json`
  - Publishes a compact Step Summary
  - Uploads fixture + schema + checker as artifacts
  - Uses SHA-pinned `actions/upload-artifact`

## Notes
This workflow is diagnostic/shadow only. It does not participate in core release gating unless
explicitly promoted via branch protection settings.
