### PR TITLE
docs(shadow): sync optional layers page with EPF stub run-manifest fi…

### DIFF
--- a/docs/OPTIONAL_LAYERS.md
+++ b/docs/OPTIONAL_LAYERS.md
@@ -80,6 +80,7 @@ Current primary hardening surface:
 - canonical fixtures:
   - `../tests/fixtures/epf_shadow_run_manifest_v0/pass.json`
   - `../tests/fixtures/epf_shadow_run_manifest_v0/degraded.json`
+  - `../tests/fixtures/epf_shadow_run_manifest_v0/stub.json`
   - `../tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json`
   - `../tests/fixtures/epf_shadow_run_manifest_v0/changed_exceeds_total_gates.json`
   - `../tests/fixtures/epf_shadow_run_manifest_v0/example_count_exceeds_changed.json`


### PR DESCRIPTION
## Summary

Update `docs/OPTIONAL_LAYERS.md` so the EPF block reflects the current
EPF run-manifest fixture set more precisely.

## Why

The broader EPF line is still best described as a `research diagnostic`
path.

At the same time, the primary machine-registered EPF surface remains:

- `epf_shadow_run_manifest.json`

and its current canonical positive fixture set now includes:

- `pass.json`
- `degraded.json`
- `stub.json`

The optional-layers page should now reflect that current truth.

## What changed

- kept EPF classified as a `research diagnostic`
- kept the run manifest documented as the primary registered surface
- kept the paradox summary documented as the secondary contract-hardened
  diagnostic surface
- added:
  - `tests/fixtures/epf_shadow_run_manifest_v0/stub.json`
  to the documented primary EPF fixture set
- preserved the non-normative boundary explicitly

## Contract intent

This PR does **not** promote EPF.

It only keeps the optional-layer page aligned with the current
machine-readable registry and the current EPF run-manifest fixture set.

## Scope

Documentation-only sync.

This PR does **not**:
- change release semantics
- modify required gates
- alter `check_gates.py`
- change workflow enforcement
- promote any shadow layer

## Intent

Keep the optional-layer map fully aligned with the current EPF
run-manifest-centered model after adding the canonical positive stub
fixture.