### PR TITLE
ci(tools-tests): include policy_to_require_args smoke test

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1182,6 +1182,7 @@ jobs:
           tests=(
              "tests/test_exporters.py"
              "tests/test_status_to_junit_smoke.py"
+             "tests/test_policy_to_require_args_smoke.py"
              "tests/test_status_to_summary_gate_flags.py"
              "tests/test_tools_governance_smoke.py"
              "tests/test_check_external_summaries_present.py"


### PR DESCRIPTION
## Context
The repo does not run pytest in CI. The tools-tests job executes an explicit `tests=(...)` list via `python "$t"`.

`tests/test_policy_to_require_args_smoke.py` was added, but it was not included in that list, so its assertions never run in CI.

## What changed
- Add `tests/test_policy_to_require_args_smoke.py` to the tools-tests explicit smoke list in `.github/workflows/pulse_ci.yml`.

## Why
Ensures regressions in `tools/policy_to_require_args.py` are caught in the same fast, fail-fast validation loop as the other governance/exporter smoke tests.

## Testing
- tools-tests CI job (py_compile + one-by-one smoke execution)
