### PR TITLE
fix(ci): update shadow registry workflow for EPF run-manifest surfaces

### DIFF
--- a/.github/workflows/shadow_layer_registry.yml
+++ b/.github/workflows/shadow_layer_registry.yml
@@ -3,14 +3,6 @@ name: Shadow Layer Registry
 on:
   pull_request:
     paths:
-      - ".github/workflows/shadow_layer_registry.yml"
-      - "requirements.txt"
-      - "shadow_layer_registry_v0.yml"
-      - "schemas/shadow_layer_registry_v0.schema.json"
-      - "PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py"
-      - "tests/fixtures/shadow_layer_registry_v0/**"
-      - "tests/test_check_shadow_layer_registry.py"
-
       # Referenced Relational Gain surfaces currently registered in the registry.
       - ".github/workflows/relational_gain_shadow.yml"
       - "schemas/relational_gain_shadow_v0.schema.json"
@@ -19,8 +11,14 @@ on:
       - "tests/test_check_relational_gain_contract.py"
       - "tests/test_relational_gain_non_interference.py"
 
-      # Referenced EPF surfaces currently registered in the registry.
+      # Referenced EPF primary run-manifest surfaces currently registered in the registry.
       - ".github/workflows/epf_experiment.yml"
+      - "schemas/epf_shadow_run_manifest_v0.schema.json"
+      - "PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py"
+      - "tests/fixtures/epf_shadow_run_manifest_v0/**"
+      - "tests/test_check_epf_shadow_run_manifest_contract.py"
+
+      # Secondary EPF contract surfaces still coupled to the registered EPF line.
       - "schemas/epf_paradox_summary_v0.schema.json"
       - "PULSE_safe_pack_v0/tools/check_epf_paradox_summary_contract.py"
       - "tests/fixtures/epf_paradox_summary_v0/**"
@@ -29,14 +27,6 @@ on:
   push:
     branches: ["main"]
     paths:
-      - ".github/workflows/shadow_layer_registry.yml"
-      - "requirements.txt"
-      - "shadow_layer_registry_v0.yml"
-      - "schemas/shadow_layer_registry_v0.schema.json"
-      - "PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py"
-      - "tests/fixtures/shadow_layer_registry_v0/**"
-      - "tests/test_check_shadow_layer_registry.py"
-
       # Referenced Relational Gain surfaces currently registered in the registry.
       - ".github/workflows/relational_gain_shadow.yml"
       - "schemas/relational_gain_shadow_v0.schema.json"
@@ -45,8 +35,14 @@ on:
       - "tests/test_check_relational_gain_contract.py"
       - "tests/test_relational_gain_non_interference.py"
 
-      # Referenced EPF surfaces currently registered in the registry.
+      # Referenced EPF primary run-manifest surfaces currently registered in the registry.
       - ".github/workflows/epf_experiment.yml"
+      - "schemas/epf_shadow_run_manifest_v0.schema.json"
+      - "PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py"
+      - "tests/fixtures/epf_shadow_run_manifest_v0/**"
+      - "tests/test_check_epf_shadow_run_manifest_contract.py"
+
+      # Secondary EPF contract surfaces still coupled to the registered EPF line.
       - "schemas/epf_paradox_summary_v0.schema.json"
       - "PULSE_safe_pack_v0/tools/check_epf_paradox_summary_contract.py"
       - "tests/fixtures/epf_paradox_summary_v0/**"

--- a/.github/workflows/shadow_layer_registry.yml
+++ b/.github/workflows/shadow_layer_registry.yml
@@ -3,6 +3,15 @@ name: Shadow Layer Registry
 on:
   pull_request:
     paths:
+      # Registry-owned surfaces
+      - ".github/workflows/shadow_layer_registry.yml"
+      - "requirements.txt"
+      - "shadow_layer_registry_v0.yml"
+      - "schemas/shadow_layer_registry_v0.schema.json"
+      - "PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py"
+      - "tests/fixtures/shadow_layer_registry_v0/**"
+      - "tests/test_check_shadow_layer_registry.py"
+
       # Referenced Relational Gain surfaces currently registered in the registry.
       - ".github/workflows/relational_gain_shadow.yml"
       - "schemas/relational_gain_shadow_v0.schema.json"
@@ -27,6 +36,15 @@ on:
   push:
     branches: ["main"]
     paths:
+      # Registry-owned surfaces
+      - ".github/workflows/shadow_layer_registry.yml"
+      - "requirements.txt"
+      - "shadow_layer_registry_v0.yml"
+      - "schemas/shadow_layer_registry_v0.schema.json"
+      - "PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py"
+      - "tests/fixtures/shadow_layer_registry_v0/**"
+      - "tests/test_check_shadow_layer_registry.py"
+
       # Referenced Relational Gain surfaces currently registered in the registry.
       - ".github/workflows/relational_gain_shadow.yml"
       - "schemas/relational_gain_shadow_v0.schema.json"
@@ -129,7 +147,7 @@ jobs:
 
       - name: Upload shadow layer registry artifacts
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: shadow-layer-registry
           if-no-files-found: warn


### PR DESCRIPTION
## Summary

Update `.github/workflows/shadow_layer_registry.yml` so the dedicated
registry workflow also watches the EPF run-manifest contract surfaces
now referenced by the EPF registry entry.

## Why

The EPF machine-registered entry in `shadow_layer_registry_v0.yml` now
uses the broader run-manifest surface as its primary contract surface.

That means the registry workflow must watch changes to:

- `schemas/epf_shadow_run_manifest_v0.schema.json`
- `PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py`
- `tests/fixtures/epf_shadow_run_manifest_v0/**`
- `tests/test_check_epf_shadow_run_manifest_contract.py`

Without that, the registry workflow could silently miss drift between the
machine-readable registry entry and the newly registered EPF primary
surface.

## What changed

Updated both:

- `on.pull_request.paths`
- `on.push.paths`

in `.github/workflows/shadow_layer_registry.yml` to include:

### EPF primary run-manifest surfaces
- `.github/workflows/epf_experiment.yml`
- `schemas/epf_shadow_run_manifest_v0.schema.json`
- `PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py`
- `tests/fixtures/epf_shadow_run_manifest_v0/**`
- `tests/test_check_epf_shadow_run_manifest_contract.py`

### EPF secondary summary surfaces
- `schemas/epf_paradox_summary_v0.schema.json`
- `PULSE_safe_pack_v0/tools/check_epf_paradox_summary_contract.py`
- `tests/fixtures/epf_paradox_summary_v0/**`
- `tests/test_check_epf_paradox_summary_contract.py`

## Contract intent

This PR does **not** change EPF authority.

It only keeps the registry workflow aligned with the current EPF
machine-registered entry and its primary/secondary contract surfaces.

## Scope

CI-only workflow correction.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- promote any shadow layer

## Review note addressed

Address Codex feedback that the shadow registry workflow still watched
only EPF paradox-summary files after the EPF registry entry was switched
to the run-manifest primary surface.