### PR TITLE
fix(ci): use repo-root gate policy for pack run and refusal-delta

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -303,7 +303,7 @@ jobs:
 
           python "${{ env.PACK_DIR }}/tools/run_all.py" \
             --pack_dir "${{ env.PACK_DIR }}" \
-            --gate_policy "${{ env.PACK_DIR }}/pulse_gate_policy_v0.yml"
+            --gate_policy "$GITHUB_WORKSPACE/pulse_gate_policy_v0.yml"
 
       - name: Show main status.json (head)
         if: always()
@@ -435,7 +435,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          POLICY="${{ env.PACK_DIR }}/pulse_gate_policy_v0.yml"
+          POLICY="$GITHUB_WORKSPACE/pulse_gate_policy_v0.yml"
           PAIRS_SCRIPT="${{ env.PACK_DIR }}/tools/policy_to_refusal_pairs.py"
           RD="${{ env.PACK_DIR }}/tools/refusal_delta.py"
           POL="${{ env.PACK_DIR }}/profiles/pulse_policy.yaml"
@@ -472,6 +472,7 @@ jobs:
           echo "----- refusal_delta_summary.json -----"
           cat "${{ env.PACK_DIR }}/artifacts/refusal_delta_summary.json" || true
           echo "-------------------------------------"
+
       - name: "Strict external evidence: require external summaries present (pre-augment, fail-closed)"
         if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') }}
         shell: bash
@@ -567,7 +568,6 @@ jobs:
           PY
 
       - name: "ci: enforce gates via check_gates (policy-derived)"
-
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
Context / Problem
refusal_delta_pass can fail when augment_status.py is fail-closed and the CI did not generate refusal_delta_summary.json. One common cause is policy path drift: some steps referenced pulse_gate_policy_v0.yml under the pack directory instead of the canonical repo-root policy.

Change

Update run_all.py invocation to pass --gate_policy from repo root ($GITHUB_WORKSPACE/pulse_gate_policy_v0.yml).

Update refusal-delta step to read policy from repo root ($GITHUB_WORKSPACE/pulse_gate_policy_v0.yml).

Expected outcome

refusal-delta pair derivation becomes deterministic (no path drift).

refusal_delta_summary.json is generated when pairs exist.

refusal_delta_pass no longer fails due to missing refusal-delta artifacts.

How to validate

CI log should show refusal-delta summary step running (or explicitly skipping only when pairs are empty).

PULSE_safe_pack_v0/artifacts/refusal_delta_summary.json should exist in the uploaded artifacts when pairs exist.

check_gates.py should no longer fail on refusal_delta_pass due solely to missing summary.