### PR TITLE
refactor(registry): bucket live registry fixtures

### DIFF
--- a/shadow_layer_registry_v0.yml
+++ b/shadow_layer_registry_v0.yml
@@ -12,7 +12,7 @@ layers:
     status_foldin: meta.relational_gain_shadow
     schema: schemas/relational_gain_shadow_v0.schema.json
     semantic_checker: PULSE_safe_pack_v0/tools/check_relational_gain_contract.py
-    fixtures:
+    valid_fixtures:
       - tests/fixtures/relational_gain_shadow_v0/pass.json
       - tests/fixtures/relational_gain_shadow_v0/warn.json
       - tests/fixtures/relational_gain_shadow_v0/fail.json
@@ -39,11 +39,12 @@ layers:
     primary_artifact: epf_shadow_run_manifest.json
     schema: schemas/epf_shadow_run_manifest_v0.schema.json
     semantic_checker: PULSE_safe_pack_v0/tools/check_epf_shadow_run_manifest_contract.py
-    fixtures:
+    valid_fixtures:
       - tests/fixtures/epf_shadow_run_manifest_v0/pass.json
       - tests/fixtures/epf_shadow_run_manifest_v0/degraded.json
       - tests/fixtures/epf_shadow_run_manifest_v0/stub.json
       - tests/fixtures/epf_shadow_run_manifest_v0/partial.json
+    invalid_fixtures:
       - tests/fixtures/epf_shadow_run_manifest_v0/changed_without_warn.json
       - tests/fixtures/epf_shadow_run_manifest_v0/changed_exceeds_total_gates.json
       - tests/fixtures/epf_shadow_run_manifest_v0/example_count_exceeds_changed.json


### PR DESCRIPTION
## Summary

This PR updates the live shadow layer registry YAML to use explicit
fixture-role buckets.

## Changes

### relational_gain_shadow
- replace `fixtures` with `valid_fixtures`

### epf_shadow_experiment_v0
- replace the flat `fixtures` list with:
  - `valid_fixtures`
  - `invalid_fixtures`

## Why

The registry schema and checker now support transitional fixture-role
buckets.

This change makes the live registry more semantically precise:
valid contract examples no longer appear in the same flat fixture list
as deliberate invalid counterexamples.

## Result

`shadow_layer_registry_v0.yml` now expresses fixture roles explicitly
while remaining compatible with the current transitional
schema/checker rollout.