### PR TITLE
feat(release): add release decision v0 schema

### DIFF
--- a/`schemas/schemas/release_decision_v0.schema.json
+++ b/`schemas/schemas/release_decision_v0.schema.json
@@ -1,0 +1,281 @@
+
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eplabsai.example/schemas/release_decision_v0.schema.json",
+  "title": "PULSE Release Decision v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "version",
+    "created_utc",
+    "producer",
+    "target",
+    "release_level",
+    "status_path",
+    "policy_path",
+    "active_gate_sets",
+    "effective_required_gates",
+    "required_gates_passed",
+    "conditions",
+    "status_schema_validation",
+    "gate_results",
+    "blocking_reasons",
+    "decision_basis"
+  ],
+  "properties": {
+    "schema": {
+      "const": "pulse_release_decision_v0"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^0\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version"
+      ],
+      "properties": {
+        "name": {
+          "const": "materialize_release_decision.py"
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "target": {
+      "type": "string",
+      "enum": [
+        "stage",
+        "prod"
+      ]
+    },
+    "release_level": {
+      "type": "string",
+      "enum": [
+        "FAIL",
+        "STAGE-PASS",
+        "PROD-PASS"
+      ]
+    },
+    "status_path": {
+      "type": "string"
+    },
+    "policy_path": {
+      "type": "string"
+    },
+    "status_sha256": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "policy_sha256": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "git_sha": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "run_mode": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "active_gate_sets": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "effective_required_gates": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "required_gates_passed": {
+      "type": "boolean"
+    },
+    "conditions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "detectors_materialized_ok",
+        "external_summaries_present",
+        "external_all_pass",
+        "stubbed",
+        "scaffold",
+        "no_stubbed_gates",
+        "external_evidence_mode"
+      ],
+      "properties": {
+        "detectors_materialized_ok": {
+          "type": "boolean"
+        },
+        "external_summaries_present": {
+          "type": "boolean"
+        },
+        "external_all_pass": {
+          "type": "boolean"
+        },
+        "stubbed": {
+          "type": "boolean"
+        },
+        "scaffold": {
+          "type": "boolean"
+        },
+        "no_stubbed_gates": {
+          "type": "boolean"
+        },
+        "external_evidence_mode": {
+          "type": "string",
+          "enum": [
+            "advisory",
+            "required"
+          ]
+        }
+      }
+    },
+    "status_schema_validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "ok",
+        "schema_path",
+        "errors"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "not_requested",
+            "validated"
+          ]
+        },
+        "ok": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "schema_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "errors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "gate_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "gate_id",
+          "present",
+          "passed",
+          "value_type",
+          "reason"
+        ],
+        "properties": {
+          "gate_id": {
+            "type": "string"
+          },
+          "present": {
+            "type": "boolean"
+          },
+          "passed": {
+            "type": "boolean"
+          },
+          "value_type": {
+            "type": "string"
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
+    },
+    "blocking_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "decision_basis": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "release_level": {
+            "const": "STAGE-PASS"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "target": {
+            "const": "stage"
+          },
+          "blocking_reasons": {
+            "maxItems": 0
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "release_level": {
+            "const": "PROD-PASS"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "target": {
+            "const": "prod"
+          },
+          "blocking_reasons": {
+            "maxItems": 0
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the JSON Schema for the `release_decision_v0` artifact.

Added:

- `schemas/release_decision_v0.schema.json`

This schema is the machine-readable contract corresponding to the already
documented release decision v0 model.

## Why

The previous PR introduced `docs/RELEASE_DECISION_v0.md`, defining the
intended release-decision artifact and the semantics for:

- `FAIL`
- `STAGE-PASS`
- `PROD-PASS`

This PR turns that documented contract into a schema surface so the next
implementation step can produce and validate a deterministic
`release_decision_v0.json` artifact.

## What the schema covers

The schema defines:

- schema identifier
- version
- creation timestamp
- producer metadata
- target lane
- release level
- status artifact path
- policy path
- optional status/policy hashes
- optional git SHA
- run mode
- active gate sets
- effective required gates
- required gate pass state
- release conditions
- optional status schema validation result
- per-gate results
- blocking reasons
- decision basis

## Release levels covered

The schema permits:

- `FAIL`
- `STAGE-PASS`
- `PROD-PASS`

It also constrains:

- `STAGE-PASS` to `target: stage`
- `PROD-PASS` to `target: prod`
- passing release levels to have no blocking reasons

## What did not change

This PR does not add or modify:

- `materialize_release_decision.py`
- tests
- CI wiring
- Quality Ledger rendering
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- release-gate semantics
- break-glass override behavior

## Boundary

This is a schema/contract PR only.

The current release-authority mechanics remain unchanged:

- `status.json`
- materialized required gate sets
- `check_gates.py`
- primary release-gating workflow

## Follow-up work

Recommended next PRs:

1. Add `PULSE_safe_pack_v0/tools/materialize_release_decision.py`.
2. Add release-decision smoke/contract tests.
3. Wire the generated `release_decision_v0.json` into the Quality Ledger.
4. Later, add `break_glass_override_v0` as a separate audited governance artifact.