### PR TITLE
test(shadow): add example-without-difference fixture for EPF paradox …

### DIFF
--- a/tests/fixtures/epf_paradox_summary_v0/example_without_difference.json
+++ b/tests/fixtures/epf_paradox_summary_v0/example_without_difference.json
@@ -1,0 +1,15 @@
+{
+  "deps_rc": "0",
+  "runall_rc": "0",
+  "baseline_rc": "0",
+  "epf_rc": "0",
+  "total_gates": 2,
+  "changed": 1,
+  "examples": [
+    {
+      "gate": "q1_grounded_ok",
+      "baseline": true,
+      "epf": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/epf_paradox_summary_v0/example_without_difference.json`
as the canonical negative fixture for the EPF summary rule that
`baseline` and `epf` must differ inside each changed-gate example.

## Why

The EPF paradox summary checker already rejects examples where
`baseline == epf`, but the fixture set should also contain a stable,
explicit negative case for this rule.

This makes the failure mode easier to test, easier to inspect, and less
dependent on ad hoc mutation inside tests.

## What changed

Added a new negative EPF summary fixture:

- `tests/fixtures/epf_paradox_summary_v0/example_without_difference.json`

The fixture is intentionally invalid only for:

- one example where `baseline` and `epf` are equal

All other fields remain aligned with the current EPF summary contract so
the failure path stays isolated.

## Contract intent

This fixture is expected to fail validation for one targeted reason only:

- `baseline` and `epf` must differ inside each changed-gate example

It should not rely on unrelated schema or checker failures.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the canonical negative fixture for one of the EPF summary
checker’s example-level semantic rules before wiring it into the
checker tests.