### PR TITLE
ci(shadow): add builder-based gravity protocol v0.1 CI wiring and artifacts

### DIFF
--- a/.github/workflows/gravity_record_protocol_v0_1_shadow.yml
+++ b/.github/workflows/gravity_record_protocol_v0_1_shadow.yml
@@ -4,17 +4,23 @@ on:
   pull_request:
     paths:
       - ".github/workflows/gravity_record_protocol_v0_1_shadow.yml"
+      - "scripts/build_gravity_record_protocol_v0_1.py"
       - "scripts/check_gravity_record_protocol_v0_1_contract.py"
       - "scripts/render_gravity_record_protocol_v0_1_md.py"
+      - "scripts/test_gravity_record_protocol_v0_1_builder_fixtures.py"
       - "schemas/gravity_record_protocol_v0_1.schema.json"
+      - "PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.raw.demo.json"
       - "PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.demo.json"
   push:
     branches: ["main"]
     paths:
       - ".github/workflows/gravity_record_protocol_v0_1_shadow.yml"
+      - "scripts/build_gravity_record_protocol_v0_1.py"
       - "scripts/check_gravity_record_protocol_v0_1_contract.py"
       - "scripts/render_gravity_record_protocol_v0_1_md.py"
+      - "scripts/test_gravity_record_protocol_v0_1_builder_fixtures.py"
       - "schemas/gravity_record_protocol_v0_1.schema.json"
+      - "PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.raw.demo.json"
       - "PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.demo.json"
   workflow_dispatch:
 
@@ -28,7 +34,7 @@ permissions:
 jobs:
   gravity-record-protocol:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     steps:
       - name: Checkout
@@ -44,13 +50,41 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check "jsonschema==4.23.0"
 
-      - name: Contract check (demo fixture)
+      - name: Builder fixtures (golden)
+        id: builder_tests
+        shell: bash
+        run: |
+          set +e
+          python scripts/test_gravity_record_protocol_v0_1_builder_fixtures.py
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Build artifact from raw fixture
+        id: build
+        shell: bash
+        run: |
+          set +e
+          python scripts/build_gravity_record_protocol_v0_1.py \
+            --raw PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.raw.demo.json \
+            --out PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.json \
+            --source-kind demo
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Contract check (built artifact)
         id: contract
         shell: bash
         run: |
           set +e
+          if [ ! -f "PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.json" ]; then
+            echo "built artifact missing"
+            echo "exit_code=1" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           python scripts/check_gravity_record_protocol_v0_1_contract.py \
-            --in PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.demo.json
+            --in PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.json
           code=$?
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
           exit 0
@@ -59,20 +93,25 @@ jobs:
         if: always()
         shell: bash
         run: |
-          python scripts/render_gravity_record_protocol_v0_1_md.py \
-            --in  PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.demo.json \
-            --out PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.md || true
+          if [ -f "PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.json" ]; then
+            python scripts/render_gravity_record_protocol_v0_1_md.py \
+              --in  PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.json \
+              --out PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.md || true
+          else
+            mkdir -p PULSE_safe_pack_v0/artifacts
+            echo "# Gravity Record Protocol v0.1 (shadow)" > PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.md
+            echo "" >> PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.md
+            echo "_Missing built JSON artifact; cannot render._" >> PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.md
+          fi
 
       - name: Publish summary
         if: always()
         shell: bash
         run: |
           echo "## Gravity Record Protocol v0.1 (shadow)" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${{ steps.contract.outputs.exit_code }}" = "0" ]; then
-            echo "- contract: ✅ PASS" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "- contract: ❌ FAIL (exit_code=${{ steps.contract.outputs.exit_code }})" >> "$GITHUB_STEP_SUMMARY"
-          fi
+          echo "- builder_fixtures: exit_code=${{ steps.builder_tests.outputs.exit_code }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- builder: exit_code=${{ steps.build.outputs.exit_code }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- contract: exit_code=${{ steps.contract.outputs.exit_code }}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
           if [ -f "PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.md" ]; then
@@ -88,15 +127,24 @@ jobs:
           name: gravity-record-protocol-v0-1
           if-no-files-found: warn
           path: |
+            PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.raw.demo.json
             PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.demo.json
+            PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.json
+            PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.md
             schemas/gravity_record_protocol_v0_1.schema.json
+            scripts/build_gravity_record_protocol_v0_1.py
             scripts/check_gravity_record_protocol_v0_1_contract.py
             scripts/render_gravity_record_protocol_v0_1_md.py
-            PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.md
+            scripts/test_gravity_record_protocol_v0_1_builder_fixtures.py
 
-      - name: Fail if contract failed
-        if: ${{ steps.contract.outputs.exit_code != '0' }}
+      - name: Fail if any step failed
+        if: always()
         shell: bash
         run: |
-          echo "Contract check failed (exit_code=${{ steps.contract.outputs.exit_code }})"
-          exit 1
+          bt="${{ steps.builder_tests.outputs.exit_code }}"
+          b="${{ steps.build.outputs.exit_code }}"
+          c="${{ steps.contract.outputs.exit_code }}"
+          if [ "$bt" != "0" ] || [ "$b" != "0" ] || [ "$c" != "0" ]; then
+            echo "One or more steps failed: builder_fixtures=$bt builder=$b contract=$c"
+            exit 1
+          fi


### PR DESCRIPTION
## Why
The Gravity Record Protocol v0.1 module is no longer fixture-only: we now have a raw→contract builder and a
contract checker. This workflow update ensures CI validates the end-to-end path and still provides diagnostics
(artifact + markdown summary) even when the contract fails.

## What changed
- Update `.github/workflows/gravity_record_protocol_v0_1_shadow.yml` to:
  - install `jsonschema` (deterministic schema validation)
  - run builder fixtures (regression protection)
  - build `PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.json` from the tracked raw demo fixture
  - contract-check the built artifact (fail-closed)
  - render `PULSE_safe_pack_v0/artifacts/gravity_record_protocol_v0_1.md`
  - append the markdown into the GitHub Step Summary
  - upload artifacts for triage

## Notes
This is a shadow workflow (diagnostic). It does not change the core PULSE release-gate semantics.
