### PR TITLE
fix(ci): enforce core_required on branches; required on version tags

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -578,11 +578,14 @@ jobs:
             exit 1
           fi
 
-          # PR -> core_required, everything else -> required
+          # Default: core_required for branch builds (keeps CI deterministic while optional signals mature)
+           POLICY_SET="core_required"
+
+          # Version tags: enforce full required gate set (release-grade, fail-closed)
+          if [[ "${GITHUB_REF}" == refs/tags/v* || "${GITHUB_REF}" == refs/tags/V* ]]; then
           POLICY_SET="required"
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            POLICY_SET="core_required"
           fi
+
 
           # Canonical helper (fail-closed, no PyYAML dependency)
           REQ_STR="$(python tools/policy_to_require_args.py --policy pulse_gate_policy_v0.yml --set "$POLICY_SET" --format space)"


### PR DESCRIPTION
Problem
CI currently enforces the full required gate set on branch pushes. required includes refusal_delta_pass, which can be legitimately false while refusal-delta remains a maturing / non-fixture signal, causing main to stay red and blocking iterative stabilization.

Change

Switch branch/push enforcement to core_required.

Keep full required enforcement on version tags (v*/V*) for release-grade fail-closed gating.

Expected outcome

Main branch CI becomes green again (core deterministic gates still enforced).

Release/tag builds remain strict (full required set).