### PR TITLE
fix(shadow): allow invalid branch_state in EPF run manifest schema

### DIFF
--- a/schemas/epf_shadow_run_manifest_v0.schema.json
+++ b/schemas/epf_shadow_run_manifest_v0.schema.json
@@ -44,6 +44,7 @@
         "partial",
         "stub",
         "degraded",
+        "invalid",
         "absent"
       ]
     },


### PR DESCRIPTION
## Summary

Update `schemas/epf_shadow_run_manifest_v0.schema.json` so
`branch_state` also allows `invalid`.

## Why

Codex correctly pointed out that the new EPF run-manifest schema allowed:

- `real`
- `partial`
- `stub`
- `degraded`
- `absent`

but not:

- `invalid`

That made it impossible to represent a branch that exists but is
structurally invalid, even though the common shadow artifact vocabulary
already includes `invalid` as a valid run-reality concept.

This PR fixes that gap.

## What changed

- added `invalid` to the `branch_state` enum in
  `schemas/epf_shadow_run_manifest_v0.schema.json`

## Contract intent

This does **not** promote EPF and does not change the broader EPF line's
authority.

It only makes the run-manifest schema able to represent invalid branch
states explicitly.

## Scope

Schema-only correction.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Review note addressed

Address Codex feedback that the EPF run-manifest schema should allow
`invalid` branch states to stay aligned with the common shadow-artifact
vocabulary.