### PR TITLE
test(shadow): add pass fixture for shadow layer registry contract

### DIFF
--- a/tests/fixtures/shadow_layer_registry_v0/pass.json
+++ b/tests/fixtures/shadow_layer_registry_v0/pass.json
@@ -1,0 +1,33 @@
+{
+  "version": "shadow_layer_registry_v0",
+  "layers": [
+    {
+      "layer_id": "relational_gain_shadow",
+      "family": "relation-dynamics",
+      "current_stage": "shadow-contracted",
+      "target_stage": "advisory",
+      "default_role": "shadow diagnostic",
+      "consumer_authority": "review-only",
+      "primary_entrypoint": ".github/workflows/relational_gain_shadow.yml",
+      "primary_artifact": "PULSE_safe_pack_v0/artifacts/relational_gain_shadow_v0.json",
+      "status_foldin": "meta.relational_gain_shadow",
+      "schema": "schemas/relational_gain_shadow_v0.schema.json",
+      "semantic_checker": "PULSE_safe_pack_v0/tools/check_relational_gain_contract.py",
+      "fixtures": [
+        "tests/fixtures/relational_gain_shadow_v0/pass.json",
+        "tests/fixtures/relational_gain_shadow_v0/warn.json",
+        "tests/fixtures/relational_gain_shadow_v0/fail.json"
+      ],
+      "tests": [
+        "tests/test_check_relational_gain_contract.py",
+        "tests/test_relational_gain_non_interference.py"
+      ],
+      "run_reality_states": [
+        "real",
+        "absent"
+      ],
+      "normative": false,
+      "notes": "Shadow-only. Contract-hardened. Must not write under gates.*."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/shadow_layer_registry_v0/pass.json` as the canonical
positive fixture for the shadow layer registry contract.

## Why

The repo now has:

- `shadow_layer_registry_v0.yml`
- `schemas/shadow_layer_registry_v0.schema.json`
- `PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py`

The next required step is a stable positive fixture so the registry
surface can be tested against a known-good baseline.

This PR adds that fixture.

## What changed

Added `tests/fixtures/shadow_layer_registry_v0/pass.json` with a valid
registry entry for the current Relational Gain shadow layer.

The fixture is aligned with the current registry contract, including:

- correct registry `version`
- one valid `layers` entry
- valid `layer_id`, `family`, and stage fields
- valid `consumer_authority`
- valid repo-relative references for:
  - workflow entrypoint
  - artifact path
  - schema
  - semantic checker
  - fixtures
  - tests
- valid `run_reality_states`
- `normative: false`
- non-empty notes

## Contract intent

This fixture is the canonical positive JSON baseline for the registry
surface.

It is also useful for exercising the JSON input path of the registry
checker independently of YAML support.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the positive baseline fixture for upcoming shadow registry
checker tests.