### PR TITLE
test(shadow): wire same-status-paths fixture into EPF run-manifest ch…

### DIFF
--- a/tests/test_check_epf_shadow_run_manifest_contract.py
+++ b/tests/test_check_epf_shadow_run_manifest_contract.py
@@ -91,6 +91,19 @@ def test_real_zero_changed_wrong_verdict_fixture_fails() -> None:
     )
 
 
+def test_same_status_paths_fixture_fails() -> None:
+    result = _run(FIXTURES / "same_status_paths.json")
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "payload.artifacts"
+        and "baseline_status_path and epf_status_path must differ" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
 def test_missing_input_is_neutral_with_if_input_present() -> None:
     result = _run(FIXTURES / "does_not_exist.json", "--if-input-present")
     assert result.returncode == 0, result.stdout + result.stderr
@@ -111,25 +124,6 @@ def test_missing_input_fails_without_if_input_present() -> None:
     assert payload["ok"] is False
     assert payload["neutral"] is False
     assert any(issue["path"] == "input" for issue in payload["errors"])
-
-
-def test_baseline_and_epf_status_paths_must_differ(tmp_path: Path) -> None:
-    fixture = _load_fixture("pass.json")
-    fixture["payload"]["artifacts"]["epf_status_path"] = fixture["payload"]["artifacts"]["baseline_status_path"]
-
-    path = tmp_path / "same_status_paths.json"
-    _write_json(path, fixture)
-
-    result = _run(path)
-    assert result.returncode == 1, result.stdout + result.stderr
-
-    payload = _stdout_json(result)
-    assert payload["ok"] is False
-    assert any(
-        issue["path"] == "payload.artifacts"
-        and "baseline_status_path and epf_status_path must differ" in issue["message"]
-        for issue in payload["errors"]
-    )
 
 
 def test_source_artifacts_must_cover_payload_artifacts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Update `tests/test_check_epf_shadow_run_manifest_contract.py` so the EPF
run-manifest rule that `baseline_status_path` and `epf_status_path` must
differ is covered through the canonical negative fixture.

## Why

The EPF run-manifest fixture set now contains an explicit negative case
for this artifact-separation rule:

- `tests/fixtures/epf_shadow_run_manifest_v0/same_status_paths.json`

The checker tests should use that fixture directly so the failure path is
anchored to a stable, named contract artifact instead of a temp-generated
mutation.

## What changed

- kept canonical positive pass fixture coverage
- kept canonical `changed_without_warn` negative fixture coverage
- kept canonical `changed_exceeds_total_gates` negative fixture coverage
- kept canonical `example_count_exceeds_changed` negative fixture coverage
- kept canonical `real_zero_changed_wrong_verdict` negative fixture coverage
- wired:
  - `tests/fixtures/epf_shadow_run_manifest_v0/same_status_paths.json`
  into the checker tests
- preserved coverage for:
  - missing-input neutral absence
  - hard failure on missing input
  - missing source-artifact coverage
  - invalid overall state without an invalid branch

## Contract intent

This remains a checker-regression test update.

It improves alignment between:
- canonical EPF run-manifest negative fixtures
- checker behavior
- regression coverage

## Scope

Test-only change.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Reduce reliance on temp-generated negative cases where a stable EPF
run-manifest fixture now exists and keep the checker tests aligned with
the expanding fixture set.