### PR TITLE
test(shadow): wire example-without-difference fixture into EPF checke…

### DIFF
--- a/tests/test_check_epf_paradox_summary_contract.py
+++ b/tests/test_check_epf_paradox_summary_contract.py
@@ -62,7 +62,8 @@ def test_changed_positive_without_examples_fixture_fails() -> None:
     payload = _stdout_json(result)
     assert payload["ok"] is False
     assert any(
-        issue["path"] == "examples" and "examples must be non-empty when changed is greater than 0" in issue["message"]
+        issue["path"] == "examples"
+        and "examples must be non-empty when changed is greater than 0" in issue["message"]
         for issue in payload["errors"]
     )
 
@@ -75,6 +76,18 @@ def test_duplicate_gate_examples_fixture_fails() -> None:
     assert payload["ok"] is False
     assert any(
         issue["path"] == "examples[1].gate" and "duplicate gate example" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_example_without_difference_fixture_fails() -> None:
+    result = _run(FIXTURES / "example_without_difference.json")
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "examples[0]" and "baseline and epf must differ" in issue["message"]
         for issue in payload["errors"]
     )
 
@@ -132,24 +145,6 @@ def test_examples_length_must_not_exceed_changed(tmp_path: Path) -> None:
     assert payload["ok"] is False
     assert any(
         issue["path"] == "examples" and "examples length must not exceed changed" in issue["message"]
-        for issue in payload["errors"]
-    )
-
-
-def test_baseline_and_epf_must_differ_inside_example(tmp_path: Path) -> None:
-    fixture = _load_fixture("pass.json")
-    fixture["examples"][0]["epf"] = fixture["examples"][0]["baseline"]
-
-    path = tmp_path / "example_without_difference.json"
-    _write_json(path, fixture)
-
-    result = _run(path)
-    assert result.returncode == 1, result.stdout + result.stderr
-
-    payload = _stdout_json(result)
-    assert payload["ok"] is False
-    assert any(
-        issue["path"] == "examples[0]" and "baseline and epf must differ" in issue["message"]
         for issue in payload["errors"]
     )
 


### PR DESCRIPTION
## Summary

Update `tests/test_check_epf_paradox_summary_contract.py` so the EPF
summary rule that `baseline` and `epf` must differ inside each changed-gate
example is covered through the canonical negative fixture.

## Why

The EPF fixture set now contains an explicit negative case for this
example-level semantic rule:

- `tests/fixtures/epf_paradox_summary_v0/example_without_difference.json`

The checker tests should use that fixture directly so the failure path is
anchored to a stable, named contract artifact instead of a temp-generated
mutation.

## What changed

- kept canonical positive pass fixture coverage
- kept canonical `changed > total_gates` negative fixture coverage
- kept canonical `changed > 0` with empty `examples` negative fixture coverage
- kept canonical duplicate `gate` negative fixture coverage
- wired:
  - `tests/fixtures/epf_paradox_summary_v0/example_without_difference.json`
  into the checker tests
- preserved coverage for:
  - missing-input neutral absence
  - hard failure on missing input
  - `changed == 0` with non-empty examples
  - examples length exceeding `changed`
  - invalid return-code strings

## Contract intent

This remains a checker-regression test update.

It improves alignment between:
- canonical EPF negative fixtures
- EPF checker behavior
- regression coverage

## Scope

Test-only change.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Reduce reliance on temp-generated negative cases where a stable EPF
fixture now exists and keep the checker tests aligned with the expanding
EPF fixture set.