### PR TITLE
test(shadow): add EPF paradox summary contract checker tests

### DIFF
--- a/tests/test_check_epf_paradox_summary_contract.py
+++ b/tests/test_check_epf_paradox_summary_contract.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "PULSE_safe_pack_v0" / "tools" / "check_epf_paradox_summary_contract.py"
+FIXTURES = ROOT / "tests" / "fixtures" / "epf_paradox_summary_v0"
+
+
+def _run(input_path: Path, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, str(SCRIPT), "--input", str(input_path), *extra_args]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def _stdout_json(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    return json.loads(result.stdout)
+
+
+def _load_fixture(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_pass_fixture_is_valid() -> None:
+    result = _run(FIXTURES / "pass.json")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is False
+    assert payload["deps_rc"] == 0
+    assert payload["runall_rc"] == 0
+    assert payload["baseline_rc"] == 0
+    assert payload["epf_rc"] == 0
+    assert payload["total_gates"] == 18
+    assert payload["changed"] == 2
+
+
+def test_changed_exceeds_total_gates_fixture_fails() -> None:
+    result = _run(FIXTURES / "changed_exceeds_total_gates.json")
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "changed" and "changed must not exceed total_gates" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_missing_input_is_neutral_with_if_input_present() -> None:
+    result = _run(FIXTURES / "does_not_exist.json", "--if-input-present")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is True
+    assert payload["changed"] is None
+    assert payload["total_gates"] is None
+
+
+def test_missing_input_fails_without_if_input_present() -> None:
+    result = _run(FIXTURES / "does_not_exist.json")
+    assert result.returncode == 1
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert payload["neutral"] is False
+    assert any(issue["path"] == "input" for issue in payload["errors"])
+
+
+def test_examples_must_be_empty_when_changed_is_zero(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    fixture["changed"] = 0
+
+    path = tmp_path / "changed_zero_with_examples.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "examples" and "examples must be empty when changed is 0" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_examples_must_be_non_empty_when_changed_is_positive(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    fixture["changed"] = 1
+    fixture["examples"] = []
+
+    path = tmp_path / "changed_positive_without_examples.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "examples" and "examples must be non-empty when changed is greater than 0" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_examples_length_must_not_exceed_changed(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    fixture["changed"] = 1
+
+    path = tmp_path / "examples_longer_than_changed.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "examples" and "examples length must not exceed changed" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_duplicate_gate_examples_fail(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    fixture["total_gates"] = 3
+    fixture["changed"] = 2
+    fixture["examples"] = [
+        {
+            "gate": "q1_grounded_ok",
+            "baseline": True,
+            "epf": False,
+        },
+        {
+            "gate": "q1_grounded_ok",
+            "baseline": False,
+            "epf": True,
+        },
+    ]
+
+    path = tmp_path / "duplicate_gate_examples.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "examples[1].gate" and "duplicate gate example" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_baseline_and_epf_must_differ_inside_example(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    fixture["examples"][0]["epf"] = fixture["examples"][0]["baseline"]
+
+    path = tmp_path / "example_without_difference.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "examples[0]" and "baseline and epf must differ" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_rc_fields_must_be_integer_strings(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    fixture["epf_rc"] = "success"
+
+    path = tmp_path / "invalid_rc_string.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "epf_rc" and "must match ^-?[0-9]+$" in issue["message"]
+        for issue in payload["errors"]
+    )


### PR DESCRIPTION
## Summary

Add `tests/test_check_epf_paradox_summary_contract.py` as regression
coverage for the current EPF shadow paradox summary contract checker.

## Why

The EPF summary hardening track now has:

- `schemas/epf_paradox_summary_v0.schema.json`
- `PULSE_safe_pack_v0/tools/check_epf_paradox_summary_contract.py`
- canonical positive fixture
- canonical `changed > total_gates` negative fixture

The next required step is executable regression coverage for the checker.

This PR adds that coverage.

## What changed

Added `tests/test_check_epf_paradox_summary_contract.py` with coverage for:

- valid pass fixture
- canonical negative fixture where `changed > total_gates`
- missing-input neutral absence via `--if-input-present`
- missing-input hard failure without neutral mode
- invalid `changed == 0` with non-empty examples
- invalid `changed > 0` with empty examples
- invalid `examples` length greater than `changed`
- duplicate gate examples
- examples where `baseline == epf`
- invalid non-integer-string return-code fields

## Contract intent

These tests validate the **current actual** EPF paradox summary artifact
shape and checker semantics.

They do not make EPF normative and do not promote the EPF line beyond
its current shadow/research role.

## Scope

Test-only change.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the regression anchor for the current EPF paradox summary checker
before expanding the EPF fixture set and workflow validation further.