### PR TITLE
test(shadow): add changed-positive-without-examples fixture for EPF p…

### DIFF
--- a/tests/fixtures/epf_paradox_summary_v0/changed_positive_without_examples.json
+++ b/tests/fixtures/epf_paradox_summary_v0/changed_positive_without_examples.json
@@ -1,0 +1,9 @@
+{
+  "deps_rc": "0",
+  "runall_rc": "0",
+  "baseline_rc": "0",
+  "epf_rc": "0",
+  "total_gates": 2,
+  "changed": 1,
+  "examples": []
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/epf_paradox_summary_v0/changed_positive_without_examples.json`
as the canonical negative fixture for the EPF summary rule that
`examples` must be non-empty when `changed > 0`.

## Why

The EPF paradox summary checker already enforces this rule, but the
fixture set should also contain a stable, explicit negative case for it.

This makes the failure mode easier to test, easier to inspect, and less
dependent on ad hoc mutation inside tests.

## What changed

Added a new negative EPF summary fixture:

- `tests/fixtures/epf_paradox_summary_v0/changed_positive_without_examples.json`

The fixture is intentionally invalid only for:

- `changed: 1`
- `examples: []`

All other fields remain aligned with the current EPF summary contract so
the failure path stays isolated.

## Contract intent

This fixture is expected to fail validation for one targeted reason only:

- `examples` must be non-empty when `changed > 0`

It should not rely on unrelated schema or checker failures.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the canonical negative fixture for one of the EPF summary
checker’s core changed/examples consistency rules before wiring it into
the checker tests.