### PR TITLE
test(shadow): add pass fixture for relational gain contract

### DIFF
--- a/tests/fixtures/relational_gain_shadow_v0/pass.json
+++ b/tests/fixtures/relational_gain_shadow_v0/pass.json
@@ -1,0 +1,18 @@
+{
+  "checker_version": "relational_gain_v0",
+  "verdict": "PASS",
+  "input": {
+    "path": "tests/fixtures/relational_gain_v0/pass.json"
+  },
+  "metrics": {
+    "checked_edges": 3,
+    "checked_cycles": 2,
+    "max_edge_gain": 0.88,
+    "max_cycle_gain": 0.79,
+    "warn_threshold": 0.95,
+    "offending_edges": [],
+    "offending_cycles": [],
+    "near_boundary_edges": [],
+    "near_boundary_cycles": []
+  }
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/relational_gain_shadow_v0/pass.json` as the
canonical PASS fixture for the current Relational Gain shadow
artifact contract.

## Why

The Relational Gain layer-specific schema and contract checker now exist.

The next step is to add stable layer-specific fixtures so the current
artifact shape can be validated against known-good and known-bad cases.

This PR adds the positive PASS baseline.

## What changed

- added `tests/fixtures/relational_gain_shadow_v0/pass.json`
- fixture models a valid current Relational Gain shadow artifact
- fixture aligns with the current contract, including:
  - `checker_version: relational_gain_v0`
  - `verdict: PASS`
  - valid `input.path`
  - valid `metrics`
  - empty `offending_edges` / `offending_cycles`
  - empty `near_boundary_edges` / `near_boundary_cycles`
  - `max_edge_gain` and `max_cycle_gain` below `warn_threshold`

## Contract intent

This fixture is meant to validate the **current actual Relational Gain
artifact shape**, not a future migrated common-envelope form.

That keeps the first layer-specific hardening pass aligned with the
existing shadow-only flow.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

This fixture becomes the baseline positive case for upcoming
Relational Gain contract checker tests.