### PR TITLE
docs(shadow): sync shadow registry page with expanded EPF run-manifes…

### DIFF
--- a/docs/shadow_layer_registry_v0.md
+++ b/docs/shadow_layer_registry_v0.md
@@ -237,7 +237,15 @@ Primary registered surface:
 - `schemas/epf_shadow_run_manifest_v0.schema.json`
 - `PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py`
 - `tests/fixtures/epf_shadow_run_manifest_v0/pass.json`
+- `tests/fixtures/epf_shadow_run_manifest_v0/degraded.json`
 - `tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json`
+- `tests/fixtures/epf_shadow_run_manifest_v0/changed_exceeds_total_gates.json`
+- `tests/fixtures/epf_shadow_run_manifest_v0/example_count_exceeds_changed.json`
+- `tests/fixtures/epf_shadow_run_manifest_v0/real_zero_changed_wrong_verdict.json`
+- `tests/fixtures/epf_shadow_run_manifest_v0/same_status_paths.json`
+- `tests/fixtures/epf_shadow_run_manifest_v0/missing_epf_report_source_artifact.json`
+- `tests/fixtures/epf_shadow_run_manifest_v0/invalid_overall_without_invalid_branch.json`
+- `tests/fixtures/epf_shadow_run_manifest_v0/degraded_without_nonreal_branch.json`
 - `tests/test_check_epf_shadow_run_manifest_contract.py`
 
 Secondary contract-hardened diagnostic surface:


### PR DESCRIPTION
## Summary

Update `docs/shadow_layer_registry_v0.md` so the EPF section reflects the
current expanded run-manifest fixture set.

## Why

The machine-readable registry entry for `epf_shadow_experiment_v0` now
tracks a broader EPF run-manifest fixture surface than the registry docs
page currently listed.

The docs page should now match that current registry reality.

## What changed

Refreshed the `### epf_shadow_experiment_v0` block to:

- keep:
  - `current_stage: research`
  - `target_stage: shadow-contracted`
  - `consumer_authority: review-only`
  - `normative: false`
- keep the EPF run manifest as the primary registered surface
- keep the paradox summary as the secondary contract-hardened diagnostic
  surface
- expand the listed EPF run-manifest fixtures to include the current
  canonical set:
  - `pass.json`
  - `degraded.json`
  - `changed_without_warn.json`
  - `changed_exceeds_total_gates.json`
  - `example_count_exceeds_changed.json`
  - `real_zero_changed_wrong_verdict.json`
  - `same_status_paths.json`
  - `missing_epf_report_source_artifact.json`
  - `invalid_overall_without_invalid_branch.json`
  - `degraded_without_nonreal_branch.json`

## Contract intent

This PR does **not** promote EPF.

It only keeps the registry reference page aligned with the current
machine-readable registry and the current EPF run-manifest fixture set.

## Scope

Documentation-only registry sync.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the shadow registry reference page fully aligned with the current
EPF primary-surface registry entry after the fixture set expanded.