### PR TITLE
ci(operator): include handoff smoke regression test

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -24,7 +24,7 @@ tests/test_paradox_diagram_renderer_v0_smoke.py
 tests/test_openai_evals_refusal_smoke_dry_run_smoke.py
 tests/test_render_quality_ledger_tests_list_smoke.py
 tests/test_authority_boundary_repro_smoke.py 
-
+tests/test_operator_handoff_smoke.py
 
 tools/operator_handoff_smoke.py
 


### PR DESCRIPTION
## Summary

This PR wires the operator handoff smoke regression test into the tools smoke
manifest.

## Changes

- add `tests/test_operator_handoff_smoke.py` to `ci/tools-tests.list`
- keep `tools/operator_handoff_smoke.py` listed as the operator handoff tool
- do not change workflows, docs, `.gitignore`, or runtime behavior

## Why

The regression test file exists in this branch, but the tools smoke manifest did
not reference it.

The repository's tools-test guard expects smoke regression tests under `tests/`
to be listed in `ci/tools-tests.list`. Adding the checked-in test path keeps the
manifest aligned with the current branch state.

## Result

The manifest now covers both surfaces:

- `tools/operator_handoff_smoke.py`
- `tests/test_operator_handoff_smoke.py`