### PR TITLE
ci(tools-tests): run validate_status_schema smoke test

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1185,6 +1185,8 @@ jobs:
              "tests/test_augment_status_smoke.py"
              "tests/test_run_all_mode_contract.py"
              "tests/test_status_to_summary_gate_flags.py"
+             "tests/test_validate_status_schema_tool.py"
+
              "tests/test_pack_tools_compile.py"
           )
    


### PR DESCRIPTION
What
Add tests/test_validate_status_schema_tool.py to the tools-tests smoke test list in .github/workflows/pulse_ci.yml.

Why
The validator is release-critical; this ensures CI executes a hermetic smoke test for its behavior and annotations.

Testing
CI: tools-tests job runs the new test in the one-by-one loop.