### PR TITLE
fix(schema): forbid status in points-only gravity inputs profiles

### DIFF
--- a/schemas/gravity_record_protocol_inputs_v0_1.schema.json
+++ b/schemas/gravity_record_protocol_inputs_v0_1.schema.json
@@ -129,6 +129,7 @@
       "additionalProperties": true,
       "required": ["points"],
       "properties": {
+        "status": false,
         "points": {
           "type": "array",
           "minItems": 1,
@@ -176,6 +177,7 @@
       "additionalProperties": true,
       "required": ["points"],
       "properties": {
+        "status": false,
         "points": {
           "type": "array",
           "minItems": 1,
@@ -223,6 +225,7 @@
       "additionalProperties": true,
       "required": ["points"],
       "properties": {
+        "status": false,
         "points": {
           "type": "array",
           "minItems": 1,


### PR DESCRIPTION
## Why
The Gravity Record Protocol inputs contract supports two profile encodings:
- `{ status, points }`
- `{ points }` (points-only)

The schema previously allowed a `status` field in the points-only branch (due to `additionalProperties: true`),
which could let invalid `status` values pass validation by matching the points-only alternative.

## What changed
- Disallow `status` in the points-only profile variants (lambda/kappa, and scalar if present) by setting:
  - `properties.status: false`

## Result
- Any profile object that includes `status` must validate via the `{status, points}` branch,
  so invalid enum values cannot slip through.

## Notes
Schema-only change; no workflow or gate semantics changes.
