### PR TITLE
fix(junit): make JUnit timestamp deterministic via created_utc

### DIFF
--- a/PULSE_safe_pack_v0/tools/status_to_junit.py
+++ b/PULSE_safe_pack_v0/tools/status_to_junit.py
@@ -109,7 +109,8 @@ def main() -> int:
     total = len(gate_names)
     failures = 0
 
-    ts = datetime.now(timezone.utc).isoformat()
+    ts = created_utc.strip() or datetime.now(timezone.utc).isoformat()
+
     testsuite = ET.Element(
         "testsuite",
         attrib={


### PR DESCRIPTION
## Context
The JUnit exporter currently stamps `<testsuite timestamp=...>` using wall-clock time, which causes JUnit artifacts to change across reruns even when `status.json` is identical.

## What changed
- `status_to_junit.py` now prefers `status.created_utc` as the JUnit `<testsuite timestamp>`.
- If `created_utc` is missing/empty, it falls back to `datetime.now(timezone.utc)`.

## Why
This reduces artifact diff noise and aligns with deterministic reporting goals, without changing any normative gating behavior (release enforcement remains `check_gates.py` + `status.json`).

## Backwards compatibility
- Legacy/minimal statuses without `created_utc` still work (fallback to current time).
- CLI/env invocation semantics unchanged.

## Testing
Run existing smoke checks:
- `python tests/test_exporters.py`
- `python tests/test_status_to_junit_smoke.py`
- `python -m py_compile PULSE_safe_pack_v0/tools/status_to_junit.py`
