### PR TITLE
ci: enforce required gates from policy in PULSE CI

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -566,7 +566,8 @@ jobs:
           print(f"OK: non-demo status.version on tag: {v}")
           PY
 
-      - name: ci: enforce gates via check_gates (policy-derived)
+      - name: "ci: enforce gates via check_gates (policy-derived)"
+
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
Problem
The repo declares check_gates.py as normative source-of-truth for release decisions, but the CI workflow does not consistently enforce the full policy-derived required gate set (only a manual strict external-evidence path is present).
This risks “green CI” while required gates are not actually fail-closed enforced.

Change

Add a dedicated CI step that:

reads pulse_gate_policy_v0.yml and derives policy.gates.required,

runs PULSE_safe_pack_v0/tools/check_gates.py on the augmented status.json with that required list.

Why this is safe

Uses existing policy as the single source of truth.

No gate semantics are redefined in the workflow; it only enforces what the policy already declares.

How to validate

Temporarily flip one required gate to false in the generated status.json (or in the demo gate map) and confirm CI fails with [X] FAIL gates:.

Temporarily delete a required gate key and confirm CI fails with [X] Missing required gates:.