### PR TITLE
docs(readme): sync implemented architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,22 @@ See also: [docs/WORKFLOW_MAP.md](docs/WORKFLOW_MAP.md)
 
 ---
 
+### Shadow registry
+
+PULSE includes a machine-readable shadow layer registry for governance-facing diagnostic surfaces.
+
+Registered shadow layers remain non-normative by default: registry presence does not promote a layer into release authority and does not change `gates.*` semantics.
+
+The registry uses explicit fixture-role buckets:
+
+- `valid_fixtures` for contract-valid examples,
+- `invalid_fixtures` for deliberate contract-breaking or consistency-failing examples,
+- `fixtures` as a transitional alias for `valid_fixtures`.
+
+`fixtures` and `valid_fixtures` must not be used together in the same layer entry.
+
+---
+
 ## Clarity First (before Paradox / EPF / Topology work)
 
 PULSE is deterministic and fail‑closed — but only if we keep the meaning of terms stable.
@@ -611,12 +627,10 @@ It:
 - compares the two and emits:
   - `epf_shadow_run_manifest.json` – primary registered EPF shadow run-manifest surface; diagnostic and non-normative
   - `epf_report.txt` – human-readable summary of baseline vs EPF decisions,
-  - `epf_paradox_summary.json` – secondary contract-hardened EPF
-    diagnostic summary (paradox candidates).
+  - `epf_shadow_run_manifest.json` – primary registered EPF run-manifest surface,
+  - `epf_paradox_summary.json` – secondary contract-hardened diagnostic summary.
 
-The EPF experiment workflow is **optional and CI-neutral**. It is intended
-for research and diagnostics (borderline gates, paradox analysis) and does
-not participate in release gating.
+The EPF experiment workflow is optional and CI-neutral. Its primary registered surface is the broader run manifest; the paradox summary remains a secondary diagnostic artifact. Neither surface participates in release gating unless explicitly promoted into the required gate set. 
 
 For guidance on what to do when baseline and EPF disagree on specific
 gates, see:


### PR DESCRIPTION
## Summary

This PR updates the README so it reflects the current implemented PULSE
architecture.

## Changes

- replace the old top-line framing with an artifact-defined release
  authority statement
- add a short shadow registry section
- document the current fixture-role bucket model:
  - `valid_fixtures`
  - `invalid_fixtures`
  - transitional `fixtures` alias
- clarify the EPF diagnostic surface split:
  - `epf_shadow_run_manifest.json` as the primary registered EPF surface
  - `epf_paradox_summary.json` as the secondary contract-hardened diagnostic surface
- refresh acknowledgments wording around human-machine collaboration
- avoid unvalidated claims about research use, HPC, external compute, or large-scale execution

## Why

The README should describe what PULSE already implements.

The current repo state includes an artifact-defined release-governance
core, a machine-readable shadow registry, fixture-role buckets, and a
clear EPF primary/secondary surface model.

This PR updates the public entrypoint to match that proven state without
adding proposal-oriented or future-facing claims.

## Result

The README now presents the implemented PULSE architecture more
accurately:

- release decisions remain bound to `status.json`, the materialized
  required gate set, and `check_gates.py`
- shadow registry entries remain governance-facing and non-normative
- fixture roles are documented through the current bucket model
- EPF run-manifest and paradox-summary surfaces are described according
  to their implemented roles