### PR TITLE
test(shadow): add invalid absent-verdict fixture for common artifact …

### DIFF
--- a/tests/fixtures/shadow_artifact_common_v0/invalid_bad_verdict_for_absent.json
+++ b/tests/fixtures/shadow_artifact_common_v0/invalid_bad_verdict_for_absent.json
@@ -1,0 +1,26 @@
+{
+  "artifact_version": "relational_gain_shadow_v0",
+  "layer_id": "relational_gain_shadow",
+  "producer": {
+    "name": "run_relational_gain_shadow.py",
+    "version": "0.1.0"
+  },
+  "contract_checker_version": "shadow_artifact_common_v0",
+  "created_utc": "2026-04-10T12:15:00Z",
+  "run_reality_state": "absent",
+  "verdict": "pass",
+  "foldin_eligible": false,
+  "source_artifacts": [],
+  "summary": {
+    "headline": "Invalid absent fixture",
+    "details": "This fixture intentionally violates the common contract."
+  },
+  "reasons": [
+    {
+      "code": "test.invalid.absent_verdict",
+      "message": "Absent runs must not use pass verdict.",
+      "severity": "error"
+    }
+  ],
+  "degraded_reasons": []
+}


### PR DESCRIPTION
Add tests/fixtures/shadow_artifact_common_v0/invalid_bad_verdict_for_absent.json
as the canonical invalid fixture for the absent-state verdict rule in the
common shadow artifact contract.

The fixture is intentionally invalid because it uses:
- run_reality_state: absent
- verdict: pass

This isolates the absent-verdict semantic failure path while keeping the
rest of the fixture aligned with the current contract, including:
- required relation_scope
- canonical UTC created_utc timestamp ending in Z
- valid summary and reasons structure

This fixture is intended for negative checker validation and regression
tests.

It does not:
- change release semantics
- modify required gates
- alter check_gates.py behavior
- change workflow enforcement
- promote any shadow layer