### PR TITLE
docs(state): sync EPF section to run-manifest primary surface

### DIFF
--- a/docs/STATE_v0.md
+++ b/docs/STATE_v0.md
@@ -197,28 +197,64 @@ It is now a fully implemented and contract-disciplined shadow pilot.
 
 ---
 
-## 8. EPF line: broader research path, narrower hardened summary surface
+## 8. EPF line: broader research path, primary run-manifest surface, secondary hardened summary surface
 
 The broader EPF line remains **research-stage** and diagnostic.
 
-That is still the right top-level classification.
+That is still the correct top-level classification.
 
-However, the current `epf_paradox_summary.json` surface is now
-contract-hardened.
+However, the EPF line now has **two** contract-relevant artifact surfaces.
+
+### Primary registered EPF surface
+
+The current primary machine-registered EPF surface is:
+
+- `epf_shadow_run_manifest.json`
+
+Current primary-surface hardening includes:
+
+- `schemas/epf_shadow_run_manifest_v0.schema.json`
+- `PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py`
+- canonical positive and negative fixtures under:
+  - `tests/fixtures/epf_shadow_run_manifest_v0/`
+- `tests/test_check_epf_shadow_run_manifest_contract.py`
+- workflow-level production and validation in:
+  - `.github/workflows/epf_experiment.yml`
+- machine-registration in:
+  - `shadow_layer_registry_v0.yml`
+
+This primary surface records:
+
+- broader EPF run context
+- branch states
+- source artifact references
+- comparison counters
+- overall `run_reality_state`
+- manifest-level `verdict`
+
+### Secondary contract-hardened diagnostic surface
+
+The current secondary EPF surface is:
+
+- `epf_paradox_summary.json`
 
 Current summary-surface hardening includes:
 
 - `schemas/epf_paradox_summary_v0.schema.json`
 - `PULSE_safe_pack_v0/tools/check_epf_paradox_summary_contract.py`
-- canonical positive and negative fixtures
+- canonical positive and negative fixtures under:
+  - `tests/fixtures/epf_paradox_summary_v0/`
 - `tests/test_check_epf_paradox_summary_contract.py`
-- workflow-level validation in `.github/workflows/epf_experiment.yml`
-- machine-registration in `shadow_layer_registry_v0.yml`
+- workflow-level production and validation in:
+  - `.github/workflows/epf_experiment.yml`
+
+This secondary surface summarizes disagreement output at the comparison level.
 
 So the correct current reading is:
 
 - **broader EPF line** → research diagnostic
-- **current paradox summary surface** → contract-hardened, non-normative summary artifact
+- **primary registered EPF surface** → broader run-manifest, non-normative
+- **secondary EPF surface** → contract-hardened paradox summary, non-normative
 
 This distinction matters.
 


### PR DESCRIPTION
## Summary

Update `docs/STATE_v0.md` so the EPF section matches the current
machine-readable and workflow reality more precisely.

## Why

The earlier EPF state text was written when the paradox summary was the
main visible hardened surface.

That is no longer the best description of the current repo state.

The current EPF line is better described as:

- broader EPF line = `research`
- primary machine-registered surface = `epf_shadow_run_manifest.json`
- secondary contract-hardened diagnostic surface = `epf_paradox_summary.json`

The high-level state snapshot should now reflect that split explicitly.

## What changed

Replaced the EPF section in `docs/STATE_v0.md` so it now:

- keeps the broader EPF line at research-stage
- introduces the primary registered EPF surface:
  - `epf_shadow_run_manifest.json`
- documents the primary-surface hardening stack:
  - schema
  - checker
  - fixtures
  - tests
  - workflow production/validation
  - machine-registration
- keeps the paradox summary as the secondary EPF surface
- documents the secondary summary hardening stack
- states the correct current reading explicitly:
  - broader line = research diagnostic
  - primary registered EPF surface = broader run-manifest, non-normative
  - secondary EPF surface = contract-hardened paradox summary, non-normative

## Contract intent

This PR does **not** promote EPF.

It only makes the repo state snapshot accurately reflect the current
EPF surface model.

## Scope

Documentation-only sync.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the high-level state snapshot aligned with the current EPF truth:
research broader line, primary run-manifest surface, and secondary
contract-hardened paradox-summary surface.