### PR TITLE
test(shadow): wire example-count-exceeds-changed fixture into EPF run…

### DIFF
--- a/tests/test_check_epf_shadow_run_manifest_contract.py
+++ b/tests/test_check_epf_shadow_run_manifest_contract.py
@@ -65,6 +65,19 @@ def test_changed_exceeds_total_gates_fixture_fails() -> None:
     )
 
 
+def test_example_count_exceeds_changed_fixture_fails() -> None:
+    result = _run(FIXTURES / "example_count_exceeds_changed.json")
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "payload.comparison.example_count"
+        and "example_count must not exceed changed" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
 def test_missing_input_is_neutral_with_if_input_present() -> None:
     result = _run(FIXTURES / "does_not_exist.json", "--if-input-present")
     assert result.returncode == 0, result.stdout + result.stderr
@@ -85,28 +98,6 @@ def test_missing_input_fails_without_if_input_present() -> None:
     assert payload["ok"] is False
     assert payload["neutral"] is False
     assert any(issue["path"] == "input" for issue in payload["errors"])
-
-
-def test_example_count_must_not_exceed_changed(tmp_path: Path) -> None:
-    fixture = _load_fixture("pass.json")
-    fixture["verdict"] = "warn"
-    fixture["payload"]["comparison"]["total_gates"] = 3
-    fixture["payload"]["comparison"]["changed"] = 1
-    fixture["payload"]["comparison"]["example_count"] = 2
-
-    path = tmp_path / "example_count_exceeds_changed.json"
-    _write_json(path, fixture)
-
-    result = _run(path)
-    assert result.returncode == 1, result.stdout + result.stderr
-
-    payload = _stdout_json(result)
-    assert payload["ok"] is False
-    assert any(
-        issue["path"] == "payload.comparison.example_count"
-        and "example_count must not exceed changed" in issue["message"]
-        for issue in payload["errors"]
-    )
 
 
 def test_real_run_with_zero_changed_requires_pass_verdict(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Update `tests/test_check_epf_shadow_run_manifest_contract.py` so the
EPF run-manifest rule that `example_count` must not exceed `changed` is
covered through the canonical negative fixture.

## Why

The EPF run-manifest fixture set now contains an explicit negative case for
this comparison-counter consistency rule:

- `tests/fixtures/epf_shadow_run_manifest_v0/example_count_exceeds_changed.json`

The checker tests should use that fixture directly so the failure path is
anchored to a stable, named contract artifact instead of a temp-generated
mutation.

## What changed

- kept canonical positive pass fixture coverage
- kept canonical `changed_without_warn` negative fixture coverage
- kept canonical `changed_exceeds_total_gates` negative fixture coverage
- wired:
  - `tests/fixtures/epf_shadow_run_manifest_v0/example_count_exceeds_changed.json`
  into the checker tests
- preserved coverage for:
  - missing-input neutral absence
  - hard failure on missing input
  - wrong verdict for real run with `changed == 0`
  - identical baseline/EPF status paths
  - missing source-artifact coverage
  - invalid overall state without an invalid branch

## Contract intent

This remains a checker-regression test update.

It improves alignment between:
- canonical EPF run-manifest negative fixtures
- checker behavior
- regression coverage

## Scope

Test-only change.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Reduce reliance on temp-generated negative cases where a stable EPF
run-manifest fixture now exists and keep the checker tests aligned with
the expanding fixture set.