### PR TITLE
fix(tools): handle missing jsonschema and cap schema errors

### DIFF
--- a/tools/validate_status_schema.py
+++ b/tools/validate_status_schema.py
@@ -2,143 +2,116 @@
 """
 Fail-closed JSON Schema validation for PULSE status artifacts.
 
-Design goals:
-- Validate a status JSON against a given JSON Schema (Draft 2020-12).
-- Emit GitHub Actions compatible ::error annotations for triage.
-- Fail-closed on any validation error.
-- Be CI-friendly: avoid unbounded error collection (respect --max-errors).
-- Be local-friendly: if jsonschema is missing, emit a helpful error instead of a traceback.
+This tool is intentionally minimal and CI-friendly:
+- validates a status JSON instance against a given JSON Schema
+- emits GitHub Actions-style ::error:: annotations
+- exits non-zero on any validation or IO failure
+
+Exit codes:
+  0 - OK (schema-valid)
+  1 - validation / IO / parse error (fail-closed)
+  2 - missing optional dependency (jsonschema)
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import sys
 from pathlib import Path
 from typing import Any
 
 
-def _ga_error(msg: str, *, file: Path | None = None) -> None:
-    if file is not None:
-        print(f"::error file={file}::{msg}")
-    else:
-        print(f"::error::{msg}")
+def _err(msg: str) -> None:
+    print(f"::error::{msg}")
 
 
-def _ga_notice(msg: str) -> None:
+def _notice(msg: str) -> None:
     print(f"::notice::{msg}")
 
 
-def _load_json(path: Path, *, label: str) -> Any | None:
+def _parse_json(path: Path) -> dict[str, Any] | None:
     try:
-        raw = path.read_text(encoding="utf-8")
+        return json.loads(path.read_text(encoding="utf-8"))
     except Exception as e:
-        _ga_error(f"Failed to read {label}: {e}", file=path)
-        return None
-
-    try:
-        return json.loads(raw)
-    except Exception as e:
-        _ga_error(f"Failed to parse {label} as JSON: {e}", file=path)
+        _err(f"Failed to parse JSON: {path}: {e}")
         return None
 
 
-def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(
-        prog="validate_status_schema.py",
-        description="Fail-closed validation of a status.json artifact against a JSON Schema.",
-    )
-    ap.add_argument("--schema", required=True, help="Path to JSON Schema (Draft 2020-12).")
-    ap.add_argument("--status", required=True, help="Path to status.json to validate.")
+def main() -> int:
+    ap = argparse.ArgumentParser(add_help=True)
+    ap.add_argument("--schema", required=True, help="Path to JSON Schema (Draft 2020-12)")
+    ap.add_argument("--status", required=True, help="Path to status JSON to validate")
     ap.add_argument(
         "--max-errors",
         type=int,
         default=50,
-        help="Maximum number of validation errors to print (also bounds computation).",
+        help="Maximum number of validation errors to emit (computation-capped)",
     )
-    args = ap.parse_args(argv)
+    args = ap.parse_args()
 
     schema_path = Path(args.schema)
     status_path = Path(args.status)
 
-    if args.max_errors <= 0:
-        _ga_error("--max-errors must be a positive integer.")
-        return 2
-
     if not schema_path.is_file():
-        _ga_error("status schema not found", file=schema_path)
+        _err(f"Schema not found at {schema_path}")
         return 1
-
     if not status_path.is_file():
-        _ga_error("status.json not found", file=status_path)
+        _err(f"status.json not found at {status_path}")
         return 1
 
-    schema = _load_json(schema_path, label="JSON Schema")
-    if schema is None:
+    schema = _parse_json(schema_path)
+    if not isinstance(schema, dict):
+        _err(f"Schema file is not a JSON object: {schema_path}")
         return 1
 
-    inst = _load_json(status_path, label="status JSON")
-    if inst is None:
+    inst = _parse_json(status_path)
+    if not isinstance(inst, dict):
+        _err(f"Status file is not a JSON object: {status_path}")
         return 1
 
-    # Import jsonschema lazily so missing dependency yields a nice ::error instead of a traceback.
+    # Lazy import so dependency-light environments produce a clean CI-friendly error.
     try:
         from jsonschema import Draft202012Validator  # type: ignore
     except ModuleNotFoundError:
-        _ga_error(
-            "Missing dependency 'jsonschema'. Install it with: python -m pip install jsonschema"
-        )
-        return 2
-    except Exception as e:
-        _ga_error(f"Failed to import jsonschema: {e}")
+        _err("Missing dependency: 'jsonschema'. Install it with: pip install jsonschema")
         return 2
 
     try:
         Draft202012Validator.check_schema(schema)
     except Exception as e:
-        _ga_error(f"Invalid JSON Schema: {e}", file=schema_path)
+        _err(f"Invalid JSON Schema ({schema_path}): {e}")
         return 1
 
-    validator = Draft202012Validator(schema)
+    v = Draft202012Validator(schema)
 
-    # Bound computation: do not collect unlimited errors, respect --max-errors.
-    errors = []
+    max_errors = int(args.max_errors) if args.max_errors is not None else 50
+    if max_errors <= 0:
+        max_errors = 1
+
+    collected = []
     truncated = False
-    try:
-    from jsonschema import Draft202012Validator
-except ModuleNotFoundError:
-    print("::error::Missing dependency: 'jsonschema'. Install it with: pip install jsonschema")
-    return 2
 
-Draft202012Validator.check_schema(schema)
-v = Draft202012Validator(schema)
+    for err in v.iter_errors(inst):
+        collected.append(err)
+        if len(collected) >= max_errors:
+            truncated = True
+            break
 
-max_errors = int(args.max_errors)
-collected = []
-truncated = False
+    # Deterministic ordering for the reported subset.
+    collected.sort(key=lambda e: (tuple(str(p) for p in e.path), str(e.message)))
 
-for err in v.iter_errors(inst):
-    collected.append(err)
-    if len(collected) >= max_errors:
-        truncated = True
-        break
+    if collected:
+        _err("status.json schema validation failed:")
+        for e in collected:
+            path = ".".join(str(p) for p in e.path) or "<root>"
+            _err(f"{path}: {e.message}")
+        if truncated:
+            _notice(f"Output truncated to --max-errors={max_errors}")
+        return 1
 
-# Deterministic output for the collected subset
-collected.sort(key=lambda e: (tuple(str(p) for p in e.path), e.message))
+    print(f"OK: schema-valid: {status_path}")
+    return 0
 
-if collected:
-    print("::error::status.json schema validation failed:")
-    for e in collected:
-        path = ".".join(str(p) for p in e.path) or "<root>"
-        print(f"::error::{path}: {e.message}")
-    if truncated:
-        print(f"::notice::Output truncated to --max-errors={max_errors}")
-    return 1
 
-print(f"OK: schema-valid: {status_path}")
-return 0
-
-        
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
Problem
tools/validate_status_schema.py imports Draft202012Validator at module load time, so environments without jsonschema crash with a traceback before emitting CI-friendly annotations.
Also, --max-errors currently limits printing but not computation because all validator errors are collected and sorted first.

Change

Import jsonschema lazily inside main() and emit a clear ::error::Missing dependency: jsonschema message on failure.

Enforce --max-errors as a true cap by collecting only the first N validation errors, sorting that subset for deterministic output, and exiting fail-closed.

How to validate

Run the tool with a valid status + schema: should print OK: schema-valid ...

Run in an env without jsonschema: should emit a ::error::Missing dependency... message (no traceback) and exit non-zero.

Introduce an invalid status file: should print up to --max-errors errors and fail.