### PR TITLE
test(shadow): add pass fixture for EPF shadow run manifest contract

### DIFF
--- a/tests/fixtures/epf_shadow_run_manifest_v0/pass.json
+++ b/tests/fixtures/epf_shadow_run_manifest_v0/pass.json
@@ -1,0 +1,64 @@
+{
+  "artifact_version": "epf_shadow_run_manifest_v0",
+  "layer_id": "epf_shadow_experiment_v0",
+  "producer": {
+    "name": "epf_experiment_workflow",
+    "version": "0.1.0"
+  },
+  "created_utc": "2026-04-13T12:00:00Z",
+  "run_reality_state": "real",
+  "verdict": "pass",
+  "source_artifacts": [
+    {
+      "path": "status_baseline.json",
+      "role": "baseline_status"
+    },
+    {
+      "path": "status_epf.json",
+      "role": "epf_status"
+    },
+    {
+      "path": "epf_paradox_summary.json",
+      "role": "paradox_summary"
+    },
+    {
+      "path": "epf_report.txt",
+      "role": "epf_report"
+    }
+  ],
+  "relation_scope": "baseline_vs_epf_shadow",
+  "summary": {
+    "headline": "EPF shadow run manifest validated",
+    "details": "Baseline and EPF branches completed as real runs with no recorded decision deltas."
+  },
+  "reasons": [
+    {
+      "code": "epf.run_manifest.ok",
+      "message": "Run manifest satisfies the current EPF shadow run contract.",
+      "severity": "info"
+    }
+  ],
+  "payload": {
+    "command_rcs": {
+      "deps_rc": "0",
+      "runall_rc": "0",
+      "baseline_rc": "0",
+      "epf_rc": "0"
+    },
+    "branch_states": {
+      "baseline_state": "real",
+      "epf_state": "real"
+    },
+    "artifacts": {
+      "baseline_status_path": "status_baseline.json",
+      "epf_status_path": "status_epf.json",
+      "paradox_summary_path": "epf_paradox_summary.json",
+      "epf_report_path": "epf_report.txt"
+    },
+    "comparison": {
+      "total_gates": 18,
+      "changed": 0,
+      "example_count": 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/epf_shadow_run_manifest_v0/pass.json` as the
canonical positive fixture for the broader EPF shadow run manifest
contract.

## Why

The broader EPF run-manifest surface now has:

- `schemas/epf_shadow_run_manifest_v0.schema.json`
- `PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py`

The next required step is a stable positive fixture so the new manifest
surface can be tested against a known-good baseline.

## What changed

Added `tests/fixtures/epf_shadow_run_manifest_v0/pass.json` with a valid
EPF shadow run manifest.

The fixture is aligned with the current contract, including:

- `artifact_version: epf_shadow_run_manifest_v0`
- `layer_id: epf_shadow_experiment_v0`
- `relation_scope: baseline_vs_epf_shadow`
- valid `producer`, `created_utc`, `summary`, and `reasons`
- valid `source_artifacts` references
- `run_reality_state: real`
- `verdict: pass`
- `baseline_state: real`
- `epf_state: real`
- `changed: 0`
- `example_count: 0`
- consistent artifact-path references between `payload.artifacts` and
  `source_artifacts`

## Contract intent

This fixture is the canonical positive baseline for the **broader EPF
shadow run manifest** surface.

It does **not** make EPF normative and does not promote EPF beyond its
current research/shadow role.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the positive baseline fixture for the next EPF run-manifest
checker test step.