### PR TITLE
docs(schema): deprecate legacy status.schema.json

### DIFF
--- a/status.schema.json
+++ b/status.schema.json
@@ -1,6 +1,8 @@
 {
+  "$comment": "DEPRECATED (legacy v0.1). Do not use for CI gating. Use schemas/status/status_v1.schema.json instead.",
+  "title": "DEPRECATED: legacy status schema (v0.1)",
+  "description": "This schema is retained for historical/backward compatibility only. The normative status schema is schemas/status/status_v1.schema.json (status v1: {version, created_utc, metrics, gates}).",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "PULSE status.json (v0.1)",
   "type": "object",
   "required": ["run", "results"],
   "properties": {


### PR DESCRIPTION
## Context
The repo’s normative status contract is status v1 (schemas/status/status_v1.schema.json).
A legacy root-level status.schema.json (v0.1) is still present, which can confuse integrators and risks accidental use in CI/tooling.

## What changed
- Add explicit DEPRECATED metadata to status.schema.json:
  - `$comment`, `title`, `description`
  - clear pointer to the normative status v1 schema path

## Why
This preserves backward compatibility while making it unambiguous that the legacy schema must not be used for release gating or CI contract validation.

## Testing
No runtime behavior change; documentation-only schema metadata update.
