### PR TITLE
test(shadow): add target-stage ordering fixture for shadow registry c…

### DIFF
--- a/tests/fixtures/shadow_layer_registry_v0/target_stage_lower_than_current.json
+++ b/tests/fixtures/shadow_layer_registry_v0/target_stage_lower_than_current.json
@@ -1,0 +1,33 @@
+{
+  "version": "shadow_layer_registry_v0",
+  "layers": [
+    {
+      "layer_id": "relational_gain_shadow",
+      "family": "relation-dynamics",
+      "current_stage": "shadow-contracted",
+      "target_stage": "research",
+      "default_role": "shadow diagnostic",
+      "consumer_authority": "review-only",
+      "primary_entrypoint": ".github/workflows/relational_gain_shadow.yml",
+      "primary_artifact": "PULSE_safe_pack_v0/artifacts/relational_gain_shadow_v0.json",
+      "status_foldin": "meta.relational_gain_shadow",
+      "schema": "schemas/relational_gain_shadow_v0.schema.json",
+      "semantic_checker": "PULSE_safe_pack_v0/tools/check_relational_gain_contract.py",
+      "fixtures": [
+        "tests/fixtures/relational_gain_shadow_v0/pass.json",
+        "tests/fixtures/relational_gain_shadow_v0/warn.json",
+        "tests/fixtures/relational_gain_shadow_v0/fail.json"
+      ],
+      "tests": [
+        "tests/test_check_relational_gain_contract.py",
+        "tests/test_relational_gain_non_interference.py"
+      ],
+      "run_reality_states": [
+        "real",
+        "absent"
+      ],
+      "normative": false,
+      "notes": "Intentionally invalid fixture: target_stage must not be lower than current_stage."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/shadow_layer_registry_v0/target_stage_lower_than_current.json`
as the canonical negative fixture for the registry rule that
`target_stage` must not be lower than `current_stage`.

## Why

The registry checker already enforces target-stage ordering, but this
failure path is still represented only through temp-generated mutation
inside tests.

This PR adds a stable, explicit negative fixture for that rule.

## What changed

Added a new negative registry fixture:

- `tests/fixtures/shadow_layer_registry_v0/target_stage_lower_than_current.json`

The fixture is intentionally invalid only for:

- `current_stage: shadow-contracted`
- `target_stage: research`

All other fields remain aligned with the current registry contract so
the failure path stays isolated.

## Contract intent

This fixture is expected to fail validation for one targeted reason only:

- `target_stage` must not be lower than `current_stage`

It should not rely on unrelated schema or checker failures.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the canonical negative fixture for registry stage-ordering
validation before wiring it into the checker tests.