### PR TITLE
test(shadow): add stub fixture for EPF run-manifest contract

### DIFF
--- a/tests/fixtures/epf_shadow_run_manifest_v0/stub.json
+++ b/tests/fixtures/epf_shadow_run_manifest_v0/stub.json
@@ -1,0 +1,71 @@
+{
+  "artifact_version": "epf_shadow_run_manifest_v0",
+  "layer_id": "epf_shadow_experiment_v0",
+  "producer": {
+    "name": "epf_experiment_workflow",
+    "version": "0.1.0"
+  },
+  "created_utc": "2026-04-13T12:50:00Z",
+  "run_reality_state": "stub",
+  "verdict": "warn",
+  "source_artifacts": [
+    {
+      "path": "status_baseline.json",
+      "role": "baseline_status"
+    },
+    {
+      "path": "status_epf.json",
+      "role": "epf_status"
+    },
+    {
+      "path": "epf_paradox_summary.json",
+      "role": "paradox_summary"
+    },
+    {
+      "path": "epf_report.txt",
+      "role": "epf_report"
+    }
+  ],
+  "relation_scope": "baseline_vs_epf_shadow",
+  "summary": {
+    "headline": "EPF shadow run manifest validated in stub mode",
+    "details": "The broader EPF run-manifest contract is satisfied for a stub-mode run where baseline and EPF branches are both non-real."
+  },
+  "reasons": [
+    {
+      "code": "epf.run_manifest.stub",
+      "message": "The EPF run manifest is valid, but the run stayed in stub mode.",
+      "severity": "warn"
+    }
+  ],
+  "degraded_reasons": [
+    {
+      "code": "epf.shadow.run_manifest.stub_mode",
+      "message": "This canonical positive fixture models a stub overall run state.",
+      "severity": "warn"
+    }
+  ],
+  "payload": {
+    "command_rcs": {
+      "deps_rc": "0",
+      "runall_rc": "0",
+      "baseline_rc": "0",
+      "epf_rc": "0"
+    },
+    "branch_states": {
+      "baseline_state": "stub",
+      "epf_state": "stub"
+    },
+    "artifacts": {
+      "baseline_status_path": "status_baseline.json",
+      "epf_status_path": "status_epf.json",
+      "paradox_summary_path": "epf_paradox_summary.json",
+      "epf_report_path": "epf_report.txt"
+    },
+    "comparison": {
+      "total_gates": 0,
+      "changed": 0,
+      "example_count": 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add `tests/fixtures/epf_shadow_run_manifest_v0/stub.json` as the
canonical positive stub-mode fixture for the broader EPF shadow
run-manifest contract.

## Why

The EPF run-manifest fixture set already has:

- a canonical positive real/pass fixture
- a canonical positive degraded fixture
- multiple canonical negative fixtures

What it did not yet have was a stable **valid stub-mode** fixture.

That matters because the broader EPF workflow can legitimately produce
stub-mode runs, and the checker should also be exercised against a
known-good stub example.

## What changed

Added a new positive EPF run-manifest fixture:

- `tests/fixtures/epf_shadow_run_manifest_v0/stub.json`

The fixture is intentionally valid and demonstrates:

- `run_reality_state: stub`
- `verdict: warn`
- non-empty `degraded_reasons`
- non-`real` baseline and EPF branch states
- valid artifact references
- valid `source_artifacts` coverage
- consistent comparison counters

## Contract intent

This fixture does **not** promote EPF.

It only provides a valid stub-mode baseline for the broader EPF
run-manifest surface.

## Scope

Fixture-only test support.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Round out the EPF run-manifest fixture set with a canonical valid
stub-mode example before wiring it into checker tests.