### PR TITLE
fix(shadow): align relational gain fail fixture with referenced input

### DIFF
--- a/tests/fixtures/relational_gain_shadow_v0/fail.json
+++ b/tests/fixtures/relational_gain_shadow_v0/fail.json
@@ -5,13 +5,13 @@
     "path": "tests/fixtures/relational_gain_v0/fail_edge.json"
   },
   "metrics": {
-    "checked_edges": 3,
+    "checked_edges": 2,
     "checked_cycles": 2,
-    "max_edge_gain": 1.07,
-    "max_cycle_gain": 0.72,
+    "max_edge_gain": 1.08,
+    "max_cycle_gain": 0.91,
     "warn_threshold": 0.95,
     "offending_edges": [
-      1.07
+      1.08
     ],
     "offending_cycles": [],
     "near_boundary_edges": [],


### PR DESCRIPTION
## Summary

Update `tests/fixtures/relational_gain_shadow_v0/fail.json` so its
metrics match the current output of `check_relational_gain.py` for the
referenced input payload.

## Why

This fixture is intended to be the canonical FAIL baseline for the
current Relational Gain shadow artifact contract.

The previous version did not match the metrics produced by the current
checker for:

- `tests/fixtures/relational_gain_v0/fail_edge.json`

That mismatch could make downstream tests fail for the wrong reason or
encode incorrect expected behavior.

## What changed

Updated the FAIL fixture so it now matches the current checker output,
including:

- `checked_edges: 2`
- `checked_cycles: 2`
- `max_edge_gain: 1.08`
- `max_cycle_gain: 0.91`
- `offending_edges: [1.08]`

## Contract intent

This keeps the canonical FAIL artifact aligned with the **current actual**
Relational Gain checker behavior for its declared `input.path`.

## Scope

Fixture-only contract correction.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Review note addressed

Address Codex feedback that the FAIL fixture metrics were not aligned
with the current checker output for the referenced input payload.