### PR TITLE
fix(docs): correct relational gain inventory row alignment

### DIFF
--- a/docs/SHADOW_CONTRACT_PROGRAM_v0.md
+++ b/docs/SHADOW_CONTRACT_PROGRAM_v0.md
@@ -388,7 +388,7 @@ It is a management surface, not a promotion statement.
 | Separation phase overlay | `separation_phase_overlay_v0` | research | — | shadow diagnostic | artifact present | none | schema + consumer rule |
 | Theory overlay v0 | `theory_overlay_v0` | research | — | shadow diagnostic | artifact present | none | schema + degraded model |
 | G-field / G snapshot family | `g_field_snapshot_family_v0` | research | — | shadow diagnostic | mixed / family-level | none | split family contracts |
-| Relational Gain v0 | `relational_gain_shadow` | research |  shadow-contracted | advisory | shadow diagnostic | artifact contracted | `meta.relational_gain_shadow` | advisory evaluation only if explicitly pursued |
+| Relational Gain v0 | `relational_gain_shadow` | shadow-contracted | advisory | shadow diagnostic | artifact contracted | `meta.relational_gain_shadow` | advisory evaluation only if explicitly pursued |
 | EPF experiment / hazard | `epf_shadow_experiment_v0` | research | — | research diagnostic | artifact family present | none | comparison contract + real/stub classifier |
 | Topology family | `topology_family_v0` | research | — | artifact-derived topology | partial family artifacts | none | standalone schema set |
 | Decision-field family | `decision_field_v0` | research | — | decision-oriented shadow read | partial family artifacts | none | vocabulary contract + artifact schema |


### PR DESCRIPTION
## Summary

Correct the Relational Gain seeded inventory row in
`docs/SHADOW_CONTRACT_PROGRAM_v0.md`.

## Why

The previous row update introduced an extra pipe-delimited cell, which
shifted values into the wrong columns.

That made the seeded inventory inaccurate for Relational Gain and
contradicted the intended sync to the current shadow-contracted state.

## What changed

Replaced the malformed Relational Gain row with the correctly aligned one:

- `current_stage: shadow-contracted`
- `target_stage: advisory`
- `default_role: shadow diagnostic`
- `primary artifact status: artifact contracted`

## Scope

Documentation-only table correction.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Review note addressed

Address Codex feedback that the Relational Gain inventory row was
misaligned because of an extra pipe-delimited cell.