### PR TITLE
test(ci): wire run_all run_mode contract test into tools-tests

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1080,7 +1080,9 @@ jobs:
             "tests/test_tools_governance_smoke.py"
             "tests/test_check_external_summaries_present.py"
             "tests/test_augment_status_smoke.py"
+            "tests/test_run_all_mode_contract.py"
           )
+      
 
           echo "Fail-fast: py_compile smoke scripts"
           python -m py_compile "${tests[@]}"


### PR DESCRIPTION
What changed
This PR adds tests/test_run_all_mode_contract.py to the tools-tests job test list in .github/workflows/pulse_ci.yml, so it runs as part of the CI smoke suite.

Why
metrics.run_mode is now a contract-critical field used to separate smoke runs (demo/core) from release-grade runs (prod). Wiring this test into CI prevents silent regressions where:

run_all.py stops emitting metrics.run_mode,

the value drifts outside demo|core|prod,

invalid PULSE_RUN_MODE is accepted and produces an invalid status artifact.

How to validate

CI tools-tests job runs and remains green.

The job logs show tests/test_run_all_mode_contract.py executed in the per-test loop.