### PR TITLE
feat(shadow): switch EPF registry entry to run-manifest primary surface

### DIFF
--- a/shadow_layer_registry_v0.yml
+++ b/shadow_layer_registry_v0.yml
@@ -36,25 +36,21 @@ layers:
       - workflow
       - tool
     primary_entrypoint: .github/workflows/epf_experiment.yml
-    primary_artifact: epf_paradox_summary.json
-    schema: schemas/epf_paradox_summary_v0.schema.json
-    semantic_checker: PULSE_safe_pack_v0/tools/check_epf_paradox_summary_contract.py
+    primary_artifact: epf_shadow_run_manifest.json
+    schema: schemas/epf_shadow_run_manifest_v0.schema.json
+    semantic_checker: PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py
     fixtures:
-      - tests/fixtures/epf_paradox_summary_v0/pass.json
-      - tests/fixtures/epf_paradox_summary_v0/changed_exceeds_total_gates.json
-      - tests/fixtures/epf_paradox_summary_v0/changed_positive_without_examples.json
-      - tests/fixtures/epf_paradox_summary_v0/duplicate_gate_examples.json
-      - tests/fixtures/epf_paradox_summary_v0/example_without_difference.json
-      - tests/fixtures/epf_paradox_summary_v0/examples_longer_than_changed.json
-      - tests/fixtures/epf_paradox_summary_v0/invalid_rc_string.json
-      - tests/fixtures/epf_paradox_summary_v0/changed_zero_with_examples.json
+      - tests/fixtures/epf_shadow_run_manifest_v0/pass.json
+      - tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json
     tests:
+      - tests/test_check_epf_shadow_run_manifest_contract.py
       - tests/test_check_epf_paradox_summary_contract.py
     run_reality_states:
       - real
       - partial
       - stub
       - degraded
+      - invalid
       - absent
     normative: false
-    notes: Research/shadow diagnostic. Contract-hardened summary artifact surface, but the overall EPF line remains non-normative and not yet promoted.
+    notes: Research/shadow diagnostic. The broader EPF line remains non-normative. The primary registered surface is now the EPF shadow run manifest; the paradox summary remains a contract-hardened secondary diagnostic artifact.


### PR DESCRIPTION
## Summary

Update `shadow_layer_registry_v0.yml` so the EPF registry entry now uses
the broader EPF shadow run manifest as its primary registered surface.

## Why

The EPF line has moved past the point where the paradox summary alone is
the best primary registry surface.

The current broader EPF run surface now has:

- `schemas/epf_shadow_run_manifest_v0.schema.json`
- `PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py`
- canonical positive and negative fixtures
- `tests/test_check_epf_shadow_run_manifest_contract.py`
- workflow-level production and validation in `.github/workflows/epf_experiment.yml`

That makes the run manifest the more accurate primary surface for the
EPF registry entry.

## What changed

Updated the `epf_shadow_experiment_v0` registry entry to:

- keep:
  - `current_stage: research`
  - `target_stage: shadow-contracted`
  - `consumer_authority: review-only`
  - `normative: false`
- switch the primary registered surface to:
  - `primary_artifact: epf_shadow_run_manifest.json`
  - `schema: schemas/epf_shadow_run_manifest_v0.schema.json`
  - `semantic_checker: PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py`
- update fixture/test references to the run-manifest-centered surface
- expand `run_reality_states` to include:
  - `invalid`
- keep an explicit note that:
  - the broader EPF line remains non-normative
  - the paradox summary remains a secondary contract-hardened diagnostic artifact

## Contract intent

This PR does **not** promote EPF.

It records a more accurate machine-readable description of the current
EPF contract surfaces:

- broader line remains `research`
- primary registry surface is now the run manifest
- paradox summary remains secondary and diagnostic

## Scope

Registry-only update.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the machine-readable shadow registry aligned with the current EPF
hardening state and make the broader run-manifest surface the primary
registered artifact for EPF.