### PR TITLE
feat(ci): add pack layout preflight step to workflow

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -296,6 +296,29 @@ jobs:
           fi
 
           echo "PACK_DIR=$PACK_DIR"
+      - name: CI pack layout preflight (fail-closed on release-grade)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          IS_RELEASE=0
+          if [[ "${GITHUB_REF:-}" == refs/tags/v* || "${GITHUB_REF:-}" == refs/tags/V* ]]; then
+            IS_RELEASE=1
+          fi
+
+          if [[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]]; then
+            STRICT="$(jq -r '.inputs.strict_external_evidence // "false"' "$GITHUB_EVENT_PATH")"
+            if [[ "$STRICT" == "true" ]]; then
+              IS_RELEASE=1
+            fi
+          fi
+
+          EXTRA=()
+          if (( IS_RELEASE )); then
+            EXTRA+=(--release-grade)
+          fi
+
+          python tools/check_pack_layout.py --pack_dir "${{ env.PACK_DIR }}" "${EXTRA[@]}"
 
       - name: Run pack gating pipeline
         shell: bash


### PR DESCRIPTION
What changed
This PR adds a CI preflight step in .github/workflows/pulse_ci.yml to validate the safe-pack/repo layout before running the gating pipeline.

Why
Critical-path failures caused by missing policy/schema/tools should fail early and loudly, not later via partial execution or silent skips. This improves determinism and reduces pack-layout drift.

Behavior

Always runs: python tools/check_pack_layout.py --pack_dir "${{ env.PACK_DIR }}"

Release-grade runs (tags v*|V* or workflow_dispatch with strict_external_evidence=true) additionally pass --release-grade to enforce fail-closed requirements.

Acceptance criteria

CI remains green on main/PR runs when required files exist.

On a release-grade run with a missing required tool/pairs source, the workflow fails early with a clear ::error:: message.