### PR TITLE
docs(epf): fix remaining quickstart wording drift for partial fixture

### DIFF
--- a/docs/PULSE_epf_shadow_quickstart_v0.md
+++ b/docs/PULSE_epf_shadow_quickstart_v0.md
@@ -347,10 +347,7 @@ including:
 - the run manifest surface captures run context, branch states,
   referenced artifacts, and comparison counters
 
-Its fixture set now includes valid real, degraded, and stub examples,
-plus targeted negative cases for verdict consistency, counter consistency,
-artifact-path separation, source-artifact coverage, and branch-state
-consistency.
+Its fixture set now includes valid real, degraded, stub, and partial examples,
 
 Both remain diagnostic and non-normative.
 


### PR DESCRIPTION
## Summary

This PR fixes the remaining wording-level truth-sync drift in
`docs/PULSE_epf_shadow_quickstart_v0.md`.

The broader EPF run-manifest section already lists the full canonical
positive fixture set, including `partial.json`, but the explanatory
sentence still described the fixture set as only:

- real
- degraded
- stub

## Change

Update the sentence to describe the current fixture set as:

- real
- degraded
- stub
- partial

## Why

The fixture list and the explanatory wording should describe the same
surface.

This PR closes the last visible wording mismatch in the EPF primary
surface quickstart.

## Result

The EPF quickstart now fully matches the current positive fixture
inventory and wording.