### PR TITLE
test(shadow): add EPF shadow run manifest contract checker tests

### DIFF
--- a/tests/test_check_epf_shadow_run_manifest_contract.py
+++ b/tests/test_check_epf_shadow_run_manifest_contract.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "PULSE_safe_pack_v0" / "tools" / "check_epf_shadow_run_manifest_contract.py"
+FIXTURES = ROOT / "tests" / "fixtures" / "epf_shadow_run_manifest_v0"
+
+
+def _run(input_path: Path, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, str(SCRIPT), "--input", str(input_path), *extra_args]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def _stdout_json(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    return json.loads(result.stdout)
+
+
+def _load_fixture(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_pass_fixture_is_valid() -> None:
+    result = _run(FIXTURES / "pass.json")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is False
+    assert payload["artifact_version"] == "epf_shadow_run_manifest_v0"
+    assert payload["run_reality_state"] == "real"
+    assert payload["verdict"] == "pass"
+
+
+def test_changed_without_warn_fixture_fails() -> None:
+    result = _run(FIXTURES / "changed_without_warn.json")
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "verdict" and "must use verdict" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_missing_input_is_neutral_with_if_input_present() -> None:
+    result = _run(FIXTURES / "does_not_exist.json", "--if-input-present")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is True
+    assert payload["artifact_version"] is None
+    assert payload["run_reality_state"] is None
+    assert payload["verdict"] is None
+
+
+def test_missing_input_fails_without_if_input_present() -> None:
+    result = _run(FIXTURES / "does_not_exist.json")
+    assert result.returncode == 1
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert payload["neutral"] is False
+    assert any(issue["path"] == "input" for issue in payload["errors"])
+
+
+def test_changed_must_not_exceed_total_gates(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    fixture["verdict"] = "warn"
+    fixture["payload"]["comparison"]["total_gates"] = 1
+    fixture["payload"]["comparison"]["changed"] = 2
+    fixture["payload"]["comparison"]["example_count"] = 2
+
+    path = tmp_path / "changed_exceeds_total_gates.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "payload.comparison.changed"
+        and "changed must not exceed total_gates" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_example_count_must_not_exceed_changed(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    fixture["verdict"] = "warn"
+    fixture["payload"]["comparison"]["total_gates"] = 3
+    fixture["payload"]["comparison"]["changed"] = 1
+    fixture["payload"]["comparison"]["example_count"] = 2
+
+    path = tmp_path / "example_count_exceeds_changed.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "payload.comparison.example_count"
+        and "example_count must not exceed changed" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_real_run_with_zero_changed_requires_pass_verdict(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    fixture["verdict"] = "warn"
+
+    path = tmp_path / "real_zero_changed_wrong_verdict.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "verdict"
+        and "must use verdict='pass' when changed=0" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_baseline_and_epf_status_paths_must_differ(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    fixture["payload"]["artifacts"]["epf_status_path"] = fixture["payload"]["artifacts"]["baseline_status_path"]
+
+    path = tmp_path / "same_status_paths.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "payload.artifacts"
+        and "baseline_status_path and epf_status_path must differ" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_source_artifacts_must_cover_payload_artifacts(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    fixture["source_artifacts"] = [
+        item
+        for item in fixture["source_artifacts"]
+        if item["path"] != "epf_report.txt"
+    ]
+
+    path = tmp_path / "missing_epf_report_source_artifact.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "source_artifacts"
+        and "epf_report.txt" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
+def test_invalid_overall_state_requires_invalid_branch(tmp_path: Path) -> None:
+    fixture = _load_fixture("pass.json")
+    fixture["run_reality_state"] = "invalid"
+    fixture["verdict"] = "invalid"
+    fixture["payload"]["branch_states"]["baseline_state"] = "real"
+    fixture["payload"]["branch_states"]["epf_state"] = "real"
+
+    path = tmp_path / "invalid_overall_without_invalid_branch.json"
+    _write_json(path, fixture)
+
+    result = _run(path)
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "payload.branch_states"
+        and "at least one branch must be invalid" in issue["message"]
+        for issue in payload["errors"]
+    )


### PR DESCRIPTION
## Summary

Add `tests/test_check_epf_shadow_run_manifest_contract.py` as regression
coverage for the broader EPF shadow run manifest contract checker.

## Why

The broader EPF run-manifest hardening track now has:

- `schemas/epf_shadow_run_manifest_v0.schema.json`
- `PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py`
- canonical positive fixture
- canonical negative `changed_without_warn` fixture

The next required step is executable regression coverage for the checker.

## What changed

Added `tests/test_check_epf_shadow_run_manifest_contract.py` with coverage for:

- valid pass fixture
- canonical negative fixture where a real run with `changed > 0` still uses `verdict: pass`
- missing-input neutral absence via `--if-input-present`
- missing-input hard failure without neutral mode
- invalid `changed > total_gates`
- invalid `example_count > changed`
- invalid real-run verdict when `changed == 0`
- invalid identical baseline/EPF status paths
- missing source-artifact coverage for referenced payload artifacts
- invalid overall state without an invalid branch

## Contract intent

These tests validate the **broader EPF shadow run manifest** surface,
not the already hardened `epf_paradox_summary.json` artifact.

They do not make EPF normative and do not promote the EPF line beyond
its current research/shadow role.

## Scope

Test-only change.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the regression anchor for the broader EPF run-manifest checker
before expanding the fixture set and workflow validation further.