### PR TITLE
feat(shadow): add EPF stub fixture to machine-readable shadow registry

### DIFF
--- a/shadow_layer_registry_v0.yml
+++ b/shadow_layer_registry_v0.yml
@@ -42,6 +42,7 @@ layers:
     fixtures:
       - tests/fixtures/epf_shadow_run_manifest_v0/pass.json
       - tests/fixtures/epf_shadow_run_manifest_v0/degraded.json
+      - tests/fixtures/epf_shadow_run_manifest_v0/stub.json
       - tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json
       - tests/fixtures/epf_shadow_run_manifest_v0/changed_exceeds_total_gates.json
       - tests/fixtures/epf_shadow_run_manifest_v0/example_count_exceeds_changed.json


### PR DESCRIPTION
## Summary

Update `shadow_layer_registry_v0.yml` so the EPF machine-registered
entry includes the canonical stub-mode run-manifest fixture.

## Why

The EPF run-manifest fixture set now includes three valid positive modes:

- `pass.json`
- `degraded.json`
- `stub.json`

The machine-readable registry should reflect that current fixture set,
otherwise the EPF registered surface remains slightly behind the actual
checker/test truth.

## What changed

Updated the `epf_shadow_experiment_v0` registry entry to keep:

- `current_stage: research`
- `target_stage: shadow-contracted`
- `primary_artifact: epf_shadow_run_manifest.json`
- `schema: schemas/epf_shadow_run_manifest_v0.schema.json`
- `semantic_checker: PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py`

and added:

- `tests/fixtures/epf_shadow_run_manifest_v0/stub.json`

to the registered EPF run-manifest fixture list.

## Contract intent

This PR does **not** promote EPF.

It only keeps the machine-readable registry aligned with the current
EPF run-manifest fixture surface.

## Scope

Registry-only update.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Complete the current EPF run-manifest fixture truth in the machine-readable
shadow registry after adding the canonical positive stub fixture.