### PR TITLE
test(shadow): wire changed-zero-with-examples fixture into EPF checke…

### DIFF
--- a/tests/test_check_epf_paradox_summary_contract.py
+++ b/tests/test_check_epf_paradox_summary_contract.py
@@ -20,14 +20,6 @@ def _stdout_json(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
     return json.loads(result.stdout)
 
 
-def _load_fixture(name: str) -> dict[str, Any]:
-    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
-
-
-def _write_json(path: Path, payload: dict[str, Any]) -> None:
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-
 def test_pass_fixture_is_valid() -> None:
     result = _run(FIXTURES / "pass.json")
     assert result.returncode == 0, result.stdout + result.stderr
@@ -116,6 +108,19 @@ def test_invalid_rc_string_fixture_fails() -> None:
     )
 
 
+def test_changed_zero_with_examples_fixture_fails() -> None:
+    result = _run(FIXTURES / "changed_zero_with_examples.json")
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "examples"
+        and "examples must be empty when changed is 0" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
 def test_missing_input_is_neutral_with_if_input_present() -> None:
     result = _run(FIXTURES / "does_not_exist.json", "--if-input-present")
     assert result.returncode == 0, result.stdout + result.stderr
@@ -135,21 +140,3 @@ def test_missing_input_fails_without_if_input_present() -> None:
     assert payload["ok"] is False
     assert payload["neutral"] is False
     assert any(issue["path"] == "input" for issue in payload["errors"])
-
-
-def test_examples_must_be_empty_when_changed_is_zero(tmp_path: Path) -> None:
-    fixture = _load_fixture("pass.json")
-    fixture["changed"] = 0
-
-    path = tmp_path / "changed_zero_with_examples.json"
-    _write_json(path, fixture)
-
-    result = _run(path)
-    assert result.returncode == 1, result.stdout + result.stderr
-
-    payload = _stdout_json(result)
-    assert payload["ok"] is False
-    assert any(
-        issue["path"] == "examples" and "examples must be empty when changed is 0" in issue["message"]
-        for issue in payload["errors"]
-    )


### PR DESCRIPTION
## Summary

Update `tests/test_check_epf_paradox_summary_contract.py` so the EPF
summary rule that `examples` must be empty when `changed == 0` is
covered through the canonical negative fixture.

## Why

The EPF fixture set now contains an explicit negative case for this
changed/examples consistency rule:

- `tests/fixtures/epf_paradox_summary_v0/changed_zero_with_examples.json`

The checker tests should use that fixture directly so the failure path is
anchored to a stable, named contract artifact instead of ad hoc
temp-generated mutation.

## What changed

- kept canonical positive pass fixture coverage
- kept canonical `changed > total_gates` negative fixture coverage
- kept canonical `changed > 0` with empty `examples` negative fixture coverage
- kept canonical duplicate `gate` negative fixture coverage
- kept canonical `baseline == epf` negative fixture coverage
- kept canonical `examples length > changed` negative fixture coverage
- kept canonical invalid RC-string negative fixture coverage
- wired:
  - `tests/fixtures/epf_paradox_summary_v0/changed_zero_with_examples.json`
  into the checker tests
- preserved coverage for:
  - missing-input neutral absence
  - hard failure on missing input

## Contract intent

This remains a checker-regression test update.

It improves alignment between:
- canonical EPF negative fixtures
- EPF checker behavior
- regression coverage

Note: under current checker semantics this fixture may also trigger the
related examples-length rule. The test intentionally asserts that the
primary `changed == 0` / non-empty examples error is present.

## Scope

Test-only change.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Finish the shift of the main EPF changed/examples failure paths from
temp-generated mutations to canonical fixtures.