### PR TITLE
docs(shadow): document relational gain fold-in in status.json surface

### DIFF
--- a/docs/status_json.md
+++ b/docs/status_json.md
@@ -267,6 +267,60 @@ Rules:
 
 ---
 
+### Example: `meta.relational_gain_shadow`
+
+A Shadow-only relational gain run may fold a descriptive summary into:
+
+```text
+status["meta"]["relational_gain_shadow"]
+```
+
+This fold-in is:
+
+- additive
+- non-normative
+- optional
+- absence-neutral
+- not a replacement for `gates.*`
+
+Recommended shape:
+
+```json
+{
+  "meta": {
+    "relational_gain_shadow": {
+      "verdict": "PASS",
+      "max_edge_gain": 0.83,
+      "max_cycle_gain": 0.91,
+      "warn_threshold": 0.95,
+      "checked_edges": 18,
+      "checked_cycles": 4,
+      "artifact": {
+        "path": "PULSE_safe_pack_v0/artifacts/relational_gain_shadow_v0.json",
+        "sha256": "..."
+      }
+    }
+  }
+}
+```
+
+Interpretation rules:
+
+- `verdict` here is a Shadow checker verdict, not a release decision
+- this fold-in must not introduce or override `gates.*`
+- `FAIL` inside `meta.relational_gain_shadow` is descriptive unless a future policy explicitly promotes relational gain into a normative gate set
+- absence of `meta.relational_gain_shadow` is neutral and must not be read as failure
+
+Primary artifact:
+
+```text
+PULSE_safe_pack_v0/artifacts/relational_gain_shadow_v0.json
+```
+
+Use this surface when you want a compact, audit-linked summary of the relational gain Shadow layer inside the final `status.json` without changing the current release semantics.
+
+---
+
 ## 11. external
 
 ### Two signals:


### PR DESCRIPTION
## Summary

This PR documents the relational gain Shadow fold-in in `docs/status_json.md`.

## What changed

- add an example section for `meta.relational_gain_shadow`
- document the recommended folded shape under `status["meta"]`
- clarify that the shadow verdict is descriptive, not a release decision
- document the primary shadow artifact path:
  - `PULSE_safe_pack_v0/artifacts/relational_gain_shadow_v0.json`
- clarify that absence of the fold-in is neutral
- clarify that the fold-in must not introduce or override `gates.*`

## Why

The relational gain Shadow module is already implemented, folded into `status.json`, and documented elsewhere in the repo.

This PR closes the remaining consumer-facing gap by documenting the actual `status.json` surface for the Shadow fold-in where status readers will expect to find it.

## Scope

Included in this PR:

- `docs/status_json.md` only

Not included in this PR:

- no tool logic change
- no policy change
- no registry change
- no workflow logic change
- no new normative gate
- no Core promotion
- no promotion into `core_required`
- no promotion into `required`
- no promotion into `release_required`
- no release-blocking semantics change

## Notes

This remains fully inside the Shadow-only boundary.

The documented expectations are:
- `meta.relational_gain_shadow` is additive
- it is non-normative
- its absence is neutral
- its verdict must not be read as a release outcome unless a future policy explicitly promotes relational gain into a normative gate set