### PR TITLE
fix(contract): enforce unique station_id in gravity inputs v0.1 checker

### DIFF
--- a/scripts/check_gravity_record_protocol_inputs_v0_1_contract.py
+++ b/scripts/check_gravity_record_protocol_inputs_v0_1_contract.py
@@ -224,8 +224,21 @@ def _check_case(case: Any, idx: int, errors: List[str]) -> None:
     else:
         if len(stations) < 2:
             errors.append(f"{path}.stations: must contain at least 2 stations")
+
+        seen_ids: set[str] = set()
         for i, st in enumerate(stations):
-            _check_station(st, f"{path}.stations[{i}]", errors)
+            sp = f"{path}.stations[{i}]"
+            _check_station(st, sp, errors)
+
+            # Enforce per-case station_id uniqueness (align with downstream artifact contract)
+            if isinstance(st, dict):
+                sid = st.get("station_id")
+                if isinstance(sid, str) and sid.strip():
+                    sid_norm = sid.strip()
+                    if sid_norm in seen_ids:
+                        errors.append(f"{sp}.station_id: duplicate station_id '{sid_norm}'")
+                    else:
+                        seen_ids.add(sid_norm)
 
     profs = case.get("profiles")
     if not isinstance(profs, dict):


### PR DESCRIPTION
## Why
The Gravity Record Protocol inputs checker should catch producer-side errors before the builder runs.
Duplicate `station_id` values currently pass inputs validation but fail later in the artifact contract check,
which defeats the purpose of the raw-input gate.

## What changed
- Enforce per-case `station_id` uniqueness in
  `scripts/check_gravity_record_protocol_inputs_v0_1_contract.py`

## Notes
This is a contract-checker tightening to match downstream invariants.
No workflow or release-gate semantics are changed.
