### PR TITLE
fix(ci): repair shadow layer registry workflow and add EPF triggers

### DIFF
--- a/.github/workflows/shadow_layer_registry.yml
+++ b/.github/workflows/shadow_layer_registry.yml
@@ -19,6 +19,13 @@ on:
       - "tests/test_check_relational_gain_contract.py"
       - "tests/test_relational_gain_non_interference.py"
 
+      # Referenced EPF surfaces currently registered in the registry.
+      - ".github/workflows/epf_experiment.yml"
+      - "schemas/epf_paradox_summary_v0.schema.json"
+      - "PULSE_safe_pack_v0/tools/check_epf_paradox_summary_contract.py"
+      - "tests/fixtures/epf_paradox_summary_v0/**"
+      - "tests/test_check_epf_paradox_summary_contract.py"
+
   push:
     branches: ["main"]
     paths:
@@ -37,6 +44,13 @@ on:
       - "tests/fixtures/relational_gain_shadow_v0/**"
       - "tests/test_check_relational_gain_contract.py"
       - "tests/test_relational_gain_non_interference.py"
+
+      # Referenced EPF surfaces currently registered in the registry.
+      - ".github/workflows/epf_experiment.yml"
+      - "schemas/epf_paradox_summary_v0.schema.json"
+      - "PULSE_safe_pack_v0/tools/check_epf_paradox_summary_contract.py"
+      - "tests/fixtures/epf_paradox_summary_v0/**"
+      - "tests/test_check_epf_paradox_summary_contract.py"
 
   workflow_dispatch: {}
 
@@ -113,8 +127,8 @@ jobs:
                   f"unexpected registry_version: {data.get('registry_version')!r}"
               )
 
-          if data.get("layer_count", 0) < 1:
-              raise SystemExit("expected at least one registered shadow layer")
+          if data.get("layer_count", 0) < 2:
+              raise SystemExit("expected at least two registered shadow layers")
           PY
 
       - name: Upload shadow layer registry artifacts


### PR DESCRIPTION
## Summary

Fix `.github/workflows/shadow_layer_registry.yml` and extend it so the
registry workflow also tracks the newly registered EPF surfaces.

## Why

Two things needed correction:

1. the workflow file had become malformed because of a duplicated top-level
   `on:` structure
2. after registering `epf_shadow_experiment_v0` in the shadow registry,
   the registry workflow also needed to trigger on the EPF surfaces
   referenced by that new entry

Without that trigger expansion, EPF contract-surface drift could bypass
the registry workflow.

## What changed

- restored a valid single top-level `on:` block
- kept the existing registry and Relational Gain trigger paths
- added EPF trigger paths for:
  - `.github/workflows/epf_experiment.yml`
  - `schemas/epf_paradox_summary_v0.schema.json`
  - `PULSE_safe_pack_v0/tools/check_epf_paradox_summary_contract.py`
  - `tests/fixtures/epf_paradox_summary_v0/**`
  - `tests/test_check_epf_paradox_summary_contract.py`
- updated the registry checker output validation step to expect at least
  two registered shadow layers

## Contract intent

This remains a registry workflow correction and coverage expansion.

It does **not**:
- create new release authority
- change release semantics
- promote EPF beyond its current registry state

## Scope

CI-only workflow correction.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- promote any shadow layer

## Review note addressed

Address Codex feedback that the registry workflow still only watched the
Relational Gain referenced surfaces after EPF was registered, and repair
the malformed workflow structure at the same time.