### PR TITLE
docs(index): add gravity record protocol inputs v0.1 entry

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -60,3 +60,4 @@ If you add/rename a doc under `docs/`, please update this index.
 - [time_as_consequence_v0_1.md](time_as_consequence_v0_1.md) — Workshop paper (v0.1): “time as consequence” via record-based operational definitions.
 - [time_as_consequence_one_pager_v0_1.md](time_as_consequence_one_pager_v0_1.md) — One-page summary (v0.1) of the record-based time framework.
 - [gravity_record_protocol_appendix_v0_1.md](gravity_record_protocol_appendix_v0_1.md) — Appendix (v0.1): gravity as a record test (λ/s/κ protocols + horizon taxonomy).
+- [gravity_record_protocol_inputs_v0_1.md](gravity_record_protocol_inputs_v0_1.md) — Inputs bundle spec (v0.1): raw producer contract for Gravity Record Protocol runs.


### PR DESCRIPTION
## Why
docs/INDEX.md is the repo’s fuller documentation index. We added the Gravity Record Protocol inputs spec,
so it should be discoverable from the index next to the other theory/protocol docs.

## What changed
- Add an entry for `docs/gravity_record_protocol_inputs_v0_1.md` under “Theory & measurement protocols (probe)”.

## Notes
Docs-only change; no schema, scripts, workflows, or release-gate semantics are modified.
