### PR TITLE
test(shadow): wire invalid-rc-string fixture into EPF checker tests

### DIFF
--- a/tests/test_check_epf_paradox_summary_contract.py
+++ b/tests/test_check_epf_paradox_summary_contract.py
@@ -104,6 +104,18 @@ def test_examples_longer_than_changed_fixture_fails() -> None:
     )
 
 
+def test_invalid_rc_string_fixture_fails() -> None:
+    result = _run(FIXTURES / "invalid_rc_string.json")
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "epf_rc" and "must match ^-?[0-9]+$" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
 def test_missing_input_is_neutral_with_if_input_present() -> None:
     result = _run(FIXTURES / "does_not_exist.json", "--if-input-present")
     assert result.returncode == 0, result.stdout + result.stderr
@@ -139,23 +151,5 @@ def test_examples_must_be_empty_when_changed_is_zero(tmp_path: Path) -> None:
     assert payload["ok"] is False
     assert any(
         issue["path"] == "examples" and "examples must be empty when changed is 0" in issue["message"]
-        for issue in payload["errors"]
-    )
-
-
-def test_rc_fields_must_be_integer_strings(tmp_path: Path) -> None:
-    fixture = _load_fixture("pass.json")
-    fixture["epf_rc"] = "success"
-
-    path = tmp_path / "invalid_rc_string.json"
-    _write_json(path, fixture)
-
-    result = _run(path)
-    assert result.returncode == 1, result.stdout + result.stderr
-
-    payload = _stdout_json(result)
-    assert payload["ok"] is False
-    assert any(
-        issue["path"] == "epf_rc" and "must match ^-?[0-9]+$" in issue["message"]
         for issue in payload["errors"]
     )


### PR DESCRIPTION
## Summary

Update `tests/test_check_epf_paradox_summary_contract.py` so the EPF
summary rule that return-code fields must be integer strings is covered
through the canonical negative fixture.

## Why

The EPF fixture set now contains an explicit negative case for the RC-field
format rule:

- `tests/fixtures/epf_paradox_summary_v0/invalid_rc_string.json`

The checker tests should use that fixture directly so the failure path is
anchored to a stable, named contract artifact instead of a temp-generated
mutation.

## What changed

- kept canonical positive pass fixture coverage
- kept canonical `changed > total_gates` negative fixture coverage
- kept canonical `changed > 0` with empty `examples` negative fixture coverage
- kept canonical duplicate `gate` negative fixture coverage
- kept canonical `baseline == epf` negative fixture coverage
- kept canonical `examples length > changed` negative fixture coverage
- wired:
  - `tests/fixtures/epf_paradox_summary_v0/invalid_rc_string.json`
  into the checker tests
- preserved coverage for:
  - missing-input neutral absence
  - hard failure on missing input
  - `changed == 0` with non-empty examples

## Contract intent

This remains a checker-regression test update.

It improves alignment between:
- canonical EPF negative fixtures
- EPF checker behavior
- regression coverage

## Scope

Test-only change.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Reduce reliance on temp-generated negative cases where a stable EPF
fixture now exists and keep the checker tests aligned with the expanding
EPF fixture set.