### PR TITLE
ci(tools-tests): include check_gates smoke scripts

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1183,6 +1183,8 @@ jobs:
              "tests/test_exporters.py"
              "tests/test_status_to_junit_smoke.py"
              "tests/test_policy_to_require_args_smoke.py"
+             "tests/test_check_gates_fail_closed.py"
+             "tests/test_policy_to_check_gates_e2e_smoke.py"
              "tests/test_status_to_summary_gate_flags.py"
              "tests/test_tools_governance_smoke.py"
              "tests/test_check_external_summaries_present.py"


### PR DESCRIPTION
## Context
The tools-tests job does not rely on pytest discovery; it executes an explicit `tests=(...)` list via `python "$t"`.
If a smoke script is not in that list, it will not run in CI.

## What changed
- Add `tests/test_check_gates_fail_closed.py` to the tools-tests explicit list.
- Add `tests/test_policy_to_check_gates_e2e_smoke.py` to the tools-tests explicit list.

## Why
These two scripts protect the normative enforcement surface:
- strict fail-closed exit codes for check_gates (0/1/2)
- end-to-end policy->require materialization -> check_gates enforcement

Wiring them into tools-tests ensures regressions are caught early with clean one-by-one logs.

## Testing
- tools-tests CI job (py_compile + one-by-one smoke execution)
