### PR TITLE
docs(workflow): document EPF shadow workflow in workflow map

### DIFF
--- a/docs/WORKFLOW_MAP.md
+++ b/docs/WORKFLOW_MAP.md
@@ -102,6 +102,41 @@ Current relation to Relational Gain:
   - `.github/workflows/relational_gain_shadow.yml`
   - Runs the relational gain Shadow path, writes a shadow artifact, and folds the result under    `meta.relational_gain_shadow` without changing the main release outcome.
 
+#### EPF experiment (shadow)
+
+**Workflow:** `.github/workflows/epf_experiment.yml`
+
+**Purpose:** compare the deterministic baseline read and the EPF shadow
+read over the same common input, then archive a diagnostic disagreement
+summary.
+
+Current workflow-emitted artifacts:
+
+- `status_baseline.json`
+- `status_epf.json`
+- `epf_report.txt`
+- `epf_paradox_summary.json`
+
+Current contract-hardened summary surface:
+
+- `schemas/epf_paradox_summary_v0.schema.json`
+- `PULSE_safe_pack_v0/tools/check_epf_paradox_summary_contract.py`
+- `tests/fixtures/epf_paradox_summary_v0/pass.json`
+- `tests/test_check_epf_paradox_summary_contract.py`
+
+Boundary:
+
+- diagnostic / CI-neutral
+- does not change release semantics
+- does not override the recorded baseline release result
+- disagreement is inspection input, not automatic policy rewrite
+
+Current state:
+
+- the broader EPF line remains `research`
+- the current `epf_paradox_summary.json` surface is contract-hardened
+- the workflow validates the produced summary artifact directly
+
 ### D. Publication / platform integration workflows
 **Purpose:** publication to GitHub-native or external-facing surfaces
 


### PR DESCRIPTION
## Summary

Update `docs/WORKFLOW_MAP.md` to document the current EPF shadow
workflow in the shadow/diagnostic workflow family.

## Why

The EPF line has moved beyond a loose experiment description.

The current workflow now has a concrete contract-hardened summary surface:

- `schemas/epf_paradox_summary_v0.schema.json`
- `PULSE_safe_pack_v0/tools/check_epf_paradox_summary_contract.py`
- canonical fixtures
- checker regression tests
- workflow-level artifact validation

The workflow map should now reflect that current state.

## What changed

Added a new `#### EPF experiment (shadow)` block under:

- `### C. Shadow / diagnostic workflows`

The new block documents:

- the workflow path
- the workflow purpose
- current workflow-emitted artifacts
- the current contract-hardened summary surface
- the diagnostic / CI-neutral boundary
- the current state split:
  - broader EPF line remains `research`
  - current `epf_paradox_summary.json` surface is contract-hardened

## Contract intent

This PR does **not** promote EPF.

It documents the current workflow more precisely while keeping the
existing authority boundary unchanged.

## Scope

Documentation-only workflow-map sync.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the workflow map aligned with the now-landed EPF schema + checker +
fixtures + tests + workflow validation surfaces.