### PR TITLE
test(shadow): wire duplicate-gate fixture into EPF checker tests

### DIFF
--- a/tests/test_check_epf_paradox_summary_contract.py
+++ b/tests/test_check_epf_paradox_summary_contract.py
@@ -67,6 +67,18 @@ def test_changed_positive_without_examples_fixture_fails() -> None:
     )
 
 
+def test_duplicate_gate_examples_fixture_fails() -> None:
+    result = _run(FIXTURES / "duplicate_gate_examples.json")
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "examples[1].gate" and "duplicate gate example" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
 def test_missing_input_is_neutral_with_if_input_present() -> None:
     result = _run(FIXTURES / "does_not_exist.json", "--if-input-present")
     assert result.returncode == 0, result.stdout + result.stderr
@@ -120,37 +132,6 @@ def test_examples_length_must_not_exceed_changed(tmp_path: Path) -> None:
     assert payload["ok"] is False
     assert any(
         issue["path"] == "examples" and "examples length must not exceed changed" in issue["message"]
-        for issue in payload["errors"]
-    )
-
-
-def test_duplicate_gate_examples_fail(tmp_path: Path) -> None:
-    fixture = _load_fixture("pass.json")
-    fixture["total_gates"] = 3
-    fixture["changed"] = 2
-    fixture["examples"] = [
-        {
-            "gate": "q1_grounded_ok",
-            "baseline": True,
-            "epf": False,
-        },
-        {
-            "gate": "q1_grounded_ok",
-            "baseline": False,
-            "epf": True,
-        },
-    ]
-
-    path = tmp_path / "duplicate_gate_examples.json"
-    _write_json(path, fixture)
-
-    result = _run(path)
-    assert result.returncode == 1, result.stdout + result.stderr
-
-    payload = _stdout_json(result)
-    assert payload["ok"] is False
-    assert any(
-        issue["path"] == "examples[1].gate" and "duplicate gate example" in issue["message"]
         for issue in payload["errors"]
     )
 


### PR DESCRIPTION
## Summary

Update `tests/test_check_epf_paradox_summary_contract.py` so the EPF
summary rule that changed-gate examples must use unique `gate` values is
covered through the canonical negative fixture.

## Why

The EPF fixture set now contains an explicit negative case for this
schema-beyond-shape semantic rule:

- `tests/fixtures/epf_paradox_summary_v0/duplicate_gate_examples.json`

The checker tests should use that fixture directly so the failure path is
anchored to a stable, named contract artifact instead of a temp-generated
mutation.

## What changed

- kept canonical positive pass fixture coverage
- kept canonical `changed > total_gates` negative fixture coverage
- kept canonical `changed > 0` with empty `examples` negative fixture coverage
- wired:
  - `tests/fixtures/epf_paradox_summary_v0/duplicate_gate_examples.json`
  into the checker tests
- preserved coverage for:
  - missing-input neutral absence
  - hard failure on missing input
  - `changed == 0` with non-empty examples
  - examples length exceeding `changed`
  - `baseline == epf` inside an example
  - invalid return-code strings

## Contract intent

This remains a checker-regression test update.

It improves alignment between:
- canonical EPF negative fixtures
- EPF checker behavior
- regression coverage

## Scope

Test-only change.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Reduce reliance on temp-generated negative cases where a stable EPF
fixture now exists and keep the checker tests aligned with the expanding
EPF fixture set.