### PR TITLE
test(shadow): wire missing-schema fixture into registry checker tests

### DIFF
--- a/tests/test_check_shadow_layer_registry.py
+++ b/tests/test_check_shadow_layer_registry.py
@@ -22,14 +22,6 @@ def _stdout_json(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
     return json.loads(result.stdout)
 
 
-def _load_fixture(name: str) -> dict[str, Any]:
-    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
-
-
-def _write_json(path: Path, payload: dict[str, Any]) -> None:
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-
 def _load_checker_module():
     spec = importlib.util.spec_from_file_location("check_shadow_layer_registry", SCRIPT)
     assert spec is not None and spec.loader is not None
@@ -132,16 +124,9 @@ def test_target_stage_lower_than_current_fixture_fails() -> None:
     )
 
 
-def test_higher_stage_requires_schema_field(tmp_path: Path) -> None:
-    fixture = _load_fixture("pass.json")
-    layer = fixture["layers"][0]
-    del layer["schema"]
-
-    path = tmp_path / "invalid_missing_schema_for_shadow_contracted.json"
-    _write_json(path, fixture)
-
-    result = _run(path)
-    assert result.returncode == 1
+def test_missing_schema_for_shadow_contracted_fixture_fails() -> None:
+    result = _run(FIXTURES / "missing_schema_for_shadow_contracted.json")
+    assert result.returncode == 1, result.stdout + result.stderr
 
     payload = _stdout_json(result)
     assert payload["ok"] is False


### PR DESCRIPTION
## Summary

Update `tests/test_check_shadow_layer_registry.py` so the registry rule
that `shadow-contracted` entries must include `schema` is covered through
the canonical negative fixture.

## Why

The registry fixture set now contains an explicit negative case for the
higher-stage required-field rule:

- `tests/fixtures/shadow_layer_registry_v0/missing_schema_for_shadow_contracted.json`

The checker tests should use that fixture directly so the failure path is
anchored to a stable, named contract artifact instead of a temp-generated
mutation.

## What changed

- kept direct validation of `shadow_layer_registry_v0.yml`
- kept canonical positive JSON fixture coverage
- kept canonical duplicate `layer_id` fixture coverage
- kept both canonical normative/current-stage negative fixtures
- kept the canonical target-stage ordering fixture
- wired:
  - `tests/fixtures/shadow_layer_registry_v0/missing_schema_for_shadow_contracted.json`
  into the checker tests
- preserved coverage for:
  - missing-input neutral absence
  - hard failure on missing input
  - JSON loading without PyYAML

## Contract intent

This remains a checker-regression test update.

It improves alignment between:
- canonical negative fixtures
- registry checker behavior
- regression coverage

## Scope

Test-only change.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Finish the shift from temp-generated negative cases to canonical
registry fixtures and keep the checker tests aligned with the now
expanded fixture set.