### PR TITLE
test(shadow): add changed-without-warn fixture for EPF shadow run man…

### DIFF
--- a/tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json
+++ b/tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json
@@ -1,0 +1,64 @@
+{
+  "artifact_version": "epf_shadow_run_manifest_v0",
+  "layer_id": "epf_shadow_experiment_v0",
+  "producer": {
+    "name": "epf_experiment_workflow",
+    "version": "0.1.0"
+  },
+  "created_utc": "2026-04-13T12:05:00Z",
+  "run_reality_state": "real",
+  "verdict": "pass",
+  "source_artifacts": [
+    {
+      "path": "status_baseline.json",
+      "role": "baseline_status"
+    },
+    {
+      "path": "status_epf.json",
+      "role": "epf_status"
+    },
+    {
+      "path": "epf_paradox_summary.json",
+      "role": "paradox_summary"
+    },
+    {
+      "path": "epf_report.txt",
+      "role": "epf_report"
+    }
+  ],
+  "relation_scope": "baseline_vs_epf_shadow",
+  "summary": {
+    "headline": "Intentionally invalid EPF shadow run manifest",
+    "details": "Real run with recorded deltas must not use pass verdict."
+  },
+  "reasons": [
+    {
+      "code": "epf.run_manifest.invalid.changed_without_warn",
+      "message": "This fixture intentionally violates the real-run changed/verdict rule.",
+      "severity": "error"
+    }
+  ],
+  "payload": {
+    "command_rcs": {
+      "deps_rc": "0",
+      "runall_rc": "0",
+      "baseline_rc": "0",
+      "epf_rc": "0"
+    },
+    "branch_states": {
+      "baseline_state": "real",
+      "epf_state": "real"
+    },
+    "artifacts": {
+      "baseline_status_path": "status_baseline.json",
+      "epf_status_path": "status_epf.json",
+      "paradox_summary_path": "epf_paradox_summary.json",
+      "epf_report_path": "epf_report.txt"
+    },
+    "comparison": {
+      "total_gates": 18,
+      "changed": 2,
+      "example_count": 2
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json`
as the canonical negative fixture for the EPF run-manifest rule that a
real run with recorded deltas must not use `verdict: pass`.

## Why

The broader EPF run-manifest checker already enforces the rule that:

- if `run_reality_state == "real"`
- and `changed > 0`

then the manifest must use:

- `verdict: warn`

The fixture set should also contain a stable, explicit negative case for
that rule.

## What changed

Added a new negative EPF run-manifest fixture:

- `tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json`

The fixture is intentionally invalid only for:

- `run_reality_state: real`
- `changed: 2`
- `verdict: pass`

All other fields remain aligned with the current EPF run-manifest
contract so the failure path stays isolated.

## Contract intent

This fixture is expected to fail validation for one targeted reason only:

- real runs with `changed > 0` must not use `verdict: pass`

It should not rely on unrelated schema or checker failures.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the canonical negative fixture for one of the broader EPF
run-manifest checker's core real-run verdict-consistency rules before
wiring it into checker tests.