### PR TITLE
test(shadow): wire release-required negative fixture into registry ch…

### DIFF
--- a/tests/test_check_shadow_layer_registry.py
+++ b/tests/test_check_shadow_layer_registry.py
@@ -93,18 +93,9 @@ def test_duplicate_layer_id_fixture_fails() -> None:
     )
 
 
-def test_release_required_requires_normative_true(tmp_path: Path) -> None:
-    fixture = _load_fixture("pass.json")
-    layer = fixture["layers"][0]
-    layer["current_stage"] = "release-required"
-    layer["target_stage"] = "release-required"
-    layer["normative"] = False
-
-    path = tmp_path / "invalid_release_required_non_normative.json"
-    _write_json(path, fixture)
-
-    result = _run(path)
-    assert result.returncode == 1
+def test_release_required_non_normative_fixture_fails() -> None:
+    result = _run(FIXTURES / "release_required_non_normative.json")
+    assert result.returncode == 1, result.stdout + result.stderr
 
     payload = _stdout_json(result)
     assert payload["ok"] is False


### PR DESCRIPTION
## Summary

Update `tests/test_check_shadow_layer_registry.py` so the
`current_stage=release-required` / `normative=false` contradiction is
tested through the canonical negative fixture instead of a temp-generated
mutation.

## Why

The registry fixture set now contains an explicit negative case for this
core authority-consistency rule:

- `tests/fixtures/shadow_layer_registry_v0/release_required_non_normative.json`

The checker tests should use that fixture directly so the failure path is
anchored to a stable, named contract artifact rather than only to an ad
hoc in-test mutation.

## What changed

- added direct use of:
  - `tests/fixtures/shadow_layer_registry_v0/release_required_non_normative.json`
- kept existing coverage for:
  - live registry YAML validation
  - canonical pass fixture
  - neutral missing-input behavior
  - hard failure on missing input
  - duplicate `layer_id` fixture failure
  - `normative=true -> current_stage=release-required`
  - `target_stage` ordering
  - higher-stage required field enforcement
  - JSON loading without PyYAML

## Contract intent

This remains a checker-regression test update.

It improves alignment between:
- canonical negative fixtures
- registry checker behavior
- regression coverage

## Scope

Test-only change.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the registry checker tests aligned with the expanding canonical
fixture set and reduce reliance on temp-generated negative cases where a
stable fixture now exists.