### PR TITLE
fix(schema): require at least two stations per gravity protocol case

### DIFF
--- a/schemas/gravity_record_protocol_v0_1.schema.json
+++ b/schemas/gravity_record_protocol_v0_1.schema.json
@@ -212,7 +212,7 @@
 
         "stations": {
           "type": "array",
-          "minItems": 1,
+          "minItems": 2,
           "items": { "$ref": "#/definitions/station_v0_1" }
         },
 


### PR DESCRIPTION
## Why
The contract checker already enforces >=2 stations per case (comparative protocol invariant),
but the JSON Schema still allowed single-station cases. This creates a schema/contract mismatch
and can allow structurally invalid artifacts to pass schema-only tooling.

## What changed
- Update `schemas/gravity_record_protocol_v0_1.schema.json`:
  - `cases[].stations.minItems`: 1 → 2

## Notes
No code or workflow behavior changes beyond stricter schema validation. The existing demo fixture
already uses two stations.
