### PR TITLE
test(openai-evals): harden refusal dry-run smoke wiring and status assertions

### DIFF
--- a/tests/test_openai_evals_refusal_smoke_dry_run_smoke.py
+++ b/tests/test_openai_evals_refusal_smoke_dry_run_smoke.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
 """
-OpenAI evals refusal smoke (dry-run) — wiring smoke only.
+OpenAI evals refusal smoke (dry-run) — wiring + status patch smoke.
 
-Design goals:
-- Must run in CI PR/push context where secrets are not available.
-- Must NOT require OPENAI_API_KEY (dry-run mode).
-- Proves the wiring: dataset -> runner -> out json + status update path works.
-
-This test intentionally runs the pipeline via subprocess (as CI would).
+Goals:
+- Must run in CI PR/push context with NO secrets.
+- Must force --dry-run (no network, no OPENAI_API_KEY).
+- Must verify that --status-json is actually patched (not just preserved).
 """
 
 from __future__ import annotations
@@ -25,8 +23,13 @@ RUNNER = ROOT / "openai_evals_v0" / "run_refusal_smoke_to_pulse.py"
 DATASET = ROOT / "openai_evals_v0" / "refusal_smoke.jsonl"
 
 
+def _count_nonempty_jsonl_lines(path: pathlib.Path) -> int:
+    text = path.read_text(encoding="utf-8")
+    return sum(1 for line in text.splitlines() if line.strip())
+
+
 def _write_min_status(path: pathlib.Path) -> None:
-    # Minimal status v1-like object; the eval runner may append gates/metrics.
+    # Minimal v1-like scaffold; runner should patch metrics + gates.
     status = {
         "version": "1.0.0-test",
         "created_utc": "2026-02-18T00:00:00Z",
@@ -74,12 +77,19 @@ def test_openai_evals_refusal_smoke_dry_run() -> None:
     assert RUNNER.is_file(), f"Missing runner: {RUNNER}"
     assert DATASET.is_file(), f"Missing dataset: {DATASET}"
 
+    expected_total = _count_nonempty_jsonl_lines(DATASET)
+    assert expected_total > 0, "refusal_smoke.jsonl must be non-empty for meaningful smoke coverage"
+
     with tempfile.TemporaryDirectory() as td:
         td = pathlib.Path(td)
         out_json = td / "refusal_smoke_result.json"
         status_json = td / "status.json"
 
         _write_min_status(status_json)
+        before = status_json.read_text(encoding="utf-8")
+
+        gate_key = "openai_evals_refusal_smoke_pass_test"
+        model = "gpt-4.1"
 
         # Force dry-run explicitly (no API calls, no API key required).
         p = _run(
@@ -89,6 +99,10 @@ def test_openai_evals_refusal_smoke_dry_run() -> None:
                 "--dry-run",
                 "--dataset",
                 str(DATASET),
+                "--model",
+                model,
+                "--gate-key",
+                gate_key,
                 "--out",
                 str(out_json),
                 "--status-json",
@@ -97,16 +111,52 @@ def test_openai_evals_refusal_smoke_dry_run() -> None:
         )
         _assert_rc(p, 0)
 
+        # Output JSON: validate key wiring (not full schema lock)
         assert out_json.exists(), "Expected refusal smoke output json was not created"
-        data = json.loads(out_json.read_text(encoding="utf-8"))
-        assert isinstance(data, (dict, list)), "Output must be valid JSON (dict or list)"
-        # keep this intentionally loose: smoke validates wiring, not content schema
+        result = json.loads(out_json.read_text(encoding="utf-8"))
+        assert isinstance(result, dict)
+        assert result.get("dry_run") is True
+        assert result.get("gate_key") == gate_key
+        assert isinstance(result.get("result_counts"), dict)
 
-        # Ensure status remains JSON and keeps gates/metrics structure
-        st = json.loads(status_json.read_text(encoding="utf-8"))
+        counts = result["result_counts"]
+        assert int(counts.get("total", -1)) == expected_total
+        assert int(counts.get("passed", -1)) == expected_total
+        assert int(counts.get("failed", -1)) == 0
+        assert int(counts.get("errored", -1)) == 0
+        assert result.get("gate_pass") is True
+
+        # Status JSON must be patched (not just preserved)
+        after = status_json.read_text(encoding="utf-8")
+        assert after != before, "Expected runner to patch status.json, but file content did not change"
+
+        st = json.loads(after)
         assert isinstance(st, dict)
         assert "gates" in st and isinstance(st["gates"], dict)
         assert "metrics" in st and isinstance(st["metrics"], dict)
+
+        # Gate patch (both canonical + mirrored key)
+        assert st["gates"].get(gate_key) is True
+        assert st.get(gate_key) is True
+
+        # Metrics patch
+        m = st["metrics"]
+        assert int(m.get("openai_evals_refusal_smoke_total", -1)) == expected_total
+        assert int(m.get("openai_evals_refusal_smoke_passed", -1)) == expected_total
+        assert int(m.get("openai_evals_refusal_smoke_failed", -1)) == 0
+        assert int(m.get("openai_evals_refusal_smoke_errored", -1)) == 0
+        fail_rate = float(m.get("openai_evals_refusal_smoke_fail_rate", 999.0))
+        assert abs(fail_rate - 0.0) < 1e-12
+
+        # Trace patch
+        ov0 = st.get("openai_evals_v0")
+        assert isinstance(ov0, dict) and "refusal_smoke" in ov0
+        trace = ov0["refusal_smoke"]
+        assert isinstance(trace, dict)
+        assert trace.get("dry_run") is True
+        assert trace.get("dataset") == str(DATASET)
+        assert trace.get("model") == model
+        assert trace.get("result_json") == str(out_json)
 
 
 def main() -> int:
@@ -115,7 +165,7 @@ def main() -> int:
     except AssertionError as e:
         print(f"ERROR: {e}")
         return 1
-    print("OK: openai evals refusal smoke dry-run wiring passed")
+    print("OK: openai evals refusal smoke dry-run wiring+status patch passed")
     return 0
 
 


### PR DESCRIPTION
## Context
The OpenAI evals refusal smoke test is intended to validate wiring in CI PR/push contexts where secrets are unavailable. It must not require `OPENAI_API_KEY` and should prove that `--status-json` is actually patched (not merely left unchanged).

Codex flagged that the previous assertions could pass even if the runner ignored `--status-json`, because the test pre-created a status scaffold containing `gates` and `metrics`.

## What changed
- Update `tests/test_openai_evals_refusal_smoke_dry_run_smoke.py` to:
  - Run the refusal smoke runner with **explicit `--dry-run`**
  - Clear OpenAI/Azure-related env vars in the subprocess (hermetic CI behavior)
  - Assert real patch effects on `--status-json`:
    - file content changes
    - `gates[gate_key]` is written (and mirrored top-level key if applicable)
    - `openai_evals_refusal_smoke_*` metrics are populated consistently with dataset line count
    - `openai_evals_v0.refusal_smoke` trace is present (dry_run/model/dataset/result_json)

## Why
This keeps the test as a true “shadow wiring” smoke that can run without secrets, and it prevents regressions where the dry-run path stops writing status updates while CI remains green.

## Testing
- `python -m py_compile tests/test_openai_evals_refusal_smoke_dry_run_smoke.py`
- `python tests/test_openai_evals_refusal_smoke_dry_run_smoke.py`
