### PR TITLE
fix(shadow): add relation_scope to absent-verdict invalid fixture

### DIFF
--- a/tests/fixtures/shadow_artifact_common_v0/invalid_bad_verdict_for_absent.json
+++ b/tests/fixtures/shadow_artifact_common_v0/invalid_bad_verdict_for_absent.json
@@ -11,9 +11,13 @@
   "verdict": "pass",
   "foldin_eligible": false,
   "source_artifacts": [],
+  "relation_scope": [
+    "edge_gain",
+    "cycle_gain"
+  ],
   "summary": {
     "headline": "Invalid absent fixture",
-    "details": "This fixture intentionally violates the common contract."
+    "details": "This fixture intentionally violates the common contract absent verdict rule."
   },
   "reasons": [
     {
@@ -22,5 +26,6 @@
       "severity": "error"
     }
   ],
-  "degraded_reasons": []
+  "degraded_reasons": [],
+  "payload": {}
 }


### PR DESCRIPTION
## Summary

Update `tests/fixtures/shadow_artifact_common_v0/invalid_bad_verdict_for_absent.json`
to include the required `relation_scope` field.

## Why

This fixture is meant to be the canonical negative case for the
`run_reality_state: absent` / `verdict: pass` mismatch.

Without `relation_scope`, the fixture also fails for a second,
unrelated reason, which weakens its value as an isolated negative test
case.

This PR restores the intended isolation of the absent-verdict failure path.

## What changed

- added `relation_scope` to
  `tests/fixtures/shadow_artifact_common_v0/invalid_bad_verdict_for_absent.json`
- kept the fixture intentionally invalid only for:
  - `run_reality_state: absent`
  - `verdict: pass`
- preserved alignment with the rest of the current common contract:
  - canonical UTC `created_utc` with trailing `Z`
  - valid `summary`
  - valid `reasons`
  - valid explicit absent artifact shape

## Scope

Fixture-only contract correction.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Review note addressed

Address Codex feedback that the fixture was missing `relation_scope`,
which caused an extra unrelated contract error and prevented the
negative case from cleanly isolating the absent-verdict rule.