### PR TITLE
test(epf): add positive partial fixture regression

### DIFF
--- a/tests/test_check_epf_shadow_run_manifest_contract.py
+++ b/tests/test_check_epf_shadow_run_manifest_contract.py
@@ -56,6 +56,21 @@ def test_stub_fixture_is_valid() -> None:
     assert payload["verdict"] == "warn"
 
 
+def test_partial_fixture_is_valid() -> None:
+    result = _run(FIXTURES / "partial.json")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is False
+    assert payload["artifact_version"] == "epf_shadow_run_manifest_v0"
+    assert payload["run_reality_state"] == "partial"
+    assert payload["verdict"] == "warn"
+
+
+def test_changed_without_warn_fixture_fails() -> None:
+
+
 def test_changed_without_warn_fixture_fails() -> None:
     result = _run(FIXTURES / "changed_without_warn.json")
     assert result.returncode == 1, result.stdout + result.stderr

--- a/tests/test_check_epf_shadow_run_manifest_contract.py
+++ b/tests/test_check_epf_shadow_run_manifest_contract.py
@@ -67,6 +67,17 @@ def test_partial_fixture_is_valid() -> None:
     assert payload["run_reality_state"] == "partial"
     assert payload["verdict"] == "warn"
 
+def test_partial_fixture_is_valid() -> None:
+    result = _run(FIXTURES / "partial.json")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    payload = _stdout_json(result)
+    assert payload["ok"] is True
+    assert payload["neutral"] is False
+    assert payload["artifact_version"] == "epf_shadow_run_manifest_v0"
+    assert payload["run_reality_state"] == "partial"
+    assert payload["verdict"] == "warn"
+
 
 def test_changed_without_warn_fixture_fails() -> None:
 

--- a/tests/test_check_epf_shadow_run_manifest_contract.py
+++ b/tests/test_check_epf_shadow_run_manifest_contract.py
@@ -67,20 +67,6 @@ def test_partial_fixture_is_valid() -> None:
     assert payload["run_reality_state"] == "partial"
     assert payload["verdict"] == "warn"
 
-def test_partial_fixture_is_valid() -> None:
-    result = _run(FIXTURES / "partial.json")
-    assert result.returncode == 0, result.stdout + result.stderr
-
-    payload = _stdout_json(result)
-    assert payload["ok"] is True
-    assert payload["neutral"] is False
-    assert payload["artifact_version"] == "epf_shadow_run_manifest_v0"
-    assert payload["run_reality_state"] == "partial"
-    assert payload["verdict"] == "warn"
-
-
-def test_changed_without_warn_fixture_fails() -> None:
-
 
 def test_changed_without_warn_fixture_fails() -> None:
     result = _run(FIXTURES / "changed_without_warn.json")


### PR DESCRIPTION
## Summary

This PR adds the missing positive `partial.json` regression test to the
EPF shadow run-manifest contract suite.

The new test is placed in the existing positive-fixture block, alongside
the current `pass`, `degraded`, and `stub` validity checks.

## Change

- add `test_partial_fixture_is_valid()` to
  `tests/test_check_epf_shadow_run_manifest_contract.py`

## Assertions

The new test validates the canonical partial fixture outcome by checking:

- `run_reality_state == "partial"`
- `verdict == "warn"`

## Why

The test suite already covers the positive `pass`, `degraded`, and `stub`
fixtures, but the positive `partial` fixture was still missing from the
regression layer.

This PR closes that gap without changing contract logic or checker behavior.

## Result

The EPF run-manifest test layer now covers the full intended positive
fixture set:
- `pass`
- `degraded`
- `stub`
- `partial`