### PR TITLE
fix(pack): validate PULSE_RUN_MODE default for run_all --mode

### DIFF
--- a/PULSE_safe_pack_v0/tools/run_all.py
+++ b/PULSE_safe_pack_v0/tools/run_all.py
@@ -33,6 +33,9 @@ now = datetime.datetime.utcnow().isoformat() + "Z"
 import argparse
 import hashlib
 
+SUPPORTED_MODES = ("demo", "core", "prod")
+
+
 def _sha256_file(p: pathlib.Path) -> str | None:
     try:
         h = hashlib.sha256()
@@ -43,16 +46,8 @@ def _sha256_file(p: pathlib.Path) -> str | None:
     except Exception:
         return None
 
-parser = argparse.ArgumentParser(add_help=True)
-parser.add_argument(
-    "--mode",
-    type=str.lower,
-    choices=list(SUPPORTED_MODES),
-    default=_default_mode,
-    help="Run profile: demo|core|prod (default: PULSE_RUN_MODE or demo)"
-)
 
-SUPPORTED_MODES = ("demo", "core", "prod")
+parser = argparse.ArgumentParser(add_help=True)
 
 _env_raw = os.getenv("PULSE_RUN_MODE")
 _env_mode = _env_raw.strip().lower() if isinstance(_env_raw, str) and _env_raw.strip() else None
@@ -64,10 +59,19 @@ if _env_mode is not None and _env_mode not in SUPPORTED_MODES:
 
 _default_mode = _env_mode or "demo"
 
+parser.add_argument(
+    "--mode",
+    type=str.lower,
+    choices=list(SUPPORTED_MODES),
+    default=_default_mode,
+    help="Run profile: demo|core|prod (default: PULSE_RUN_MODE or demo)",
+)
+
 # Accept existing workflow args (may be used for provenance even if pack is self-contained)
 parser.add_argument("--pack_dir", default=str(ROOT))
 parser.add_argument("--gate_policy", default=str(REPO_ROOT / "pulse_gate_policy_v0.yml"))
 args, _unknown = parser.parse_known_args()
+
 
 RUN_MODE = str(args.mode).strip().lower()
 if RUN_MODE == "demo":


### PR DESCRIPTION
Why
argparse does not validate default values against choices. If PULSE_RUN_MODE is set to an unsupported value, run_all.py can emit an invalid/incorrect metrics.run_mode and downstream checks may fail in a confusing way.

What

Validate PULSE_RUN_MODE immediately after parser creation.

Normalize env/CLI mode to lowercase (type=str.lower).

Fail fast via parser.error(...) on invalid env values.

Result
Misconfigured environments are detected deterministically and early; release-grade classification remains stable.