### PR TITLE
docs(workflow-map): update registry and EPF surface references

### DIFF
--- a/docs/WORKFLOW_MAP.md
+++ b/docs/WORKFLOW_MAP.md
@@ -70,24 +70,22 @@ Current registry stack:
 - `tests/test_check_shadow_layer_registry.py`
 
 Current canonical registry fixture:
-
 - `tests/fixtures/shadow_layer_registry_v0/pass.json`
 
-Current registered layer:
-
+Current registered layers:
 - `relational_gain_shadow`
+- `epf_shadow_experiment_v0`
 
 Boundary:
-
 - registry validation is descriptive and governance-facing
 - it does not change release semantics
 - it does not promote a layer by registry presence alone
 - it does not create normative authority
 
-Current relation to Relational Gain:
-
-- the registry currently tracks the contract-hardened Relational Gain shadow pilot
-- the dedicated registry workflow also watches the currently referenced Relational Gain surfaces
+Current registry coverage:
+- the registry tracks the contract-hardened Relational Gain shadow pilot
+- the registry also tracks the EPF shadow experiment line as a research diagnostic layer
+- for EPF, the primary registered surface is the broader run manifest rather than the paradox summary
 
 ### C. Shadow / diagnostic workflows
 **Purpose:** extra diagnostics, research layers, or explanatory surfaces
@@ -119,10 +117,9 @@ Current workflow-emitted artifacts:
 - `epf_shadow_run_manifest.json`
 
 Current primary registered EPF surface:
-
 - `schemas/epf_shadow_run_manifest_v0.schema.json`
 - `PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py`
-- `tests/fixtures/epf_shadow_run_manifest_v0/pass.json`
+- canonical positive fixtures under `tests/fixtures/epf_shadow_run_manifest_v0/` (`pass`, `degraded`, `stub`, `partial`)
 - `tests/test_check_epf_shadow_run_manifest_contract.py`
 
 Current secondary contract-hardened diagnostic surface:


### PR DESCRIPTION
## Summary

This PR updates `docs/WORKFLOW_MAP.md` so it reflects the current shadow
registry and EPF surface structure more accurately.

## Changes

- change the shadow registry section from a single registered layer to
  the current registered layers
- add EPF registry coverage wording to the shadow registry workflow
  section
- update the EPF primary registered surface description so it no longer
  implies a pass-only fixture view
- describe the canonical positive EPF fixture set as:
  - pass
  - degraded
  - stub
  - partial

## Why

The workflow map still reflected an older state where:
- the registry was described as tracking only `relational_gain_shadow`
- the EPF primary surface was shown through a single `pass.json`
  fixture reference

The current registry-backed structure is broader than that.

## Result

`docs/WORKFLOW_MAP.md` now matches the current shadow registry and EPF
primary-surface architecture more closely, while using wording that is
clearer and less drift-prone.