### PR TITLE
docs(optional-layers): sync EPF primary fixture list

### DIFF
--- a/docs/OPTIONAL_LAYERS.md
+++ b/docs/OPTIONAL_LAYERS.md
@@ -81,6 +81,7 @@ Current primary hardening surface:
   - `../tests/fixtures/epf_shadow_run_manifest_v0/pass.json`
   - `../tests/fixtures/epf_shadow_run_manifest_v0/degraded.json`
   - `../tests/fixtures/epf_shadow_run_manifest_v0/stub.json`
+  - `../tests/fixtures/epf_shadow_run_manifest_v0/partial.json`
   - `../tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json`
   - `../tests/fixtures/epf_shadow_run_manifest_v0/changed_exceeds_total_gates.json`
   - `../tests/fixtures/epf_shadow_run_manifest_v0/example_count_exceeds_changed.json`


### PR DESCRIPTION
## Summary

This PR updates `docs/OPTIONAL_LAYERS.md` so the EPF primary hardening
surface matches the current canonical positive fixture set for the
run-manifest contract.

## Changes

- add `../tests/fixtures/epf_shadow_run_manifest_v0/stub.json`
- add `../tests/fixtures/epf_shadow_run_manifest_v0/partial.json`

## Placement

The new entries are inserted in the EPF canonical fixture list:
- after `degraded.json`
- before `changed_without_warn.json`

## Why

The optional-layers EPF section still reflected only a partial positive
fixture set, even though the broader EPF primary surface now uses the
full positive set:

- `pass.json`
- `degraded.json`
- `stub.json`
- `partial.json`

This PR closes that documentation-level truth-sync gap.

## Result

The EPF primary hardening surface in `docs/OPTIONAL_LAYERS.md` now
matches the current positive fixture inventory more accurately.