### PR TITLE
docs(registry): sync EPF primary fixture list in shadow registry doc

### DIFF
--- a/docs/shadow_layer_registry_v0.md
+++ b/docs/shadow_layer_registry_v0.md
@@ -239,6 +239,7 @@ Primary registered surface:
 - `tests/fixtures/epf_shadow_run_manifest_v0/pass.json`
 - `tests/fixtures/epf_shadow_run_manifest_v0/degraded.json`
 - `tests/fixtures/epf_shadow_run_manifest_v0/stub.json`
+- `tests/fixtures/epf_shadow_run_manifest_v0/partial.json`
 - `tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json`
 - `tests/fixtures/epf_shadow_run_manifest_v0/changed_exceeds_total_gates.json`
 - `tests/fixtures/epf_shadow_run_manifest_v0/example_count_exceeds_changed.json`


### PR DESCRIPTION
## Summary

This PR updates `docs/shadow_layer_registry_v0.md` so the EPF
`Primary registered surface` section matches the current canonical
positive fixture set for the run-manifest contract.

## Changes

- add `tests/fixtures/epf_shadow_run_manifest_v0/stub.json`
- add `tests/fixtures/epf_shadow_run_manifest_v0/partial.json`

## Placement

The new entries are inserted in the EPF primary fixture list:
- after `degraded.json`
- before `changed_without_warn.json`

## Why

The shadow registry doc still listed only a partial positive EPF fixture
set, even though the registered EPF run-manifest surface now uses the
broader positive set:

- `pass.json`
- `degraded.json`
- `stub.json`
- `partial.json`

This PR closes that documentation-level truth-sync gap.

## Result

The shadow registry documentation now matches the current EPF primary
positive fixture inventory more accurately.