### PR TITLE
test(shadow): add release-required non-normative fixture for shadow r…

### DIFF
--- a/tests/fixtures/shadow_layer_registry_v0/release_required_non_normative.json
+++ b/tests/fixtures/shadow_layer_registry_v0/release_required_non_normative.json
@@ -1,0 +1,32 @@
+{
+  "version": "shadow_layer_registry_v0",
+  "layers": [
+    {
+      "layer_id": "relational_gain_shadow",
+      "family": "relation-dynamics",
+      "current_stage": "release-required",
+      "default_role": "shadow diagnostic",
+      "consumer_authority": "policy-bound",
+      "primary_entrypoint": ".github/workflows/relational_gain_shadow.yml",
+      "primary_artifact": "PULSE_safe_pack_v0/artifacts/relational_gain_shadow_v0.json",
+      "status_foldin": "meta.relational_gain_shadow",
+      "schema": "schemas/relational_gain_shadow_v0.schema.json",
+      "semantic_checker": "PULSE_safe_pack_v0/tools/check_relational_gain_contract.py",
+      "fixtures": [
+        "tests/fixtures/relational_gain_shadow_v0/pass.json",
+        "tests/fixtures/relational_gain_shadow_v0/warn.json",
+        "tests/fixtures/relational_gain_shadow_v0/fail.json"
+      ],
+      "tests": [
+        "tests/test_check_relational_gain_contract.py",
+        "tests/test_relational_gain_non_interference.py"
+      ],
+      "run_reality_states": [
+        "real",
+        "absent"
+      ],
+      "normative": false,
+      "notes": "Intentionally invalid fixture: release-required must not be non-normative."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/shadow_layer_registry_v0/release_required_non_normative.json`
as the canonical negative fixture for the registry rule that
`current_stage: release-required` must not appear with `normative: false`.

## Why

The registry checker already enforces this rule, but the fixture set
should also contain a stable, explicit negative case for it.

This makes the failure mode easier to test, easier to inspect, and less
dependent on ad hoc temp-file mutation inside tests.

## What changed

Added a new negative registry fixture:

- `tests/fixtures/shadow_layer_registry_v0/release_required_non_normative.json`

The fixture is intentionally invalid only for:

- `current_stage: release-required`
- `normative: false`

All other fields remain aligned with the current registry contract so
the failure path stays isolated.

## Contract intent

This fixture is expected to fail validation for one targeted reason only:

- release-required entries must be normative

It should not rely on unrelated schema or checker failures.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the canonical negative fixture for one of the registry's core
authority-consistency rules before wiring it into the checker tests.