### PR TITLE
docs(gravity): add gravity record protocol inputs v0.1 spec

### DIFF
--- a/docs/gravity_record_protocol_inputs_v0_1.md
+++ b/docs/gravity_record_protocol_inputs_v0_1.md
@@ -1,0 +1,54 @@
+# Gravity Record Protocol Inputs v0.1
+
+This page defines the **raw input bundle** contract used to build a
+`gravity_record_protocol_v0_1` artifact.
+
+This is producer-facing: a pipeline, simulator, or measurement harness can emit
+this bundle and have it validated fail-closed before we build the contract artifact.
+
+## Files
+
+- Schema: `schemas/gravity_record_protocol_inputs_v0_1.schema.json`
+- Contract checker: `scripts/check_gravity_record_protocol_inputs_v0_1_contract.py`
+- Builder (raw → contract artifact): `scripts/build_gravity_record_protocol_v0_1.py`
+
+## Minimal contract
+
+Top-level:
+- `source_kind` (enum): `demo | measurement | simulation | pipeline | manual | missing`
+- `cases` (array, min 1)
+
+Each case:
+- `case_id` (string, non-empty)
+- `stations` (array, **min 2**)
+- `profiles` (object)
+
+Profiles:
+- required: `profiles.lambda`, `profiles.kappa`
+- optional: `profiles.s`, `profiles.g`
+
+Profile encoding supports two forms (to keep migration flexible):
+1) **Status form**
+   - `{ "status": "PASS|FAIL|MISSING", "points": [...] }`
+   - If `status=PASS`, `points` must be a non-empty array.
+2) **Points-only form**
+   - `{ "points": [...] }`
+   - Interpreted as `status=PASS`.
+
+Points:
+- `r`: number or non-empty string label
+- `value`: finite number
+- Constraints:
+  - lambda: `value > 0`
+  - kappa: `0 <= value <= 1`
+- Optional:
+  - `uncertainty` (>=0)
+  - `n` (>=0 integer)
+
+## Validation (local)
+
+Validate a raw bundle:
+
+```bash
+python scripts/check_gravity_record_protocol_inputs_v0_1_contract.py \
+  --in PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.raw.demo.json


### PR DESCRIPTION
## Why
We need a single, discoverable producer-facing reference for what constitutes a valid
Gravity Record Protocol v0.1 raw inputs bundle, before adding any log-format adapters.

## What changed
- Add `docs/gravity_record_protocol_inputs_v0_1.md`

## Contents
- Minimal bundle contract (top-level + per-case requirements)
- Profiles contract (lambda/kappa required; s/g optional)
- Profile encoding rules (`{status, points}` vs `{points}`)
- Point constraints and validation notes
- Example commands:
  - validate raw bundle via the fail-closed checker
  - build a contract artifact via the builder
  - contract-check + render the built artifact

## Notes
Docs-only change; no workflow or gate logic modifications in this PR.
