### PR TITLE
test(shadow): add missing-schema fixture for shadow-contracted regist…

### DIFF
--- a/tests/fixtures/shadow_layer_registry_v0/missing_schema_for_shadow_contracted.json
+++ b/tests/fixtures/shadow_layer_registry_v0/missing_schema_for_shadow_contracted.json
@@ -1,0 +1,32 @@
+{
+  "version": "shadow_layer_registry_v0",
+  "layers": [
+    {
+      "layer_id": "relational_gain_shadow",
+      "family": "relation-dynamics",
+      "current_stage": "shadow-contracted",
+      "target_stage": "advisory",
+      "default_role": "shadow diagnostic",
+      "consumer_authority": "review-only",
+      "primary_entrypoint": ".github/workflows/relational_gain_shadow.yml",
+      "primary_artifact": "PULSE_safe_pack_v0/artifacts/relational_gain_shadow_v0.json",
+      "status_foldin": "meta.relational_gain_shadow",
+      "semantic_checker": "PULSE_safe_pack_v0/tools/check_relational_gain_contract.py",
+      "fixtures": [
+        "tests/fixtures/relational_gain_shadow_v0/pass.json",
+        "tests/fixtures/relational_gain_shadow_v0/warn.json",
+        "tests/fixtures/relational_gain_shadow_v0/fail.json"
+      ],
+      "tests": [
+        "tests/test_check_relational_gain_contract.py",
+        "tests/test_relational_gain_non_interference.py"
+      ],
+      "run_reality_states": [
+        "real",
+        "absent"
+      ],
+      "normative": false,
+      "notes": "Intentionally invalid fixture: shadow-contracted entries must include schema."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/shadow_layer_registry_v0/missing_schema_for_shadow_contracted.json`
as the canonical negative fixture for the registry rule that
`shadow-contracted` entries must include a `schema` field.

## Why

The registry checker already enforces higher-stage required fields, but
this failure path is still represented through temp-generated mutation in
tests.

This PR adds a stable, explicit negative fixture for the missing-schema
case.

## What changed

Added a new negative registry fixture:

- `tests/fixtures/shadow_layer_registry_v0/missing_schema_for_shadow_contracted.json`

The fixture is intentionally invalid only for:

- `current_stage: shadow-contracted`
- missing `schema`

All other fields remain aligned with the current registry contract so the
failure path stays isolated.

## Contract intent

This fixture is expected to fail validation for one targeted reason only:

- `shadow-contracted` entries must include `schema`

It should not rely on unrelated schema or checker failures.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the canonical negative fixture for the higher-stage required-field
rule before wiring it into the registry checker tests.