### PR TITLE
fix(shadow): add relation_scope to degraded fixture

### DIFF
--- a/tests/fixtures/shadow_artifact_common_v0/degraded.json
+++ b/tests/fixtures/shadow_artifact_common_v0/degraded.json
@@ -17,6 +17,9 @@
       "role": "baseline_status"
     }
   ],
+  "relation_scope": [
+    "baseline_vs_epf_comparison"
+  ],
   "summary": {
     "headline": "EPF comparison degraded",
     "details": "Comparison produced a partial shadow read only."


### PR DESCRIPTION
## Summary

Update `tests/fixtures/shadow_artifact_common_v0/degraded.json`
to include the required `relation_scope` field.

## Why

The common shadow artifact contract now requires `relation_scope`
across docs, schema, and runtime checker surfaces.

The degraded fixture omitted that field, which made the supposed
canonical degraded sample invalid and caused contract validation to fail.

This PR restores the degraded fixture as a valid degraded baseline.

## What changed

- added `relation_scope` to `tests/fixtures/shadow_artifact_common_v0/degraded.json`
- kept the fixture aligned with the current common contract:
  - canonical UTC `created_utc` with trailing `Z`
  - `run_reality_state: degraded`
  - `verdict: warn`
  - non-empty `degraded_reasons`
  - valid `source_artifacts`
  - valid `summary`
  - valid `reasons`

## Scope

Fixture-only contract correction.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Review note addressed

Address Codex feedback that the degraded fixture was missing the
required `relation_scope` field and therefore could not serve as a
valid degraded baseline under the current common contract.