### PR TITLE
test(tools): add smoke tests for validate_status_schema

### DIFF
--- a/tests/test_validate_status_schema_tool.py
+++ b/tests/test_validate_status_schema_tool.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+"""
+Hermetic smoke tests for tools/validate_status_schema.py.
+
+Goals:
+- Runnable as a plain script: python tests/test_validate_status_schema_tool.py
+- Discoverable by pytest: contains test_* functions (no main-only execution)
+- Robust when jsonschema is missing:
+    * if jsonschema is installed: validate OK path + FAIL path
+    * if jsonschema is missing: validate the tool emits CI-friendly ::error:: and exits 2
+"""
+
+from __future__ import annotations
+
 import json
 import os
 import pathlib
@@ -9,7 +22,15 @@ import tempfile
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 TOOL = REPO_ROOT / "tools" / "validate_status_schema.py"
-SCHEMA = REPO_ROOT / "schemas" / "status" / "status_v1.schema.json"
+
+
+def _have_jsonschema() -> bool:
+    try:
+        import jsonschema  # noqa: F401
+
+        return True
+    except Exception:
+        return False
 
 
 def _run(schema_path: pathlib.Path, status_path: pathlib.Path) -> subprocess.CompletedProcess[str]:
@@ -31,17 +52,35 @@ def _run(schema_path: pathlib.Path, status_path: pathlib.Path) -> subprocess.Com
     )
 
 
-def main() -> int:
-    if not TOOL.is_file():
-        raise SystemExit(f"validate_status_schema.py not found at: {TOOL}")
-    if not SCHEMA.is_file():
-        raise SystemExit(f"status_v1 schema not found at: {SCHEMA}")
+def _out(r: subprocess.CompletedProcess[str]) -> str:
+    return (r.stdout or "") + "\n" + (r.stderr or "")
+
+
+def test_validate_status_schema_tool_smoke() -> None:
+    # pytest will collect this function; script-mode will call it from main().
+    assert TOOL.is_file(), f"validate_status_schema tool not found at {TOOL}"
 
     with tempfile.TemporaryDirectory() as td:
         td = pathlib.Path(td)
 
-        # Minimal valid instance for status_v1:
-        # - required: version, created_utc, metrics, gates
+        # Minimal Draft 2020-12 schema for a "status-like" object.
+        # Keep it tiny and hermetic: no repo artifacts required.
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "required": ["version", "created_utc", "metrics", "gates"],
+            "properties": {
+                "version": {"type": "string"},
+                "created_utc": {"type": "string"},
+                "metrics": {"type": "object"},
+                "gates": {"type": "object"},
+            },
+            "additionalProperties": True,
+        }
+
+        schema_path = td / "schema.json"
+        schema_path.write_text(json.dumps(schema), encoding="utf-8")
+
         valid = {
             "version": "1.0.0-core",
             "created_utc": "2026-02-17T00:00:00Z",
@@ -51,32 +90,49 @@ def main() -> int:
         valid_path = td / "valid_status.json"
         valid_path.write_text(json.dumps(valid), encoding="utf-8")
 
-        r_ok = _run(SCHEMA, valid_path)
-        if r_ok.returncode != 0:
-            print("STDOUT:\n", r_ok.stdout)
-            print("STDERR:\n", r_ok.stderr)
-            raise SystemExit(f"Expected valid status to pass, got exit={r_ok.returncode}")
-
-        # Invalid: missing required keys (e.g., gates)
         invalid = {
             "version": "1.0.0-core",
             "created_utc": "2026-02-17T00:00:00Z",
             "metrics": {"run_mode": "core"},
+            # missing "gates"
         }
         invalid_path = td / "invalid_status.json"
         invalid_path.write_text(json.dumps(invalid), encoding="utf-8")
 
-        r_bad = _run(SCHEMA, invalid_path)
-        if r_bad.returncode == 0:
-            print("STDOUT:\n", r_bad.stdout)
-            print("STDERR:\n", r_bad.stderr)
-            raise SystemExit("Expected invalid status to fail validation, but it passed")
+        have = _have_jsonschema()
 
-        # Assert it emits CI-friendly ::error:: lines
-        out = (r_bad.stdout or "") + "\n" + (r_bad.stderr or "")
-        if "::error::" not in out:
-            print("OUTPUT:\n", out)
-            raise SystemExit("Expected ::error:: annotation in output for invalid status")
+        # Always run once to cover either:
+        # - normal validation path (jsonschema present)
+        # - dependency-missing path (jsonschema absent)
+        r_ok = _run(schema_path, valid_path)
+        out_ok = _out(r_ok)
+
+        if not have:
+            # In dependency-light environments, the tool should fail cleanly with exit 2
+            # and emit CI-friendly ::error:: annotation (no traceback requirement).
+            assert r_ok.returncode == 2, (
+                f"Expected exit 2 when jsonschema is missing, got exit={r_ok.returncode}\n{out_ok}"
+            )
+            assert "::error::" in out_ok, f"Expected ::error:: annotation when dependency missing\n{out_ok}"
+            assert "jsonschema" in out_ok.lower(), f"Expected mention of jsonschema in output\n{out_ok}"
+            return
+
+        # jsonschema is available => valid should pass
+        assert r_ok.returncode == 0, f"Expected valid status to pass, got exit={r_ok.returncode}\n{out_ok}"
+
+        # invalid should fail and emit ::error::
+        r_bad = _run(schema_path, invalid_path)
+        out_bad = _out(r_bad)
+        assert r_bad.returncode != 0, "Expected invalid status to fail validation"
+        assert "::error::" in out_bad, f"Expected ::error:: annotations on validation failure\n{out_bad}"
+
+
+def main() -> int:
+    try:
+        test_validate_status_schema_tool_smoke()
+    except AssertionError as e:
+        print(f"ERROR: {e}")
+        return 1
 
     print("OK: validate_status_schema tool smoke tests passed")
     return 0


### PR DESCRIPTION
Why
The status schema validator is release-critical. Add hermetic tests so its OK/FAIL behavior and CI-friendly annotations remain stable over time.

What

Add tests/test_validate_status_schema_tool.py (hermetic schema + valid/invalid fixtures)

Install jsonschema in tools-tests

Run the new test from the hardcoded tools-tests list

How to validate
CI tools-tests job runs:
python tests/test_validate_status_schema_tool.py