### PR TITLE
test(shadow): expand shadow layer registry checker coverage

### DIFF
--- a/tests/test_check_shadow_layer_registry.py
+++ b/tests/test_check_shadow_layer_registry.py
@@ -7,11 +7,10 @@ import sys
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "PULSE_safe_pack_v0" / "tools" / "check_shadow_layer_registry.py"
 FIXTURES = ROOT / "tests" / "fixtures" / "shadow_layer_registry_v0"
+REGISTRY = ROOT / "shadow_layer_registry_v0.yml"
 
 
 def _run(input_path: Path, *extra_args: str) -> subprocess.CompletedProcess[str]:
@@ -37,6 +36,17 @@ def _load_checker_module():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def test_registry_yaml_is_valid() -> None:
+    result = _run(REGISTRY)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is False
+    assert payload["registry_version"] == "shadow_layer_registry_v0"
+    assert payload["layer_count"] >= 1
 
 
 def test_pass_fixture_is_valid() -> None:
@@ -71,17 +81,9 @@ def test_missing_input_fails_without_if_input_present() -> None:
     assert any(issue["path"] == "input" for issue in payload["errors"])
 
 
-def test_duplicate_layer_id_fails(tmp_path: Path) -> None:
-    fixture = _load_fixture("pass.json")
-    duplicate = json.loads(json.dumps(fixture["layers"][0]))
-    duplicate["notes"] = "Duplicate layer entry for negative test."
-    fixture["layers"].append(duplicate)
-
-    path = tmp_path / "duplicate_layer_id.json"
-    _write_json(path, fixture)
-
-    result = _run(path)
-    assert result.returncode == 1
+def test_duplicate_layer_id_fixture_fails() -> None:
+    result = _run(FIXTURES / "duplicate_layer_id.json")
+    assert result.returncode == 1, result.stdout + result.stderr
 
     payload = _stdout_json(result)
     assert payload["ok"] is False


### PR DESCRIPTION
## Summary

Update `tests/test_check_shadow_layer_registry.py` to expand coverage
for the current shadow layer registry stack.

## Why

The registry hardening track now has:

- `shadow_layer_registry_v0.yml`
- `schemas/shadow_layer_registry_v0.schema.json`
- `PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py`
- canonical positive JSON fixture
- canonical duplicate-layer negative fixture
- dedicated workflow coverage

The test file should now validate the real registry YAML directly and
use the canonical duplicate-layer fixture instead of generating that case
ad hoc inside the test.

## What changed

- added direct validation of `shadow_layer_registry_v0.yml`
- kept validation of the canonical positive JSON fixture
- replaced the temp-generated duplicate-layer case with:
  - `tests/fixtures/shadow_layer_registry_v0/duplicate_layer_id.json`
- preserved coverage for:
  - missing-input neutral absence
  - missing-input hard failure
  - `current_stage=release-required -> normative=true`
  - `normative=true -> current_stage=release-required`
  - `target_stage` ordering
  - higher-stage required field enforcement
  - JSON loading without PyYAML

## Contract intent

This remains a checker-regression test file.

It validates the registry as a machine-readable shadow contract surface,
not as a release gate.

## Scope

Test-only change.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the registry checker tests aligned with the now-landed registry
YAML, canonical fixtures, and dedicated workflow surface.