### PR TITLE
test(shadow): add invalid-overall-without-invalid-branch fixture for …

### DIFF
--- a/tests/fixtures/epf_shadow_run_manifest_v0/invalid_overall_without_invalid_branch.json
+++ b/tests/fixtures/epf_shadow_run_manifest_v0/invalid_overall_without_invalid_branch.json
@@ -1,0 +1,64 @@
+{
+  "artifact_version": "epf_shadow_run_manifest_v0",
+  "layer_id": "epf_shadow_experiment_v0",
+  "producer": {
+    "name": "epf_experiment_workflow",
+    "version": "0.1.0"
+  },
+  "created_utc": "2026-04-13T12:35:00Z",
+  "run_reality_state": "invalid",
+  "verdict": "invalid",
+  "source_artifacts": [
+    {
+      "path": "status_baseline.json",
+      "role": "baseline_status"
+    },
+    {
+      "path": "status_epf.json",
+      "role": "epf_status"
+    },
+    {
+      "path": "epf_paradox_summary.json",
+      "role": "paradox_summary"
+    },
+    {
+      "path": "epf_report.txt",
+      "role": "epf_report"
+    }
+  ],
+  "relation_scope": "baseline_vs_epf_shadow",
+  "summary": {
+    "headline": "Intentionally invalid EPF shadow run manifest",
+    "details": "This fixture intentionally violates the rule that an invalid overall EPF run must contain at least one invalid branch state."
+  },
+  "reasons": [
+    {
+      "code": "epf.run_manifest.invalid.invalid_overall_without_invalid_branch",
+      "message": "This fixture intentionally violates the invalid-overall-state branch consistency rule.",
+      "severity": "error"
+    }
+  ],
+  "payload": {
+    "command_rcs": {
+      "deps_rc": "0",
+      "runall_rc": "0",
+      "baseline_rc": "0",
+      "epf_rc": "0"
+    },
+    "branch_states": {
+      "baseline_state": "real",
+      "epf_state": "real"
+    },
+    "artifacts": {
+      "baseline_status_path": "status_baseline.json",
+      "epf_status_path": "status_epf.json",
+      "paradox_summary_path": "epf_paradox_summary.json",
+      "epf_report_path": "epf_report.txt"
+    },
+    "comparison": {
+      "total_gates": 18,
+      "changed": 0,
+      "example_count": 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/epf_shadow_run_manifest_v0/invalid_overall_without_invalid_branch.json`
as the canonical negative fixture for the EPF run-manifest rule that an
overall `invalid` run must contain at least one `invalid` branch state.

## Why

The broader EPF run-manifest checker already enforces this consistency
rule, but the fixture set should also contain a stable, explicit
negative case for it.

This makes the failure mode easier to test, easier to inspect, and less
dependent on ad hoc mutation inside tests.

## What changed

Added a new negative EPF run-manifest fixture:

- `tests/fixtures/epf_shadow_run_manifest_v0/invalid_overall_without_invalid_branch.json`

The fixture is intentionally invalid only for:

- `run_reality_state: invalid`
- `payload.branch_states.baseline_state: real`
- `payload.branch_states.epf_state: real`

All other fields remain aligned with the current EPF run-manifest
contract so the failure path stays isolated.

## Contract intent

This fixture is expected to fail validation for one targeted reason only:

- an overall `invalid` EPF run must contain at least one invalid branch

It should not rely on unrelated schema or checker failures.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Create the canonical negative fixture for the EPF run-manifest invalid
overall-state consistency rule before wiring it into the checker tests.