### PR TITLE
test(shadow): add fail fixture for relational gain contract

### DIFF
--- a/tests/fixtures/relational_gain_shadow_v0/fail.json
+++ b/tests/fixtures/relational_gain_shadow_v0/fail.json
@@ -1,0 +1,20 @@
+{
+  "checker_version": "relational_gain_v0",
+  "verdict": "FAIL",
+  "input": {
+    "path": "tests/fixtures/relational_gain_v0/fail_edge.json"
+  },
+  "metrics": {
+    "checked_edges": 3,
+    "checked_cycles": 2,
+    "max_edge_gain": 1.07,
+    "max_cycle_gain": 0.72,
+    "warn_threshold": 0.95,
+    "offending_edges": [
+      1.07
+    ],
+    "offending_cycles": [],
+    "near_boundary_edges": [],
+    "near_boundary_cycles": []
+  }
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/relational_gain_shadow_v0/fail.json` as the
canonical FAIL fixture for the current Relational Gain shadow
artifact contract.

## Why

The Relational Gain layer-specific hardening track now has:
- schema
- contract checker
- PASS fixture
- WARN fixture

The next step is to add the stable FAIL baseline so the current
artifact shape is covered across the full verdict surface.

## What changed

- added `tests/fixtures/relational_gain_shadow_v0/fail.json`
- fixture models a valid current Relational Gain shadow artifact with a FAIL outcome
- fixture aligns with the current contract, including:
  - `checker_version: relational_gain_v0`
  - `verdict: FAIL`
  - valid `input.path`
  - valid `metrics`
  - non-empty `offending_edges`
  - empty `offending_cycles`
  - `max_edge_gain == max(offending_edges)`
  - `max_cycle_gain < warn_threshold`

## Contract intent

This fixture validates the **current actual Relational Gain artifact
shape**, not a future migrated envelope.

It is meant to isolate the valid FAIL path:
- at least one offending gain above 1.0
- verdict consistent with metrics
- no unrelated contract failures

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

This fixture becomes the baseline FAIL case for upcoming
Relational Gain contract checker tests.