### PR TITLE
docs(spec): clarify builder exit-code semantics for gravity_record_protocol_inputs_v0_1

### DIFF
--- a/docs/gravity_record_protocol_inputs_v0_1.md
+++ b/docs/gravity_record_protocol_inputs_v0_1.md
@@ -165,18 +165,22 @@ If a required profile has no points in the rawlog, the builder emits an explicit
 {"status":"MISSING","points":null}
 ```
 
-This ensures the builder cannot exit successfully while producing a contract-invalid bundle
-with missing required profile keys.
+This representation prevents “missing required profile key” failures by emitting required profile objects explicitly (`status: "MISSING"`, `points: null`) instead of omitting the profile object entirely.
 
 ---
 
-## Fail-closed behavior
+## Fail-closed behavior (builder)
 
-The builder always attempts to write the output JSON.
+The builder always attempts to write a JSON output bundle (even when the input is malformed), and records producer-facing issues under `raw_errors`.
 
 Exit codes:
-- `0` → bundle written and no `raw_errors`
-- `2` → bundle written but `raw_errors` present (contract/protocol violations or malformed rawlog)
+- `0` → bundle written **and** `raw_errors` is empty
+- `2` → bundle written **and** `raw_errors` is non-empty
 
-When `raw_errors` exist, the bundle is intended for triage (inspect errors) rather than downstream use.
+Important: the builder is **not** a full contract validator.  
+An exit code of `0` means the raw→bundle transformation did not record producer errors, but it does **not** guarantee the output bundle satisfies the full `gravity_record_protocol_inputs_v0_1` contract (e.g. non-empty `cases`, required profiles, etc.).
+
+For contract enforcement, always run:
+- `python scripts/check_gravity_record_protocol_inputs_v0_1_contract.py --in <bundle.json>`
+
 


### PR DESCRIPTION
## Why
The docs implied that the builder’s exit code (`rc=2`) covers all contract/protocol violations. In reality, the builder does not run full schema/contract validation and can still emit contract-invalid bundles without `raw_errors` in some edge cases.

## What changed
- Clarify builder exit codes as `raw_errors` signaling only.
- Add an explicit note that full enforcement requires running `check_gravity_record_protocol_inputs_v0_1_contract.py`.
- Normalize the missing-status example to `MISSING` (English, contract-consistent).

## Notes
Docs-only change. No schema, scripts, workflows, or release-gate semantics are modified.
