### PR TITLE
feat(shadow): add relational gain shadow schema v0

### DIFF
--- a/schemas/relational_gain_shadow_v0.schema.json
+++ b/schemas/relational_gain_shadow_v0.schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/relational_gain_shadow_v0.schema.json",
+  "title": "Relational Gain Shadow Artifact v0",
+  "description": "Schema for the current shadow-only Relational Gain v0 artifact emitted by check_relational_gain.py.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "checker_version",
+    "verdict",
+    "input",
+    "metrics"
+  ],
+  "properties": {
+    "checker_version": {
+      "type": "string",
+      "const": "relational_gain_v0",
+      "description": "Exact checker version expected by the current fold-in path."
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "PASS",
+        "WARN",
+        "FAIL"
+      ],
+      "description": "Shadow-only checker verdict."
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path to the input JSON consumed by the checker."
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "checked_edges",
+        "checked_cycles",
+        "max_edge_gain",
+        "max_cycle_gain",
+        "warn_threshold",
+        "offending_edges",
+        "offending_cycles",
+        "near_boundary_edges",
+        "near_boundary_cycles"
+      ],
+      "properties": {
+        "checked_edges": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "checked_cycles": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "max_edge_gain": {
+          "type": "number",
+          "minimum": 0
+        },
+        "max_cycle_gain": {
+          "type": "number",
+          "minimum": 0
+        },
+        "warn_threshold": {
+          "type": "number",
+          "minimum": 0
+        },
+        "offending_edges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_negative_number"
+          }
+        },
+        "offending_cycles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_negative_number"
+          }
+        },
+        "near_boundary_edges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_negative_number"
+          }
+        },
+        "near_boundary_cycles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_negative_number"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "non_negative_number": {
+      "type": "number",
+      "minimum": 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add `schemas/relational_gain_shadow_v0.schema.json` as the
layer-specific machine-readable schema for the Relational Gain shadow artifact.

## Why

The common shadow scaffold is now in place:

- repo-level shadow contract program
- common shadow artifact contract doc
- common schema
- common checker
- common fixtures
- common checker tests

The next step is to harden the first full layer-specific pilot.

Relational Gain v0 is the right pilot because it already exists as a
shadow-only module with:
- docs
- tools
- fixtures
- tests
- workflow
- status fold-in surface

This PR adds the machine-readable schema that lets the Relational Gain
artifact move from “working shadow module” toward “contracted shadow layer”.

## What is included

- new `schemas/relational_gain_shadow_v0.schema.json`
- layer-specific schema for the Relational Gain artifact
- schema surface aligned with the current shadow-only flow
- schema intended to sit on top of the common shadow artifact contract

## What is not included

This PR does **not**:

- add the layer-specific semantic checker yet
- add Relational Gain contract fixtures yet
- add Relational Gain checker tests yet
- add the non-interference test yet
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

This is the first layer-specific hardening step for the Relational Gain pilot.

The next separate commits in this phase should add:

1. `PULSE_safe_pack_v0/tools/check_relational_gain_contract.py`
2. Relational Gain contract fixtures
3. Relational Gain checker tests
4. Relational Gain non-interference test

## Notes

This PR should keep the current authority boundary unchanged:

- Relational Gain remains shadow-only
- schema hardening does not imply promotion
- fold-in remains additive and non-normative