### PR TITLE
docs(operator): fix handoff reconstruction flow

### DIFF
--- a/docs/OPERATOR_HANDOFF_v0.md
+++ b/docs/OPERATOR_HANDOFF_v0.md
@@ -4,11 +4,14 @@
 
 This document defines the minimum operator handoff evidence for PULSE.
 
-The goal is to make the release-authority path reproducible from repository artifacts, policies, schemas, fixtures, workflows, and deterministic checks without relying on private maintainer memory.
+The goal is to make the release-authority path reproducible from repository
+artifacts, policies, schemas, fixtures, workflows, and deterministic checks
+without relying on private maintainer memory.
 
 This document does not define a new release gate.
 
-It defines how a new operator can reconstruct the PULSE release-decision mechanics from the repository state.
+It defines how a new operator can reconstruct the PULSE release-decision
+mechanics from the repository state.
 
 ## Scope
 
@@ -46,9 +49,11 @@ Release decisions, however, are defined by mechanical state:
 - workflows,
 - and deterministic checkers.
 
-A maintainer may operate the system, but private maintainer memory is not release authority.
+A maintainer may operate the system, but private maintainer memory is not
+release authority.
 
-If a release decision cannot be reconstructed from repository artifacts and deterministic checks, it is not a complete PULSE release-authority record.
+If a release decision cannot be reconstructed from repository artifacts and
+deterministic checks, it is not a complete PULSE release-authority record.
 
 ## Release-authority path
 
@@ -64,16 +69,41 @@ The normative PULSE release-authority path is reconstructed from:
 
 The release-authority path is artifact-defined.
 
-Shadow outputs, overlays, diagnostic summaries, registry entries, Pages views, dashboards, and publication surfaces do not define release outcomes unless explicitly promoted into the required gate set by policy and workflow.
+Shadow outputs, overlays, diagnostic summaries, registry entries, Pages
+views, dashboards, and publication surfaces do not define release outcomes
+unless explicitly promoted into the required gate set by policy and workflow.
+
+## Status artifact prerequisite
+
+A clean checkout does not by itself guarantee the presence of the live
+release-authority artifact:
+
+- `PULSE_safe_pack_v0/artifacts/status.json`
+
+Before running gate reconstruction commands, the operator must either:
+
+1. generate a local Core status artifact, or
+2. provide an archived `status.json` from the CI/release run being inspected.
+
+The handoff record must state which artifact source was used.
+
+A locally generated Core artifact is suitable for Core-lane reconstruction.
+
+A release-grade handoff requires a release-grade status artifact from the
+relevant workflow run, or an equivalent locally produced release-grade artifact
+with the same evidence conditions.
+
+A Core-only status artifact must not be treated as release-grade evidence.
 
 ## Operator handoff condition
 
-An operator handoff is mechanically reproducible when a new operator can, from a clean checkout:
+An operator handoff is mechanically reproducible when a new operator can,
+from a clean checkout plus a generated or archived `status.json` artifact:
 
 1. identify the primary release-gating workflow,
 2. identify which workflows are diagnostic or publication-only,
 3. inspect the current `status.json`,
-4. materialize the required gate set from policy,
+4. materialize the relevant gate set from policy,
 5. run `check_gates.py` against the materialized gate set,
 6. validate the gate registry / policy consistency path,
 7. validate the shadow layer registry,
@@ -83,7 +113,8 @@ An operator handoff is mechanically reproducible when a new operator can, from a
 
 The practical test is not whether the original maintainer is available.
 
-The practical test is whether the release-decision mechanics can be reconstructed from repository state.
+The practical test is whether the release-decision mechanics can be
+reconstructed from repository state and the relevant release artifact.
 
 ## Minimum handoff checklist
 
@@ -98,7 +129,8 @@ The operator must identify:
 - `PULSE_safe_pack_v0/artifacts/status.json`
 - the materialized required gate set used by the workflow
 
-The operator must not treat shadow workflows, renderers, Pages outputs, or diagnostic overlays as release-authority sources.
+The operator must not treat shadow workflows, renderers, Pages outputs,
+or diagnostic overlays as release-authority sources.
 
 ### 2. What is the current gate policy?
 
@@ -127,11 +159,13 @@ The operator must understand that the normative gate state is read from:
 
 - `status["gates"]`
 
-Top-level mirrors, dashboards, rendered HTML, Pages output, and `meta.*` diagnostics are not the release authority unless explicitly specified by policy and workflow.
+Top-level mirrors, dashboards, rendered HTML, Pages output, and `meta.*`
+diagnostics are not the release authority unless explicitly specified by
+policy and workflow.
 
-### 4. How is the required gate set materialized?
+### 4. How is the gate set materialized?
 
-The operator should be able to run the policy materialization command used by the Core lane:
+The operator should be able to run the policy materialization helper:
 
 ```bash
 python tools/policy_to_require_args.py \
@@ -139,11 +173,28 @@ python tools/policy_to_require_args.py \
   --set core_required
 ```
 
+For release-grade reconstruction, the operator must also materialize:
+
+```bash
+python tools/policy_to_require_args.py \
+  --policy pulse_gate_policy_v0.yml \
+  --set required
+```
+
+and:
+
+```bash
+python tools/policy_to_require_args.py \
+  --policy pulse_gate_policy_v0.yml \
+  --set release_required
+```
+
 The resulting gate list is the input to the deterministic gate checker.
 
-### 5. Can the gate decision be reproduced?
+### 5. Can the Core gate decision be reproduced?
 
-The operator should be able to run:
+For a Core-lane handoff, the operator should be able to generate or provide a
+Core `status.json` artifact, materialize `core_required`, and run:
 
 ```bash
 python PULSE_safe_pack_v0/tools/check_gates.py \
@@ -153,11 +204,30 @@ python PULSE_safe_pack_v0/tools/check_gates.py \
 
 A failing required gate or missing required gate must fail closed.
 
-A missing or malformed release-authority artifact must not be silently interpreted as PASS.
+A missing or malformed release-authority artifact must not be silently
+interpreted as PASS.
 
-### 6. Which surfaces are diagnostic only?
+### 6. Can the release-grade gate decision be reproduced?
 
-The operator must identify diagnostic / shadow surfaces, including but not limited to:
+For a release-grade handoff, `core_required` alone is not sufficient.
+
+The effective release-grade gate set is:
+
+```text
+required + release_required
+```
+
+The operator must use a release-grade `status.json` artifact from the
+relevant workflow run, or an equivalent locally produced release-grade artifact
+with the same evidence conditions.
+
+The operator must not report a release-grade decision from a Core-only artifact
+or a Core-only gate set.
+
+### 7. Which surfaces are diagnostic only?
+
+The operator must identify diagnostic / shadow surfaces, including but not
+limited to:
 
 - EPF shadow outputs,
 - paradox summaries,
@@ -172,7 +242,7 @@ These surfaces may explain, inspect, or validate their own contracts.
 
 They do not change release outcomes by default.
 
-### 7. Can the shadow registry be validated?
+### 8. Can the shadow registry be validated?
 
 The operator should be able to run:
 
@@ -185,7 +255,7 @@ The shadow layer registry is governance-facing and machine-readable.
 
 Registry presence does not promote a shadow layer into release authority.
 
-### 8. Are fixture roles clear?
+### 9. Are fixture roles clear?
 
 The operator must understand the registry fixture-role model:
 
@@ -198,7 +268,7 @@ The canonical registry self-check fixtures are documented in:
 
 - `docs/shadow_layer_registry_v0.md`
 
-### 9. Can EPF surfaces be classified correctly?
+### 10. Can EPF surfaces be classified correctly?
 
 The operator must be able to identify the current EPF split:
 
@@ -210,15 +280,15 @@ The operator must be able to identify the current EPF split:
   - secondary contract-hardened EPF diagnostic summary
   - diagnostic and non-normative by default
 
-Neither EPF surface participates in release gating unless explicitly promoted into the required gate set.
+Neither EPF surface participates in release gating unless explicitly
+promoted into the required gate set.
 
-### 10. Can the Quality Ledger be inspected?
+### 11. Can the Quality Ledger be inspected?
 
 When present, the operator should inspect:
 
 - `PULSE_safe_pack_v0/artifacts/report_card.html`
-
-Quality Ledger fields derived from `status.json`
+- Quality Ledger fields derived from `status.json`
 
 The Quality Ledger is a human-readable explanation surface.
 
@@ -226,19 +296,104 @@ It does not override the normative `status["gates"]` decision.
 
 ## Recommended local handoff commands
 
-From a clean checkout, the operator should run the following checks.
+A clean checkout does not by itself contain the live release-authority
+`status.json` artifact.
+
+Before running gate reconstruction commands, the operator must either:
+
+1. generate a local Core status artifact, or
+2. provide an archived `status.json` from the CI/release run being inspected.
+
+The handoff command path must state which artifact source was used.
+
+### Prepare a local Core status artifact
+
+For a local Core handoff smoke, generate `status.json` first:
+
+```bash
+python PULSE_safe_pack_v0/tools/run_all.py \
+  --mode core \
+  --pack_dir PULSE_safe_pack_v0 \
+  --gate_policy pulse_gate_policy_v0.yml
+```
+
+This writes:
+
+```text
+PULSE_safe_pack_v0/artifacts/status.json
+```
+
+The generated artifact is suitable for Core-lane reconstruction.
+
+It is not, by itself, proof of a release-grade run.
 
 ### Core release-authority reconstruction
+
+For the Core lane, materialize `core_required`:
 
 ```bash
 python tools/policy_to_require_args.py \
   --policy pulse_gate_policy_v0.yml \
   --set core_required
+```
 
+Then run the deterministic gate checker against the generated Core
+`status.json`:
+
+```bash
 python PULSE_safe_pack_v0/tools/check_gates.py \
   --status PULSE_safe_pack_v0/artifacts/status.json \
   --require $(python tools/policy_to_require_args.py --policy pulse_gate_policy_v0.yml --set core_required)
 ```
+
+This reconstructs the Core lane only.
+
+### Release-grade reconstruction
+
+Release-grade reconstruction must not use `core_required` alone.
+
+For a release-grade handoff, the operator must use a release-grade
+`status.json` artifact from the relevant workflow run, or an equivalent
+locally produced release-grade artifact with the same evidence conditions.
+
+If the archived release-grade artifact is not located at the default path,
+copy it into the expected location or set `STATUS_PATH` explicitly:
+
+```bash
+STATUS_PATH="PULSE_safe_pack_v0/artifacts/status.json"
+```
+
+The effective release-grade gate set is:
+
+```text
+required + release_required
+```
+
+Materialize and enforce that combined set:
+
+```bash
+REQ_STR="$(python tools/policy_to_require_args.py \
+  --policy pulse_gate_policy_v0.yml \
+  --set required \
+  --format space)"
+
+RELEASE_REQ_STR="$(python tools/policy_to_require_args.py \
+  --policy pulse_gate_policy_v0.yml \
+  --set release_required \
+  --format space)"
+
+read -r -a REQ <<< "$REQ_STR"
+read -r -a RELEASE_REQ <<< "$RELEASE_REQ_STR"
+
+STATUS_PATH="${STATUS_PATH:-PULSE_safe_pack_v0/artifacts/status.json}"
+
+python PULSE_safe_pack_v0/tools/check_gates.py \
+  --status "$STATUS_PATH" \
+  --require "${REQ[@]}" "${RELEASE_REQ[@]}"
+```
+
+A release-grade handoff is incomplete if it omits `release_required` or uses
+a Core-only status artifact as if it were release-grade evidence.
 
 ### Shadow registry validation
 
@@ -271,7 +426,11 @@ A complete handoff run should preserve or make inspectable:
 
 - the exact commit SHA,
 - the checked `status.json`,
+- the source of the `status.json` artifact:
+  - locally generated Core artifact, or
+  - archived CI/release artifact,
 - the materialized required gate list,
+- whether the reconstruction was Core or release-grade,
 - the `check_gates.py` result,
 - the shadow registry checker result,
 - relevant pytest results,
@@ -293,7 +452,9 @@ A handoff is not mechanically complete if any of the following are true:
 
 - the release decision depends on undocumented maintainer knowledge,
 - the required gate set cannot be reconstructed,
-- `status.json` cannot be located or validated,
+- `status.json` cannot be located, generated, provided, or validated,
+- a Core-only artifact is treated as release-grade evidence,
+- a release-grade reconstruction omits `release_required`,
 - required gates are missing and not treated as failure,
 - a diagnostic surface is treated as release authority without policy promotion,
 - a rendered view contradicts `status["gates"]` and is treated as authoritative,
@@ -316,7 +477,8 @@ Human maintainers remain responsible for:
 
 The purpose of operator handoff is narrower:
 
-to ensure that the release-authority mechanics are not private, implicit, or person-bound.
+to ensure that the release-authority mechanics are not private, implicit, or
+person-bound.
 
 ## Non-goals
 
@@ -327,19 +489,25 @@ This document does not claim:
 - that all diagnostic surfaces are release-ready,
 - that shadow workflows define release decisions,
 - that rendered documentation is normative,
+- that a clean checkout alone contains the live release artifact,
+- that a Core-lane reconstruction is equivalent to release-grade reconstruction,
 - that external environments have been validated unless separately documented.
 
-This document only defines the handoff evidence required to reconstruct the PULSE release-authority path from repository state.
+This document only defines the handoff evidence required to reconstruct the
+PULSE release-authority path from repository state and the relevant status
+artifact.
 
 ## Maintenance rule
 
-Any change to the release-authority path should update this document if it changes one of the following:
+Any change to the release-authority path should update this document if it
+changes one of the following:
 
 - the primary release-gating workflow,
 - the policy file used to materialize required gates,
 - the gate registry or gate-set semantics,
 - the location or semantics of `status.json`,
 - the gate checker path or behavior,
+- the release-grade gate-set composition,
 - the shadow registry validation path,
 - the EPF primary / secondary surface split,
 - fixture-role semantics,
@@ -349,7 +517,10 @@ If the mechanics change, the handoff record must change with them.
 
 ## Summary
 
-PULSE release authority is operator-reproducible when the release decision can be reconstructed from repository artifacts, materialized gate requirements, schemas, fixtures, policies, workflows, and deterministic checks.
+PULSE release authority is operator-reproducible when the release decision can
+be reconstructed from repository artifacts, a generated or archived status
+artifact, materialized gate requirements, schemas, fixtures, policies,
+workflows, and deterministic checks.
 
 The maintainer operates the system.
 


### PR DESCRIPTION
## Summary

This PR updates `docs/OPERATOR_HANDOFF_v0.md` so the documented handoff
flow is mechanically reproducible and matches the actual release-gating
paths.

## Changes

- add an explicit prerequisite for `status.json`
- clarify that a clean checkout does not automatically contain the live
  release-authority artifact
- document how to generate a local Core `status.json` artifact with
  `run_all.py`
- separate Core reconstruction from release-grade reconstruction
- clarify that Core reconstruction uses `core_required`
- clarify that release-grade reconstruction uses:
  - `required`
  - `release_required`
- require a release-grade status artifact for release-grade handoff
- add failure conditions for:
  - missing or unprovided `status.json`
  - treating a Core-only artifact as release-grade evidence
  - omitting `release_required` in release-grade reconstruction

## Why

The previous handoff text implied that the release-authority checks could
be run directly from a clean checkout, but a clean checkout does not by
itself contain the live `PULSE_safe_pack_v0/artifacts/status.json`
artifact.

It also documented only the Core gate set. That is correct for Core-lane
handoff, but incomplete for release-grade reconstruction, where the
effective enforced set is `required + release_required`.

## Result

The operator handoff document now distinguishes:

- clean checkout state
- generated local Core artifacts
- archived CI/release artifacts
- Core gate reconstruction
- release-grade gate reconstruction

This keeps the handoff protocol accurate without changing CI behavior,
release semantics, gate policy, or shadow promotion rules.