### PR TITLE
test(shadow): add duplicate layer_id fixture for shadow registry checker

### DIFF
--- a/tests/fixtures/shadow_layer_registry_v0/duplicate_layer_id.json
+++ b/tests/fixtures/shadow_layer_registry_v0/duplicate_layer_id.json
@@ -1,0 +1,61 @@
+{
+  "version": "shadow_layer_registry_v0",
+  "layers": [
+    {
+      "layer_id": "relational_gain_shadow",
+      "family": "relation-dynamics",
+      "current_stage": "shadow-contracted",
+      "target_stage": "advisory",
+      "default_role": "shadow diagnostic",
+      "consumer_authority": "review-only",
+      "primary_entrypoint": ".github/workflows/relational_gain_shadow.yml",
+      "primary_artifact": "PULSE_safe_pack_v0/artifacts/relational_gain_shadow_v0.json",
+      "status_foldin": "meta.relational_gain_shadow",
+      "schema": "schemas/relational_gain_shadow_v0.schema.json",
+      "semantic_checker": "PULSE_safe_pack_v0/tools/check_relational_gain_contract.py",
+      "fixtures": [
+        "tests/fixtures/relational_gain_shadow_v0/pass.json",
+        "tests/fixtures/relational_gain_shadow_v0/warn.json",
+        "tests/fixtures/relational_gain_shadow_v0/fail.json"
+      ],
+      "tests": [
+        "tests/test_check_relational_gain_contract.py",
+        "tests/test_relational_gain_non_interference.py"
+      ],
+      "run_reality_states": [
+        "real",
+        "absent"
+      ],
+      "normative": false,
+      "notes": "Shadow-only. Contract-hardened. Must not write under gates.*."
+    },
+    {
+      "layer_id": "relational_gain_shadow",
+      "family": "relation-dynamics",
+      "current_stage": "shadow-contracted",
+      "target_stage": "advisory",
+      "default_role": "shadow diagnostic",
+      "consumer_authority": "review-only",
+      "primary_entrypoint": ".github/workflows/relational_gain_shadow.yml",
+      "primary_artifact": "PULSE_safe_pack_v0/artifacts/relational_gain_shadow_v0.json",
+      "status_foldin": "meta.relational_gain_shadow",
+      "schema": "schemas/relational_gain_shadow_v0.schema.json",
+      "semantic_checker": "PULSE_safe_pack_v0/tools/check_relational_gain_contract.py",
+      "fixtures": [
+        "tests/fixtures/relational_gain_shadow_v0/pass.json",
+        "tests/fixtures/relational_gain_shadow_v0/warn.json",
+        "tests/fixtures/relational_gain_shadow_v0/fail.json"
+      ],
+      "tests": [
+        "tests/test_check_relational_gain_contract.py",
+        "tests/test_relational_gain_non_interference.py"
+      ],
+      "run_reality_states": [
+        "real",
+        "absent"
+      ],
+      "normative": false,
+      "notes": "Duplicate layer entry for negative fixture isolation."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/shadow_layer_registry_v0/duplicate_layer_id.json`
as the canonical negative fixture for duplicate `layer_id` detection in
the shadow layer registry checker.

## Why

The registry checker enforces a key semantic rule that schema alone
cannot fully guarantee for object-array entries:

- each `layer_id` must be unique

The current test suite exercises this through a temp-file mutation, but
it is useful to also have a stable, explicit negative fixture for this
rule.

## What changed

- added `tests/fixtures/shadow_layer_registry_v0/duplicate_layer_id.json`
- fixture contains two registry entries with the same `layer_id`
- entries are intentionally not exact duplicates, so the failure remains
  focused on duplicate `layer_id` detection rather than generic
  duplicate-object rejection

## Contract intent

This fixture is intended to fail validation for one targeted reason:

- duplicate `layer_id`

It should not depend on unrelated contract errors to trigger failure.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create a canonical negative fixture for one of the registry checker's
most important schema-beyond-semantics rules: duplicate `layer_id`
rejection.