### PR TITLE
fix(shadow): align relational gain warn fixture with referenced input

### DIFF
--- a/tests/fixtures/relational_gain_shadow_v0/warn.json
+++ b/tests/fixtures/relational_gain_shadow_v0/warn.json
@@ -7,13 +7,14 @@
   "metrics": {
     "checked_edges": 3,
     "checked_cycles": 2,
-    "max_edge_gain": 0.98,
-    "max_cycle_gain": 0.72,
+    "max_edge_gain": 0.97,
+    "max_cycle_gain": 0.91,
     "warn_threshold": 0.95,
     "offending_edges": [],
     "offending_cycles": [],
     "near_boundary_edges": [
-      0.98
+      0.95,
+      0.97
     ],
     "near_boundary_cycles": []
   }


### PR DESCRIPTION
## Summary

Update `tests/fixtures/relational_gain_shadow_v0/warn.json` so its
metrics match the current output of `check_relational_gain.py` for the
referenced input payload.

## Why

This fixture is intended to be the canonical WARN baseline for the
current Relational Gain shadow artifact contract.

The previous version did not match the metrics produced by the current
checker for:

- `tests/fixtures/relational_gain_v0/warn.json`

That mismatch could make downstream tests fail for the wrong reason or
encode incorrect expected behavior.

## What changed

Updated the WARN fixture so it now matches the current checker output,
including:

- `checked_edges: 3`
- `checked_cycles: 2`
- `max_edge_gain: 0.97`
- `max_cycle_gain: 0.91`
- `near_boundary_edges: [0.95, 0.97]`

## Contract intent

This keeps the canonical WARN artifact aligned with the **current actual**
Relational Gain checker behavior for its declared `input.path`.

## Scope

Fixture-only contract correction.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Review note addressed

Address Codex feedback that the WARN fixture metrics were not aligned
with the current checker output for the referenced input payload.