### PR TITLE
fix(registry): harden legacy fixture alias

### DIFF
--- a/PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py
+++ b/PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py
@@ -462,6 +462,19 @@ def validate_shadow_layer_registry(obj: Any) -> dict[str, Any]:
                     f"fixture must not appear in both valid_fixtures and invalid_fixtures: {item}",
                 )
 
+        if "fixtures" in layer and "valid_fixtures" in layer:
+            _add_issue(
+                errors,
+                f"{path_prefix}.valid_fixtures",
+                "fixtures and valid_fixtures must not be used together",
+            )
+        elif "fixtures" in layer:
+            _add_issue(
+                warnings,
+                f"{path_prefix}.fixtures",
+                "fixtures is a transitional alias; prefer valid_fixtures",
+            )
+        
         if "tests" in layer:
             tests = _validate_non_empty_string_array(
                 layer.get("tests"),


### PR DESCRIPTION
## Summary

This PR hardens the legacy `fixtures` alias semantics in the shadow
layer registry checker.

## File changed

- `PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py`

## Changes

- emit a warning when `fixtures` is used on its own
- reject layers that use both `fixtures` and `valid_fixtures`
- preserve backward compatibility for the ongoing bucket rollout

## Why

The transitional bucket rollout still needs to accept the legacy
`fixtures` field, but dual representation should not remain ambiguous.

This PR makes the checker behavior explicit:
- `fixtures` alone: accepted with warning
- `fixtures` + `valid_fixtures`: invalid

## Result

The registry checker now treats `fixtures` as a true transitional alias
rather than an unbounded parallel representation.