### PR TITLE
docs(status): clarify that EPF is machine-registered without status f…

### DIFF
--- a/docs/STATUS_CONTRACT.md
+++ b/docs/STATUS_CONTRACT.md
@@ -258,6 +258,37 @@ Non-goals:
 - no promotion
 - no overall decision change
 
+---
+
+### Not every machine-registered shadow layer folds into the final status
+
+Current counter-example:
+
+- `epf_shadow_experiment_v0`
+
+The broader EPF line is machine-registered, but its current contract
+surfaces remain external to the final normative status artifact.
+
+Current EPF surfaces:
+
+- primary registered surface:
+  - `epf_shadow_run_manifest.json`
+- secondary contract-hardened diagnostic surface:
+  - `epf_paradox_summary.json`
+
+Interpretation rule:
+
+- the absence of an EPF-specific `meta.*` block in the final `status.json`
+  is currently expected
+- that absence must not be interpreted as failure
+- those EPF artifact surfaces remain descriptive and diagnostic only
+- they do not change the normative authority of:
+  - `status.json["gates"]`
+  - the materialized required gate set
+  - `check_gates.py`
+
+If a future EPF fold-in surface is added to `status.json`, it should be
+documented explicitly as an additive, non-normative status surface.
 
 ---
 


### PR DESCRIPTION
## Summary

Update `docs/STATUS_CONTRACT.md` to clarify that not every
machine-registered shadow layer appears as a `meta.*` fold-in in the
final `status.json`.

## Why

The repo now has two clearly different shadow-surface patterns:

- `relational_gain_shadow`
  - additive `meta.relational_gain_shadow` fold-in
- `epf_shadow_experiment_v0`
  - machine-registered, but currently surfaced through:
    - `epf_shadow_run_manifest.json`
    - `epf_paradox_summary.json`

Without stating that distinction explicitly in the status contract page,
a reader can too easily assume that every machine-registered shadow layer
must appear under `status["meta"]`.

## What changed

Added a new clarification block before `## Typical lifecycle` that:

- states that not every machine-registered shadow layer folds into the
  final status
- names EPF as the current counter-example
- records the current EPF primary and secondary artifact surfaces
- explains that the absence of an EPF-specific `meta.*` block is
  expected
- preserves the normative authority boundary around:
  - `status.json["gates"]`
  - the materialized required gate set
  - `check_gates.py`

## Contract intent

This PR does **not** add a new EPF fold-in surface.

It only clarifies the current repository state and the current status
contract boundary.

## Scope

Documentation-only clarification.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the canonical status-contract page aligned with the current
machine-registered shadow model and remove the implicit assumption that
every registered shadow layer must fold into final `status.json`.