### PR TITLE
fix(ci): sync operator handoff smoke manifest

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -24,7 +24,7 @@ tests/test_paradox_diagram_renderer_v0_smoke.py
 tests/test_openai_evals_refusal_smoke_dry_run_smoke.py
 tests/test_render_quality_ledger_tests_list_smoke.py
 tests/test_authority_boundary_repro_smoke.py 
-tests/test_operator_handoff_smoke.py
+
 
 tools/operator_handoff_smoke.py
 

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -24,6 +24,7 @@ tests/test_paradox_diagram_renderer_v0_smoke.py
 tests/test_openai_evals_refusal_smoke_dry_run_smoke.py
 tests/test_render_quality_ledger_tests_list_smoke.py
 tests/test_authority_boundary_repro_smoke.py 
+tests/test_operator_handoff_smoke.py
 
 tools/operator_handoff_smoke.py
 


### PR DESCRIPTION
## Summary

This PR fixes the tools-tests manifest sync for the operator handoff
smoke coverage.

## Changes

- add `tests/test_operator_handoff_smoke.py` to `ci/tools-tests.list`
- keep `tools/operator_handoff_smoke.py` in `ci/tools-tests.list`

## Why

The tools-tests guard reported:

```text
ERROR: Smoke scripts missing from ci/tools-tests.list:
  - tests/test_operator_handoff_smoke.py
 ``` 

The test file is now detected by the manifest guard, so it must be listed.

The operator handoff tool itself remains listed as well, so the manifest
covers both:

the pytest regression smoke
the executable handoff smoke tool
Result

The tools-tests manifest is self-consistent again and includes the full
operator handoff smoke surface.