### PR TITLE
test(shadow): add warn fixture for relational gain contract

### DIFF
--- a/tests/fixtures/relational_gain_shadow_v0/warn.json
+++ b/tests/fixtures/relational_gain_shadow_v0/warn.json
@@ -1,0 +1,20 @@
+{
+  "checker_version": "relational_gain_v0",
+  "verdict": "WARN",
+  "input": {
+    "path": "tests/fixtures/relational_gain_v0/warn.json"
+  },
+  "metrics": {
+    "checked_edges": 3,
+    "checked_cycles": 2,
+    "max_edge_gain": 0.98,
+    "max_cycle_gain": 0.72,
+    "warn_threshold": 0.95,
+    "offending_edges": [],
+    "offending_cycles": [],
+    "near_boundary_edges": [
+      0.98
+    ],
+    "near_boundary_cycles": []
+  }
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/relational_gain_shadow_v0/warn.json` as the
canonical WARN fixture for the current Relational Gain shadow
artifact contract.

## Why

The Relational Gain layer-specific hardening track now has:
- schema
- contract checker
- PASS fixture

The next step is to add the stable WARN baseline so the current
artifact shape is covered across the middle verdict path as well.

## What changed

- added `tests/fixtures/relational_gain_shadow_v0/warn.json`
- fixture models a valid current Relational Gain shadow artifact
- fixture aligns with the current contract, including:
  - `checker_version: relational_gain_v0`
  - `verdict: WARN`
  - valid `input.path`
  - valid `metrics`
  - empty `offending_edges` / `offending_cycles`
  - non-empty `near_boundary_edges`
  - `max_edge_gain == max(near_boundary_edges)`
  - `max_cycle_gain < warn_threshold`

## Contract intent

This fixture validates the **current actual Relational Gain artifact
shape**, not a future migrated envelope.

It is meant to isolate the valid WARN path:
- no FAIL-level offending gains
- at least one near-boundary gain
- verdict consistent with metrics

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

This fixture becomes the baseline WARN case for upcoming
Relational Gain contract checker tests.