### PR TITLE
ci(tools-tests): complete tools smoke manifest

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -1,2 +1,23 @@
+# Tools smoke tests executed by the tools-tests CI job.
+#
+# One path per line. Blank lines and comments are ignored.
+# This manifest must match the current tools-tests suite.
+
 tests/test_exporters.py
 tests/test_tools_tests_list_smoke.py
+tests/test_status_to_junit_smoke.py
+tests/test_status_to_sarif_smoke.py
+tests/test_policy_to_require_args_smoke.py
+tests/test_check_gates_fail_closed.py
+tests/test_policy_to_check_gates_e2e_smoke.py
+tests/test_status_to_summary_gate_flags.py
+tests/test_tools_governance_smoke.py
+tests/test_check_external_summaries_present.py
+tests/test_augment_status_smoke.py
+tests/test_run_all_mode_contract.py
+tests/test_validate_status_schema_tool.py
+tests/test_no_legacy_status_schema_refs_smoke.py
+tests/test_pack_tools_compile.py
+tests/test_paradox_diagram_example_v0_smoke.py
+tests/test_paradox_diagram_renderer_v0_smoke.py
+tests/test_openai_evals_refusal_smoke_dry_run_smoke.py


### PR DESCRIPTION
## Summary
Complete `ci/tools-tests.list` so it matches the current tools-tests suite (18 scripts) defined in
the workflow `tests=(...)` array.

## Why
The manifest was merged incomplete (only 2 entries). When we later switch CI to consume this file,
missing entries would silently stop running. This PR restores suite coherence.

## Changes
- Update `ci/tools-tests.list` to contain the full 18-script tools smoke suite (one path per line).

## Notes
No CI behavior change yet. The follow-up will:
- wire the tools-tests job to read `ci/tools-tests.list`, and
- update the guard to validate this manifest as the source of truth.

## Testing
- Manual verification: 18 entries after filtering comments/blank lines.