### PR TITLE
fix(shadow): add relation_scope to absent fixture

### DIFF
--- a/tests/fixtures/shadow_artifact_common_v0/absent.json
+++ b/tests/fixtures/shadow_artifact_common_v0/absent.json
@@ -11,6 +11,10 @@
   "verdict": "absent",
   "foldin_eligible": false,
   "source_artifacts": [],
+  "relation_scope": [
+    "edge_gain",
+    "cycle_gain"
+  ],
   "summary": {
     "headline": "Relational Gain shadow input absent",
     "details": "No shadow artifact was materialized for this run."


### PR DESCRIPTION
## Summary

Update `tests/fixtures/shadow_artifact_common_v0/absent.json`
to include the required `relation_scope` field.

## Why

The common shadow artifact contract requires `relation_scope` for all
artifacts, including explicit absent artifacts.

The absent fixture omitted that field, which made the supposed canonical
absent sample invalid and caused contract validation to fail before the
absent-state behavior could be exercised.

This PR restores the absent fixture as a valid explicit-absent baseline.

## What changed

- added `relation_scope` to `tests/fixtures/shadow_artifact_common_v0/absent.json`
- kept the fixture aligned with the current common contract:
  - canonical UTC `created_utc` with trailing `Z`
  - `run_reality_state: absent`
  - `verdict: absent`
  - `foldin_eligible: false`
  - valid `summary`
  - valid `reasons`

## Important distinction

This fixture represents an explicit absent artifact.

It is not the same as a missing file handled through
`--if-input-present`, which exercises neutral absence at the input boundary.

## Scope

Fixture-only contract correction.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Review note addressed

Address Codex feedback that the absent fixture was missing the required
`relation_scope` field and therefore could not serve as a valid absent
baseline under the current common contract.