### PR TITLE
test(ci): run safe-pack compile smoke test in tools-tests

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1104,6 +1104,7 @@ jobs:
             "tests/test_check_external_summaries_present.py"
             "tests/test_augment_status_smoke.py"
             "tests/test_run_all_mode_contract.py"
+            "tests/test_pack_tools_compile.py"
           )
       
 


### PR DESCRIPTION
What changed
Wire tests/test_pack_tools_compile.py into the tools-tests job so CI compiles critical safe-pack scripts on every run.

Why
This prevents runtime failures caused by indentation/syntax/import errors in safe-pack tools used by the snapshot pipeline.