### PR TITLE
docs(shadow): sync EPF inventory row to current summary-contract state

### DIFF
--- a/docs/SHADOW_CONTRACT_PROGRAM_v0.md
+++ b/docs/SHADOW_CONTRACT_PROGRAM_v0.md
@@ -389,7 +389,7 @@ It is a management surface, not a promotion statement.
 | Theory overlay v0 | `theory_overlay_v0` | research | — | shadow diagnostic | artifact present | none | schema + degraded model |
 | G-field / G snapshot family | `g_field_snapshot_family_v0` | research | — | shadow diagnostic | mixed / family-level | none | split family contracts |
 | Relational Gain v0 | `relational_gain_shadow` | shadow-contracted | advisory | shadow diagnostic | artifact contracted | `meta.relational_gain_shadow` | advisory evaluation only if explicitly pursued |
-| EPF experiment / hazard | `epf_shadow_experiment_v0` | research | — | research diagnostic | artifact family present | none | comparison contract + real/stub classifier |
+| EPF experiment / hazard | `epf_shadow_experiment_v0` | research | shadow-contracted | research diagnostic | summary artifact contracted | none | broader EPF line hardening beyond summary artifact |
 | Topology family | `topology_family_v0` | research | — | artifact-derived topology | partial family artifacts | none | standalone schema set |
 | Decision-field family | `decision_field_v0` | research | — | decision-oriented shadow read | partial family artifacts | none | vocabulary contract + artifact schema |
 | Parameter Golf v0 | `parameter_golf_submission_evidence_v0` | research | shadow-contracted | external challenge companion | artifact present | none | sync inventory with companion schema |


### PR DESCRIPTION
## Summary

Update `docs/SHADOW_CONTRACT_PROGRAM_v0.md` so the EPF seeded inventory
row matches the current state of the EPF paradox summary hardening work.

## Why

The EPF line is not fully contract-hardened as a whole, so
`current_stage: research` is still the correct repo-level classification.

At the same time, the EPF paradox summary surface now has:

- schema
- semantic checker
- canonical fixtures
- checker regression tests
- workflow validation
- registry presence

That means the inventory row should no longer describe EPF only as a
loosely present artifact family.

## What changed

Updated the EPF seeded inventory row to:

- keep `current_stage: research`
- set `target_stage: shadow-contracted`
- describe the artifact status as `summary artifact contracted`
- clarify the next hardening step as broader EPF-line hardening beyond
  the current summary artifact

## Contract intent

This PR does **not** promote EPF.

It records a more precise split between:
- the current EPF line as a whole
- the now contract-hardened paradox summary artifact surface

## Scope

Documentation-only inventory update.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the repo-level shadow inventory aligned with the actual EPF
hardening state without overstating EPF promotion.