### PR TITLE
test(shadow): add pass fixture for EPF paradox summary contract

### DIFF
--- a/tests/fixtures/epf_paradox_summary_v0/pass.json
+++ b/tests/fixtures/epf_paradox_summary_v0/pass.json
@@ -1,0 +1,20 @@
+{
+  "deps_rc": "0",
+  "runall_rc": "0",
+  "baseline_rc": "0",
+  "epf_rc": "0",
+  "total_gates": 18,
+  "changed": 2,
+  "examples": [
+    {
+      "gate": "q1_grounded_ok",
+      "baseline": true,
+      "epf": false
+    },
+    {
+      "gate": "q4_slo_ok",
+      "baseline": false,
+      "epf": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/epf_paradox_summary_v0/pass.json` as the canonical
positive fixture for the current EPF shadow paradox summary artifact
contract.

## Why

The EPF summary hardening track now has:

- `schemas/epf_paradox_summary_v0.schema.json`
- `PULSE_safe_pack_v0/tools/check_epf_paradox_summary_contract.py`

The next required step is a stable positive fixture so the current
artifact shape can be tested against a known-good baseline.

## What changed

Added `tests/fixtures/epf_paradox_summary_v0/pass.json` with a valid
EPF paradox summary artifact.

The fixture is aligned with the current contract, including:

- `deps_rc`, `runall_rc`, `baseline_rc`, `epf_rc` as integer strings
- non-negative `total_gates`
- non-negative `changed`
- `changed <= total_gates`
- non-empty `examples` because `changed > 0`
- `examples` length not exceeding `changed`
- changed-gate examples where `baseline` and `epf` differ

## Contract intent

This fixture is the canonical positive baseline for the **current actual**
EPF paradox summary artifact shape.

It does **not** make the EPF line normative and does not promote it
beyond its current shadow/research role.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the positive baseline fixture for the next EPF contract-checker
test step.