### PR TITLE
test(gates): add fail-closed smoke coverage for check_gates

### DIFF
--- a/tests/test_check_gates_fail_closed.py
+++ b/tests/test_check_gates_fail_closed.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Smoke test for PULSE_safe_pack_v0/tools/check_gates.py
+
+Locks down fail-closed semantics and exit codes:
+- 0: all required gates are literal True
+- 1: at least one required gate is present but not literal True
+- 2: missing required gate(s) OR status missing/invalid
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+TOOL = ROOT / "PULSE_safe_pack_v0" / "tools" / "check_gates.py"
+
+
+def _write_status(path: pathlib.Path, gates: dict) -> None:
+    status = {
+        "version": "1.0.0-test",
+        "created_utc": "2026-02-18T00:00:00Z",
+        "metrics": {"run_mode": "core"},
+        "gates": gates,
+    }
+    path.write_text(json.dumps(status, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _run(status_path: pathlib.Path, require: list[str]) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    return subprocess.run(
+        [sys.executable, str(TOOL), "--status", str(status_path), "--require", *require],
+        cwd=str(ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _assert_rc(p: subprocess.CompletedProcess[str], rc: int) -> None:
+    if p.returncode != rc:
+        raise AssertionError(
+            f"Unexpected return code: expected={rc} got={p.returncode}\n"
+            f"STDOUT:\n{p.stdout}\n"
+            f"STDERR:\n{p.stderr}\n"
+        )
+
+
+def test_check_gates_fail_closed() -> None:
+    assert TOOL.is_file(), f"Missing tool at: {TOOL}"
+
+    with tempfile.TemporaryDirectory() as td:
+        td = pathlib.Path(td)
+        status_path = td / "status.json"
+
+        _write_status(
+            status_path,
+            {
+                "gate_true": True,
+                "gate_false": False,
+                "gate_str": "true",  # should NOT pass
+            },
+        )
+
+        # PASS
+        p = _run(status_path, ["gate_true"])
+        _assert_rc(p, 0)
+
+        # FAIL (false)
+        p = _run(status_path, ["gate_false"])
+        _assert_rc(p, 1)
+
+        # FAIL (non-bool truthy)
+        p = _run(status_path, ["gate_str"])
+        _assert_rc(p, 1)
+
+        # Missing gate => exit 2
+        p = _run(status_path, ["missing_gate"])
+        _assert_rc(p, 2)
+
+        # Missing dominates (even if another gate fails)
+        p = _run(status_path, ["gate_false", "missing_gate"])
+        _assert_rc(p, 2)
+
+        # Duplicate requires should not break
+        p = _run(status_path, ["gate_true", "gate_true"])
+        _assert_rc(p, 0)
+
+
+def main() -> int:
+    try:
+        test_check_gates_fail_closed()
+    except AssertionError as e:
+        print(f"ERROR: {e}")
+        return 1
+    print("OK: check_gates fail-closed smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Context
`check_gates.py` is a **normative** enforcement tool: CI relies on its exit codes to block releases. We recently hardened it to **True-only PASS** semantics and preserved the fail-closed exit code contract.

Given how critical this tool is, we should lock down its behavior with a hermetic smoke test that runs the script the same way CI does (as a subprocess), and asserts the return codes for both happy-path and negative cases.

## What changed
- Add `tests/test_check_gates_fail_closed.py`:
  - Generates a minimal **status v1** JSON on the fly (`version`, `created_utc`, `metrics`, `gates`)
  - Runs `PULSE_safe_pack_v0/tools/check_gates.py` via explicit CLI (`--status`, `--require`)
  - Asserts the exit code contract:
    - `0` when all required gates are literal `True`
    - `1` when a required gate is present but not literal `True` (e.g. `False`, `"true"`)
    - `2` when a required gate is missing (fail-closed)
  - Includes coverage for:
    - non-bool truthy values (string `"true"`) must **not** pass
    - missing gate dominates even if another required gate fails
    - duplicate `--require` entries should not break execution
- Wire the smoke script into the tools-tests one-by-one run list (fast CI loop), so regressions are caught early with clean logs.

## Why
- Prevents silent regressions in the release gate enforcement surface.
- Ensures the normative tool remains consistent with the repo’s “missing/invalid must never imply PASS” principle.
- Keeps CI debugging easy: failures surface as a single failing smoke script with clear output.

## Testing
- `python -m py_compile tests/test_check_gates_fail_closed.py`
- `python tests/test_check_gates_fail_closed.py`
- tools-tests CI job (one-by-one smoke execution)
