### PR TITLE
feat(ci): schema-validate status.json after augmentation

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -279,6 +279,7 @@ jobs:
           set -euo pipefail
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
+          python -m pip install jsonschema
 
       - name: Prepare pack dir (workspace)
         shell: bash
@@ -586,6 +587,50 @@ jobs:
             --status "$STATUS" \
             --thresholds "$THRESH" \
             --external_dir "$EXT_DIR"
+     
+      - name: "ci: schema validate status.json (status_v1)"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          STATUS="${{ env.PACK_DIR }}/artifacts/status.json"
+          SCHEMA="schemas/status/status_v1.schema.json"
+
+          if [ ! -f "$STATUS" ]; then
+            echo "::error::status.json not found at $STATUS"
+            exit 1
+          fi
+          if [ ! -f "$SCHEMA" ]; then
+            echo "::error::status schema not found at $SCHEMA"
+            exit 1
+          fi
+
+          python - <<'PY'
+          import json, sys
+          from jsonschema import Draft202012Validator
+
+          schema_path = "schemas/status/status_v1.schema.json"
+          status_path = "PULSE_safe_pack_v0/artifacts/status.json"
+
+          with open(schema_path, "r", encoding="utf-8") as f:
+              schema = json.load(f)
+
+          Draft202012Validator.check_schema(schema)
+          v = Draft202012Validator(schema)
+
+          with open(status_path, "r", encoding="utf-8") as f:
+              inst = json.load(f)
+
+          errors = sorted(v.iter_errors(inst), key=lambda e: (list(e.path), e.message))
+          if errors:
+              print("::error::status.json schema validation failed:")
+              for e in errors[:50]:
+                  path = ".".join([str(p) for p in e.path]) or "<root>"
+                  print(f"::error::{path}: {e.message}")
+              sys.exit(1)
+
+          print("OK: status.json is schema-valid (status_v1)")
+          PY
 
       - name: "ci: forbid demo status on version tags"
         if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V')


### PR DESCRIPTION
Problem
status.json is the critical artifact across the release-gating pipeline (run → augment → enforce). Without CI schema validation, contract drift can silently break enforcement/export/ledger while CI appears green.

Change

Add python -m pip install jsonschema to the PULSE CI dependency install step.

Add a new step after Augment status (external + top-level flags) that validates PULSE_safe_pack_v0/artifacts/status.json against schemas/status/status_v1.schema.json (fail-closed).

Step name is quoted to avoid YAML : parsing issues.

Why after augmentation
The enforced decision should validate the final status artifact (including refusal-delta/external fields), not the pre-augment baseline.

How to validate

CI logs should include: OK: status.json is schema-valid (status_v1)

If contract breaks, CI should fail with ::error::... schema validation failed showing the offending JSON path(s).

Acceptance criteria

jsonschema is installed in CI.

Schema validation step runs after augmentation and fails the job on validation errors.

Merge szöveg (squash)