### PR TITLE
fix(shadow): require relation_scope in common artifact schema

### DIFF
--- a/schemas/shadow_artifact_common_v0.schema.json
+++ b/schemas/shadow_artifact_common_v0.schema.json
@@ -12,6 +12,7 @@
     "run_reality_state",
     "verdict",
     "source_artifacts",
+    "relation_scope",
     "summary",
     "reasons"
   ],
@@ -83,13 +84,15 @@
         },
         {
           "type": "array",
+          "minItems": 1, 
           "items": {
             "type": "string",
             "minLength": 1
           }
         },
         {
-          "type": "object"
+          "type": "object",
+          "minProperties": 1
         }
       ]
     },


### PR DESCRIPTION
## Summary

Update `schemas/shadow_artifact_common_v0.schema.json` so
`relation_scope` is required in the common shadow artifact envelope.

## Why

`docs/SHADOW_ARTIFACT_COMMON_v0.md` already declares `relation_scope`
as required provenance, but the machine-readable schema still allowed
artifacts without that field.

That created a doc/runtime mismatch and weakened the scoped provenance
rule for relation-dynamics artifacts.

This PR aligns the schema with the documented contract.

## What changed

- added `relation_scope` to the schema `required` array
- tightened `relation_scope` validation so it must be one of:
  - non-empty string
  - non-empty array of non-empty strings
  - non-empty object for layer-specific structured scope
- prevented missing or empty scope values from passing schema validation

## Scope

Schema-only contract correction.

This PR does **not**:

- add runtime checker enforcement yet
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Review note addressed

Address Codex feedback that the docs now require `relation_scope`,
but the common artifact schema still did not enforce that requirement.