### PR TITLE
test(shadow): isolate degraded branch-state failure in EPF run-manife…

### DIFF
--- a/tests/fixtures/epf_shadow_run_manifest_v0/degraded_without_nonreal_branch.json
+++ b/tests/fixtures/epf_shadow_run_manifest_v0/degraded_without_nonreal_branch.json
@@ -38,6 +38,13 @@
       "severity": "error"
     }
   ],
+  "degraded_reasons": [
+    {
+      "code": "epf.shadow.run_manifest.synthetic_degraded_state",
+      "message": "This fixture declares a degraded overall state in order to isolate the non-real branch requirement.",
+      "severity": "warn"
+    }
+  ],
   "payload": {
     "command_rcs": {
       "deps_rc": "0",


### PR DESCRIPTION
## Summary

Update `tests/fixtures/epf_shadow_run_manifest_v0/degraded_without_nonreal_branch.json`
so it is invalid for the intended reason only.

## Why

Codex correctly pointed out that the fixture currently failed for two reasons:

1. it set `run_reality_state: degraded`
2. but it omitted the required top-level `degraded_reasons` array

That made the fixture unsuitable as a canonical single-failure negative case
for the degraded branch-state rule.

## What changed

Added a non-empty `degraded_reasons` array to:

- `tests/fixtures/epf_shadow_run_manifest_v0/degraded_without_nonreal_branch.json`

The fixture now still fails, but only for the intended rule:

- a degraded overall run must include at least one non-real branch state

## Contract intent

This PR does **not** change the EPF run-manifest contract.

It only fixes the fixture so it isolates the intended checker failure path.

## Scope

Fixture-only correction.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Review note addressed

Address Codex feedback that degraded fixtures must include
`degraded_reasons` under the common shadow artifact contract.