### PR TITLE
docs(shadow): sync EPF quickstart with stub run-manifest fixture

### DIFF
--- a/docs/PULSE_epf_shadow_quickstart_v0.md
+++ b/docs/PULSE_epf_shadow_quickstart_v0.md
@@ -303,6 +303,7 @@ Current canonical positive fixtures:
 ```text
 tests/fixtures/epf_shadow_run_manifest_v0/pass.json
 tests/fixtures/epf_shadow_run_manifest_v0/degraded.json
+tests/fixtures/epf_shadow_run_manifest_v0/stub.json
 ```
 
 Current canonical negative fixtures include:
@@ -345,8 +346,8 @@ including:
 - the run manifest surface captures run context, branch states,
   referenced artifacts, and comparison counters
 
-Its fixture set now includes both valid real/degraded examples and
-targeted negative cases for verdict consistency, counter consistency,
+Its fixture set now includes valid real, degraded, and stub examples,
+plus targeted negative cases for verdict consistency, counter consistency,
 artifact-path separation, source-artifact coverage, and branch-state
 consistency.
 


### PR DESCRIPTION
## Summary

Update `docs/PULSE_epf_shadow_quickstart_v0.md` so the EPF quickstart
reflects the current broader run-manifest positive fixture set.

## Why

The EPF run-manifest surface now has three valid positive examples:

- `pass.json`
- `degraded.json`
- `stub.json`

The quickstart had already been updated for the broader run-manifest
surface, but it still only documented the first two positive fixtures.

This PR closes that small documentation gap.

## What changed

In the `### B. Broader EPF run-manifest surface` section, this PR:

- adds:
  - `tests/fixtures/epf_shadow_run_manifest_v0/stub.json`
  to the documented canonical positive fixtures
- updates the interpretation text so it now explicitly says that the
  fixture set includes valid:
  - real
  - degraded
  - stub
  examples

## Contract intent

This PR does **not** promote EPF.

It only keeps the EPF quickstart aligned with the current run-manifest
fixture truth.

## Scope

Documentation-only sync.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the EPF quickstart fully aligned with the current broader
run-manifest surface after adding the canonical positive stub fixture.