### PR TITLE
docs(registry): document fixture alias semantics

### DIFF
--- a/docs/shadow_layer_registry_v0.md
+++ b/docs/shadow_layer_registry_v0.md
@@ -136,6 +136,13 @@ Each layer entry may describe:
 - `normative`
 - `notes`
 
+Transition semantics:
+- `valid_fixtures` is the preferred field for contract-valid examples.
+- `invalid_fixtures` holds deliberate contract-breaking or consistency-failing examples.
+- `fixtures` remains accepted as a transitional alias for `valid_fixtures`.
+- `fixtures` and `valid_fixtures` must not be used together in the same layer entry.
+- use of `fixtures` on its own remains rollout-valid, but it is no longer the preferred steady-state form.
+
 The schema and checker together define which of these are required and
 which stage-dependent constraints apply.
 


### PR DESCRIPTION
## Summary

This PR updates `docs/shadow_layer_registry_v0.md` so it explicitly
documents the current transitional alias behavior for registry fixture
buckets.

## Changes

- describe `valid_fixtures` as the preferred field
- describe `invalid_fixtures` as the invalid/counterexample bucket
- describe `fixtures` as a transitional alias
- state that `fixtures` and `valid_fixtures` must not be used together
- note that `fixtures` alone remains rollout-valid but is no longer the
  preferred steady-state form

## Why

The schema, checker, and tests now agree on the legacy alias semantics.

The registry documentation should say the same thing explicitly so the
machine-readable rollout rules are also clear on the public-facing doc
surface.

## Result

The main shadow registry doc now matches the current alias behavior:
- legacy alias still works
- dual representation is invalid
- valid_fixtures is the preferred long-term field