### PR TITLE
test(shadow): add normative-true without release-required fixture for…

### DIFF
--- a/tests/fixtures/shadow_layer_registry_v0/normative_true_without_release_required.json
+++ b/tests/fixtures/shadow_layer_registry_v0/normative_true_without_release_required.json
@@ -1,0 +1,33 @@
+{
+  "version": "shadow_layer_registry_v0",
+  "layers": [
+    {
+      "layer_id": "relational_gain_shadow",
+      "family": "relation-dynamics",
+      "current_stage": "shadow-contracted",
+      "target_stage": "advisory",
+      "default_role": "shadow diagnostic",
+      "consumer_authority": "review-only",
+      "primary_entrypoint": ".github/workflows/relational_gain_shadow.yml",
+      "primary_artifact": "PULSE_safe_pack_v0/artifacts/relational_gain_shadow_v0.json",
+      "status_foldin": "meta.relational_gain_shadow",
+      "schema": "schemas/relational_gain_shadow_v0.schema.json",
+      "semantic_checker": "PULSE_safe_pack_v0/tools/check_relational_gain_contract.py",
+      "fixtures": [
+        "tests/fixtures/relational_gain_shadow_v0/pass.json",
+        "tests/fixtures/relational_gain_shadow_v0/warn.json",
+        "tests/fixtures/relational_gain_shadow_v0/fail.json"
+      ],
+      "tests": [
+        "tests/test_check_relational_gain_contract.py",
+        "tests/test_relational_gain_non_interference.py"
+      ],
+      "run_reality_states": [
+        "real",
+        "absent"
+      ],
+      "normative": true,
+      "notes": "Intentionally invalid fixture: normative=true requires current_stage=release-required."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/shadow_layer_registry_v0/normative_true_without_release_required.json`
as the canonical negative fixture for the registry rule that
`normative: true` must imply `current_stage: release-required`.

## Why

The registry fixture set already contains the inverse negative case:

- `release_required_non_normative.json`

But it does not yet contain the symmetric negative fixture for:

- `normative: true`
- `current_stage != release-required`

This PR adds that missing canonical failure case.

## What changed

Added a new negative registry fixture:

- `tests/fixtures/shadow_layer_registry_v0/normative_true_without_release_required.json`

The fixture is intentionally invalid only for:

- `normative: true`
- `current_stage: shadow-contracted`

All other fields remain aligned with the current registry contract so
the failure path stays isolated.

## Contract intent

This fixture is expected to fail validation for one targeted reason only:

- normative entries must use `current_stage: release-required`

It should not rely on unrelated schema or checker failures.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the canonical negative fixture for the second half of the
registry's bidirectional normative/current_stage consistency rule.