### PR TITLE
ci(workflow): wire gravity protocol inputs fixtures into shadow pipeline

### DIFF
--- a/.github/workflows/gravity_record_protocol_v0_1_shadow.yml
+++ b/.github/workflows/gravity_record_protocol_v0_1_shadow.yml
@@ -8,10 +8,14 @@ on:
       - "scripts/check_gravity_record_protocol_v0_1_contract.py"
       - "scripts/check_gravity_record_protocol_inputs_v0_1_contract.py"
       - "scripts/test_gravity_record_protocol_inputs_v0_1_contract_fixtures.py"
+      - "scripts/build_gravity_record_protocol_inputs_v0_1.py"
+      - "scripts/test_gravity_record_protocol_inputs_v0_1_builder_fixtures.py"
       - "scripts/render_gravity_record_protocol_v0_1_md.py"
       - "scripts/test_gravity_record_protocol_v0_1_builder_fixtures.py"
       - "schemas/gravity_record_protocol_v0_1.schema.json"
+      - "schemas/gravity_record_protocol_inputs_v0_1.schema.json"
       - "PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.raw.demo.json"
+      - "PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.rawlog.demo.jsonl"
       - "PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.demo.json"
   push:
     branches: ["main"]
@@ -21,10 +25,14 @@ on:
       - "scripts/check_gravity_record_protocol_v0_1_contract.py"
       - "scripts/check_gravity_record_protocol_inputs_v0_1_contract.py"
       - "scripts/test_gravity_record_protocol_inputs_v0_1_contract_fixtures.py"
+      - "scripts/build_gravity_record_protocol_inputs_v0_1.py"
+      - "scripts/test_gravity_record_protocol_inputs_v0_1_builder_fixtures.py"
       - "scripts/render_gravity_record_protocol_v0_1_md.py"
       - "scripts/test_gravity_record_protocol_v0_1_builder_fixtures.py"
       - "schemas/gravity_record_protocol_v0_1.schema.json"
+      - "schemas/gravity_record_protocol_inputs_v0_1.schema.json"
       - "PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.raw.demo.json"
+      - "PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.rawlog.demo.jsonl"
       - "PULSE_safe_pack_v0/fixtures/gravity_record_protocol_v0_1.demo.json"
   workflow_dispatch:
 
@@ -53,6 +61,16 @@ jobs:
         shell: bash
         run: |
           python -m pip install --disable-pip-version-check "jsonschema==4.23.0"
+
+      - name: Run inputs contract fixtures (gravity_record_protocol_inputs_v0_1)
+        shell: bash
+        run: |
+          python scripts/test_gravity_record_protocol_inputs_v0_1_contract_fixtures.py
+
+      - name: Run inputs builder fixtures (rawlog -> inputs bundle)
+        shell: bash
+        run: |
+          python scripts/test_gravity_record_protocol_inputs_v0_1_builder_fixtures.py
 
       - name: Builder fixtures (golden)
         id: builder_tests


### PR DESCRIPTION
## Why
We added a producer-facing inputs contract for `gravity_record_protocol_inputs_v0_1`, including regression fixtures, but the new fixture suites were not executed by CI. This PR wires them into the existing shadow workflow so contract drift cannot land silently.

## What changed
- Run `scripts/test_gravity_record_protocol_inputs_v0_1_contract_fixtures.py` in the gravity shadow workflow.
- Run `scripts/test_gravity_record_protocol_inputs_v0_1_builder_fixtures.py` in the gravity shadow workflow.
- Extend workflow path filters to include the inputs schema and the new fixture entrypoints, so schema-only edits still trigger CI.

## How to test
- Open a PR that changes the inputs schema or checker and verify the "gravity record protocol v0.1 (shadow)" workflow runs and executes both fixture suites.
- Locally (optional):
  - `python scripts/test_gravity_record_protocol_inputs_v0_1_contract_fixtures.py`
  - `python scripts/test_gravity_record_protocol_inputs_v0_1_builder_fixtures.py`

## Notes
This is CI wiring only. No release-gate semantics are changed.
