### PR TITLE
docs(index): add relational gain docs to documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Rule:
 Only the primary release-gating workflow changes release outcomes by default.
 Shadow and publication workflows must stay non-normative unless explicitly promoted into the required gate set.
 
-See also: `docs/WORKFLOW_MAP.md`
+See also:  [docs/WORKFLOW_MAP.md](docs/WORKFLOW_MAP.md)
 
 ---
 
@@ -209,8 +209,8 @@ Main components:
 - fold-in tool: `PULSE_safe_pack_v0/tools/fold_relational_gain_shadow.py`
 - runner: `PULSE_safe_pack_v0/tools/run_relational_gain_shadow.py`
 - workflow: `.github/workflows/relational_gain_shadow.yml`
-- scope note: `docs/shadow_relational_gain_v0.md`
-- rationale paper: `docs/papers/equivalence_drift_and_grounded_new_element.md`
+- scope note: [docs/shadow_relational_gain_v0.md](docs/shadow_relational_gain_v0.md)
+- rationale paper: [docs/papers/equivalence_drift_and_grounded_new_element.md](docs/papers/equivalence_drift_and_grounded_new_element.md)
 
 Primary shadow artifact:
 
@@ -251,8 +251,10 @@ This module remains Shadow-only unless explicitly promoted later.
 > - `docs/status_json.md`
 > - `docs/RUNBOOK.md`
 >
+> [docs/OPTIONAL_LAYERS.md](docs/OPTIONAL_LAYERS.md)
+
 > Optional overlays, shadow workflows, and publication surfaces are mapped here:
-> `docs/OPTIONAL_LAYERS.md`
+
 
 ### Debugging (when CI warns/fails)
 If the OpenAI evals refusal smoke shadow workflow warns or fails, start here:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 # PULSE — Release Gates for Safe & Useful AI
 
-#### AI Release Stability Engineering
+#### AI Release Stability Engineering 
 
 > 💡 **Continuous expansion**
 >

--- a/README.md
+++ b/README.md
@@ -875,6 +875,8 @@ Curated entrypoints (repo-level docs under `docs/`):
 - [docs/STATE_v0.md](docs/STATE_v0.md) — Current snapshot of PULSE v0 gates, signals, and tooling.
 - [docs/STATUS_CONTRACT.md](docs/STATUS_CONTRACT.md) — Contract for `status.json` shape and semantics.
 - [docs/GLOSSARY_v0.md](docs/GLOSSARY_v0.md) — Canonical term definitions used across docs.
+- [WORKFLOW_MAP.md](WORKFLOW_MAP.md) — Fast orientation for Core, shadow, research, and platform workflows.
+- [OPTIONAL_LAYERS.md](OPTIONAL_LAYERS.md) — Optional diagnostic, research, and platform layers that do not define release outcomes by default.
 
 ### Status, ledger & external signals
 - [docs/quality_ledger.md](docs/quality_ledger.md) — Quality Ledger layout and purpose.
@@ -898,6 +900,11 @@ Curated entrypoints (repo-level docs under `docs/`):
 - [docs/PULSE_topology_overview_v0.md](docs/PULSE_topology_overview_v0.md) — Topology layer overview (diagnostic overlay).
 - [docs/PULSE_decision_field_v0_overview.md](docs/PULSE_decision_field_v0_overview.md) — Decision field v0 overview.
 - [docs/FIELD_FIRST_INTERPRETATION.md](docs/FIELD_FIRST_INTERPRETATION.md) — Field-first interpretation (question as projection).
+
+### Shadow layers & explanatory papers
+
+- [shadow_relational_gain_v0.md](shadow_relational_gain_v0.md) — Relational Gain v0 scope, artifact contract, CLI contract, fixtures, and Shadow-only boundary.
+- [papers/equivalence_drift_and_grounded_new_element.md](papers/equivalence_drift_and_grounded_new_element.md) — Explanatory paper on equivalence drift and the grounded introduction of the new Shadow-only element.
 
 ### Examples & contributing
 - [docs/examples/README.md](docs/examples/README.md) — Reproducible examples index.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img alt="Run PULSE before you ship." src="hero_dark_4k.png" width="100%">
 
 <p align="center">
-  <em>Prefer a light version?</em>
+  <em>Prefer a light version?</em> 
 </p>
 
 <details>


### PR DESCRIPTION
## Summary

This PR updates `docs/INDEX.md` so the new relational gain documentation is discoverable from the main documentation index.

## What changed

- add `WORKFLOW_MAP.md` to the orientation section
- add `OPTIONAL_LAYERS.md` to the orientation section
- add a dedicated `### Shadow layers & explanatory papers` subsection
- index:
  - `docs/shadow_relational_gain_v0.md`
  - `docs/papers/equivalence_drift_and_grounded_new_element.md`

## Why

The new relational gain Shadow module is already documented across the repo, but the documentation index did not yet point to those surfaces.

This PR closes that discoverability gap and keeps the index aligned with the actual docs surface.

## Scope

Included in this PR:

- `docs/INDEX.md` only

Not included in this PR:

- no tool logic change
- no policy change
- no registry change
- no workflow logic change
- no new normative gate
- no Core promotion
- no release-blocking semantics change

## Notes

The new heading is intentionally a `###` subsection so it stays aligned with the surrounding subsection structure in the index.