### PR TITLE
build(conda): add jsonschema to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,4 +5,5 @@ channels:
 dependencies:
   - python=3.10
   - pyyaml>=6.0
+  - jsonschema>=4.0
   # Add additional dependencies here if your evaluation scripts require them


### PR DESCRIPTION
## Context
The repo provides `environment.yml` for conda-based setups. Schema validation tools rely on the `jsonschema` library; without it, contract validation falls back to a dependency-missing path.

## What changed
- Add `jsonschema>=4.0` to `environment.yml`.

## Why
Ensures conda users get the same active schema validation behavior as pip installs, improving contract enforcement reliability without altering any normative gating semantics.

## Testing
- `conda env create -f environment.yml` (or `conda env update -f environment.yml --prune`)
- `python -m py_compile tests/test_validate_status_schema_tool.py`
- `python tests/test_validate_status_schema_tool.py`
