### PR TITLE
feat(shadow): register EPF shadow experiment in shadow layer registry

### DIFF
--- a/shadow_layer_registry_v0.yml
+++ b/shadow_layer_registry_v0.yml
@@ -24,3 +24,37 @@ layers:
       - absent
     normative: false
     notes: Shadow-only. Contract-hardened. Must not write under gates.*.
+
+  - layer_id: epf_shadow_experiment_v0
+    family: epf-shadow
+    current_stage: research
+    target_stage: shadow-contracted
+    default_role: research diagnostic
+    consumer_authority: review-only
+    owner_surface:
+      - docs
+      - workflow
+      - tool
+    primary_entrypoint: .github/workflows/epf_experiment.yml
+    primary_artifact: epf_paradox_summary.json
+    schema: schemas/epf_paradox_summary_v0.schema.json
+    semantic_checker: PULSE_safe_pack_v0/tools/check_epf_paradox_summary_contract.py
+    fixtures:
+      - tests/fixtures/epf_paradox_summary_v0/pass.json
+      - tests/fixtures/epf_paradox_summary_v0/changed_exceeds_total_gates.json
+      - tests/fixtures/epf_paradox_summary_v0/changed_positive_without_examples.json
+      - tests/fixtures/epf_paradox_summary_v0/duplicate_gate_examples.json
+      - tests/fixtures/epf_paradox_summary_v0/example_without_difference.json
+      - tests/fixtures/epf_paradox_summary_v0/examples_longer_than_changed.json
+      - tests/fixtures/epf_paradox_summary_v0/invalid_rc_string.json
+      - tests/fixtures/epf_paradox_summary_v0/changed_zero_with_examples.json
+    tests:
+      - tests/test_check_epf_paradox_summary_contract.py
+    run_reality_states:
+      - real
+      - partial
+      - stub
+      - degraded
+      - absent
+    normative: false
+    notes: Research/shadow diagnostic. Contract-hardened summary artifact surface, but the overall EPF line remains non-normative and not yet promoted.


### PR DESCRIPTION
## Summary

Update `shadow_layer_registry_v0.yml` to add the current EPF shadow
experiment as a machine-registered shadow layer.

## Why

The EPF paradox summary line now has a real contract surface:

- `schemas/epf_paradox_summary_v0.schema.json`
- `PULSE_safe_pack_v0/tools/check_epf_paradox_summary_contract.py`
- canonical positive and negative fixtures
- `tests/test_check_epf_paradox_summary_contract.py`
- workflow-level validation in `.github/workflows/epf_experiment.yml`

That is enough for machine-registration.

At the same time, the broader EPF line is still best described as a
research/shadow diagnostic, not a promoted contract-hardened layer.

This PR records exactly that state.

## What changed

Added a new registry entry under `layers:` for:

- `epf_shadow_experiment_v0`

The new entry records:

- family: `epf-shadow`
- current stage: `research`
- target stage: `shadow-contracted`
- default role: `research diagnostic`
- consumer authority: `review-only`
- workflow entrypoint
- primary artifact
- schema
- semantic checker
- fixtures
- tests
- run reality states
- explicit non-normative note

## Contract intent

This PR registers EPF as a machine-readable shadow layer entry.

It does **not**:

- make EPF normative
- promote EPF to `shadow-contracted`
- change release semantics
- change required gate meaning

## Scope

Registry-only update.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Record the current EPF contract surface in the machine-readable shadow
registry while keeping its authority and promotion boundary explicit.