### PR TITLE
test(shadow): add changed-zero-with-examples fixture for EPF paradox …

### DIFF
--- a/tests/fixtures/epf_paradox_summary_v0/changed_zero_with_examples.json
+++ b/tests/fixtures/epf_paradox_summary_v0/changed_zero_with_examples.json
@@ -1,0 +1,15 @@
+{
+  "deps_rc": "0",
+  "runall_rc": "0",
+  "baseline_rc": "0",
+  "epf_rc": "0",
+  "total_gates": 2,
+  "changed": 0,
+  "examples": [
+    {
+      "gate": "q1_grounded_ok",
+      "baseline": true,
+      "epf": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/epf_paradox_summary_v0/changed_zero_with_examples.json`
as the canonical negative fixture for the EPF summary rule that
`examples` must be empty when `changed == 0`.

## Why

The EPF fixture set already covers several canonical negative cases, but
the `changed == 0` with non-empty `examples` path is still represented
only through temp-generated mutation inside tests.

This PR adds an explicit fixture for that case.

## What changed

Added a new negative EPF summary fixture:

- `tests/fixtures/epf_paradox_summary_v0/changed_zero_with_examples.json`

The fixture is intentionally invalid for:

- `changed: 0`
- non-empty `examples`

All other fields remain aligned with the current EPF summary contract.

## Important note

Under the current checker logic this fixture may trigger more than one
related examples/count error, because a non-empty `examples` array also
implies `examples length > changed` when `changed == 0`.

That is acceptable for this fixture; its role is to represent the
`changed == 0` / non-empty `examples` contradiction canonically.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the canonical negative fixture for the last remaining EPF
changed/examples contradiction before wiring it into the checker tests.