### PR TITLE
docs(brand): introduce PULSEmech public project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 **See the latest Quality Ledger (live):** https://hkati.github.io/pulse-release-gates-0.1/
 
 
-# PULSE — Release Gates for Safe & Useful AI
+# PULSEmech — Release Gates for Safe & Useful AI
 
 #### [PULSE is an artifact-defined, deterministic release-governance layer: `status.json`, materialized required gates, and `check_gates.py` define the release decision.](#start-here)
 


### PR DESCRIPTION
## Summary

This PR introduces **PULSEmech** as the public project-facing name in the
README title.

The original **PULSE** name is preserved as the historical and technical core
identity, especially because the project began under the PULSE name in the
Kaggle/research/publication track.

## Why

There are many projects and products named "Pulse".

`PULSEmech` keeps the existing PULSE identity while adding a clear
mechanical-governance differentiator:

- `PULSE` = historical project identity
- `mech` = mechanics / mechanical release governance

This better reflects the project’s actual focus: deterministic,
artifact-defined, fail-closed release mechanics.

## Naming rule

Going forward:

- public/project-facing name: `PULSEmech`
- historical/core name: `PULSE`
- technical paths and compatibility surfaces: remain unchanged unless a
  separate migration is explicitly planned

## What changed

- README title/public-facing name updated to `PULSEmech`
- Existing technical release-authority wording is preserved

## What did not change

This PR does not rename or change:

- repository paths
- `PULSE_safe_pack_v0/`
- schemas
- artifacts
- badges
- Kaggle references
- Zenodo/DOI references
- workflows
- release semantics
- gate policy
- `status.json`
- `check_gates.py`

## Release semantics

No release-governance behavior changes.

The release authority remains defined by:

- `status.json`
- the materialized required gate set
- `check_gates.py`
- the primary release-gating workflow

## Risk

Low.

This is a public naming / documentation change only. The existing PULSE name
is intentionally preserved for backward compatibility and historical continuity.

## Follow-up

Future docs may gradually use the wording:

> PULSEmech, historically PULSE, is an artifact-defined deterministic
> release-governance layer.

No mass rename is required in this PR.