### PR TITLE
test(sarif): add env-default smoke coverage for SARIF exporter

### DIFF
--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,28 +1,86 @@
-import os, json, subprocess, pathlib
+import os
+import json
+import subprocess
+import pathlib
+import sys
+
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 FIX = ROOT / "tests" / "fixtures" / "status_min.json"
 OUT = ROOT / "tests" / "out"
 OUT.mkdir(parents=True, exist_ok=True)
 
+
 def run(cmd, env=None):
+    """
+    Run a command in repo root with optional env overrides.
+    Accepts either a string (shell=True) or a list (shell=False).
+    """
     e = os.environ.copy()
     if env:
         e.update(env)
-    subprocess.check_call(cmd, shell=True, cwd=str(ROOT), env=e)
+
+    if isinstance(cmd, str):
+        subprocess.check_call(cmd, shell=True, cwd=str(ROOT), env=e)
+    else:
+        subprocess.check_call(cmd, cwd=str(ROOT), env=e)
+
 
 def test_junit_exporter_smoke():
     junit = OUT / "junit.xml"
+    if junit.exists():
+        junit.unlink()
+
     env = {"PULSE_STATUS": str(FIX), "PULSE_JUNIT": str(junit)}
-    run("python PULSE_safe_pack_v0/tools/status_to_junit.py", env=env)
+    run([sys.executable, "PULSE_safe_pack_v0/tools/status_to_junit.py"], env=env)
+
     assert junit.exists()
     text = junit.read_text(encoding="utf-8")
     assert "<testsuite" in text
 
-def test_sarif_exporter_smoke():
+
+def test_sarif_exporter_env_smoke():
+    """
+    Env-default invocation (legacy wrapper style) for SARIF exporter:
+    - No CLI flags, relies on PULSE_STATUS / PULSE_SARIF
+    - Uses a v1-compatible status payload so we can assert real gate->result mapping
+    """
     sarif = OUT / "sarif.json"
-    env = {"PULSE_STATUS": str(FIX), "PULSE_SARIF": str(sarif)}
-    run("python PULSE_safe_pack_v0/tools/status_to_sarif.py", env=env)
+    status = OUT / "status_v1_for_sarif_env_smoke.json"
+
+    if sarif.exists():
+        sarif.unlink()
+    if status.exists():
+        status.unlink()
+
+    payload = {
+        "version": "1.0.0-test",
+        "created_utc": "2026-02-18T00:00:00Z",
+        "metrics": {"run_mode": "core"},
+        "gates": {"gate_a": True, "gate_b": False},
+    }
+    status.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    env = {"PULSE_STATUS": str(status), "PULSE_SARIF": str(sarif)}
+    run([sys.executable, "PULSE_safe_pack_v0/tools/status_to_sarif.py"], env=env)
+
     assert sarif.exists()
     data = json.loads(sarif.read_text(encoding="utf-8"))
-    assert "version" in data and "runs" in data
+
+    assert data.get("version") == "2.1.0"
+    runs = data.get("runs")
+    assert isinstance(runs, list) and len(runs) >= 1
+
+    results = runs[0].get("results") or []
+    rule_ids = [r.get("ruleId") for r in results]
+    assert "gate_b" in rule_ids
+
+
+def main():
+    test_junit_exporter_smoke()
+    test_sarif_exporter_env_smoke()
+    print("OK: exporters smoke passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Context
We already have a hermetic CLI smoke test for SARIF export. What can still regress silently is the legacy invocation path where wrappers call the exporter with no flags and rely on env defaults.

## What changed
- Extend `tests/test_exporters.py` with a SARIF env-default smoke test:
  - Sets `PULSE_STATUS` and `PULSE_SARIF`
  - Runs `status_to_sarif.py` without CLI flags
  - Asserts SARIF output is written and parseable (optionally: failing gate => SARIF result)

## Why
This mirrors the dual-interface protection we already use for JUnit (env + CLI) and prevents integration breakage for existing CI wrappers.

## Testing
- `python tests/test_exporters.py`
- (Existing) `python tests/test_status_to_sarif_smoke.py`
