### PR TITLE
docs(shadow): sync relational gain inventory to shadow-contracted state

### DIFF
--- a/docs/SHADOW_CONTRACT_PROGRAM_v0.md
+++ b/docs/SHADOW_CONTRACT_PROGRAM_v0.md
@@ -356,8 +356,8 @@ Each registered shadow layer should have a record like this.
 layer_id: relational_gain_shadow
 family: relation-dynamics
 default_role: shadow diagnostic
-current_stage: research
-target_stage: shadow-contracted
+current_stage: shadow-contracted
+target_stage: advisory
 owner_surface:
   - docs
   - workflow
@@ -367,13 +367,12 @@ primary_artifact: PULSE_safe_pack_v0/artifacts/relational_gain_shadow_v0.json
 status_foldin: meta.relational_gain_shadow
 schema: schemas/relational_gain_shadow_v0.schema.json
 semantic_checker: PULSE_safe_pack_v0/tools/check_relational_gain_contract.py
-run_reality_states: [real, degraded, invalid, absent]
+run_reality_states: [real, absent]
 consumer_authority: review-only
 non_interference_test: tests/test_relational_gain_non_interference.py
 promotion_blockers:
-  - schema not landed
-  - contract checker not landed
-notes: Shadow-only. Must not write under gates.*.
+ - advisory promotion not evaluated
+notes: Shadow-only. Contract-hardened. Must not write under gates.*.
 ```
 
 ---
@@ -389,7 +388,7 @@ It is a management surface, not a promotion statement.
 | Separation phase overlay | `separation_phase_overlay_v0` | research | — | shadow diagnostic | artifact present | none | schema + consumer rule |
 | Theory overlay v0 | `theory_overlay_v0` | research | — | shadow diagnostic | artifact present | none | schema + degraded model |
 | G-field / G snapshot family | `g_field_snapshot_family_v0` | research | — | shadow diagnostic | mixed / family-level | none | split family contracts |
-| Relational Gain v0 | `relational_gain_shadow` | research | shadow-contracted | shadow diagnostic | artifact present | `meta.relational_gain_shadow` | land schema + contract checker |
+| Relational Gain v0 | `relational_gain_shadow` | research |  shadow-contracted | advisory | shadow diagnostic | artifact contracted | `meta.relational_gain_shadow` | advisory evaluation only if explicitly pursued |
 | EPF experiment / hazard | `epf_shadow_experiment_v0` | research | — | research diagnostic | artifact family present | none | comparison contract + real/stub classifier |
 | Topology family | `topology_family_v0` | research | — | artifact-derived topology | partial family artifacts | none | standalone schema set |
 | Decision-field family | `decision_field_v0` | research | — | decision-oriented shadow read | partial family artifacts | none | vocabulary contract + artifact schema |


### PR DESCRIPTION
## Summary

Update `docs/SHADOW_CONTRACT_PROGRAM_v0.md` so the Relational Gain
record example and seeded inventory match the current hardened
shadow-only state.

## Why

The Relational Gain shadow track now has:

- layer-specific schema
- layer-specific contract checker
- canonical PASS / WARN / FAIL fixtures
- checker regression tests
- non-interference coverage
- updated workflow coverage
- refreshed layer-specific docs

The repo-level shadow inventory should now reflect that reality.

## What changed

- updated the Relational Gain example record to:
  - `current_stage: shadow-contracted`
  - keep future movement in `target_stage`
  - reflect current actual run reality states
  - remove stale pre-hardening blockers
- updated the seeded inventory row for Relational Gain to:
  - move current stage from `research` to `shadow-contracted`
  - keep advisory movement explicit and separate
  - reflect that the artifact is now contract-hardened

## Contract intent

This PR does **not** promote Relational Gain into release authority.

It only syncs the repo-level shadow inventory with the current
documented and implemented shadow state.

## Scope

Documentation-only inventory update.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

This makes the repo-level shadow contract program consistent with the
now-completed Relational Gain schema + checker + fixtures + tests +
non-interference hardening loop.