### PR TITLE
build(deps): add jsonschema to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyyaml>=6.0
+jsonschema>=4.0


### PR DESCRIPTION
## Context
This repo includes schema validation tooling (e.g. validate_status_schema.py) and smoke tests that exercise schema validation. Without `jsonschema` installed, the tools fall back to a dependency-missing path, which reduces the practical strength of contract enforcement.

## What changed
- Add `jsonschema>=4.0` to `requirements.txt`.

## Why
Ensures schema validation runs in full mode in default pip installs and CI environments that install `requirements.txt`, improving contract enforcement reliability without changing normative gating behavior.

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile tests/test_validate_status_schema_tool.py`
- `python tests/test_validate_status_schema_tool.py`
