### PR TITLE
test(shadow): add missing-epf-report-source-artifact fixture for EPF …

### DIFF
--- a/tests/fixtures/epf_shadow_run_manifest_v0/missing_epf_report_source_artifact.json
+++ b/tests/fixtures/epf_shadow_run_manifest_v0/missing_epf_report_source_artifact.json
@@ -1,0 +1,60 @@
+{
+  "artifact_version": "epf_shadow_run_manifest_v0",
+  "layer_id": "epf_shadow_experiment_v0",
+  "producer": {
+    "name": "epf_experiment_workflow",
+    "version": "0.1.0"
+  },
+  "created_utc": "2026-04-13T12:30:00Z",
+  "run_reality_state": "real",
+  "verdict": "pass",
+  "source_artifacts": [
+    {
+      "path": "status_baseline.json",
+      "role": "baseline_status"
+    },
+    {
+      "path": "status_epf.json",
+      "role": "epf_status"
+    },
+    {
+      "path": "epf_paradox_summary.json",
+      "role": "paradox_summary"
+    }
+  ],
+  "relation_scope": "baseline_vs_epf_shadow",
+  "summary": {
+    "headline": "Intentionally invalid EPF shadow run manifest",
+    "details": "This fixture intentionally omits the epf_report source_artifact while still referencing epf_report_path in payload.artifacts."
+  },
+  "reasons": [
+    {
+      "code": "epf.run_manifest.invalid.missing_epf_report_source_artifact",
+      "message": "This fixture intentionally violates source_artifacts coverage for epf_report.txt.",
+      "severity": "error"
+    }
+  ],
+  "payload": {
+    "command_rcs": {
+      "deps_rc": "0",
+      "runall_rc": "0",
+      "baseline_rc": "0",
+      "epf_rc": "0"
+    },
+    "branch_states": {
+      "baseline_state": "real",
+      "epf_state": "real"
+    },
+    "artifacts": {
+      "baseline_status_path": "status_baseline.json",
+      "epf_status_path": "status_epf.json",
+      "paradox_summary_path": "epf_paradox_summary.json",
+      "epf_report_path": "epf_report.txt"
+    },
+    "comparison": {
+      "total_gates": 18,
+      "changed": 0,
+      "example_count": 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/epf_shadow_run_manifest_v0/missing_epf_report_source_artifact.json`
as the canonical negative fixture for the EPF run-manifest rule that
`source_artifacts` must cover the artifact paths referenced in
`payload.artifacts`.

## Why

The broader EPF run-manifest checker already enforces source-artifact
coverage, but the fixture set should also contain a stable, explicit
negative case for it.

This particular case is useful because it isolates a realistic failure
mode:

- `epf_report_path` is still present in `payload.artifacts`
- but `epf_report.txt` is missing from `source_artifacts`

## What changed

Added a new negative EPF run-manifest fixture:

- `tests/fixtures/epf_shadow_run_manifest_v0/missing_epf_report_source_artifact.json`

The fixture is intentionally invalid only for:

- missing `epf_report.txt` coverage in `source_artifacts`

All other fields remain aligned with the current EPF run-manifest
contract so the failure path stays isolated.

## Contract intent

This fixture is expected to fail validation for one targeted reason only:

- `source_artifacts` must cover referenced payload artifacts

It should not rely on unrelated schema or checker failures.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the canonical negative fixture for one of the broader EPF
run-manifest checker’s source-artifact coverage rules before wiring it
into the checker tests.