### PR TITLE
docs(readme): replace top README line with explicit positioning state…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 # PULSE — Release Gates for Safe & Useful AI
 
-#### AI Release Stability Engineering
+#### [PULSE is a deterministic, auditable decision layer for release governance, designed to run consistently across environments.](#start-here)
 
 > 💡 **Continuous expansion**
 >
@@ -1140,8 +1140,8 @@ CI wiring corresponding to the preprint.
 
 ## Acknowledgments
 
-This work used **ChatGPT (GPT‑ Pro)** for drafting support, CI workflow tips, and repo‑hygiene suggestions.  
-Human authors retain full responsibility for the design, verification, and decisions.
+PULSE is developed through human–machine collaboration, including ChatGPT support for drafting, CI workflow refinement, and repo-hygiene suggestions.
+Human authors retain full responsibility for the design, verification, and release decisions.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR improves the README front page by replacing the generic
"AI Release Stability Engineering" line with a direct positioning
statement that says what PULSE is and keeps the existing jump to
`#start-here`.

It also updates the `Acknowledgments` section to reflect the actual
development model more clearly through human–machine collaboration,
while preserving explicit human responsibility for design, verification,
and release decisions.

## Changes

- remove the generic top README heading
- replace it with a clickable positioning sentence linked to `#start-here`
- preserve the existing `Start here` navigation behavior
- keep the `Continuous expansion` note in place
- refine `Acknowledgments` for clearer public-facing wording

## Why

The README top section is a public-facing surface.
Its first strong sentence should define PULSE directly, not describe it
through a broad category label.

This change improves clarity, positioning, and presentation quality
without changing semantics or navigation structure.

## Result

The README now presents PULSE more cleanly as a deterministic,
auditable decision layer for release governance, designed to run
consistently across environments.

The acknowledgments text is also better aligned with how the project
is actually developed.