### PR TITLE
feat(shadow): add common shadow artifact schema v0

### DIFF
--- a/schemas/shadow_artifact_common_v0.schema.json
+++ b/schemas/shadow_artifact_common_v0.schema.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/shadow_artifact_common_v0.schema.json",
+  "title": "Shadow Artifact Common v0",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "artifact_version",
+    "layer_id",
+    "producer",
+    "created_utc",
+    "run_reality_state",
+    "verdict",
+    "source_artifacts",
+    "summary",
+    "reasons"
+  ],
+  "properties": {
+    "artifact_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "layer_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9_]+$"
+    },
+    "producer": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "name",
+        "version"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "contract_checker_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "run_reality_state": {
+      "type": "string",
+      "enum": [
+        "real",
+        "partial",
+        "stub",
+        "degraded",
+        "invalid",
+        "absent"
+      ]
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "warn",
+        "fail",
+        "unknown",
+        "invalid",
+        "absent"
+      ]
+    },
+    "foldin_eligible": {
+      "type": "boolean"
+    },
+    "relation_scope": {
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        {
+          "type": "object"
+        }
+      ]
+    },
+    "source_artifacts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/source_artifact"
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "headline"
+      ],
+      "properties": {
+        "headline": {
+          "type": "string",
+          "minLength": 1
+        },
+        "details": {
+          "type": "string"
+        }
+      }
+    },
+    "reasons": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/reason"
+      }
+    },
+    "degraded_reasons": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/reason"
+      }
+    },
+    "checks": {
+      "type": "object"
+    },
+    "payload": {
+      "type": "object"
+    }
+  },
+  "$defs": {
+    "source_artifact": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "artifact_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[A-Fa-f0-9]{64}$"
+        },
+        "role": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "artifact_id"
+          ]
+        },
+        {
+          "required": [
+            "path"
+          ]
+        }
+      ]
+    },
+    "reason": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "info",
+            "warn",
+            "error"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add `schemas/shadow_artifact_common_v0.schema.json` as the shared
JSON Schema for machine-readable shadow artifacts.

This schema is the machine-readable counterpart to
`docs/SHADOW_ARTIFACT_COMMON_v0.md` and defines the common envelope
that layer-specific shadow artifacts can later extend.

## Why

The shadow contract program now has a repo-level docs anchor and a
common artifact contract description.

The next step is to make that contract machine-readable.

This PR adds the shared schema surface before semantic checking,
fixtures, and tests are introduced in separate commits.

## What is included

- new `schemas/shadow_artifact_common_v0.schema.json`
- required common top-level fields
- producer object shape
- run reality enum
- verdict enum
- source artifact reference definition
- reason object definition
- optional common fields such as:
  - `contract_checker_version`
  - `foldin_eligible`
  - `relation_scope`
  - `degraded_reasons`
  - `checks`
  - `payload`

## What is not included

This PR does **not**:

- add runtime validation wiring yet
- add the common semantic checker yet
- add fixtures yet
- add tests yet
- change release semantics
- modify required gates
- alter workflow enforcement
- promote any shadow layer

## Intent

This is the schema anchor for the next separate commits in the same phase:

1. common semantic checker
2. common fixtures
3. common checker tests

## Notes

This schema defines shape and allowed enums.
It does not replace semantic validation.

Layer-specific contracts may extend this schema, but should not weaken
the common envelope.