### PR TITLE
test(shadow): add degraded positive fixture coverage for EPF run-mani…

### DIFF
--- a/tests/test_check_epf_shadow_run_manifest_contract.py
+++ b/tests/test_check_epf_shadow_run_manifest_contract.py
@@ -32,6 +32,18 @@ def test_pass_fixture_is_valid() -> None:
     assert payload["verdict"] == "pass"
 
 
+def test_degraded_fixture_is_valid() -> None:
+    result = _run(FIXTURES / "degraded.json")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is False
+    assert payload["artifact_version"] == "epf_shadow_run_manifest_v0"
+    assert payload["run_reality_state"] == "degraded"
+    assert payload["verdict"] == "warn"
+
+
 def test_changed_without_warn_fixture_fails() -> None:
     result = _run(FIXTURES / "changed_without_warn.json")
     assert result.returncode == 1, result.stdout + result.stderr


### PR DESCRIPTION
## Summary

Update `tests/test_check_epf_shadow_run_manifest_contract.py` to add
positive degraded-fixture coverage for the broader EPF run-manifest
contract.

## Why

The EPF run-manifest fixture set now includes not only a canonical
positive real/pass fixture, but also a canonical positive degraded-mode
fixture:

- `tests/fixtures/epf_shadow_run_manifest_v0/degraded.json`

The checker tests should validate both positive states so the run-manifest
surface is covered for:

- real runs
- degraded but still contract-valid runs

## What changed

- kept canonical positive pass fixture coverage
- added:
  - `test_degraded_fixture_is_valid()`
- kept the canonical negative fixture coverage for:
  - `changed_without_warn`
  - `changed_exceeds_total_gates`
  - `example_count_exceeds_changed`
  - `real_zero_changed_wrong_verdict`
  - `same_status_paths`
  - `missing_epf_report_source_artifact`
  - `invalid_overall_without_invalid_branch`
  - `degraded_without_nonreal_branch`
- preserved coverage for:
  - missing-input neutral absence
  - hard failure on missing input

## Contract intent

This remains a checker-regression test update.

It broadens positive coverage for the EPF run-manifest checker without
changing the contract itself.

## Scope

Test-only change.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Round out the EPF run-manifest checker tests with a valid degraded-mode
example and reduce the risk of overfitting positive coverage to the
real/pass case only.