### PR TITLE
fix(tools): prefer gates.* over mirrors in status_to_summary

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1185,6 +1185,8 @@ jobs:
             "tests/test_augment_status_smoke.py"
             "tests/test_run_all_mode_contract.py"
             "tests/test_pack_tools_compile.py"
+            "tests/test_status_to_summary_gate_flags.py"
+
           )
       
 


### PR DESCRIPTION
Problem
status_to_summary.py could miss gate flags when top-level mirrors are absent, even though the status contract stores gate outcomes under status["gates"]. This can produce inaccurate summary artifacts from schema-valid status files.

Change

Prefer status["gates"].external_all_pass / status["gates"].refusal_delta_pass

Fallback to external.all_pass and top-level mirror fields

Add a smoke test ensuring correct behavior when mirrors are missing

Wire the test into the tools-tests CI job

Testing
CI tools-tests runs the new summary contract smoke test.