### PR TITLE
fix(shadow): allow JSON registry validation without PyYAML

### DIFF
--- a/PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py
+++ b/PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py
@@ -190,9 +190,6 @@ def _validate_enum_string_array(
 
 
 def _load_registry(path: Path) -> Any:
-    if yaml is None:
-        raise ValueError("PyYAML is required to read shadow layer registry files")
-
     try:
         text = path.read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -200,11 +197,18 @@ def _load_registry(path: Path) -> Any:
     except OSError as exc:
         raise ValueError(f"failed to read {path}: {exc}") from exc
 
-    try:
-        if path.suffix.lower() == ".json":
+    if path.suffix.lower() == ".json":
+        try:
             return json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid registry syntax: {exc}") from exc
+
+    if yaml is None:
+        raise ValueError("PyYAML is required to read non-JSON shadow layer registry files")
+
+    try:
         return yaml.safe_load(text)
-    except (json.JSONDecodeError, yaml.YAMLError) as exc:  # type: ignore[attr-defined]
+    except yaml.YAMLError as exc:  # type: ignore[attr-defined]
         raise ValueError(f"invalid registry syntax: {exc}") from exc
 
 


### PR DESCRIPTION
## Summary

Update `PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py` so
valid JSON registry inputs can be checked even when PyYAML is not installed.

## Why

The registry checker CLI accepts both YAML and JSON inputs.

However, the previous loader required PyYAML before branching on file type,
which meant a valid `.json` registry file would still fail in an
environment where PyYAML was unavailable.

This PR fixes that compatibility bug.

## What changed

- moved the PyYAML dependency check to the non-JSON branch only
- kept JSON parsing fully independent of PyYAML
- split JSON and YAML parsing paths cleanly
- avoided referencing `yaml.YAMLError` when `yaml` is unavailable

## Contract intent

This does not change registry semantics.

It only ensures that the checker behaves consistently with its stated
input contract:
- JSON should work without YAML support
- YAML should still require PyYAML

## Scope

Checker-only compatibility correction.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Review note addressed

Address Codex feedback that JSON registry validation should remain usable
without PyYAML installed.