### PR TITLE
docs(shadow): update optional layers map for EPF run-manifest primary…

### DIFF
--- a/docs/OPTIONAL_LAYERS.md
+++ b/docs/OPTIONAL_LAYERS.md
@@ -26,7 +26,7 @@ the required gate set.
 | Theory overlay v0 | shadow diagnostic | `.github/workflows/theory_overlay_v0.yml` | overlay JSON + markdown summary | No |
 | G-field / G snapshot surfaces | shadow diagnostic | G-field / snapshot shadow workflows | overlay JSONs + snapshot markdown | No |
 | Relational Gain v0 | shadow diagnostic (contract-hardened) | `.github/workflows/relational_gain_shadow.yml` | `relational_gain_shadow_v0.json`, folded `meta.relational_gain_shadow` | No |
-| EPF experiment / hazard | research diagnostic (summary artifact contract-hardened) | `.github/workflows/epf_experiment.yml` | `epf_paradox_summary.json` | No |
+| EPF experiment / hazard | research diagnostic (run-manifest primary; summary surface also contract-hardened) | `.github/workflows/epf_experiment.yml` | `epf_shadow_run_manifest.json`, `epf_paradox_summary.json` | No |
 | Parameter Golf v0 | external challenge companion | `../parameter_golf_v0/README.md` | submission evidence JSON + review receipt | No |
 | Publication surfaces | opt-in platform integration | `upload_sarif.yml`, PR comments, badge write-back, Pages snapshots | GitHub-native / published surfaces | No |
 
@@ -64,10 +64,26 @@ Its artifact and folded `meta.relational_gain_shadow` summary do not change rele
 
 The broader EPF line remains a **research diagnostic** path.
 
-However, the current `epf_paradox_summary.json` surface is now
-**contract-hardened**.
+Its current **primary** machine-registered surface is now:
 
-Current hardening surface:
+- `epf_shadow_run_manifest.json`
+
+The current `epf_paradox_summary.json` surface remains a **secondary
+contract-hardened diagnostic artifact**.
+
+Current primary hardening surface:
+
+- schema:
+  - `../schemas/epf_shadow_run_manifest_v0.schema.json`
+- contract checker:
+  - `../PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py`
+- canonical fixtures:
+  - `../tests/fixtures/epf_shadow_run_manifest_v0/pass.json`
+  - `../tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json`
+- checker regression tests:
+  - `../tests/test_check_epf_shadow_run_manifest_contract.py`
+
+Current secondary summary surface:
 
 - schema:
   - `../schemas/epf_paradox_summary_v0.schema.json`
@@ -85,10 +101,10 @@ Current hardening surface:
 - checker regression tests:
   - `../tests/test_check_epf_paradox_summary_contract.py`
 
-This surface remains **non-normative**.
+Both surfaces remain **non-normative**.
 
-Its artifact is descriptive and diagnostic only, and does not change
-release authority.
+They are descriptive and diagnostic only, and do not change release
+authority.
 
 ## External challenge companions
 


### PR DESCRIPTION
## Summary

Update `docs/OPTIONAL_LAYERS.md` so the EPF entry reflects the current
registered-surface model more accurately.

## Why

The broader EPF line is still best described as a `research diagnostic`
path.

At the same time, the EPF machine-registered entry now uses:

- `epf_shadow_run_manifest.json`

as its **primary** registered surface, while

- `epf_paradox_summary.json`

remains an important **secondary contract-hardened diagnostic surface**.

The optional-layer map should now reflect that split explicitly.

## What changed

- updated the EPF row in the optional-layer table
- rewrote the `### EPF experiment / hazard` block
- documented:
  - the broader EPF line as `research diagnostic`
  - the run manifest as the primary machine-registered surface
  - the paradox summary as the secondary contract-hardened diagnostic surface
- linked the EPF line to:
  - workflow entrypoint
  - primary run-manifest schema/checker/fixtures/tests
  - secondary paradox-summary schema/checker/fixtures/tests
- kept the non-normative boundary explicit

## Contract intent

This PR does **not** promote EPF.

It documents the current state more precisely:

- broader EPF line remains research-stage
- primary registered surface is now the run manifest
- paradox summary remains secondary and diagnostic
- both surfaces remain non-normative

## Scope

Documentation-only sync.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the optional-layer map aligned with the current registry and docs
truth for the EPF line after the shift to the run-manifest-centered
model.