### PR TITLE
fix(gates): harden check_gates with True-only PASS semantics

### DIFF
--- a/PULSE_safe_pack_v0/tools/check_gates.py
+++ b/PULSE_safe_pack_v0/tools/check_gates.py
@@ -1,22 +1,89 @@
 #!/usr/bin/env python3
-import argparse, json, sys, os
-ap = argparse.ArgumentParser()
-ap.add_argument("--status", required=True)
-ap.add_argument("--require", nargs="+", required=True)
-args = ap.parse_args()
+"""
+PULSE check_gates.py
 
-data = json.load(open(args.status, encoding="utf-8"))
-g = data.get("gates") or {}
+Deterministic, fail-closed enforcement of required gates from status.json.
 
-missing = [k for k in args.require if k not in g]
-fails = [k for k in args.require if not g.get(k, False)]
+PASS semantics (strict):
+- A gate PASSES only if its value is the literal boolean True.
+- Any other value (False, None, missing, string, number, etc.) is NOT PASS.
 
-if missing:
-    print("[X] Missing required gates:", ", ".join(missing))
-    sys.exit(2)
+Exit codes:
+- 0: all required gates PASS
+- 1: at least one required gate is present but not literal True
+- 2: status missing/invalid OR one or more required gates are missing
+"""
 
-if fails:
-    print("[X] FAIL gates:", ", ".join(fails))
-    sys.exit(1)
+from __future__ import annotations
 
-print("[OK] All required gates PASS")
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _eprint(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def _load_status(path: Path) -> dict[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except Exception as e:
+        _eprint(f"[X] Failed to read/parse status JSON at {path}: {e}")
+        return None
+
+
+def _unique_preserve_order(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for x in items:
+        if x in seen:
+            continue
+        seen.add(x)
+        out.append(x)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--status", required=True, help="Path to status.json")
+    ap.add_argument("--require", nargs="+", required=True, help="Gate IDs that must PASS")
+    args = ap.parse_args(argv)
+
+    status_path = Path(args.status)
+    data = _load_status(status_path)
+    if data is None or not isinstance(data, dict):
+        _eprint(f"[X] Invalid or missing status.json: {status_path}")
+        return 2
+
+    gates = data.get("gates")
+    if not isinstance(gates, dict):
+        _eprint(f"[X] status.json is missing a 'gates' object: {status_path}")
+        return 2
+
+    required = _unique_preserve_order([str(x) for x in args.require])
+
+    missing = [k for k in required if k not in gates]
+    if missing:
+        print("[X] Missing required gates:", ", ".join(missing))
+        return 2
+
+    # Strict: True-only PASS
+    failing = [k for k in required if gates.get(k) is not True]
+    if failing:
+        print("[X] FAIL gates:", ", ".join(failing))
+        # Helpful values for CI logs
+        details = ", ".join(f"{k}={json.dumps(gates.get(k), ensure_ascii=False)}" for k in failing)
+        print("[X] Values:", details)
+        return 1
+
+    print("[OK] All required gates PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Context
`check_gates.py` is part of the **normative release decision path** (CI-enforced). It must be deterministic and fail-closed.

The repo’s reporting layers (summary/JUnit/SARIF) already use **True-only PASS** semantics, but `check_gates.py` previously treated truthy values as passing (e.g. `"true"`), which can create an inconsistency and a potential bypass if a gate value is malformed.

## What changed
- Harden `check_gates.py` required gate evaluation to **strict True-only PASS**:
  - A gate passes **only if** its value is the literal boolean `True`.
  - Any other value (`False`, `None`, missing, string, number, etc.) is treated as NOT PASS.
- Keep fail-closed behavior and exit code contract:
  - `0` = all required gates pass
  - `1` = required gate present but not literal `True`
  - `2` = missing/invalid status OR missing required gate(s)
- Improve CI diagnostics:
  - On failure, print failing gate IDs and their raw values for quick debugging.
- Preserve deterministic behavior:
  - De-duplicate `--require` while preserving user-specified order.

## Why
- Aligns the **normative enforcement** semantics with the rest of the tooling and documentation principle: “missing/unknown/invalid must never be interpreted as PASS”.
- Reduces the risk of “truthy” regressions or accidental bypasses from malformed status data.
- Improves auditability (explicit, stable exit codes + readable logs).

## Backwards compatibility
- Intended compatibility is with the policy/registry gate pipeline and v1 status schema.
- If any existing integration relied on non-boolean truthy values being accepted as PASS, this change will correctly surface it as a failure (which is desired for a release gate).

## Testing
- Existing tools-tests smoke suite (unchanged in this PR)
- Manual quick check:
  - `python PULSE_safe_pack_v0/tools/check_gates.py --status <status.json> --require <gate_id>`
