### PR TITLE
docs(status): clarify that not every shadow layer folds into status.json

### DIFF
--- a/docs/status_json.md
+++ b/docs/status_json.md
@@ -321,6 +321,45 @@ Use this surface when you want a compact, audit-linked summary of the relational
 
 ---
 
+### Not every shadow artifact folds into `status.json`
+
+Machine-registered shadow layers do not all use a `meta.*` fold-in.
+
+Current example:
+
+- `relational_gain_shadow`
+  - may fold a compact summary into:
+    - `status["meta"]["relational_gain_shadow"]`
+
+Counter-example:
+
+- `epf_shadow_experiment_v0`
+  - is machine-registered,
+  - but its current primary artifact is:
+    - `epf_paradox_summary.json`
+  - and its current diagnostic workflow also produces:
+    - `status_baseline.json`
+    - `status_epf.json`
+    - `epf_report.txt`
+
+Interpretation rule:
+
+- a machine-registered shadow layer may surface itself either:
+  - as an additive `meta.*` fold-in inside the final `status.json`, or
+  - as a separate diagnostic artifact outside the final normative status surface
+
+Important boundary:
+
+- the absence of an EPF block under `status["meta"]` is currently expected
+- this absence must not be read as failure
+- `epf_paradox_summary.json` is descriptive and diagnostic only
+- it does not change the normative authority of `status["gates"]`
+
+If a future EPF status fold-in is introduced, that should be documented as
+a separate additive, non-normative status surface.
+
+---
+
 ## 11. external
 
 ### Two signals:


### PR DESCRIPTION
## Summary

Update `docs/status_json.md` to clarify that not every machine-registered
shadow layer appears as a `meta.*` fold-in inside the final `status.json`.

## Why

The repo now contains at least two different shadow-surface patterns:

- `relational_gain_shadow`
  - additive `meta.relational_gain_shadow` fold-in
- `epf_shadow_experiment_v0`
  - separate diagnostic artifacts such as:
    - `status_baseline.json`
    - `status_epf.json`
    - `epf_report.txt`
    - `epf_paradox_summary.json`

Without stating that distinction explicitly, a reader can too easily
assume that every shadow layer must surface itself under `status["meta"]`.

This PR removes that ambiguity.

## What changed

Added a short clarification block after the Relational Gain fold-in
example explaining that:

- some machine-registered shadow layers use additive `meta.*` fold-ins
- others currently remain separate diagnostic artifacts
- the absence of an EPF `meta.*` block is expected
- EPF’s current summary artifact is descriptive only and does not change
  the normative authority of `status["gates"]`

## Contract intent

This PR does **not** add a new EPF fold-in surface.

It only clarifies the current state of the repo’s shadow-surface model.

## Scope

Documentation-only clarification.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Make the status-surface docs match the current repository reality and
remove the implicit assumption that every shadow layer must fold into the
final `status.json`.