### PR TITLE
docs(shadow): sync shadow registry page to EPF run-manifest primary s…

### DIFF
--- a/docs/shadow_layer_registry_v0.md
+++ b/docs/shadow_layer_registry_v0.md
@@ -230,9 +230,19 @@ Current recorded state:
 - `consumer_authority: review-only`
 - `normative: false`
 
-Current registered surfaces include:
+Primary registered surface:
 
 - `.github/workflows/epf_experiment.yml`
+- `epf_shadow_run_manifest.json`
+- `schemas/epf_shadow_run_manifest_v0.schema.json`
+- `PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py`
+- `tests/fixtures/epf_shadow_run_manifest_v0/pass.json`
+- `tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json`
+- `tests/test_check_epf_shadow_run_manifest_contract.py`
+
+Secondary contract-hardened diagnostic surface:
+
+- `epf_paradox_summary.json`
 - `schemas/epf_paradox_summary_v0.schema.json`
 - `PULSE_safe_pack_v0/tools/check_epf_paradox_summary_contract.py`
 - `tests/fixtures/epf_paradox_summary_v0/pass.json`
@@ -244,6 +254,13 @@ Current registered surfaces include:
 - `tests/fixtures/epf_paradox_summary_v0/invalid_rc_string.json`
 - `tests/fixtures/epf_paradox_summary_v0/changed_zero_with_examples.json`
 - `tests/test_check_epf_paradox_summary_contract.py`
+
+Interpretation:
+
+- the broader EPF line remains `research`
+- the primary machine-registered EPF surface is now the broader run manifest
+- the paradox summary remains a secondary contract-hardened diagnostic artifact
+- neither surface is normative
 
 ---
 
@@ -282,8 +299,10 @@ It currently validates:
 - the registry checker tests,
 - and the registry checker output surface.
 
-It also watches currently referenced Relational Gain and EPF surfaces so
-registered layers cannot silently drift away from the registry contract.
+It also watches currently referenced Relational Gain surfaces, the EPF
+primary run-manifest surfaces, and the EPF secondary paradox-summary
+surfaces so registered layers cannot silently drift away from the
+registry contract.
 
 ---
 


### PR DESCRIPTION
## Summary

Update `docs/shadow_layer_registry_v0.md` so the registry reference page
matches the current EPF machine-registration state.

## Why

The EPF registry entry no longer points primarily to the paradox-summary
surface.

The current machine-readable registry now treats:

- `epf_shadow_run_manifest.json`

as the **primary registered EPF surface**, while

- `epf_paradox_summary.json`

remains a **secondary contract-hardened diagnostic surface**.

The registry reference page should now reflect that split explicitly.

## What changed

- replaced the EPF registered-layer block with an updated version that:
  - keeps EPF at `current_stage: research`
  - keeps `target_stage: shadow-contracted`
  - keeps `consumer_authority: review-only`
  - keeps `normative: false`
- documented the EPF run manifest as the primary registered surface
- documented the paradox summary as a secondary contract-hardened
  diagnostic surface
- clarified the interpretation boundary:
  - broader EPF line remains research
  - primary machine-registered EPF surface is now the run manifest
  - neither surface is normative
- updated the workflow-validation note so it names:
  - Relational Gain surfaces
  - EPF primary run-manifest surfaces
  - EPF secondary paradox-summary surfaces

## Contract intent

This PR does **not** promote EPF.

It only makes the registry reference page accurately reflect the current
machine-readable registry and workflow scope.

## Scope

Documentation-only registry sync.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the registry reference page aligned with the current EPF primary vs
secondary surface split after the EPF registry entry moved to the
run-manifest-centered model.