### PR TITLE
fix(shadow): require relation_scope in common artifact contract

### DIFF
--- a/docs/SHADOW_ARTIFACT_COMMON_v0.md
+++ b/docs/SHADOW_ARTIFACT_COMMON_v0.md
@@ -39,6 +39,7 @@ A common shadow artifact must contain:
 - `run_reality_state`
 - `verdict`
 - `source_artifacts`
+- `relation_scope`
 - `summary`
 - `reasons`
 
@@ -102,6 +103,28 @@ Optional fields may include:
 - `sha256`
 - `role`
 
+### `relation_scope`
+
+Required relation-context identifier for the artifact.
+
+This field states which relational context the artifact describes.
+
+Without `relation_scope`, audit trails and cross-run comparison can become
+ambiguous for layers that emit more than one relation surface.
+
+Allowed shapes:
+
+- non-empty string
+- non-empty array of non-empty strings
+- non-empty object for layer-specific structured scope
+
+`relation_scope` must remain specific enough to distinguish parallel
+relation outputs emitted by the same layer family.
+
+It is required even for `absent` runs.
+
+Absence of input is still a scoped result, not an unscoped result.
+
 ### `summary`
 
 Object with at least:
@@ -133,7 +156,6 @@ The common scaffold also allows:
 
 - `contract_checker_version`
 - `foldin_eligible`
-- `relation_scope`
 - `degraded_reasons`
 - `checks`
 - `payload`
@@ -145,6 +167,13 @@ Layer-specific contracts may require some of these.
 ## Common semantic rules
 
 The common checker must enforce the following rules.
+
+### Relation scope requirements
+
+`relation_scope` must always be present.
+
+It must identify the relation context being described, including
+`absent` runs.
 
 ### Real runs
 


### PR DESCRIPTION
## Summary

Update `docs/SHADOW_ARTIFACT_COMMON_v0.md` so `relation_scope`
is required in the common shadow artifact envelope.

## Why

The repo-level shadow contract program already treats
`relation_scope` as part of minimum provenance.

Leaving it optional in the common artifact contract weakens that
existing provenance threshold and creates ambiguity for layers that
emit more than one relational surface.

This PR aligns the common artifact docs with the repo-level rule.

## What changed

- added `relation_scope` to required top-level fields
- documented `relation_scope` as required scoped provenance
- clarified that scope must remain specific enough to distinguish
  parallel relation outputs from the same layer family
- made explicit that `relation_scope` is required even for `absent` runs
- removed `relation_scope` from optional top-level fields
- added a semantic rule that `relation_scope` must always be present

## Scope

Documentation-only contract correction.

This PR does **not**:

- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Review note addressed

Address Codex feedback that the common shadow artifact contract should
not make `relation_scope` optional when the repo-level shadow contract
program already treats it as minimum provenance.