### PR TITLE
test(shadow): add common shadow artifact checker tests

### DIFF
--- a/tests/test_check_shadow_artifact_contract.py
+++ b/tests/test_check_shadow_artifact_contract.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "PULSE_safe_pack_v0" / "tools" / "check_shadow_artifact_contract.py"
+FIXTURES = ROOT / "tests" / "fixtures" / "shadow_artifact_common_v0"
+
+
+def _run(input_path: Path, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, str(SCRIPT), "--input", str(input_path), *extra_args]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def _stdout_json(result: subprocess.CompletedProcess[str]) -> dict:
+    return json.loads(result.stdout)
+
+
+def test_pass_fixture_is_valid() -> None:
+    result = _run(
+        FIXTURES / "pass.json",
+        "--expected-layer-id",
+        "relational_gain_shadow",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is False
+    assert payload["run_reality_state"] == "real"
+    assert payload["verdict"] == "pass"
+
+
+def test_degraded_fixture_is_valid() -> None:
+    result = _run(
+        FIXTURES / "degraded.json",
+        "--expected-layer-id",
+        "epf_shadow_experiment_v0",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["run_reality_state"] == "degraded"
+    assert payload["verdict"] == "warn"
+
+
+def test_absent_fixture_is_valid() -> None:
+    result = _run(
+        FIXTURES / "absent.json",
+        "--expected-layer-id",
+        "relational_gain_shadow",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["run_reality_state"] == "absent"
+    assert payload["verdict"] == "absent"
+
+
+def test_invalid_absent_verdict_fails() -> None:
+    result = _run(
+        FIXTURES / "invalid_bad_verdict_for_absent.json",
+        "--expected-layer-id",
+        "relational_gain_shadow",
+    )
+    assert result.returncode == 1
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "verdict" and "absent runs must use verdict=absent" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_if_input_present_preserves_neutral_absence_for_missing_file() -> None:
+    result = _run(
+        FIXTURES / "does_not_exist.json",
+        "--expected-layer-id",
+        "relational_gain_shadow",
+        "--if-input-present",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is True
+    assert payload["run_reality_state"] == "absent"
+    assert payload["verdict"] == "absent"
+
+
+def test_layer_id_mismatch_fails() -> None:
+    result = _run(
+        FIXTURES / "pass.json",
+        "--expected-layer-id",
+        "wrong_layer",
+    )
+    assert result.returncode == 1
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(issue["path"] == "layer_id" for issue in payload["errors"])


### PR DESCRIPTION
## Summary

Add `tests/test_check_shadow_artifact_contract.py` as the regression
test file for the common shadow artifact checker.

## Why

The common shadow artifact scaffold now has:

- docs
- schema
- runtime checker
- positive and negative fixtures

The next required step is executable test coverage for the shared checker.

This PR adds that coverage.

## What changed

Added `tests/test_check_shadow_artifact_contract.py` with coverage for:

- valid pass fixture
- valid degraded fixture
- valid explicit absent fixture
- invalid absent-verdict fixture
- missing-input neutral absence via `--if-input-present`
- expected `layer_id` mismatch failure

## Intent

The goal of this test file is to lock the current common checker behavior
to the shared contract surface and fixture set, so later layer-specific
hardening can build on a stable floor.

## Scope

Test-only change.

This PR does **not**:

- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Notes

These tests validate the checker as a contract-enforcement surface,
not as a release gate.

They are intended to catch drift between:
- the common docs contract
- the common schema
- the common checker
- the shared fixture set