### PR TITLE
test(junit): strengthen exporters env smoke with v1 status

### DIFF
--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -3,6 +3,7 @@ import json
 import subprocess
 import pathlib
 import sys
+import xml.etree.ElementTree as ET
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -27,16 +28,50 @@ def run(cmd, env=None):
 
 
 def test_junit_exporter_smoke():
+    """
+    Env-default invocation (legacy wrapper style) for JUnit exporter:
+    - No CLI flags, relies on PULSE_STATUS / PULSE_JUNIT
+    - Uses a v1-compatible status payload so we validate real gate->JUnit mapping
+    """
     junit = OUT / "junit.xml"
+    status = OUT / "status_v1_for_junit_env_smoke.json"
+
     if junit.exists():
         junit.unlink()
+    if status.exists():
+        status.unlink()
 
-    env = {"PULSE_STATUS": str(FIX), "PULSE_JUNIT": str(junit)}
+    payload = {
+        "version": "1.0.0-test",
+        "created_utc": "2026-02-18T00:00:00Z",
+        "metrics": {"run_mode": "core"},
+        "gates": {"gate_a": True, "gate_b": False},
+    }
+    status.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    env = {"PULSE_STATUS": str(status), "PULSE_JUNIT": str(junit)}
     run([sys.executable, "PULSE_safe_pack_v0/tools/status_to_junit.py"], env=env)
 
     assert junit.exists()
-    text = junit.read_text(encoding="utf-8")
-    assert "<testsuite" in text
+    xml_text = junit.read_text(encoding="utf-8")
+    assert "<testsuite" in xml_text
+
+    # Stronger checks: parse and assert counts + failing gate presence
+    root = ET.fromstring(xml_text)
+    assert root.tag == "testsuite"
+
+    tests = int(root.attrib.get("tests", "0"))
+    failures = int(root.attrib.get("failures", "0"))
+    assert tests >= 2
+    assert failures >= 1
+
+    # Ensure the failing gate shows up in at least one failing testcase
+    failing_names = []
+    for tc in root.findall("testcase"):
+        if tc.find("failure") is not None:
+            failing_names.append(tc.attrib.get("name", ""))
+
+    assert any("gate_b" in name for name in failing_names), f"Expected gate_b failure, got: {failing_names}"
 
 
 def test_sarif_exporter_env_smoke():


### PR DESCRIPTION
## Context
Exporter env-smoke previously exercised JUnit output creation but could still yield `tests=0` if the status fixture didn’t contain v1 gates. That leaves a gap: env-default invocation might silently stop mapping gates into JUnit.

## What changed
- Update `tests/test_exporters.py` JUnit env-smoke to generate a minimal **status v1** payload (`gates`, `metrics`, `created_utc`) on the fly.
- Assert JUnit content:
  - `<testsuite>` parses
  - tests/failures are non-zero
  - failing gate (`gate_b`) appears in a failing testcase

## Why
Locks down env-default + v1 gate-to-JUnit mapping and prevents silent regressions masked by `tests=0`.

## Testing
- `python -m py_compile tests/test_exporters.py`
- `python tests/test_exporters.py`
