### PR TITLE
fix(ci): enforce required gates on strict workflow_dispatch runs

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -578,14 +578,21 @@ jobs:
             exit 1
           fi
 
-          # Default: core_required for branch builds (keeps CI deterministic while optional signals mature)
-           POLICY_SET="core_required"
+          # Default: core_required for branch builds
+          POLICY_SET="core_required"
 
           # Version tags: enforce full required gate set (release-grade, fail-closed)
-          if [[ "${GITHUB_REF}" == refs/tags/v* || "${GITHUB_REF}" == refs/tags/V* ]]; then
-          POLICY_SET="required"
+          if [[ "${GITHUB_REF:-}" == refs/tags/v* || "${GITHUB_REF:-}" == refs/tags/V* ]]; then
+            POLICY_SET="required"
           fi
 
+          # Manual strict runs should behave like release-grade gating too
+          if [[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]]; then
+            STRICT="$(jq -r '.inputs.strict_external_evidence // "false"' "$GITHUB_EVENT_PATH")"
+            if [[ "$STRICT" == "true" ]]; then
+              POLICY_SET="required"
+            fi
+          fi
 
           # Canonical helper (fail-closed, no PyYAML dependency)
           REQ_STR="$(python tools/policy_to_require_args.py --policy pulse_gate_policy_v0.yml --set "$POLICY_SET" --format space)"
@@ -602,6 +609,7 @@ jobs:
           python "${{ env.PACK_DIR }}/tools/check_gates.py" \
             --status "$STATUS" \
             --require "${REQ[@]}"
+  
 
       - name: Gate registry sync check
         shell: bash


### PR DESCRIPTION
Problem
After switching branch builds to core_required, a manual workflow_dispatch run with strict_external_evidence=true no longer enforces the full required gate set (e.g. external_all_pass). This weakens the intended fail-closed, release-grade manual verification path.

Change

Select policy gate set as follows:

default: core_required (branch builds)

version tags (v*/V*): required

workflow_dispatch with strict_external_evidence=true: required

Why
This preserves fast iteration on branches while restoring strict manual runs as release-grade enforcement.

Validation

Run workflow_dispatch with strict_external_evidence=true and confirm logs show POLICY_SET=required.

Confirm check_gates.py enforces gates from policy.gates.required including external_all_pass.