### PR TITLE
test(shadow): add absent fixture for common artifact contract

### DIFF
--- a/tests/fixtures/shadow_artifact_common_v0/absent.json
+++ b/tests/fixtures/shadow_artifact_common_v0/absent.json
@@ -1,0 +1,27 @@
+{
+  "artifact_version": "relational_gain_shadow_v0",
+  "layer_id": "relational_gain_shadow",
+  "producer": {
+    "name": "run_relational_gain_shadow.py",
+    "version": "0.1.0"
+  },
+  "contract_checker_version": "shadow_artifact_common_v0",
+  "created_utc": "2026-04-10T12:10:00Z",
+  "run_reality_state": "absent",
+  "verdict": "absent",
+  "foldin_eligible": false,
+  "source_artifacts": [],
+  "summary": {
+    "headline": "Relational Gain shadow input absent",
+    "details": "No shadow artifact was materialized for this run."
+  },
+  "reasons": [
+    {
+      "code": "shadow.input.absent",
+      "message": "Optional shadow artifact was not present.",
+      "severity": "info"
+    }
+  ],
+  "degraded_reasons": [],
+  "payload": {}
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/shadow_artifact_common_v0/absent.json` as the
canonical explicit-absent fixture for the common shadow artifact contract.

## Why

The common shadow artifact scaffold needs a stable absent baseline in
addition to pass and degraded fixtures.

This PR adds the explicit absent case so checker and regression coverage
can validate the contract behavior for artifact-level absence.

## What changed

- added `tests/fixtures/shadow_artifact_common_v0/absent.json`
- fixture models a valid absent common shadow artifact
- fixture aligns with current contract requirements, including:
  - required `relation_scope`
  - canonical UTC `created_utc` with trailing `Z`
  - `run_reality_state: absent`
  - `verdict: absent`
  - `foldin_eligible: false`
  - valid `summary`
  - valid `reasons`

## Important distinction

This fixture represents an **explicit absent artifact**.

It is not the same as a missing file handled by
`check_shadow_artifact_contract.py --if-input-present`, which exercises
neutral absence at the input boundary.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

This fixture becomes the baseline absent positive case for the common
shadow artifact checker and future regression tests.