### PR TITLE
fix(summary): read external_all_pass and refusal_delta_pass from status.gates

### DIFF
--- a/PULSE_safe_pack_v0/tools/status_to_summary.py
+++ b/PULSE_safe_pack_v0/tools/status_to_summary.py
@@ -88,6 +88,7 @@ def main() -> int:
     def _as_bool_or_none(x):
     return x if isinstance(x, bool) else None
 
+
 gates = status.get("gates") or {}
 if not isinstance(gates, dict):
     gates = {}


### PR DESCRIPTION
Problem

status_to_summary.py could emit null for external_all_pass / refusal_delta_pass when the status artifact is contract-aligned (flags live under status["gates"]) but top-level mirrors are missing. This makes status_summary.json inaccurate and can confuse snapshot/report consumers.

Change

Prefer status["gates"]["external_all_pass"] / status["gates"]["refusal_delta_pass"] first (contract-first).

Fallbacks retained for compatibility:

status["external"]["all_pass"]

top-level mirrors (status["external_all_pass"], status["refusal_delta_pass"])

How to validate

Run summary export on a status artifact that only has gates.* set (no mirrors) and confirm the summary contains correct boolean values.

CI: Export top-level summary for snapshot should succeed and produce the expected flags.