### PR TITLE
docs(registry): add partial EPF fixture to shadow layer registry

### DIFF
--- a/shadow_layer_registry_v0.yml
+++ b/shadow_layer_registry_v0.yml
@@ -43,6 +43,7 @@ layers:
       - tests/fixtures/epf_shadow_run_manifest_v0/pass.json
       - tests/fixtures/epf_shadow_run_manifest_v0/degraded.json
       - tests/fixtures/epf_shadow_run_manifest_v0/stub.json
+      - tests/fixtures/epf_shadow_run_manifest_v0/partial.json
       - tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json
       - tests/fixtures/epf_shadow_run_manifest_v0/changed_exceeds_total_gates.json
       - tests/fixtures/epf_shadow_run_manifest_v0/example_count_exceeds_changed.json


### PR DESCRIPTION
## Summary

This PR updates `shadow_layer_registry_v0.yml` to register the missing
positive `partial.json` fixture for the EPF shadow run-manifest surface.

## Change

- add `tests/fixtures/epf_shadow_run_manifest_v0/partial.json`
  to the EPF `fixtures:` list

## Placement

The new entry is inserted in the EPF fixture block:
- after `stub.json`
- before `changed_without_warn.json`

## Why

The EPF registry entry already includes `partial` in its
`run_reality_states`, but the corresponding positive fixture was not yet
listed in the registry fixture inventory.

This PR closes that registry-level truth-sync gap.

## Result

The EPF registry entry now reflects the full intended positive fixture set:

- `pass.json`
- `degraded.json`
- `stub.json`
- `partial.json`