### PR TITLE
ci: forbid demo status on version tags

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -537,6 +537,37 @@ jobs:
             --thresholds "$THRESH" \
             --external_dir "$EXT_DIR"
 
+      - name: "ci: forbid demo status on version tags"
+        if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V')
+        shell: bash
+        run: |
+          set -euo pipefail
+          STATUS="${{ env.PACK_DIR }}/artifacts/status.json"
+          if [ ! -f "$STATUS" ]; then
+            echo "::error::status.json not found at $STATUS"
+            exit 1
+          fi
+
+          export STATUS
+          python - <<'PY'
+          import json, os, sys
+
+          p = os.environ["STATUS"]
+          try:
+            with open(p, "r", encoding="utf-8") as f:
+              s = json.load(f)
+          except Exception as e:
+            print(f"::error::failed to parse status.json: {e}")
+            sys.exit(1)
+
+          v = str(s.get("version", ""))
+          if "demo" in v.lower():
+            print(f"::error::demo status.version is not allowed on version tags: {v}")
+            sys.exit(1)
+
+          print(f"OK: non-demo status.version on tag: {v}")
+          PY
+
       - name: Gate registry sync check
         shell: bash
         run: |


### PR DESCRIPTION
Problem
The safe-pack currently produces a demo status (status.json.version contains demo).
Now that version tags run CI, we must prevent demo outputs from being interpreted as release-gating results.

Change

Add a tag-only guard to pulse_ci.yml that fails if status.json.version includes demo.

Expected behavior

push to refs/tags/v* or refs/tags/V* fails with a clear error until a non-demo production status is produced.

PR and main branch behavior is unchanged.

How to validate

Create and push a test tag (v0.0.0-tag-guard) and confirm the workflow fails with the “demo status.version not allowed” error.