### PR TITLE
fix(shadow): enforce canonical UTC timestamps in common artifact schema

### DIFF
--- a/schemas/shadow_artifact_common_v0.schema.json
+++ b/schemas/shadow_artifact_common_v0.schema.json
@@ -49,7 +49,8 @@
     },
     "created_utc": {
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
     },
     "run_reality_state": {
       "type": "string",


### PR DESCRIPTION
## Summary

Update `schemas/shadow_artifact_common_v0.schema.json` so
`created_utc` requires canonical UTC timestamps with a trailing `Z`.

## Why

The common artifact contract already documents `created_utc` as a UTC
timestamp, but `format: "date-time"` alone still accepts non-UTC offsets
and UTC-equivalent offset representations such as `+00:00`.

That leaves room for timestamp representation drift across producers and
can break consumers that assume canonical UTC strings.

## What changed

- tightened `created_utc` validation
- kept `format: "date-time"` for RFC3339 shape
- added a regex pattern that requires canonical UTC `Z`
- allowed optional fractional seconds

Accepted examples:

- `2026-04-10T12:00:00Z`
- `2026-04-10T12:00:00.123Z`

Rejected examples:

- `2026-04-10T12:00:00+00:00`
- `2026-04-10T05:00:00-07:00`

## Scope

Schema-only contract correction.

This PR does **not**:
- add runtime enforcement yet
- change release semantics
- modify required gates
- alter workflow enforcement
- promote any shadow layer

## Review note addressed

Address Codex feedback that `created_utc` should enforce canonical UTC
representation rather than accepting arbitrary RFC3339 offsets.