### PR TITLE
docs(workflow-map): list canonical invalid registry fixtures

### DIFF
--- a/docs/WORKFLOW_MAP.md
+++ b/docs/WORKFLOW_MAP.md
@@ -67,8 +67,10 @@ Current registry stack:
 - `PULSE_safe_pack_v0/tools/check_shadow_layer_registry.py`
 - `tests/test_check_shadow_layer_registry.py`
 
-Current canonical registry fixture:
+Current canonical registry fixtures:
 - `tests/fixtures/shadow_layer_registry_v0/pass.json`
+- `tests/fixtures/shadow_layer_registry_v0/overlapping_fixture_buckets.json`
+- `tests/fixtures/shadow_layer_registry_v0/fixtures_and_valid_fixtures_together.json`
 
 Current registered layers:
 - `relational_gain_shadow`
@@ -84,6 +86,7 @@ Current registry coverage:
 - the registry tracks the contract-hardened Relational Gain shadow pilot
 - the registry also tracks the EPF shadow experiment line as a research diagnostic layer
 - the registry now uses explicit fixture-role buckets (`valid_fixtures` / `invalid_fixtures`) with `fixtures` retained as a transitional alias
+- registry self-check coverage now includes canonical invalid examples for bucket overlap and alias-collision semantics
 
 ### C. Shadow / diagnostic workflows
 **Purpose:** extra diagnostics, research layers, or explanatory surfaces


### PR DESCRIPTION
## Summary

This PR updates `docs/WORKFLOW_MAP.md` so the shadow layer registry
workflow section reflects the current canonical registry fixture set.

## Changes

- change `Current canonical registry fixture` to plural
- keep `pass.json` in the list
- add the two canonical invalid registry fixtures:
  - `overlapping_fixture_buckets.json`
  - `fixtures_and_valid_fixtures_together.json`
- note the current self-check coverage more explicitly

## Why

The registry fixture inventory now includes checked-in invalid examples
for the new bucket semantics.

The workflow map should reflect that these are now first-class registry
fixtures rather than only inline test scenarios.

## Result

The workflow map now shows the full current registry fixture surface,
including the canonical invalid examples for bucket-overlap and
alias-collision behavior.