### PR TITLE
test(shadow): add invalid-rc-string fixture for EPF paradox summary c…

### DIFF
--- a/tests/fixtures/epf_paradox_summary_v0/invalid_rc_string.json
+++ b/tests/fixtures/epf_paradox_summary_v0/invalid_rc_string.json
@@ -1,0 +1,15 @@
+{
+  "deps_rc": "0",
+  "runall_rc": "0",
+  "baseline_rc": "0",
+  "epf_rc": "success",
+  "total_gates": 2,
+  "changed": 1,
+  "examples": [
+    {
+      "gate": "q1_grounded_ok",
+      "baseline": true,
+      "epf": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/epf_paradox_summary_v0/invalid_rc_string.json`
as the canonical negative fixture for the EPF summary rule that
return-code fields must be integer strings.

## Why

The EPF paradox summary checker already validates RC fields such as
`deps_rc`, `runall_rc`, `baseline_rc`, and `epf_rc`, but the fixture set
does not yet contain a stable, explicit negative case for this rule.

This PR adds that missing canonical failure case.

## What changed

Added a new negative EPF summary fixture:

- `tests/fixtures/epf_paradox_summary_v0/invalid_rc_string.json`

The fixture is intentionally invalid only for:

- `epf_rc: "success"`

All other fields remain aligned with the current EPF summary contract so
the failure path stays isolated.

## Contract intent

This fixture is expected to fail validation for one targeted reason only:

- return-code fields must be integer strings

It should not rely on unrelated schema or checker failures.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the canonical negative fixture for the EPF paradox summary
checker’s RC-field format rule before wiring it into the checker tests.