### PR TITLE
ci: run PULSE CI on version tags (v*/V*)

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -3,9 +3,7 @@ name: PULSE CI
 on:
   push:
     branches: [main]
-    tags:
-      - "v*"
-      - "V*"
+    tags: ["v*", "V*"]
     paths-ignore:
       - "docs/**"
       - "**/*.md"


### PR DESCRIPTION
Problem
Currently pulse_ci.yml runs on pushes to main and on PRs, but not on tag pushes. This leaves a gap where a tagged release can exist without the gating workflow running.

Change

Add on.push.tags: ["v*", "V*"] to pulse_ci.yml.

Why it’s safe

No changes to gating semantics or tool execution order; only the trigger matrix expands.

How to validate

Push a test tag (e.g. v0.0.0-ci-smoke) and confirm a workflow run appears for the tag ref.

Risk

Low. Potentially more workflow runs (only when tags are pushed).