### PR TITLE
docs(shadow): sync optional layers page with expanded EPF run-manifes…

### DIFF
--- a/docs/OPTIONAL_LAYERS.md
+++ b/docs/OPTIONAL_LAYERS.md
@@ -79,7 +79,15 @@ Current primary hardening surface:
   - `../PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py`
 - canonical fixtures:
   - `../tests/fixtures/epf_shadow_run_manifest_v0/pass.json`
+  - `../tests/fixtures/epf_shadow_run_manifest_v0/degraded.json`
   - `../tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json`
+  - `../tests/fixtures/epf_shadow_run_manifest_v0/changed_exceeds_total_gates.json`
+  - `../tests/fixtures/epf_shadow_run_manifest_v0/example_count_exceeds_changed.json`
+  - `../tests/fixtures/epf_shadow_run_manifest_v0/real_zero_changed_wrong_verdict.json`
+  - `../tests/fixtures/epf_shadow_run_manifest_v0/same_status_paths.json`
+  - `../tests/fixtures/epf_shadow_run_manifest_v0/missing_epf_report_source_artifact.json`
+  - `../tests/fixtures/epf_shadow_run_manifest_v0/invalid_overall_without_invalid_branch.json`
+  - `../tests/fixtures/epf_shadow_run_manifest_v0/degraded_without_nonreal_branch.json`
 - checker regression tests:
   - `../tests/test_check_epf_shadow_run_manifest_contract.py`
 


### PR DESCRIPTION
## Summary

Update `docs/OPTIONAL_LAYERS.md` so the EPF block matches the current
EPF primary/secondary surface split and the expanded run-manifest fixture set.

## Why

The broader EPF line is still best described as a `research diagnostic`
path.

At the same time, the current machine-registered EPF primary surface is:

- `epf_shadow_run_manifest.json`

and the secondary contract-hardened diagnostic surface remains:

- `epf_paradox_summary.json`

Since the run-manifest fixture set has expanded, the optional-layers page
should now reflect that current state more completely.

## What changed

- kept EPF classified as a `research diagnostic`
- kept the run manifest documented as the primary registered surface
- kept the paradox summary documented as the secondary contract-hardened
  diagnostic surface
- expanded the listed EPF run-manifest fixtures to include the current
  canonical set:
  - `pass.json`
  - `degraded.json`
  - `changed_without_warn.json`
  - `changed_exceeds_total_gates.json`
  - `example_count_exceeds_changed.json`
  - `real_zero_changed_wrong_verdict.json`
  - `same_status_paths.json`
  - `missing_epf_report_source_artifact.json`
  - `invalid_overall_without_invalid_branch.json`
  - `degraded_without_nonreal_branch.json`
- kept the non-normative boundary explicit

## Contract intent

This PR does **not** promote EPF.

It only keeps the optional-layers page aligned with the current
machine-readable registry and the current EPF run-manifest fixture set.

## Scope

Documentation-only sync.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the optional-layer map fully aligned with the current EPF
run-manifest-centered model and the now-expanded canonical fixture set.