### PR TITLE
test(shadow): add examples-longer-than-changed fixture for EPF parado…

### DIFF
--- a/tests/fixtures/epf_paradox_summary_v0/examples_longer_than_changed.json
+++ b/tests/fixtures/epf_paradox_summary_v0/examples_longer_than_changed.json
@@ -1,0 +1,20 @@
+{
+  "deps_rc": "0",
+  "runall_rc": "0",
+  "baseline_rc": "0",
+  "epf_rc": "0",
+  "total_gates": 3,
+  "changed": 1,
+  "examples": [
+    {
+      "gate": "q1_grounded_ok",
+      "baseline": true,
+      "epf": false
+    },
+    {
+      "gate": "q4_slo_ok",
+      "baseline": false,
+      "epf": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/epf_paradox_summary_v0/examples_longer_than_changed.json`
as the canonical negative fixture for the EPF summary rule that
`examples` length must not exceed `changed`.

## Why

The EPF paradox summary checker already enforces this rule, but the
fixture set should also contain a stable, explicit negative case for it.

This makes the failure mode easier to test, easier to inspect, and less
dependent on ad hoc mutation inside tests.

## What changed

Added a new negative EPF summary fixture:

- `tests/fixtures/epf_paradox_summary_v0/examples_longer_than_changed.json`

The fixture is intentionally invalid only for:

- `changed: 1`
- `examples` length: 2

All other fields remain aligned with the current EPF summary contract so
the failure path stays isolated.

## Contract intent

This fixture is expected to fail validation for one targeted reason only:

- `examples` length must not exceed `changed`

It should not rely on unrelated schema or checker failures.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the canonical negative fixture for one of the EPF summary
checker’s core changed/examples consistency rules before wiring it into
the checker tests.