### PR TITLE
fix(gravity): emit missing required profiles as MISSING in inputs builder

### DIFF
--- a/scripts/build_gravity_record_protocol_inputs_v0_1.py
+++ b/scripts/build_gravity_record_protocol_inputs_v0_1.py
@@ -254,11 +254,19 @@ def main() -> int:
         stations = [stations_map[k] for k in sorted(stations_map.keys())]
 
         profiles_out: Dict[str, Any] = {}
+        required_profiles = {"lambda", "kappa"}
+
         for prof in ("lambda", "kappa", "s", "g"):
             pts = prof_map.get(prof) or []
             pts_sorted = sorted(pts, key=lambda p: _r_sort_key(p.get("r")))
+
             if pts_sorted:
+                # points-only encoding (implied PASS)
                 profiles_out[prof] = {"points": pts_sorted}
+            elif prof in required_profiles:
+                # required profiles must always be present; represent missing measurement explicitly
+                profiles_out[prof] = {"status": "MISSING", "points": None}
+            # optional profiles (s/g): omit if no points
 
         case_list.append(
             {


### PR DESCRIPTION
## Why
`gravity_record_protocol_inputs_v0_1` requires both `profiles.lambda` and `profiles.kappa` per case.
The builder previously omitted required profiles when no points were present, which could yield a
contract-invalid bundle while still returning exit code 0.

## What changed
- Update `scripts/build_gravity_record_protocol_inputs_v0_1.py` to always emit required profiles:
  - points present → points-only encoding `{ "points": [...] }`
  - points absent → explicit missing encoding `{ "status": "MISSING", "points": null }`

## Result
- The builder can no longer succeed (rc=0) while producing a bundle that fails the inputs contract.
- Missing measurements are represented explicitly and remain contract-valid.

## Notes
Builder-only behavioral fix. Contract enforcement remains the source of truth via the inputs checker.
