### PR TITLE
docs(registry): list canonical self-check fixtures

### DIFF
--- a/docs/shadow_layer_registry_v0.md
+++ b/docs/shadow_layer_registry_v0.md
@@ -148,6 +148,21 @@ which stage-dependent constraints apply.
 
 ---
 
+### Canonical registry self-check fixtures
+
+The registry self-check surface currently includes:
+
+- `tests/fixtures/shadow_layer_registry_v0/pass.json`
+- `tests/fixtures/shadow_layer_registry_v0/overlapping_fixture_buckets.json`
+- `tests/fixtures/shadow_layer_registry_v0/fixtures_and_valid_fixtures_together.json`
+
+These fixtures cover:
+- canonical passing registry structure,
+- invalid overlap between `valid_fixtures` and `invalid_fixtures`,
+- and invalid simultaneous use of `fixtures` with `valid_fixtures`.
+
+---
+
 ## Stage model
 
 The current contract-stage vocabulary is:


### PR DESCRIPTION
## Summary

This PR updates `docs/shadow_layer_registry_v0.md` so the main registry
doc explicitly lists the current canonical self-check fixtures.

## Changes

Add a short subsection naming:
- `tests/fixtures/shadow_layer_registry_v0/pass.json`
- `tests/fixtures/shadow_layer_registry_v0/overlapping_fixture_buckets.json`
- `tests/fixtures/shadow_layer_registry_v0/fixtures_and_valid_fixtures_together.json`

It also states what these fixtures cover:
- canonical passing structure
- bucket-overlap failure
- alias-collision failure

## Why

The canonical invalid registry fixtures are now checked in and used by
tests, but the main registry doc should also expose them directly.

## Result

The primary registry documentation now reflects the current self-check
fixture surface more completely.