### PR TITLE
docs(changelog): add glossary note for shadow-program terminology update

### DIFF
--- a/docs/policy/CHANGELOG.md
+++ b/docs/policy/CHANGELOG.md
@@ -39,6 +39,11 @@ This changelog records **semantic** changes that can affect release gating outco
   - Impact: clarifies the current repository architecture for readers; no change to release authority, required gates, or `check_gates.py` behavior.
   - Migration: none. `docs/STATE_v0.md` remains a descriptive state snapshot, not a normative contract surface.
 
+- `docs/GLOSSARY_v0.md` / `glossary`:
+  - Changed: added the missing shadow-program and registry terminology needed to describe the current repository state more precisely, including `shadow-contracted`, `machine-registered`, `research diagnostic`, `contract-hardened summary surface`, and `non-interference`.
+  - Why: outside readers could already encounter these distinctions in the repo state, but the glossary did not yet define them explicitly.
+  - Impact: clarifies the current shadow-contract program, machine-readable registry, Relational Gain pilot state, and the EPF split between the broader research line and the hardened summary surface; no change to release authority, required gates, or `check_gates.py` behavior.
+  - Migration: none. This is a terminology and interpretation update only.
 
 ## 0.1.0 — Initial baseline
 


### PR DESCRIPTION
## Summary

Update `docs/policy/CHANGELOG.md` so the `Unreleased` section records the
recent `docs/GLOSSARY_v0.md` terminology update.

## Why

The repo's changelog enforcement treats `docs/GLOSSARY_v0.md` as a
semantic documentation surface.

That means changes to `docs/GLOSSARY_v0.md` must be reflected in the
`Unreleased` section of `docs/policy/CHANGELOG.md` with a matching
`glossary` token.

This PR adds that missing changelog note.

## What changed

Added an `Unreleased` changelog entry for:

- `docs/GLOSSARY_v0.md` / `glossary`

The new note records that the glossary now includes the terminology
needed to describe the current shadow-program and registry state more
precisely, including:

- `shadow-contracted`
- `machine-registered`
- `research diagnostic`
- `contract-hardened summary surface`
- `non-interference`

## Scope

Changelog-only correction.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Make the semantic changelog surface consistent with the recent
`GLOSSARY_v0` update and satisfy changelog enforcement for this PR.