### PR TITLE
test(shadow): add real-zero-changed-wrong-verdict fixture for EPF run…

### DIFF
--- a/tests/fixtures/epf_shadow_run_manifest_v0/real_zero_changed_wrong_verdict.json
+++ b/tests/fixtures/epf_shadow_run_manifest_v0/real_zero_changed_wrong_verdict.json
@@ -1,0 +1,64 @@
+{
+  "artifact_version": "epf_shadow_run_manifest_v0",
+  "layer_id": "epf_shadow_experiment_v0",
+  "producer": {
+    "name": "epf_experiment_workflow",
+    "version": "0.1.0"
+  },
+  "created_utc": "2026-04-13T12:20:00Z",
+  "run_reality_state": "real",
+  "verdict": "warn",
+  "source_artifacts": [
+    {
+      "path": "status_baseline.json",
+      "role": "baseline_status"
+    },
+    {
+      "path": "status_epf.json",
+      "role": "epf_status"
+    },
+    {
+      "path": "epf_paradox_summary.json",
+      "role": "paradox_summary"
+    },
+    {
+      "path": "epf_report.txt",
+      "role": "epf_report"
+    }
+  ],
+  "relation_scope": "baseline_vs_epf_shadow",
+  "summary": {
+    "headline": "Intentionally invalid EPF shadow run manifest",
+    "details": "This fixture intentionally violates the real-run zero-changed verdict rule."
+  },
+  "reasons": [
+    {
+      "code": "epf.run_manifest.invalid.real_zero_changed_wrong_verdict",
+      "message": "This fixture intentionally violates the rule that a real run with zero changed gates must use pass verdict.",
+      "severity": "error"
+    }
+  ],
+  "payload": {
+    "command_rcs": {
+      "deps_rc": "0",
+      "runall_rc": "0",
+      "baseline_rc": "0",
+      "epf_rc": "0"
+    },
+    "branch_states": {
+      "baseline_state": "real",
+      "epf_state": "real"
+    },
+    "artifacts": {
+      "baseline_status_path": "status_baseline.json",
+      "epf_status_path": "status_epf.json",
+      "paradox_summary_path": "epf_paradox_summary.json",
+      "epf_report_path": "epf_report.txt"
+    },
+    "comparison": {
+      "total_gates": 18,
+      "changed": 0,
+      "example_count": 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/epf_shadow_run_manifest_v0/real_zero_changed_wrong_verdict.json`
as the canonical negative fixture for the EPF run-manifest rule that a
real run with `changed == 0` must use `verdict: pass`.

## Why

The broader EPF run-manifest checker already enforces this real-run
verdict-consistency rule, but the fixture set should also contain a
stable, explicit negative case for it.

This makes the failure mode easier to test, easier to inspect, and less
dependent on ad hoc mutation inside tests.

## What changed

Added a new negative EPF run-manifest fixture:

- `tests/fixtures/epf_shadow_run_manifest_v0/real_zero_changed_wrong_verdict.json`

The fixture is intentionally invalid only for:

- `run_reality_state: real`
- `changed: 0`
- `verdict: warn`

All other fields remain aligned with the current EPF run-manifest
contract so the failure path stays isolated.

## Contract intent

This fixture is expected to fail validation for one targeted reason only:

- real runs with `changed == 0` must use `verdict: pass`

It should not rely on unrelated schema or checker failures.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the canonical negative fixture for one of the broader EPF
run-manifest checker’s core real-run verdict-consistency rules before
wiring it into the checker tests.