### PR TITLE
test(shadow): add relational gain contract checker tests

### DIFF
--- a/tests/test_check_relational_gain_contract.py
+++ b/tests/test_check_relational_gain_contract.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "PULSE_safe_pack_v0" / "tools" / "check_relational_gain_contract.py"
+FIXTURES = ROOT / "tests" / "fixtures" / "relational_gain_shadow_v0"
+
+
+def _run(input_path: Path, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, str(SCRIPT), "--input", str(input_path), *extra_args]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def _stdout_json(result: subprocess.CompletedProcess[str]) -> dict:
+    return json.loads(result.stdout)
+
+
+def test_pass_fixture_is_valid() -> None:
+    result = _run(FIXTURES / "pass.json")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is False
+    assert payload["artifact_checker_version"] == "relational_gain_v0"
+    assert payload["verdict"] == "PASS"
+
+
+def test_warn_fixture_is_valid() -> None:
+    result = _run(FIXTURES / "warn.json")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is False
+    assert payload["artifact_checker_version"] == "relational_gain_v0"
+    assert payload["verdict"] == "WARN"
+
+
+def test_fail_fixture_is_valid() -> None:
+    result = _run(FIXTURES / "fail.json")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is False
+    assert payload["artifact_checker_version"] == "relational_gain_v0"
+    assert payload["verdict"] == "FAIL"
+
+
+def test_missing_input_is_neutral_with_if_input_present() -> None:
+    result = _run(FIXTURES / "does_not_exist.json", "--if-input-present")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is True
+    assert payload["artifact_checker_version"] is None
+    assert payload["verdict"] is None
+
+
+def test_missing_input_fails_without_if_input_present() -> None:
+    result = _run(FIXTURES / "does_not_exist.json")
+    assert result.returncode == 1
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert payload["neutral"] is False
+    assert any(issue["path"] == "input" for issue in payload["errors"])
+
+
+def test_warn_requires_near_boundary_signal(tmp_path: Path) -> None:
+    fixture = json.loads((FIXTURES / "warn.json").read_text(encoding="utf-8"))
+    fixture["metrics"]["near_boundary_edges"] = []
+    fixture["metrics"]["max_edge_gain"] = 0.94
+
+    path = tmp_path / "invalid_warn_missing_boundary.json"
+    path.write_text(json.dumps(fixture, indent=2) + "\n", encoding="utf-8")
+
+    result = _run(path)
+    assert result.returncode == 1
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(issue["path"] == "verdict" for issue in payload["errors"])
+
+
+def test_fail_requires_offending_signal(tmp_path: Path) -> None:
+    fixture = json.loads((FIXTURES / "fail.json").read_text(encoding="utf-8"))
+    fixture["metrics"]["offending_edges"] = []
+    fixture["metrics"]["max_edge_gain"] = 0.91
+    fixture["verdict"] = "FAIL"
+
+    path = tmp_path / "invalid_fail_without_offending.json"
+    path.write_text(json.dumps(fixture, indent=2) + "\n", encoding="utf-8")
+
+    result = _run(path)
+    assert result.returncode == 1
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(issue["path"] == "verdict" for issue in payload["errors"])
+
+
+def test_exact_checker_version_is_required(tmp_path: Path) -> None:
+    fixture = json.loads((FIXTURES / "pass.json").read_text(encoding="utf-8"))
+    fixture["checker_version"] = "relational_gain_v0_dev"
+
+    path = tmp_path / "invalid_checker_version.json"
+    path.write_text(json.dumps(fixture, indent=2) + "\n", encoding="utf-8")
+
+    result = _run(path)
+    assert result.returncode == 1
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(issue["path"] == "checker_version" for issue in payload["errors"])
+
+
+def test_pass_must_not_contain_near_boundary_entries(tmp_path: Path) -> None:
+    fixture = json.loads((FIXTURES / "pass.json").read_text(encoding="utf-8"))
+    fixture["metrics"]["near_boundary_edges"] = [0.96]
+    fixture["metrics"]["max_edge_gain"] = 0.96
+
+    path = tmp_path / "invalid_pass_with_boundary.json"
+    path.write_text(json.dumps(fixture, indent=2) + "\n", encoding="utf-8")
+
+    result = _run(path)
+    assert result.returncode == 1
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(issue["path"] == "verdict" for issue in payload["errors"])


### PR DESCRIPTION
## Summary

Add `tests/test_check_relational_gain_contract.py` as regression
coverage for the current Relational Gain shadow contract checker.

## Why

The Relational Gain layer-specific hardening track now has:

- layer-specific schema
- layer-specific contract checker
- canonical PASS / WARN / FAIL fixtures

The next required step is executable regression coverage for the checker.

This PR adds that coverage.

## What changed

Added `tests/test_check_relational_gain_contract.py` with coverage for:

- valid PASS fixture
- valid WARN fixture
- valid FAIL fixture
- missing-input neutral absence via `--if-input-present`
- missing-input hard failure without neutral mode
- invalid WARN case without near-boundary signal
- invalid FAIL case without offending signal
- invalid checker version
- invalid PASS case with near-boundary entries

## Contract intent

These tests validate the **current actual Relational Gain artifact shape**
and the current layer-specific checker semantics.

They are intended to lock the current shadow-only contract behavior
before later non-interference coverage is added.

## Scope

Test-only change.

This PR does **not**:

- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

This test file becomes the regression anchor for the current
Relational Gain contract checker and completes the first layer-specific
schema + checker + fixture + tests loop.

## Notes

These tests validate the checker as a shadow contract-enforcement surface,
not as a release gate.