### PR TITLE
feat(shadow): add EPF paradox summary schema v0

### DIFF
--- a/schemas/epf_paradox_summary_v0.schema.json
+++ b/schemas/epf_paradox_summary_v0.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/epf_paradox_summary_v0.schema.json",
+  "title": "EPF Paradox Summary v0",
+  "description": "Schema for the current epf_paradox_summary.json artifact emitted by the EPF experiment shadow workflow.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "deps_rc",
+    "runall_rc",
+    "baseline_rc",
+    "epf_rc",
+    "total_gates",
+    "changed",
+    "examples"
+  ],
+  "properties": {
+    "deps_rc": {
+      "type": "string",
+      "pattern": "^-?[0-9]+$",
+      "description": "Dependency-install step return code as recorded by the current workflow."
+    },
+    "runall_rc": {
+      "type": "string",
+      "pattern": "^-?[0-9]+$",
+      "description": "run_all.py step return code as recorded by the current workflow."
+    },
+    "baseline_rc": {
+      "type": "string",
+      "pattern": "^-?[0-9]+$",
+      "description": "Baseline check_gates step return code as recorded by the current workflow."
+    },
+    "epf_rc": {
+      "type": "string",
+      "pattern": "^-?[0-9]+$",
+      "description": "EPF shadow check_gates step return code as recorded by the current workflow."
+    },
+    "total_gates": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of baseline gates considered in the comparison."
+    },
+    "changed": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of baseline->EPF gate decision differences recorded."
+    },
+    "examples": {
+      "type": "array",
+      "description": "Sample changed gates emitted by the current workflow.",
+      "items": {
+        "$ref": "#/$defs/example"
+      }
+    }
+  },
+  "$defs": {
+    "example": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "gate",
+        "baseline",
+        "epf"
+      ],
+      "properties": {
+        "gate": {
+          "type": "string",
+          "minLength": 1
+        },
+        "baseline": {},
+        "epf": {}
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add `schemas/epf_paradox_summary_v0.schema.json` as the machine-readable
schema for the current EPF shadow paradox summary artifact.

## Why

The EPF shadow track already emits a concrete comparison/summary artifact,
but that surface is not yet schema-bound.

Before adding a layer-specific checker or tests, the current actual
artifact shape should be frozen in a machine-readable contract.

This PR adds that schema.

## What changed

Added `schemas/epf_paradox_summary_v0.schema.json` with validation for:

- workflow return-code fields:
  - `deps_rc`
  - `runall_rc`
  - `baseline_rc`
  - `epf_rc`
- comparison counters:
  - `total_gates`
  - `changed`
- changed-gate examples:
  - `examples[*].gate`
  - `examples[*].baseline`
  - `examples[*].epf`

## Contract intent

This schema is intentionally tied to the **current actual**
`epf_paradox_summary.json` shape produced by the EPF shadow workflow.

It does **not** reinterpret that artifact as normative and does not
promote the EPF line beyond its current shadow/research role.

## Scope

Schema-only hardening for the EPF summary artifact.

This PR does **not**:
- add a semantic checker yet
- add fixtures yet
- add tests yet
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Start the EPF artifact-hardening track in the same order used for
Relational Gain:

1. current artifact schema
2. semantic checker
3. canonical fixtures
4. checker tests