### PR TITLE
test(shadow): wire normative consistency fixtures into registry check…

### DIFF
--- a/tests/test_check_shadow_layer_registry.py
+++ b/tests/test_check_shadow_layer_registry.py
@@ -106,16 +106,9 @@ def test_release_required_non_normative_fixture_fails() -> None:
     )
 
 
-def test_normative_true_requires_release_required_stage(tmp_path: Path) -> None:
-    fixture = _load_fixture("pass.json")
-    layer = fixture["layers"][0]
-    layer["normative"] = True
-
-    path = tmp_path / "invalid_normative_true_without_release_required.json"
-    _write_json(path, fixture)
-
-    result = _run(path)
-    assert result.returncode == 1
+def test_normative_true_without_release_required_fixture_fails() -> None:
+    result = _run(FIXTURES / "normative_true_without_release_required.json")
+    assert result.returncode == 1, result.stdout + result.stderr
 
     payload = _stdout_json(result)
     assert payload["ok"] is False


### PR DESCRIPTION
## Summary

Update `tests/test_check_shadow_layer_registry.py` so both directions of
the registry's normative/current_stage consistency rule are covered
through canonical negative fixtures.

## Why

The registry fixture set now contains explicit negative cases for both:

- `current_stage: release-required` with `normative: false`
- `normative: true` without `current_stage: release-required`

The checker tests should use those fixtures directly so the failure paths
are anchored to stable, named contract artifacts instead of temp-generated
mutations.

## What changed

- kept direct validation of `shadow_layer_registry_v0.yml`
- kept canonical positive JSON fixture coverage
- kept canonical duplicate `layer_id` fixture coverage
- wired:
  - `release_required_non_normative.json`
  - `normative_true_without_release_required.json`
  into the checker tests
- preserved coverage for:
  - missing-input neutral absence
  - hard failure on missing input
  - `target_stage` ordering
  - higher-stage required field enforcement
  - JSON loading without PyYAML

## Contract intent

This remains a checker-regression test update.

It improves alignment between:
- canonical negative fixtures
- registry checker behavior
- regression coverage

## Scope

Test-only change.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Reduce reliance on temp-generated negative cases where stable registry
fixtures now exist and make the checker tests more explicit and inspectable.