### PR TITLE
fix(ci): require refusal-delta summary on release-grade runs

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -435,65 +435,84 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Tag build? -> refusal-delta must be computed if pairs exist (fail-closed).
-          IS_TAG=0
+          # Release-grade runs:
+          # - version tags (v*/V*)
+          # - workflow_dispatch with strict_external_evidence=true
+          IS_RELEASE=0
           if [[ "${GITHUB_REF:-}" == refs/tags/v* || "${GITHUB_REF:-}" == refs/tags/V* ]]; then
-            IS_TAG=1
+            IS_RELEASE=1
+          fi
+          if [[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]]; then
+            STRICT="$(jq -r '.inputs.strict_external_evidence // "false"' "$GITHUB_EVENT_PATH")"
+            if [[ "$STRICT" == "true" ]]; then
+              IS_RELEASE=1
+            fi
           fi
 
-          # Canonical locations
           POLICY="${GITHUB_WORKSPACE}/pulse_gate_policy_v0.yml"
           PAIRS_SCRIPT="${{ env.PACK_DIR }}/tools/policy_to_refusal_pairs.py"
           RD="${{ env.PACK_DIR }}/tools/refusal_delta.py"
-          POL="${{ env.PACK_DIR }}/profiles/pulse_policy.yaml"
+          POLCFG="${{ env.PACK_DIR }}/profiles/pulse_policy.yaml"
 
           OUT="${{ env.PACK_DIR }}/artifacts/refusal_delta_summary.json"
           PAIRS_FILE="${{ env.PACK_DIR }}/examples/refusal_pairs.jsonl"
 
           if [ ! -f "$RD" ]; then
+            if (( IS_RELEASE )); then
+              echo "::error::refusal_delta.py not found at $RD"
+              exit 1
+            fi
             echo "::warning::refusal_delta.py not found at $RD; skipping refusal-delta."
             exit 0
           fi
 
-          # 1) Try to derive pairs from policy (if helper exists)
+          if [ ! -f "$POLCFG" ]; then
+            if (( IS_RELEASE )); then
+              echo "::error::policy config not found at $POLCFG"
+              exit 1
+            fi
+            echo "::warning::policy config not found at $POLCFG; skipping refusal-delta."
+            exit 0
+          fi
+
+          # 1) Try to derive pairs from policy (preferred if available)
           PAIRS=""
           if [ -f "$PAIRS_SCRIPT" ] && [ -f "$POLICY" ]; then
             PAIRS="$(python "$PAIRS_SCRIPT" --policy "$POLICY" || true)"
           fi
 
-          # 2) Fallback: if the pack ships a pairs file, use it as pairs source-of-truth
+          # 2) Fallback: if the pack ships a pairs file, use it
           if [[ -z "${PAIRS}" && -f "$PAIRS_FILE" ]]; then
-            echo "::notice::policy_to_refusal_pairs returned empty; using pairs file: $PAIRS_FILE"
+            echo "::notice::policy-derived pairs empty; using pairs file: $PAIRS_FILE"
             PAIRS="$PAIRS_FILE"
           fi
 
-          # 3) If still no pairs: tag => fail, branch => skip
+          # 3) If still no pairs: release-grade => fail, otherwise => skip
           if [[ -z "${PAIRS}" ]]; then
-            if (( IS_TAG )); then
-              echo "::error::refusal-delta pairs are required on version tags, but no pairs source was found."
-              echo "::error::Expected either:"
-              echo "::error::- non-empty output from $PAIRS_SCRIPT (policy: $POLICY)"
-              echo "::error::- or an existing pairs file at $PAIRS_FILE"
+            if (( IS_RELEASE )); then
+              echo "::error::refusal-delta pairs are required on release-grade runs, but no pairs source was found."
+              echo "::error::Expected either non-empty output from $PAIRS_SCRIPT (policy: $POLICY) or file $PAIRS_FILE"
               exit 1
             fi
             echo "::warning::No refusal-delta pairs available; skipping refusal-delta summary."
             exit 0
           fi
 
-          # 4) Compute summary (deterministic, local)
+          # 4) Compute summary
           python "$RD" \
             --pairs "$PAIRS" \
             --out "$OUT" \
-            --policy_config "$POL"
+            --policy_config "$POLCFG"
 
-          # 5) Postcondition: summary must exist on tags (fail-closed)
+          # 5) Postcondition: summary must exist on release-grade runs (fail-closed)
           if [ ! -f "$OUT" ]; then
-            if (( IS_TAG )); then
+            if (( IS_RELEASE )); then
               echo "::error::refusal_delta_summary.json was not created at $OUT"
               exit 1
             fi
-            echo "::warning::refusal_delta_summary.json missing after refusal-delta run; augment_status may fail-closed."
+            echo "::warning::refusal_delta_summary.json missing after refusal-delta run."
           fi
+   
     
 
       - name: Show refusal-delta summary


### PR DESCRIPTION
Problem
augment_status.py sets refusal_delta_pass fail-closed when examples/refusal_pairs.jsonl exists but artifacts/refusal_delta_summary.json is missing. This can happen when refusal-delta computation silently skips due to empty pair derivation.
Since refusal_delta_pass is in the policy required set, release-grade enforcement (tags/strict) fails.

Change

Make refusal-delta summary generation deterministic:

derive pairs from policy when possible,

fallback to PULSE_safe_pack_v0/examples/refusal_pairs.jsonl when present,

on release-grade runs (version tags, strict workflow_dispatch): fail-closed if pairs are missing or summary is not created.

Expected outcome

No more “silent skip” → refusal_delta_pass reflects computed summary rather than missing-artifact fail-closed.