### PR TITLE
feat(shadow): add EPF shadow run manifest schema v0

### DIFF
--- a/schemas/epf_shadow_run_manifest_v0.schema.json
+++ b/schemas/epf_shadow_run_manifest_v0.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schemas/epf_shadow_run_manifest_v0.schema.json",
+  "title": "EPF Shadow Run Manifest v0",
+  "description": "Machine-readable manifest for the broader EPF shadow run, built on top of the common shadow artifact contract.",
+  "allOf": [
+    {
+      "$ref": "shadow_artifact_common_v0.schema.json"
+    },
+    {
+      "type": "object",
+      "required": [
+        "payload"
+      ],
+      "properties": {
+        "artifact_version": {
+          "const": "epf_shadow_run_manifest_v0"
+        },
+        "layer_id": {
+          "const": "epf_shadow_experiment_v0"
+        },
+        "relation_scope": {
+          "const": "baseline_vs_epf_shadow"
+        },
+        "payload": {
+          "$ref": "#/$defs/payload"
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "int_string": {
+      "type": "string",
+      "pattern": "^-?[0-9]+$"
+    },
+    "path_string": {
+      "type": "string",
+      "minLength": 1
+    },
+    "branch_state": {
+      "type": "string",
+      "enum": [
+        "real",
+        "partial",
+        "stub",
+        "degraded",
+        "absent"
+      ]
+    },
+    "payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "command_rcs",
+        "branch_states",
+        "artifacts",
+        "comparison"
+      ],
+      "properties": {
+        "command_rcs": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "deps_rc",
+            "runall_rc",
+            "baseline_rc",
+            "epf_rc"
+          ],
+          "properties": {
+            "deps_rc": {
+              "$ref": "#/$defs/int_string"
+            },
+            "runall_rc": {
+              "$ref": "#/$defs/int_string"
+            },
+            "baseline_rc": {
+              "$ref": "#/$defs/int_string"
+            },
+            "epf_rc": {
+              "$ref": "#/$defs/int_string"
+            }
+          }
+        },
+        "branch_states": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "baseline_state",
+            "epf_state"
+          ],
+          "properties": {
+            "baseline_state": {
+              "$ref": "#/$defs/branch_state"
+            },
+            "epf_state": {
+              "$ref": "#/$defs/branch_state"
+            }
+          }
+        },
+        "artifacts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "baseline_status_path",
+            "epf_status_path",
+            "paradox_summary_path"
+          ],
+          "properties": {
+            "baseline_status_path": {
+              "$ref": "#/$defs/path_string"
+            },
+            "epf_status_path": {
+              "$ref": "#/$defs/path_string"
+            },
+            "paradox_summary_path": {
+              "$ref": "#/$defs/path_string"
+            },
+            "epf_report_path": {
+              "$ref": "#/$defs/path_string"
+            }
+          }
+        },
+        "comparison": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "total_gates",
+            "changed",
+            "example_count"
+          ],
+          "properties": {
+            "total_gates": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "changed": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "example_count": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add `schemas/epf_shadow_run_manifest_v0.schema.json` as the machine-readable
schema for the broader EPF shadow run manifest surface.

## Why

The current EPF paradox summary artifact is already contract-hardened:

- schema
- semantic checker
- canonical fixtures
- checker regression tests
- workflow-level validation

The next step is to define the broader EPF run surface above that summary
artifact.

This PR introduces the first machine-readable schema for that broader
surface.

## What changed

Added `schemas/epf_shadow_run_manifest_v0.schema.json`.

The new schema:

- builds on `schemas/shadow_artifact_common_v0.schema.json`
- fixes the EPF run-manifest identity:
  - `artifact_version: epf_shadow_run_manifest_v0`
  - `layer_id: epf_shadow_experiment_v0`
  - `relation_scope: baseline_vs_epf_shadow`
- defines an EPF-specific `payload` with:
  - `command_rcs`
    - `deps_rc`
    - `runall_rc`
    - `baseline_rc`
    - `epf_rc`
  - `branch_states`
    - `baseline_state`
    - `epf_state`
  - `artifacts`
    - `baseline_status_path`
    - `epf_status_path`
    - `paradox_summary_path`
    - optional `epf_report_path`
  - `comparison`
    - `total_gates`
    - `changed`
    - `example_count`

## Contract intent

This schema is for the **broader EPF shadow run manifest**, not for the
already hardened `epf_paradox_summary.json` surface.

It does **not** make the EPF line normative and does not promote EPF
beyond its current research/shadow role.

## Scope

Schema-only hardening for the broader EPF run surface.

This PR does **not**:
- add the semantic checker yet
- add fixtures yet
- add tests yet
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Start the next EPF hardening phase with the same pattern already used
successfully elsewhere:

1. schema
2. semantic checker
3. canonical fixtures
4. regression tests
5. workflow validation