### PR TITLE
docs(epf): sync quickstart fixture list with partial run-manifest surface

### DIFF
--- a/docs/PULSE_epf_shadow_quickstart_v0.md
+++ b/docs/PULSE_epf_shadow_quickstart_v0.md
@@ -304,6 +304,7 @@ Current canonical positive fixtures:
 tests/fixtures/epf_shadow_run_manifest_v0/pass.json
 tests/fixtures/epf_shadow_run_manifest_v0/degraded.json
 tests/fixtures/epf_shadow_run_manifest_v0/stub.json
+tests/fixtures/epf_shadow_run_manifest_v0/partial.json
 ```
 
 Current canonical negative fixtures include:


### PR DESCRIPTION
## Summary

This PR updates `docs/PULSE_epf_shadow_quickstart_v0.md` so the
broader EPF run-manifest section matches the current canonical positive
fixture set.

## Changes

- add `tests/fixtures/epf_shadow_run_manifest_v0/partial.json`
  to the `Current canonical positive fixtures` block
- update the summary sentence so it describes the fixture set as:
  - real
  - degraded
  - stub
  - partial

## Why

The quickstart still documented only a partial positive fixture set for
the EPF run-manifest surface, even though the broader primary surface
now includes `partial.json` as part of the canonical positive set.

This PR closes that quickstart-level truth-sync gap.

## Result

The EPF quickstart now describes the broader run-manifest surface with
the correct positive fixture inventory and wording.