### PR TITLE
feat(schema): require metrics.run_mode in status v1

### DIFF
--- a/schemas/status/status_v1.schema.json
+++ b/schemas/status/status_v1.schema.json
@@ -15,6 +15,10 @@
 
     "metrics": {
       "type": "object",
+      "required": ["run_mode"],
+      "properties": {
+        "run_mode": { "type": "string", "enum": ["demo", "core", "prod"] }
+      },
       "additionalProperties": true
     },
 


### PR DESCRIPTION
What
Tighten schemas/status/status_v1.schema.json by requiring metrics.run_mode and validating it as demo|core|prod.

Why
run_mode is now a critical contract signal used for CI classification and release-grade behavior. Schema-level enforcement prevents silent regressions where the field disappears or becomes invalid.

Acceptance criteria

CI schema validation passes on the augmented status.json.

metrics.run_mode is present and one of demo/core/prod.