### PR TITLE
docs(shadow): sync shadow registry page with EPF stub run-manifest fi…

### DIFF
--- a/docs/shadow_layer_registry_v0.md
+++ b/docs/shadow_layer_registry_v0.md
@@ -238,6 +238,7 @@ Primary registered surface:
 - `PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py`
 - `tests/fixtures/epf_shadow_run_manifest_v0/pass.json`
 - `tests/fixtures/epf_shadow_run_manifest_v0/degraded.json`
+- `tests/fixtures/epf_shadow_run_manifest_v0/stub.json`
 - `tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json`
 - `tests/fixtures/epf_shadow_run_manifest_v0/changed_exceeds_total_gates.json`
 - `tests/fixtures/epf_shadow_run_manifest_v0/example_count_exceeds_changed.json`


### PR DESCRIPTION
## Summary

Update `docs/shadow_layer_registry_v0.md` so the EPF section matches the
current machine-readable registry state after adding the canonical
stub-mode run-manifest fixture.

## Why

The EPF machine-registered entry now includes a broader primary
run-manifest fixture set, including:

- `pass.json`
- `degraded.json`
- `stub.json`

The registry reference page should reflect that current truth explicitly.

## What changed

Updated the `### epf_shadow_experiment_v0` block to:

- keep:
  - `current_stage: research`
  - `target_stage: shadow-contracted`
  - `consumer_authority: review-only`
  - `normative: false`
- keep the EPF run manifest as the primary registered surface
- keep the paradox summary as the secondary contract-hardened diagnostic
  surface
- add:
  - `tests/fixtures/epf_shadow_run_manifest_v0/stub.json`
  to the documented primary EPF fixture set
- preserve the interpretation boundary that neither EPF surface is normative

## Contract intent

This PR does **not** promote EPF.

It only keeps the shadow registry reference page aligned with the current
machine-readable registry and the expanded EPF run-manifest fixture set.

## Scope

Documentation-only registry sync.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the registry reference page fully aligned with the current EPF
primary-surface fixture inventory after the stub-mode positive fixture
was added.