### PR TITLE
test(registry): add overlapping bucket fixture

### DIFF
--- a/tests/fixtures/shadow_layer_registry_v0/overlapping_fixture_buckets.json
+++ b/tests/fixtures/shadow_layer_registry_v0/overlapping_fixture_buckets.json
@@ -1,0 +1,36 @@
+{
+  "version": "shadow_layer_registry_v0",
+  "layers": [
+    {
+      "layer_id": "relational_gain_shadow",
+      "family": "relation-dynamics",
+      "current_stage": "shadow-contracted",
+      "target_stage": "advisory",
+      "default_role": "shadow diagnostic",
+      "consumer_authority": "review-only",
+      "primary_entrypoint": ".github/workflows/relational_gain_shadow.yml",
+      "primary_artifact": "PULSE_safe_pack_v0/artifacts/relational_gain_shadow_v0.json",
+      "status_foldin": "meta.relational_gain_shadow",
+      "schema": "schemas/relational_gain_shadow_v0.schema.json",
+      "semantic_checker": "PULSE_safe_pack_v0/tools/check_relational_gain_contract.py",
+      "valid_fixtures": [
+        "tests/fixtures/relational_gain_shadow_v0/pass.json",
+        "tests/fixtures/relational_gain_shadow_v0/warn.json",
+        "tests/fixtures/relational_gain_shadow_v0/fail.json"
+      ],
+      "invalid_fixtures": [
+        "tests/fixtures/relational_gain_shadow_v0/pass.json"
+      ],
+      "tests": [
+        "tests/test_check_relational_gain_contract.py",
+        "tests/test_relational_gain_non_interference.py"
+      ],
+      "run_reality_states": [
+        "real",
+        "absent"
+      ],
+      "normative": false,
+      "notes": "Shadow-only. Contract-hardened. Must not write under gates.*."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds a canonical invalid registry fixture for overlapping
fixture buckets.

## File added

- `tests/fixtures/shadow_layer_registry_v0/overlapping_fixture_buckets.json`

## What it represents

The fixture captures the invalid case where the same fixture path
appears in both:
- `valid_fixtures`
- `invalid_fixtures`

## Why

The shadow registry checker now enforces a no-overlap rule between
valid and invalid fixture buckets.

This invalid state should exist as a checked-in fixture example, not
only as an inline temp-json mutation inside tests.

## Result

The bucket-overlap failure mode is now represented as a canonical
invalid registry fixture.