### PR TITLE
ci(gravity): add raw inputs contract check to gravity protocol shadow workflow

### DIFF
--- a/.github/workflows/gravity_record_protocol_v0_1_shadow.yml
+++ b/.github/workflows/gravity_record_protocol_v0_1_shadow.yml
@@ -6,6 +6,7 @@ on:
       - ".github/workflows/gravity_record_protocol_v0_1_shadow.yml"
       - "scripts/build_gravity_record_protocol_v0_1.py"
       - "scripts/check_gravity_record_protocol_v0_1_contract.py"
+      - "scripts/check_gravity_record_protocol_inputs_v0_1_contract.py"
       - "scripts/render_gravity_record_protocol_v0_1_md.py"
       - "scripts/test_gravity_record_protocol_v0_1_builder_fixtures.py"
       - "schemas/gravity_record_protocol_v0_1.schema.json"
@@ -17,6 +18,7 @@ on:
       - ".github/workflows/gravity_record_protocol_v0_1_shadow.yml"
       - "scripts/build_gravity_record_protocol_v0_1.py"
       - "scripts/check_gravity_record_protocol_v0_1_contract.py"
+      - "scripts/check_gravity_record_protocol_inputs_v0_1_contract.py"
       - "scripts/render_gravity_record_protocol_v0_1_md.py"
       - "scripts/test_gravity_record_protocol_v0_1_builder_fixtures.py"
       - "schemas/gravity_record_protocol_v0_1.schema.json"
@@ -56,6 +58,17 @@ jobs:
         run: |
           set +e
           python scripts/test_gravity_record_protocol_v0_1_builder_fixtures.py
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Contract check (raw inputs fixture)
+        id: raw_contract
+        shell: bash
+        run: |
+          set +e
+          python scripts/check_gravity_record_protocol_inputs_v0_1_contract.py \
+            --in PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.raw.demo.json
           code=$?
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
           exit 0
@@ -110,6 +123,7 @@ jobs:
         run: |
           echo "## Gravity Record Protocol v0.1 (shadow)" >> "$GITHUB_STEP_SUMMARY"
           echo "- builder_fixtures: exit_code=${{ steps.builder_tests.outputs.exit_code }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- raw_contract: exit_code=${{ steps.raw_contract.outputs.exit_code }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- builder: exit_code=${{ steps.build.outputs.exit_code }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- contract: exit_code=${{ steps.contract.outputs.exit_code }}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -134,6 +148,7 @@ jobs:
             schemas/gravity_record_protocol_v0_1.schema.json
             scripts/build_gravity_record_protocol_v0_1.py
             scripts/check_gravity_record_protocol_v0_1_contract.py
+            scripts/check_gravity_record_protocol_inputs_v0_1_contract.py
             scripts/render_gravity_record_protocol_v0_1_md.py
             scripts/test_gravity_record_protocol_v0_1_builder_fixtures.py
 
@@ -142,9 +157,10 @@ jobs:
         shell: bash
         run: |
           bt="${{ steps.builder_tests.outputs.exit_code }}"
+          rc="${{ steps.raw_contract.outputs.exit_code }}"
           b="${{ steps.build.outputs.exit_code }}"
           c="${{ steps.contract.outputs.exit_code }}"
-          if [ "$bt" != "0" ] || [ "$b" != "0" ] || [ "$c" != "0" ]; then
-            echo "One or more steps failed: builder_fixtures=$bt builder=$b contract=$c"
+          if [ "$bt" != "0" ] || [ "$rc" != "0" ] || [ "$b" != "0" ] || [ "$c" != "0" ]; then
+            echo "One or more steps failed: builder_fixtures=$bt raw_contract=$rc builder=$b contract=$c"
             exit 1
           fi


### PR DESCRIPTION
## Why
We now have an explicit producer-facing raw inputs contract for Gravity Record Protocol v0.1.
This workflow should enforce it before running the raw→artifact builder so upstream drift is caught early.

## What changed
- Update `.github/workflows/gravity_record_protocol_v0_1_shadow.yml` to run:
  - `scripts/check_gravity_record_protocol_inputs_v0_1_contract.py`
  against the tracked raw fixture before invoking the builder.

## Notes
Shadow-only CI wiring; no core release-gate semantics are modified.
