### PR TITLE
docs(shadow): sync EPF inventory row to run-manifest primary surface

### DIFF
--- a/docs/SHADOW_CONTRACT_PROGRAM_v0.md
+++ b/docs/SHADOW_CONTRACT_PROGRAM_v0.md
@@ -389,7 +389,7 @@ It is a management surface, not a promotion statement.
 | Theory overlay v0 | `theory_overlay_v0` | research | — | shadow diagnostic | artifact present | none | schema + degraded model |
 | G-field / G snapshot family | `g_field_snapshot_family_v0` | research | — | shadow diagnostic | mixed / family-level | none | split family contracts |
 | Relational Gain v0 | `relational_gain_shadow` | shadow-contracted | advisory | shadow diagnostic | artifact contracted | `meta.relational_gain_shadow` | advisory evaluation only if explicitly pursued |
-| EPF experiment / hazard | `epf_shadow_experiment_v0` | research | shadow-contracted | research diagnostic | summary artifact contracted | none | broader EPF line hardening beyond summary artifact |
+| EPF experiment / hazard | `epf_shadow_experiment_v0` | research | shadow-contracted | research diagnostic | run-manifest contracted (summary surface secondary) | none | broader EPF line hardening beyond the current primary run-manifest surface |
 | Topology family | `topology_family_v0` | research | — | artifact-derived topology | partial family artifacts | none | standalone schema set |
 | Decision-field family | `decision_field_v0` | research | — | decision-oriented shadow read | partial family artifacts | none | vocabulary contract + artifact schema |
 | Parameter Golf v0 | `parameter_golf_submission_evidence_v0` | research | shadow-contracted | external challenge companion | artifact present | none | sync inventory with companion schema |


### PR DESCRIPTION
## Summary

Update `docs/SHADOW_CONTRACT_PROGRAM_v0.md` so the EPF seeded inventory
row matches the current EPF registered-surface model.

## Why

The EPF line is still not fully contract-hardened as a whole, so
`current_stage: research` remains the correct repo-level classification.

At the same time, the current EPF machine-registered primary surface is
no longer best described as only a summary artifact.

The current state is more precise as:

- broader EPF line = `research`
- primary registered surface = `epf_shadow_run_manifest.json`
- secondary contract-hardened surface = `epf_paradox_summary.json`

The seeded inventory row should now reflect that split.

## What changed

Updated the EPF seeded inventory row to:

- keep `current_stage: research`
- keep `target_stage: shadow-contracted`
- keep `default_role: research diagnostic`
- describe the artifact state as:
  - `run-manifest contracted (summary surface secondary)`
- clarify the next hardening step as:
  - broader EPF line hardening beyond the current primary run-manifest surface

## Contract intent

This PR does **not** promote EPF.

It records a more accurate split between:

- the broader EPF line as a whole
- the current primary registered run-manifest surface
- the secondary contract-hardened paradox-summary surface

## Scope

Documentation-only inventory update.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the repo-level shadow inventory aligned with the current EPF
registry/docs truth after the shift to the run-manifest-centered model.