### PR TITLE
docs(shadow-contract): update EPF inventory row to current surface model

### DIFF
--- a/docs/SHADOW_CONTRACT_PROGRAM_v0.md
+++ b/docs/SHADOW_CONTRACT_PROGRAM_v0.md
@@ -389,7 +389,7 @@ It is a management surface, not a promotion statement.
 | Theory overlay v0 | `theory_overlay_v0` | research | — | shadow diagnostic | artifact present | none | schema + degraded model |
 | G-field / G snapshot family | `g_field_snapshot_family_v0` | research | — | shadow diagnostic | mixed / family-level | none | split family contracts |
 | Relational Gain v0 | `relational_gain_shadow` | shadow-contracted | advisory | shadow diagnostic | artifact contracted | `meta.relational_gain_shadow` | advisory evaluation only if explicitly pursued |
-| EPF experiment / hazard | `epf_shadow_experiment_v0` | research | shadow-contracted | research diagnostic | run-manifest contracted (summary surface secondary) | none | broader EPF line hardening beyond the current primary run-manifest surface |
+| EPF experiment / hazard | `epf_shadow_experiment_v0` | research | shadow-contracted | research diagnostic | primary run-manifest surface registered; summary surface contract-hardened | none | broader EPF line hardening beyond current primary/secondary contract surfaces |
 | Topology family | `topology_family_v0` | research | — | artifact-derived topology | partial family artifacts | none | standalone schema set |
 | Decision-field family | `decision_field_v0` | research | — | decision-oriented shadow read | partial family artifacts | none | vocabulary contract + artifact schema |
 | Parameter Golf v0 | `parameter_golf_submission_evidence_v0` | research | shadow-contracted | external challenge companion | artifact present | none | sync inventory with companion schema |


### PR DESCRIPTION
## Summary

This PR updates the EPF row in the seeded inventory table of
`docs/SHADOW_CONTRACT_PROGRAM_v0.md`.

## Changes

- replace the outdated EPF primary-artifact wording
- align the row with the current registry-backed EPF surface model
- update the next-step wording so it no longer frames EPF hardening as
  moving beyond the summary artifact alone

## Why

The seeded inventory still described the EPF line as if the summary
artifact were the contracted primary surface.

The current registry-backed state is broader than that:
- the EPF shadow run manifest is the primary registered surface
- the paradox summary remains a contract-hardened secondary diagnostic artifact

## Result

The seeded inventory now reflects the current EPF primary/secondary
surface split more accurately, without changing semantics or promotion
status.