### PR TITLE
docs(readme): fix relational gain documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Rule:
 Only the primary release-gating workflow changes release outcomes by default.
 Shadow and publication workflows must stay non-normative unless explicitly promoted into the required gate set.
 
-See also: `docs/WORKFLOW_MAP.md`
+See also: [docs/WORKFLOW_MAP.md](docs/WORKFLOW_MAP.md)
 
 ---
 
@@ -209,8 +209,8 @@ Main components:
 - fold-in tool: `PULSE_safe_pack_v0/tools/fold_relational_gain_shadow.py`
 - runner: `PULSE_safe_pack_v0/tools/run_relational_gain_shadow.py`
 - workflow: `.github/workflows/relational_gain_shadow.yml`
-- scope note: `docs/shadow_relational_gain_v0.md`
-- rationale paper: `docs/papers/equivalence_drift_and_grounded_new_element.md`
+- scope note: [docs/shadow_relational_gain_v0.md](docs/shadow_relational_gain_v0.md)
+- rationale paper: [docs/papers/equivalence_drift_and_grounded_new_element.md](docs/papers/equivalence_drift_and_grounded_new_element.md)
 
 Primary shadow artifact:
 
@@ -252,7 +252,7 @@ This module remains Shadow-only unless explicitly promoted later.
 > - `docs/RUNBOOK.md`
 >
 > Optional overlays, shadow workflows, and publication surfaces are mapped here:
-> `docs/OPTIONAL_LAYERS.md`
+> [docs/OPTIONAL_LAYERS.md](docs/OPTIONAL_LAYERS.md)
 
 ### Debugging (when CI warns/fails)
 If the OpenAI evals refusal smoke shadow workflow warns or fails, start here:


### PR DESCRIPTION
## Summary

This PR fixes broken README links for the relational gain Shadow documentation.

## What changed

- update README link targets so they resolve correctly from the repo root
- fix links to:
  - `docs/WORKFLOW_MAP.md`
  - `docs/OPTIONAL_LAYERS.md`
  - `docs/shadow_relational_gain_v0.md`
  - `docs/papers/equivalence_drift_and_grounded_new_element.md`

## Why

The README lives at the repository root, so doc links must include the `docs/` prefix.

Without that prefix, the markdown link checker resolves the targets against the repo root and fails closed.

## Scope

Included in this PR:

- `README.md` link-target fix only

Not included in this PR:

- no tool logic change
- no policy change
- no registry change
- no workflow logic change
- no new normative gate
- no Core promotion
- no release-blocking semantics change

## Notes

This is a docs-only fix to restore correct link resolution and keep the README aligned with the current relational gain documentation surface.