### PR TITLE
fix(registry): accept fixture buckets

### DIFF
--- a/PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py
+++ b/PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py
@@ -82,6 +82,8 @@ LAYER_ALLOWED = LAYER_REQUIRED | {
     "schema",
     "semantic_checker",
     "fixtures",
+    "valid_fixtures",
+    "invalid_fixtures",
     "tests",
     "promotion_blockers",
 }
@@ -416,7 +418,48 @@ def validate_shadow_layer_registry(obj: Any) -> dict[str, Any]:
                         errors=errors,
                         must_exist=True,
                     )
+            valid_fixtures: list[str] | None = None
+        invalid_fixtures: list[str] | None = None
 
+        if "valid_fixtures" in layer:
+            valid_fixtures = _validate_non_empty_string_array(
+                layer.get("valid_fixtures"),
+                path=f"{path_prefix}.valid_fixtures",
+                errors=errors,
+            )
+            if valid_fixtures is not None:
+                for fixture_idx, fixture in enumerate(valid_fixtures):
+                    _validate_repo_relative_path(
+                        fixture,
+                        path=f"{path_prefix}.valid_fixtures[{fixture_idx}]",
+                        errors=errors,
+                        must_exist=True,
+                    )
+
+        if "invalid_fixtures" in layer:
+            invalid_fixtures = _validate_non_empty_string_array(
+                layer.get("invalid_fixtures"),
+                path=f"{path_prefix}.invalid_fixtures",
+                errors=errors,
+            )
+            if invalid_fixtures is not None:
+                for fixture_idx, fixture in enumerate(invalid_fixtures):
+                    _validate_repo_relative_path(
+                        fixture,
+                        path=f"{path_prefix}.invalid_fixtures[{fixture_idx}]",
+                        errors=errors,
+                        must_exist=True,
+                    )
+
+        if valid_fixtures is not None and invalid_fixtures is not None:
+            overlap = sorted(set(valid_fixtures) & set(invalid_fixtures))
+            for item in overlap:
+                _add_issue(
+                    errors,
+                    f"{path_prefix}.invalid_fixtures",
+                    f"fixture must not appear in both valid_fixtures and invalid_fixtures: {item}",
+                )
+        
         if "tests" in layer:
             tests = _validate_non_empty_string_array(
                 layer.get("tests"),
@@ -459,7 +502,6 @@ def validate_shadow_layer_registry(obj: Any) -> dict[str, Any]:
                 "primary_artifact",
                 "schema",
                 "semantic_checker",
-                "fixtures",
                 "tests",
             ):
                 if required_field not in layer:
@@ -469,6 +511,13 @@ def validate_shadow_layer_registry(obj: Any) -> dict[str, Any]:
                         f"{required_field} is required when current_stage is {current_stage_s}",
                     )
 
+                    if "fixtures" not in layer and "valid_fixtures" not in layer:
+                _add_issue(
+                    errors,
+                    f"{path_prefix}.valid_fixtures",
+                    f"fixtures or valid_fixtures is required when current_stage is {current_stage_s}",
+                )
+        
         if normative is True and current_stage_s != "release-required":
             _add_issue(
                 errors,

--- a/PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py
+++ b/PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py
@@ -496,7 +496,7 @@ def validate_shadow_layer_registry(obj: Any) -> dict[str, Any]:
         if not _is_non_empty_str(layer.get("notes")):
             _add_issue(errors, f"{path_prefix}.notes", "notes must be a non-empty string")
 
-        if current_stage_s in HIGHER_STAGES:
+                if current_stage_s in HIGHER_STAGES:
             for required_field in (
                 "primary_entrypoint",
                 "primary_artifact",
@@ -511,7 +511,7 @@ def validate_shadow_layer_registry(obj: Any) -> dict[str, Any]:
                         f"{required_field} is required when current_stage is {current_stage_s}",
                     )
 
-                    if "fixtures" not in layer and "valid_fixtures" not in layer:
+            if "fixtures" not in layer and "valid_fixtures" not in layer:
                 _add_issue(
                     errors,
                     f"{path_prefix}.valid_fixtures",

--- a/PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py
+++ b/PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py
@@ -404,6 +404,10 @@ def validate_shadow_layer_registry(obj: Any) -> dict[str, Any]:
                 must_exist=True,
             )
 
+        fixtures: list[str] | None = None
+        valid_fixtures: list[str] | None = None
+        invalid_fixtures: list[str] | None = None
+
         if "fixtures" in layer:
             fixtures = _validate_non_empty_string_array(
                 layer.get("fixtures"),
@@ -418,8 +422,6 @@ def validate_shadow_layer_registry(obj: Any) -> dict[str, Any]:
                         errors=errors,
                         must_exist=True,
                     )
-            valid_fixtures: list[str] | None = None
-        invalid_fixtures: list[str] | None = None
 
         if "valid_fixtures" in layer:
             valid_fixtures = _validate_non_empty_string_array(
@@ -459,7 +461,7 @@ def validate_shadow_layer_registry(obj: Any) -> dict[str, Any]:
                     f"{path_prefix}.invalid_fixtures",
                     f"fixture must not appear in both valid_fixtures and invalid_fixtures: {item}",
                 )
-        
+
         if "tests" in layer:
             tests = _validate_non_empty_string_array(
                 layer.get("tests"),
@@ -496,7 +498,7 @@ def validate_shadow_layer_registry(obj: Any) -> dict[str, Any]:
         if not _is_non_empty_str(layer.get("notes")):
             _add_issue(errors, f"{path_prefix}.notes", "notes must be a non-empty string")
 
-                if current_stage_s in HIGHER_STAGES:
+        if current_stage_s in HIGHER_STAGES:
             for required_field in (
                 "primary_entrypoint",
                 "primary_artifact",
@@ -517,7 +519,7 @@ def validate_shadow_layer_registry(obj: Any) -> dict[str, Any]:
                     f"{path_prefix}.valid_fixtures",
                     f"fixtures or valid_fixtures is required when current_stage is {current_stage_s}",
                 )
-        
+
         if normative is True and current_stage_s != "release-required":
             _add_issue(
                 errors,


### PR DESCRIPTION
## Summary

This PR updates the shadow layer registry checker so it supports the new
fixture-bucket vocabulary without breaking the current registry.

## Changes

- allow `valid_fixtures`
- allow `invalid_fixtures`
- keep `fixtures` as a transitional alias
- validate both new fixture arrays as repo-relative existing paths
- reject overlap between `valid_fixtures` and `invalid_fixtures`
- allow higher-stage layers to satisfy fixture requirements with either:
  - `fixtures`, or
  - `valid_fixtures`

## Why

The rollout should stay transitional.

The checker previously only allowed `fixtures` and also required
`fixtures` for higher-stage layers, which would block migration of the
live registry YAML to fixture-role buckets.

## Result

The checker now supports the new bucket structure while remaining
compatible with the current registry-backed flow.