### PR TITLE
fix(shadow): tighten registry schema consistency

### DIFF
--- a/schemas/shadow_layer_registry_v0.schema.json
+++ b/schemas/shadow_layer_registry_v0.schema.json
@@ -17,6 +17,7 @@
     "layers": {
       "type": "array",
       "minItems": 1,
+      "uniqueItems": true,
       "items": {
         "$ref": "#/$defs/layer"
       }
@@ -206,7 +207,32 @@
               "current_stage": {
                 "const": "release-required"
               }
-            }
+            },
+            "required": [
+              "current_stage"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "current_stage": {
+                "const": "release-required"
+              }
+            },
+            "required": [
+              "current_stage"
+            ]
+          },
+          "then": {
+            "properties": {
+              "normative": {
+                "const": true
+              }
+            },
+            "required": [
+              "normative"
+            ]
           }
         }
       ]


### PR DESCRIPTION
## Summary

Update `schemas/shadow_layer_registry_v0.schema.json` to tighten
registry-state consistency rules.

## Why

Codex correctly pointed out two issues:

1. the schema enforced only one direction of the
   `normative` / `current_stage` relationship
2. the top-level `layers` array had no duplicate-entry protection at all

That allowed internally contradictory entries such as:

- `current_stage: release-required`
- `normative: false`

This PR fixes the stage-consistency gap and adds partial duplicate-entry
protection.

## What changed

- added the inverse rule:
  - `current_stage: release-required` -> `normative: true`
- kept the existing rule:
  - `normative: true` -> `current_stage: release-required`
- added `uniqueItems: true` to the top-level `layers` array as partial
  protection against exact duplicate entries

## Important note

The concern about duplicate `layer_id` values is valid, but full
uniqueness of a single property across object-array items is not
robustly enforceable in standard JSON Schema.

That full check belongs in the upcoming registry semantic checker.

## Scope

Schema-only correction.

This PR does **not**:
- add the runtime registry checker yet
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Review note addressed

Address Codex feedback about:
- `release-required` being allowed with `normative: false`
- missing duplicate-entry protection at the top-level `layers` array