### PR TITLE
test(shadow): add degraded fixture for EPF run-manifest contract

### DIFF
--- a/tests/fixtures/epf_shadow_run_manifest_v0/degraded.json
+++ b/tests/fixtures/epf_shadow_run_manifest_v0/degraded.json
@@ -1,0 +1,71 @@
+{
+  "artifact_version": "epf_shadow_run_manifest_v0",
+  "layer_id": "epf_shadow_experiment_v0",
+  "producer": {
+    "name": "epf_experiment_workflow",
+    "version": "0.1.0"
+  },
+  "created_utc": "2026-04-13T12:45:00Z",
+  "run_reality_state": "degraded",
+  "verdict": "warn",
+  "source_artifacts": [
+    {
+      "path": "status_baseline.json",
+      "role": "baseline_status"
+    },
+    {
+      "path": "status_epf.json",
+      "role": "epf_status"
+    },
+    {
+      "path": "epf_paradox_summary.json",
+      "role": "paradox_summary"
+    },
+    {
+      "path": "epf_report.txt",
+      "role": "epf_report"
+    }
+  ],
+  "relation_scope": "baseline_vs_epf_shadow",
+  "summary": {
+    "headline": "EPF shadow run manifest validated in degraded mode",
+    "details": "At least one branch is non-real, degraded reasons are present, and the broader EPF run-manifest contract remains satisfied."
+  },
+  "reasons": [
+    {
+      "code": "epf.run_manifest.degraded",
+      "message": "The EPF run manifest is valid, but at least one branch is degraded.",
+      "severity": "warn"
+    }
+  ],
+  "degraded_reasons": [
+    {
+      "code": "epf.shadow.run_manifest.non_real_branch",
+      "message": "The EPF branch is degraded in this canonical positive fixture.",
+      "severity": "warn"
+    }
+  ],
+  "payload": {
+    "command_rcs": {
+      "deps_rc": "0",
+      "runall_rc": "0",
+      "baseline_rc": "0",
+      "epf_rc": "1"
+    },
+    "branch_states": {
+      "baseline_state": "real",
+      "epf_state": "degraded"
+    },
+    "artifacts": {
+      "baseline_status_path": "status_baseline.json",
+      "epf_status_path": "status_epf.json",
+      "paradox_summary_path": "epf_paradox_summary.json",
+      "epf_report_path": "epf_report.txt"
+    },
+    "comparison": {
+      "total_gates": 18,
+      "changed": 0,
+      "example_count": 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/epf_shadow_run_manifest_v0/degraded.json` as the
canonical positive degraded fixture for the EPF shadow run-manifest
contract.

## Why

The EPF run-manifest fixture set already has:

- one canonical positive real/pass fixture
- multiple canonical negative fixtures

What it did not yet have was a stable **valid degraded-mode** fixture.

That matters because the broader EPF workflow can legitimately produce
non-real states, and the checker should also be exercised against a
known-good degraded example.

## What changed

Added a new positive EPF run-manifest fixture:

- `tests/fixtures/epf_shadow_run_manifest_v0/degraded.json`

The fixture is intentionally valid and demonstrates:

- `run_reality_state: degraded`
- `verdict: warn`
- non-empty `degraded_reasons`
- at least one non-`real` branch state
- valid artifact references
- valid `source_artifacts` coverage
- consistent comparison counters

## Contract intent

This fixture does **not** promote EPF.

It only provides a valid degraded-mode baseline for the broader EPF
run-manifest surface.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Round out the EPF run-manifest fixture set with a canonical valid
degraded example before wiring it into checker tests.