### PR TITLE
ci: require changelog for status schema changes

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -253,6 +253,7 @@ jobs:
               key = Path(p).stem.replace(".", " ").replace("_", " ").lower()
               if key not in unrel_l:
                 missing.append((p, f"missing '{key}' mention in Unreleased"))
+
               
               elif p.startswith("schemas/status/") and p.endswith(".json"):
               key = Path(p).stem.replace(".", " ").replace("_", " ").lower()


### PR DESCRIPTION
Problem
Status schema updates change the meaning of release-gating outputs, but the CI semantic-change guard did not require changelog coverage for schemas/status/* modifications.

Change

Treat schemas/status/ changes as semantic.

Require an Unreleased changelog mention derived from the schema filename (e.g. status v1 schema).

How to validate

A PR that changes schemas/status/status_v1.schema.json without updating docs/policy/CHANGELOG.md should fail.

Adding an Unreleased entry containing status v1 schema should pass.