### PR TITLE
feat(shadow): add machine-readable shadow layer registry v0

### DIFF
--- a/shadow_layer_registry_v0.yml
+++ b/shadow_layer_registry_v0.yml
@@ -1,0 +1,26 @@
+version: "shadow_layer_registry_v0"
+
+layers:
+  - layer_id: relational_gain_shadow
+    family: relation-dynamics
+    current_stage: shadow-contracted
+    target_stage: advisory
+    default_role: shadow diagnostic
+    consumer_authority: review-only
+    primary_entrypoint: .github/workflows/relational_gain_shadow.yml
+    primary_artifact: PULSE_safe_pack_v0/artifacts/relational_gain_shadow_v0.json
+    status_foldin: meta.relational_gain_shadow
+    schema: schemas/relational_gain_shadow_v0.schema.json
+    semantic_checker: PULSE_safe_pack_v0/tools/check_relational_gain_contract.py
+    fixtures:
+      - tests/fixtures/relational_gain_shadow_v0/pass.json
+      - tests/fixtures/relational_gain_shadow_v0/warn.json
+      - tests/fixtures/relational_gain_shadow_v0/fail.json
+    tests:
+      - tests/test_check_relational_gain_contract.py
+      - tests/test_relational_gain_non_interference.py
+    run_reality_states:
+      - real
+      - absent
+    normative: false
+    notes: Shadow-only. Contract-hardened. Must not write under gates.*.


### PR DESCRIPTION
## Summary

Add `shadow_layer_registry_v0.yml` as the machine-readable registry
surface for shadow layers.

## Why

The repo now has:
- a repo-level shadow contract program
- a common shadow artifact scaffold
- one fully hardened layer-specific pilot (Relational Gain v0)
- synced docs across shadow inventory, optional layers, and status surface

What is still missing is a single machine-readable source of truth for
shadow-layer registration state.

This PR adds that registry.

## What changed

- added `shadow_layer_registry_v0.yml`
- registered the current Relational Gain shadow layer
- recorded:
  - `layer_id`
  - family
  - current stage
  - target stage
  - consumer authority
  - primary workflow entrypoint
  - primary artifact
  - status fold-in location
  - schema
  - semantic checker
  - fixtures
  - tests
  - run reality states
  - normative boundary note

## Contract intent

This registry is descriptive and management-facing.

It does **not**:
- create new authority
- change release semantics
- promote any shadow layer
- make registry presence normative by itself

## Scope

Registry-only infrastructure addition.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the machine-readable repo-level anchor that future shadow layers
can register against, starting from the contract-hardened Relational Gain pilot.