### PR TITLE
docs(workflow): add shadow layer registry workflow to workflow map

### DIFF
--- a/docs/WORKFLOW_MAP.md
+++ b/docs/WORKFLOW_MAP.md
@@ -52,10 +52,42 @@ If you are opening this repository for the first time, use this order:
 
 ### B. Repo / workflow guardrails
 **Purpose:** repo integrity, workflow integrity, governance preflight
-
 - These workflows protect workflow YAML, policy wiring, and related guardrails.
 - They do not create a second release semantic layer.
 - Their job is to prevent damage or ambiguity in the existing mechanism.
+
+#### Shadow layer registry workflow
+
+**Workflow:** `.github/workflows/shadow_layer_registry.yml`
+
+**Purpose:** validate the machine-readable shadow layer registry surface.
+
+Current registry stack:
+
+- `shadow_layer_registry_v0.yml`
+- `schemas/shadow_layer_registry_v0.schema.json`
+- `PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py`
+- `tests/test_check_shadow_layer_registry.py`
+
+Current canonical registry fixture:
+
+- `tests/fixtures/shadow_layer_registry_v0/pass.json`
+
+Current registered layer:
+
+- `relational_gain_shadow`
+
+Boundary:
+
+- registry validation is descriptive and governance-facing
+- it does not change release semantics
+- it does not promote a layer by registry presence alone
+- it does not create normative authority
+
+Current relation to Relational Gain:
+
+- the registry currently tracks the contract-hardened Relational Gain shadow pilot
+- the dedicated registry workflow also watches the currently referenced Relational Gain surfaces
 
 ### C. Shadow / diagnostic workflows
 **Purpose:** extra diagnostics, research layers, or explanatory surfaces


### PR DESCRIPTION
## Summary

Update `docs/WORKFLOW_MAP.md` to include the dedicated shadow layer
registry workflow.

## Why

The repo now has a full registry stack:

- `shadow_layer_registry_v0.yml`
- `schemas/shadow_layer_registry_v0.schema.json`
- `PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py`
- `.github/workflows/shadow_layer_registry.yml`

The workflow map should now name that workflow explicitly so the repo's
workflow picture stays in sync with the current implementation.

## What changed

- added a new shadow layer registry workflow block to `docs/WORKFLOW_MAP.md`
- placed it under the workflow-families section near repo/workflow guardrails
- documented:
  - the workflow path
  - the current registry stack
  - the canonical registry fixture
  - the currently registered Relational Gain layer
  - the non-normative boundary

## Contract intent

This PR does **not** create new authority.

It documents the registry workflow as a governance-facing validation
surface and keeps it separate from normative release semantics.

## Scope

Documentation-only workflow-map update.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the workflow map aligned with the now-landed registry stack without
flattening the file structure or creating a new top-level docs branch.