### PR TITLE
test(shadow): wire degraded-without-nonreal-branch fixture into EPF r…

### DIFF
--- a/tests/test_check_epf_shadow_run_manifest_contract.py
+++ b/tests/test_check_epf_shadow_run_manifest_contract.py
@@ -122,6 +122,19 @@ def test_invalid_overall_without_invalid_branch_fixture_fails() -> None:
     )
 
 
+def test_degraded_without_nonreal_branch_fixture_fails() -> None:
+    result = _run(FIXTURES / "degraded_without_nonreal_branch.json")
+    assert result.returncode == 1, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is False
+    assert any(
+        issue["path"] == "payload.branch_states"
+        and "at least one branch must be non-real" in issue["message"]
+        for issue in payload["errors"]
+    )
+
+
 def test_missing_input_is_neutral_with_if_input_present() -> None:
     result = _run(FIXTURES / "does_not_exist.json", "--if-input-present")
     assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary

Update `tests/test_check_epf_shadow_run_manifest_contract.py` so the EPF
run-manifest rule that a `degraded` overall run must include at least
one non-`real` branch state is covered through the canonical negative
fixture.

## Why

The EPF run-manifest fixture set now contains an explicit negative case
for this degraded-state consistency rule:

- `tests/fixtures/epf_shadow_run_manifest_v0/degraded_without_nonreal_branch.json`

The checker tests should use that fixture directly so the failure path is
anchored to a stable, named contract artifact instead of a temp-generated
mutation.

## What changed

- kept canonical positive pass fixture coverage
- kept canonical `changed_without_warn` negative fixture coverage
- kept canonical `changed_exceeds_total_gates` negative fixture coverage
- kept canonical `example_count_exceeds_changed` negative fixture coverage
- kept canonical `real_zero_changed_wrong_verdict` negative fixture coverage
- kept canonical `same_status_paths` negative fixture coverage
- kept canonical `missing_epf_report_source_artifact` negative fixture coverage
- kept canonical `invalid_overall_without_invalid_branch` negative fixture coverage
- wired:
  - `tests/fixtures/epf_shadow_run_manifest_v0/degraded_without_nonreal_branch.json`
  into the checker tests
- preserved coverage for:
  - missing-input neutral absence
  - hard failure on missing input

## Contract intent

This remains a checker-regression test update.

It improves alignment between:
- canonical EPF run-manifest negative fixtures
- checker behavior
- regression coverage

## Scope

Test-only change.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Finish the shift of the main EPF degraded-state branch-consistency path
from temp-generated mutation to a canonical fixture and keep the checker
tests aligned with the expanded fixture set.