### PR TITLE
ci(pulse_ci): run safe pack once (remove duplicate run_all invocation)

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -353,9 +353,6 @@ jobs:
             --pack_dir "${{ env.PACK_DIR }}" \
             --gate_policy "${GITHUB_WORKSPACE}/pulse_gate_policy_v0.yml"
 
-          python "${{ env.PACK_DIR }}/tools/run_all.py" \
-            --pack_dir "${{ env.PACK_DIR }}" \
-            --gate_policy "$GITHUB_WORKSPACE/pulse_gate_policy_v0.yml"
       
       - name: Preserve baseline status.json (pre-augment)
         shell: bash


### PR DESCRIPTION
## Summary
Remove the duplicate `run_all.py` execution from the main PULSE CI workflow.

## Why
The workflow ran `run_all.py` twice (once with explicit `--mode`, then again without mode),
which can overwrite artifacts and introduce mode/config drift.

## What changed
- Keep a single `run_all.py` invocation with explicit `--mode "$MODE"`.
- Remove the second invocation to prevent artifact overwrite.

## Testing
- GitHub Actions (PULSE CI) on this PR.

Closes #1293