### PR TITLE
feat(shadow): expand EPF registry entry to current run-manifest fixtu…

### DIFF
--- a/shadow_layer_registry_v0.yml
+++ b/shadow_layer_registry_v0.yml
@@ -41,7 +41,15 @@ layers:
     semantic_checker: PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py
     fixtures:
       - tests/fixtures/epf_shadow_run_manifest_v0/pass.json
+      - tests/fixtures/epf_shadow_run_manifest_v0/degraded.json
       - tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json
+      - tests/fixtures/epf_shadow_run_manifest_v0/changed_exceeds_total_gates.json
+      - tests/fixtures/epf_shadow_run_manifest_v0/example_count_exceeds_changed.json
+      - tests/fixtures/epf_shadow_run_manifest_v0/real_zero_changed_wrong_verdict.json
+      - tests/fixtures/epf_shadow_run_manifest_v0/same_status_paths.json
+      - tests/fixtures/epf_shadow_run_manifest_v0/missing_epf_report_source_artifact.json
+      - tests/fixtures/epf_shadow_run_manifest_v0/invalid_overall_without_invalid_branch.json
+      - tests/fixtures/epf_shadow_run_manifest_v0/degraded_without_nonreal_branch.json
     tests:
       - tests/test_check_epf_shadow_run_manifest_contract.py
       - tests/test_check_epf_paradox_summary_contract.py


### PR DESCRIPTION
## Summary

Update `shadow_layer_registry_v0.yml` so the EPF machine-registered
entry reflects the current broader run-manifest fixture set.

## Why

The EPF registry entry already points to the broader run-manifest as its
primary registered surface.

Since then, the run-manifest contract surface has gained a fuller
canonical fixture set, including both valid and invalid cases.

The machine-readable registry should now reflect that current reality.

## What changed

Updated the `epf_shadow_experiment_v0` entry to keep:

- `current_stage: research`
- `target_stage: shadow-contracted`
- `primary_artifact: epf_shadow_run_manifest.json`
- `schema: schemas/epf_shadow_run_manifest_v0.schema.json`
- `semantic_checker: PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py`

and expanded the registered EPF run-manifest fixture list to include:

- `pass.json`
- `degraded.json`
- `changed_without_warn.json`
- `changed_exceeds_total_gates.json`
- `example_count_exceeds_changed.json`
- `real_zero_changed_wrong_verdict.json`
- `same_status_paths.json`
- `missing_epf_report_source_artifact.json`
- `invalid_overall_without_invalid_branch.json`
- `degraded_without_nonreal_branch.json`

## Contract intent

This PR does **not** promote EPF.

It only updates the machine-readable registry so it matches the current
run-manifest contract surface more completely.

## Scope

Registry-only update.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Bring the machine-readable shadow registry fully in line with the now
expanded EPF run-manifest fixture surface.