### PR TITLE
docs(changelog): add status contract note for relational gain shadow …

### DIFF
--- a/docs/policy/CHANGELOG.md
+++ b/docs/policy/CHANGELOG.md
@@ -21,11 +21,19 @@ This changelog records **semantic** changes that can affect release gating outco
 
 ## Unreleased
 
+
 - `pulse_gate_policy_v0.yml` / `pulse-gate-policy-v0` (policy 0.1.3):
   - Changed: add `detectors_materialized_ok` to `gates.release_required`.
   - Why: scaffold / placeholder booleans must not be misread as materialized release evidence in release-grade paths.
   - Impact: policy consumers deriving `release_required` now fail closed until detectors are materialized.
   - Migration: wire deterministic producers for the release-grade detector-backed gates before treating scaffold output as passing release evidence.
+
+- `docs/STATUS_CONTRACT.md` / `status contract`:
+  - Changed: documented the `meta.relational_gain_shadow` fold-in surface as additive, descriptive, and non-normative shadow metadata.
+  - Why: make the public status contract reflect the implemented Relational Gain shadow fold-in behavior.
+  - Impact: clarifies consumer expectations for `meta.relational_gain_shadow`; no change to release authority, required gates, or `check_gates.py` behavior.
+  - Migration: none. Consumers must continue treating `meta.relational_gain_shadow` as non-normative shadow metadata.
+
 
 ## 0.1.0 — Initial baseline
 


### PR DESCRIPTION
## Summary

Update `docs/policy/CHANGELOG.md` so the `Unreleased` section records the
recent `docs/STATUS_CONTRACT.md` change.

## Why

The repo's changelog enforcement treats `docs/STATUS_CONTRACT.md` as a
semantic documentation surface.

That means changes to `docs/STATUS_CONTRACT.md` must be reflected in the
`Unreleased` section of `docs/policy/CHANGELOG.md` with a matching
`status contract` token.

This PR adds that missing changelog note.

## What changed

Added an `Unreleased` changelog entry for:

- `docs/STATUS_CONTRACT.md` / `status contract`

The new note records that:

- `meta.relational_gain_shadow` is now documented as an additive,
  descriptive, non-normative fold-in surface
- consumer expectations are clarified
- release authority remains unchanged

## Scope

Changelog-only correction.

This PR does **not**:

- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Make the semantic changelog surface consistent with the recent
`STATUS_CONTRACT` update and satisfy changelog enforcement for this PR.