### PR TITLE
docs(status): fix formatting and align docs to status_v1 schema

### DIFF
--- a/docs/status_json.md
+++ b/docs/status_json.md
@@ -1,193 +1,307 @@
-## The PULSE status artefact (`status.json`)
+# The PULSE status artefact (`status.json`)
 
 PULSE safe-packs produce a single machine-readable status artefact for each CI run:
 
-- `artifacts/status.json`
+```
+PULSE_safe_pack_v0/artifacts/status.json
+```
 
 This file is the central place where all gate-relevant information is collected. It is:
 
 - written by PULSE tools during the safe-pack run,
 - consumed by other tools (e.g. `augment_status.py`, `check_gates.py`),
-- and used as input for human-readable reports such as the Quality Ledger.
+- used as input for human-readable reports such as the Quality Ledger and snapshot renderers.
 
-A single `status.json` corresponds to exactly one release candidate (model or service
-configuration) and one concrete CI run.
+A single `status.json` corresponds to exactly one release candidate (model/service configuration) and one concrete CI run.
 
 ---
 
-### High-level structure
+## Source of truth
 
-At a high level, `status.json` is a JSON object with three main sections:
+The canonical contract for `status.json` is the JSON Schema:
 
-- release-level metadata (optional, but recommended),
+```
+schemas/status/status_v1.schema.json
+```
+
+CI validates produced artefacts using:
+
+```
+tools/validate_status_schema.py
+```
+
+In:
+
+```
+.github/workflows/pulse_ci.yml
+```
+
+Steps named like:
+
+```
+ci: schema validate status.json (status_v1)
+```
+
+(optionally)
+
+```
+ci: schema validate status_baseline.json (status_v1)
+```
+
+if you emit a baseline file.
+
+Consumers should treat the schema as normative; this document explains the fields and conventions.
+
+---
+
+## Artefact lifecycle (baseline vs final)
+
+Typical pipeline flow:
+
+1. Baseline `status.json` is written by the safe-pack entrypoint  
+   (e.g. `PULSE_safe_pack_v0/tools/run_all.py`).
+
+2. The status may then be augmented  
+   (e.g. external thresholds, refusal-delta summaries) by `augment_status.py`.
+
+3. CI enforces required gates via `check_gates.py`  
+   on the final status artefact.
+
+Some setups also write a separate `status_baseline.json` before augmentation.  
+If present, treat it as an intermediate artefact; the final `status.json` is the enforcement input.
+
+---
+
+## High-level structure
+
+At a high level, `status.json` is a JSON object with:
+
+- required contract fields (see schema),
 - `metrics`: numeric and boolean signals produced by tests and detectors,
-- `gates`: boolean decisions derived from metrics and policies.
+- `gates`: boolean gate decisions derived from metrics and policy,
+- optional metadata and optional convenience mirrors.
 
 A typical layout looks like:
 
 ```json
 {
-  "release_id": "model-x-2026-01-15",
-  "model_version": "v3.1.0",
-  "metrics": {
-    "...": "..."
+  "version": "1.0.0-core",
+  "created_utc": "2026-02-17T12:34:56Z",
+
+  "meta": {
+    "release_id": "model-x-2026-01-15",
+    "model_version": "v3.1.0",
+    "notes": "optional human context"
   },
+
+  "metrics": {
+    "run_mode": "core",
+    "RDSI": 0.92,
+    "build_time": "2026-02-17T12:34:56Z",
+    "git_sha": "abcdef1234...",
+    "run_key": "GITHUB_RUN_ID=...|GITHUB_RUN_NUMBER=...",
+    "gate_policy_path": "pulse_gate_policy_v0.yml",
+    "gate_policy_sha256": "..."
+  },
+
   "gates": {
-    "...": true
+    "q1_grounded_ok": true,
+    "q2_consistency_ok": true,
+    "refusal_delta_pass": true,
+    "external_all_pass": false
+  },
+
+  "external": {
+    "metrics": [
+      {
+        "name": "promptguard_attack_detect_rate",
+        "value": 0.20,
+        "threshold": 0.10,
+        "pass": false
+      }
+    ],
+    "all_pass": false
   },
 
   "refusal_delta_pass": true,
   "external_all_pass": false
-
-  /* possibly other top-level mirrors or summary fields */
 }
+```
 
-The exact set of fields depends on the safe-pack configuration and the detectors that
-are enabled, but the pattern is consistent:
+### Interpretation
 
-metrics describe what was measured,
+- `metrics` describe what was measured (signals, rates, counts, provenance).
+- `gates` describe what decision was taken (boolean outcomes enforced by policy/CI).
 
-gates describe what decision was taken.
+---
 
-Metrics
+## Metrics
 
-metrics is a flat object that aggregates numerical and boolean signals from the
-safe-pack. Examples include:
+`metrics` is a flat object that aggregates numerical and boolean signals from the safe-pack.
 
-refusal-related metrics:
+### Refusal / safety metrics
 
-metrics.refusal_delta_n – number of evaluated refusal pairs
+- `metrics.refusal_delta_n` — number of evaluated refusal pairs  
+- `metrics.refusal_delta` — estimated refusal delta  
+- `metrics.refusal_delta_ci_low` / `metrics.refusal_delta_ci_high`  
+- `metrics.refusal_policy` — policy name/config used for evaluation  
+- `metrics.refusal_pass_min` / `metrics.refusal_pass_strict`
 
-metrics.refusal_delta – estimated refusal delta
+### External detector metrics  
+(typically populated by `augment_status.py`)
 
-metrics.refusal_delta_ci_low / metrics.refusal_delta_ci_high
+- `metrics.llamaguard_violation_rate`
+- `metrics.promptfoo_fail_rate`
+- `metrics.garak_issue_rate`
+- `metrics.azure_risk_rate`
+- `metrics.promptguard_attack_detect_rate`
 
-metrics.refusal_policy – the policy name used for evaluation
+When an `external` section is present, per-detector details live there; the flat copy in `metrics` remains a simple consumer-friendly view for CI/dashboards.
 
-metrics.refusal_pass_min / metrics.refusal_pass_strict
+### Provenance / determinism hints (recommended)
 
-external detector metrics (populated by augment_status.py):
+- `metrics.run_mode`
+- `metrics.git_sha`
+- `metrics.run_key`
+- `metrics.gate_policy_path`
+- `metrics.gate_policy_sha256`
 
-metrics.llamaguard_violation_rate
+---
 
-metrics.promptfoo_fail_rate
+## Run modes
 
-metrics.garak_issue_rate
+`metrics.run_mode` is one of:
 
-metrics.azure_risk_rate
+- `demo`
+- `core`
+- `prod`
 
-metrics.promptguard_attack_detect_rate
+The safe-pack entrypoint `PULSE_safe_pack_v0/tools/run_all.py` selects the mode via:
 
-Each external metric entry is also recorded in external.metrics with its threshold and
-per-detector pass flag. The copy in metrics provides a simple, flat view that is
-easy to consume from CI, dashboards and post-processing scripts.
+- CLI `--mode demo|core|prod`, and/or
+- environment `PULSE_RUN_MODE`
 
-Safe-packs may add additional metrics as needed (SLOs, invariants, business-specific
-checks, etc.). All of them share the same purpose: they record what the tests saw.
+Release-grade runs (version tags and strict manual runs) must use `run_mode=prod`.
 
-Gates
+---
 
-gates is a map of boolean decisions. Each gate typically corresponds to one safety
-or quality contract that must hold for the release to proceed. Examples:
+## Gates
 
-gates.refusal_delta_pass – derived from the refusal delta summary
+`gates` is a map of boolean decisions. Each gate typically corresponds to one safety or quality contract that must hold for the release to proceed.
 
-gates.external_all_pass – aggregate decision over all external detectors
+Examples:
 
-other gates defined by the safe-pack (e.g. invariants, SLOs)
+- `gates.refusal_delta_pass` — derived from the refusal-delta summary  
+- `gates.external_all_pass` — aggregate decision over all external detectors  
+- `gates.q1_grounded_ok`  
+- `gates.q2_consistency_ok`  
+- `gates.q3_fairness_ok`  
+- `gates.q4_slo_ok`  
+- other gates defined by the safe-pack and registry/policy  
 
-In addition to the gates object, some gates are also mirrored at the top level of the
-status artefact for convenience:
+CI uses `check_gates.py` to enforce required gate sets derived from policy (fail-closed).
 
+---
+
+## Gate flags and mirrors
+
+Normative location: all gate outcomes are stored under:
+
+```
+status["gates"][<gate_id>]
+```
+
+Some pipelines may also write convenience “mirror” fields at top-level, e.g.:
+
+```
+status["external_all_pass"]
 status["refusal_delta_pass"]
+```
 
-status["external_all_pass"]
+These mirrors can make simple CLI queries easier, but consumers should:
 
-These mirrors make it easy to query individual gates with simple CLI tools such as
-jq without digging into nested structures.
+- read from `gates.*` first when available, and
+- treat top-level mirrors as optional convenience fields.
 
-Downstream tooling may also compute an overall decision such as:
+---
 
-overall_pass – combined result of all required gates
+## External detector section (`external`)
 
-depending on the governance policy of the project.
+When present, `augment_status.py` maintains a dedicated `external` section that describes per-detector metrics and the aggregate external decision.
 
-External detector section: external
+Example:
 
-augment_status.py maintains a dedicated external section that describes the
-per-detector metrics and the aggregate external gate:
-
-"external": {
-  "metrics": [
-    {
-      "name": "promptguard_attack_detect_rate",
-      "value": 0.20,
-      "threshold": 0.10,
-      "pass": false
-    }
-  ],
-  "all_pass": false
+```json
+{
+  "external": {
+    "metrics": [
+      {
+        "name": "promptguard_attack_detect_rate",
+        "value": 0.20,
+        "threshold": 0.10,
+        "pass": false
+      }
+    ],
+    "all_pass": false
+  }
 }
+```
 
-Key points:
+### Key points
 
-external.metrics – list of objects, one per external detector:
+- `external.metrics` — list of objects, one per external detector:
+  - `name` — metric name  
+  - `value` — measured value (typically a rate)  
+  - `threshold` — configured maximum allowed value  
+  - `pass` — detector-level decision (`value <= threshold`)  
 
-name – metric name,
+- `external.all_pass` — aggregate decision across all external detectors, controlled by the configured overall policy.
 
-value – measured rate,
+The aggregate decision is typically mirrored into:
 
-threshold – configured maximum allowed rate,
-
-pass – detector-level decision (value <= threshold).
-
-external.all_pass – aggregate decision across all external detectors,
-controlled by the external_overall_policy setting in thresholds.json.
-
-The value of external.all_pass is mirrored into:
-
+```
 gates["external_all_pass"]
+```
 
+optionally:
+
+```
 status["external_all_pass"]
+```
 
-so CI and other tools can rely on a single boolean flag.
+so CI and downstream tools can rely on a single boolean gate.
 
-Relationship to other artefacts
+---
 
-status.json is designed to be consumed by multiple tools:
+## Relationship to other artefacts and tools
 
-augment_status.py
+### `augment_status.py`
 
-takes a baseline status.json,
+- takes a baseline `status.json`,
+- enriches it with refusal, external and other derived metrics,
+- ensures derived gate decisions exist under `gates.*`,
+- may write optional top-level mirrors.
 
-enriches it with refusal, external and other derived metrics,
+### `check_gates.py`
 
-ensures gate mirrors (refusal_delta_pass, external_all_pass) are present.
+- reads the final `status.json`,
+- enforces required gates (exits non-zero if any mandatory gate is false or missing),
+- required lists are derived from the policy (single source of truth).
 
-check_gates.py (or equivalent gate-checking tool)
+### Quality Ledger / human-readable reports
 
-reads the extended status.json,
+- use `metrics` and `gates` to render tables and explanations,
+- provide an audit/forensic trail for incident response.
 
-enforces required gates (e.g. exits non-zero if a mandatory gate is false),
+Because the status artefact is a simple JSON file, it can be archived, versioned and diffed like any other build artefact. This makes it a natural anchor for questions like:
 
-may compute an overall_pass flag for convenience.
+- “What exactly did we test for release X?”
+- “How did refusal metrics change between release N and N+1?”
+- “Which external detectors blocked this deployment?”
 
-Quality Ledger / human-readable reports
+---
 
-use metrics and gates to render tables and explanations,
+## Contract evolution
 
-provide the forensic trail for audits and incident response.
-
-Because the status artefact is a simple JSON file, it can also be archived, versioned
-and diffed like any other build artefact. This makes it a natural anchor for
-forensic-style questions such as:
-
-“What exactly did we test for release X?”
-
-“How did our refusal metrics change between release N and N+1?”
-
-“Which external detectors blocked this deployment?”
-
-
-
-
+The status contract is versioned and enforced by schema validation in CI.  
+Any semantic changes to the status schema must be accompanied by changelog updates per repository policy.


### PR DESCRIPTION
Problem
The docs/status_json.md example block was missing proper fencing, causing the document to render incorrectly. Also, the docs did not clearly state the schema-first contract and CI enforcement points.

Change

Fix markdown structure and code fences

Add schema-first “Source of truth” section

Clarify run modes, gates vs mirrors, and external section layout

How to verify
Open the rendered markdown and confirm sections render correctly and the JSON example is fully fenced.