### PR TITLE
test(shadow): wire target-stage ordering fixture into registry checke…

### DIFF
--- a/tests/test_check_shadow_layer_registry.py
+++ b/tests/test_check_shadow_layer_registry.py
@@ -119,17 +119,9 @@ def test_normative_true_without_release_required_fixture_fails() -> None:
     )
 
 
-def test_target_stage_must_not_be_lower_than_current_stage(tmp_path: Path) -> None:
-    fixture = _load_fixture("pass.json")
-    layer = fixture["layers"][0]
-    layer["current_stage"] = "advisory"
-    layer["target_stage"] = "research"
-
-    path = tmp_path / "invalid_target_stage_lower_than_current.json"
-    _write_json(path, fixture)
-
-    result = _run(path)
-    assert result.returncode == 1
+def test_target_stage_lower_than_current_fixture_fails() -> None:
+    result = _run(FIXTURES / "target_stage_lower_than_current.json")
+    assert result.returncode == 1, result.stdout + result.stderr
 
     payload = _stdout_json(result)
     assert payload["ok"] is False


### PR DESCRIPTION
## Summary

Update `tests/test_check_shadow_layer_registry.py` so the registry rule
that `target_stage` must not be lower than `current_stage` is covered
through the canonical negative fixture.

## Why

The registry fixture set now contains an explicit negative case for the
stage-ordering rule:

- `tests/fixtures/shadow_layer_registry_v0/target_stage_lower_than_current.json`

The checker tests should use that fixture directly so the failure path is
anchored to a stable, named contract artifact instead of a temp-generated
mutation.

## What changed

- kept direct validation of `shadow_layer_registry_v0.yml`
- kept canonical positive JSON fixture coverage
- kept canonical duplicate `layer_id` fixture coverage
- kept both canonical normative/current-stage negative fixtures
- wired:
  - `tests/fixtures/shadow_layer_registry_v0/target_stage_lower_than_current.json`
  into the checker tests
- preserved coverage for:
  - missing-input neutral absence
  - hard failure on missing input
  - higher-stage required field enforcement
  - JSON loading without PyYAML

## Contract intent

This remains a checker-regression test update.

It improves alignment between:
- canonical negative fixtures
- registry checker behavior
- regression coverage

## Scope

Test-only change.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Reduce reliance on temp-generated negative cases where a stable registry
fixture now exists and keep the checker tests aligned with the expanding
fixture set.