### PR TITLE
test(shadow): add shadow layer registry checker tests

### DIFF
--- a/tests/test_check_shadow_layer_registry.py
+++ b/tests/test_check_shadow_layer_registry.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "PULSE_safe_pack_v0" / "tools" / "check_shadow_layer_registry.py"
+FIXTURES = ROOT / "tests" / "fixtures" / "shadow_layer_registry_v0"
+
+
+def _run(input_path: Path, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, str(SCRIPT), "--input", str(input_path), *extra_args]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def _stdout_json(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    return json.loads(result.stdout)
+
+
+def _load_fixture(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _load_checker_module():
+    spec = importlib.util.spec_from_file_location("check_shadow_layer_registry", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_pass_fixture_is_valid() -> None:
+    result = _run(FIXTURES / "pass.json")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is False
+    assert payload["registry_version"] == "shadow_layer_registry_v0"
+    assert payload["layer_count"] == 1
+
+
+def test_missing_input_is_neutral_with_if_input_present() -> None:
+    result = _run(FIXTURES / "does_not_exist.json", "--if-input-present")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is True
+    assert payload["registry_version"] is None
+    assert payload["layer_count"] == 0
+
+
+def test_missing_input_fails_without_if_input_present() -> None:
+    result = _run(FIXTURES / "does_not_exist.json")
+    assert result.returncode == 1
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert payload["neutral"] is False
+    assert any(issue["path"] == "input" for issue in payload["errors"])
+
+
+def test_duplicate_layer_id_fails(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    duplicate = json.loads(json.dumps(fixture["layers"][0]))
+    duplicate["notes"] = "Duplicate layer entry for negative test."
+    fixture["layers"].append(duplicate)
+
+    path = tmp_path / "duplicate_layer_id.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "layers[1].layer_id" and "duplicate layer_id" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_release_required_requires_normative_true(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    layer = fixture["layers"][0]
+    layer["current_stage"] = "release-required"
+    layer["target_stage"] = "release-required"
+    layer["normative"] = False
+
+    path = tmp_path / "invalid_release_required_non_normative.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "layers[0].normative"
+        and "current_stage=release-required requires normative=true" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_normative_true_requires_release_required_stage(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    layer = fixture["layers"][0]
+    layer["normative"] = True
+
+    path = tmp_path / "invalid_normative_true_without_release_required.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "layers[0].current_stage"
+        and "normative=true requires current_stage=release-required" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_target_stage_must_not_be_lower_than_current_stage(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    layer = fixture["layers"][0]
+    layer["current_stage"] = "advisory"
+    layer["target_stage"] = "research"
+
+    path = tmp_path / "invalid_target_stage_lower_than_current.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "layers[0].target_stage"
+        and "target_stage must not be lower than current_stage" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_higher_stage_requires_schema_field(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    layer = fixture["layers"][0]
+    del layer["schema"]
+
+    path = tmp_path / "invalid_missing_schema_for_shadow_contracted.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "layers[0].schema"
+        and "required when current_stage is shadow-contracted" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_json_registry_loads_without_pyyaml_when_yaml_is_none() -> None:
+    module = _load_checker_module()
+    original_yaml = module.yaml
+    module.yaml = None
+    try:
+        obj = module._load_registry(FIXTURES / "pass.json")
+    finally:
+        module.yaml = original_yaml
+
+    assert isinstance(obj, dict)
+    assert obj["version"] == "shadow_layer_registry_v0"
+    assert obj["layers"][0]["layer_id"] == "relational_gain_shadow"


### PR DESCRIPTION
## Summary

Add `tests/test_check_shadow_layer_registry.py` as regression coverage
for the shadow layer registry contract checker.

## Why

The shadow registry hardening track now has:

- `shadow_layer_registry_v0.yml`
- `schemas/shadow_layer_registry_v0.schema.json`
- `PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py`
- canonical positive JSON fixture

The next required step is executable regression coverage for the checker.

This PR adds that coverage.

## What changed

Added `tests/test_check_shadow_layer_registry.py` with coverage for:

- valid pass fixture
- missing-input neutral absence via `--if-input-present`
- missing-input hard failure without neutral mode
- duplicate `layer_id` rejection
- `current_stage=release-required` requiring `normative=true`
- `normative=true` requiring `current_stage=release-required`
- `target_stage` not being lower than `current_stage`
- higher-stage required field enforcement
- JSON loading path working without PyYAML

## Contract intent

These tests validate the registry as a machine-readable shadow contract
surface, not as a release gate.

They are intended to lock the current checker behavior before later
registry fixture expansion or workflow wiring.

## Scope

Test-only change.

This PR does **not**:

- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

This test file becomes the regression anchor for the shadow layer
registry checker and closes the first schema + checker + fixture + tests
loop for the registry surface.