### PR TITLE
fix(registry): preserve fixtures alias

### DIFF
--- a/schemas/shadow_layer_registry_v0.schema.json
+++ b/schemas/shadow_layer_registry_v0.schema.json
@@ -125,7 +125,15 @@
         "semantic_checker": {
           "$ref": "#/$defs/path_string"
         },
-        "fixtures": {
+        "valid_fixtures": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/path_string"
+          }
+        },
+        "invalid_fixtures": {
           "type": "array",
           "minItems": 1,
           "uniqueItems": true,
@@ -186,7 +194,7 @@
               "primary_artifact",
               "schema",
               "semantic_checker",
-              "fixtures",
+              "valid_fixtures",
               "tests"
             ]
           }

--- a/schemas/shadow_layer_registry_v0.schema.json
+++ b/schemas/shadow_layer_registry_v0.schema.json
@@ -62,6 +62,14 @@
       "type": "string",
       "minLength": 1
     },
+    "path_array": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/path_string"
+      }
+    },
     "layer": {
       "type": "object",
       "additionalProperties": false,
@@ -125,29 +133,18 @@
         "semantic_checker": {
           "$ref": "#/$defs/path_string"
         },
+        "fixtures": {
+          "$ref": "#/$defs/path_array",
+          "description": "Transitional alias for valid_fixtures during registry migration."
+        },
         "valid_fixtures": {
-          "type": "array",
-          "minItems": 1,
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/$defs/path_string"
-          }
+          "$ref": "#/$defs/path_array"
         },
         "invalid_fixtures": {
-          "type": "array",
-          "minItems": 1,
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/$defs/path_string"
-          }
+          "$ref": "#/$defs/path_array"
         },
         "tests": {
-          "type": "array",
-          "minItems": 1,
-          "uniqueItems": true,
-          "items": {
-            "$ref": "#/$defs/path_string"
-          }
+          "$ref": "#/$defs/path_array"
         },
         "run_reality_states": {
           "type": "array",
@@ -194,8 +191,19 @@
               "primary_artifact",
               "schema",
               "semantic_checker",
-              "valid_fixtures",
               "tests"
+            ],
+            "anyOf": [
+              {
+                "required": [
+                  "fixtures"
+                ]
+              },
+              {
+                "required": [
+                  "valid_fixtures"
+                ]
+              }
             ]
           }
         },


### PR DESCRIPTION
## Summary

This PR starts the shadow registry fixture-role hardening by updating
`schemas/shadow_layer_registry_v0.schema.json`.

## Changes

- add `valid_fixtures`
- add `invalid_fixtures`
- keep `fixtures` as a transitional alias
- change the higher-stage fixture requirement from a hard
  `fixtures` requirement to:
  - `fixtures`, or
  - `valid_fixtures`

## Why

The registry is moving from a flat fixture bucket toward a more explicit
fixture-role model.

However, the current repo still uses `fixtures` in the live registry,
checker, and tests, so the first step should be additive and
compatibility-preserving rather than a breaking cut.

## Result

The schema now supports the new fixture-role vocabulary while remaining
compatible with the current registry-backed flow.