### PR TITLE
test(release): cover release decision materializer

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -24,7 +24,7 @@ tests/test_paradox_diagram_renderer_v0_smoke.py
 tests/test_openai_evals_refusal_smoke_dry_run_smoke.py
 tests/test_render_quality_ledger_tests_list_smoke.py
 tests/test_authority_boundary_repro_smoke.py 
-
+tests/test_release_decision_v0_smoke.py
 
 tools/operator_handoff_smoke.py
 

--- a/tests/test_release_decision_v0_smoke.py
+++ b/tests/test_release_decision_v0_smoke.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "PULSE_safe_pack_v0" / "tools" / "materialize_release_decision.py"
+
+
+POLICY_TEXT = """\
+policy:
+  id: pulse-gate-policy-v0-test
+  version: "0.0.0"
+
+enforcement:
+  required_missing: FAIL
+  required_false: FAIL
+  advisory_missing: WARN
+  advisory_false: WARN
+
+gates:
+  required:
+    - pass_controls_refusal
+    - q1_grounded_ok
+  core_required:
+    - pass_controls_refusal
+  release_required:
+    - detectors_materialized_ok
+    - external_summaries_present
+    - external_all_pass
+  advisory:
+    - external_summaries_present
+    - external_all_pass
+"""
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _status(
+    gates: dict[str, Any],
+    *,
+    run_mode: str = "prod",
+    diagnostics: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "version": "status_v1",
+        "created_utc": "2026-04-20T00:00:00Z",
+        "metrics": {
+            "run_mode": run_mode
+        },
+        "gates": gates,
+    }
+    if diagnostics is not None:
+        payload["diagnostics"] = diagnostics
+    return payload
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    status: dict[str, Any],
+    target: str,
+) -> tuple[subprocess.CompletedProcess[str], dict[str, Any]]:
+    status_path = tmp_path / "status.json"
+    policy_path = tmp_path / "pulse_gate_policy_v0.yml"
+    out_path = tmp_path / "release_decision_v0.json"
+
+    _write_json(status_path, status)
+    policy_path.write_text(POLICY_TEXT, encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--status",
+            str(status_path),
+            "--policy",
+            str(policy_path),
+            "--target",
+            target,
+            "--out",
+            str(out_path),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert out_path.exists(), result.stdout + result.stderr
+    return result, _read_json(out_path)
+
+
+def test_stage_pass_requires_required_and_materialized_detectors() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-release-decision-") as tmp:
+        result, decision = _run(
+            Path(tmp),
+            target="stage",
+            status=_status(
+                {
+                    "pass_controls_refusal": True,
+                    "q1_grounded_ok": True,
+                    "detectors_materialized_ok": True
+                },
+                run_mode="prod",
+            ),
+        )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert decision["release_level"] == "STAGE-PASS"
+    assert decision["target"] == "stage"
+    assert decision["active_gate_sets"] == ["required"]
+    assert decision["conditions"]["external_evidence_mode"] == "advisory"
+    assert decision["blocking_reasons"] == []
+
+
+def test_prod_pass_requires_required_and_release_required() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-release-decision-") as tmp:
+        result, decision = _run(
+            Path(tmp),
+            target="prod",
+            status=_status(
+                {
+                    "pass_controls_refusal": True,
+                    "q1_grounded_ok": True,
+                    "detectors_materialized_ok": True,
+                    "external_summaries_present": True,
+                    "external_all_pass": True
+                },
+                run_mode="prod",
+            ),
+        )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert decision["release_level"] == "PROD-PASS"
+    assert decision["target"] == "prod"
+    assert decision["active_gate_sets"] == ["required", "release_required"]
+    assert decision["conditions"]["external_evidence_mode"] == "required"
+    assert decision["blocking_reasons"] == []
+
+
+def test_prod_fails_when_release_required_evidence_is_missing() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-release-decision-") as tmp:
+        result, decision = _run(
+            Path(tmp),
+            target="prod",
+            status=_status(
+                {
+                    "pass_controls_refusal": True,
+                    "q1_grounded_ok": True,
+                    "detectors_materialized_ok": True
+                },
+                run_mode="prod",
+            ),
+        )
+
+    assert result.returncode == 1
+    assert decision["release_level"] == "FAIL"
+    assert any(
+        "external_summaries_present: missing required gate" in reason
+        for reason in decision["blocking_reasons"]
+    )
+    assert any(
+        "external_all_pass: missing required gate" in reason
+        for reason in decision["blocking_reasons"]
+    )
+
+
+def test_stage_fails_when_status_is_stubbed() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-release-decision-") as tmp:
+        result, decision = _run(
+            Path(tmp),
+            target="stage",
+            status=_status(
+                {
+                    "pass_controls_refusal": True,
+                    "q1_grounded_ok": True,
+                    "detectors_materialized_ok": True
+                },
+                run_mode="core",
+                diagnostics={
+                    "gates_stubbed": True,
+                    "stub_profile": "all_true_smoke"
+                },
+            ),
+        )
+
+    assert result.returncode == 1
+    assert decision["release_level"] == "FAIL"
+    assert decision["conditions"]["stubbed"] is True
+    assert any("stubbed diagnostics are present" in reason for reason in decision["blocking_reasons"])
+
+
+def test_non_literal_true_gate_fails_closed() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-release-decision-") as tmp:
+        result, decision = _run(
+            Path(tmp),
+            target="stage",
+            status=_status(
+                {
+                    "pass_controls_refusal": "true",
+                    "q1_grounded_ok": True,
+                    "detectors_materialized_ok": True
+                },
+                run_mode="prod",
+            ),
+        )
+
+    assert result.returncode == 1
+    assert decision["release_level"] == "FAIL"
+    assert any(
+        item["gate_id"] == "pass_controls_refusal"
+        and item["present"] is True
+        and item["passed"] is False
+        and item["value_type"] == "string"
+        for item in decision["gate_results"]
+    )
+
+
+def main() -> int:
+    tests = [
+        test_stage_pass_requires_required_and_materialized_detectors,
+        test_prod_pass_requires_required_and_release_required,
+        test_prod_fails_when_release_required_evidence_is_missing,
+        test_stage_fails_when_status_is_stubbed,
+        test_non_literal_true_gate_fails_closed,
+    ]
+
+    for test in tests:
+        try:
+            test()
+        except AssertionError as exc:
+            print(f"ERROR in {test.__name__}: {exc}")
+            return 1
+
+    print("OK: release_decision_v0 smoke checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds smoke coverage for the `release_decision_v0` materializer.

Added:

- `tests/test_release_decision_v0_smoke.py`

Also updated:

- `ci/tools-tests.list`

## Why

The release decision contract and schema are now present, and the materializer
tool has been merged.

The next step is to lock in the intended behavior with smoke coverage before
wiring the artifact into the Quality Ledger or primary release workflow.

This test protects the first runtime implementation of:

- `FAIL`
- `STAGE-PASS`
- `PROD-PASS`

as materialized by:

```text
PULSE_safe_pack_v0/tools/materialize_release_decision.py
```

## What the test covers

The new smoke test covers:

### Stage pass

A stage target can produce `STAGE-PASS` when:

- the `required` gate set passes,
- `detectors_materialized_ok` is literal `true`,
- no stubbed/scaffold diagnostics are present.

### Prod pass

A prod target can produce `PROD-PASS` when:

- the `required` gate set passes,
- the `release_required` gate set passes,
- external evidence presence and aggregate external pass are literal `true`,
- no stubbed/scaffold diagnostics are present.

### Missing release evidence fails prod

A prod target fails when `release_required` evidence is incomplete, including
missing:

- `external_summaries_present`
- `external_all_pass`

### Stubbed status fails stage

A stage target fails if stubbed/scaffold diagnostics are present, even when the
required gates are otherwise true.

This prevents local smoke/scaffold evidence from being misread as release-level
evidence.

### Non-literal true fails closed

The test verifies that a string such as:

```json
"true"
```

does not pass as a release gate.

Only the literal JSON boolean:

```json
true
```

is accepted.

## Manifest registration

Because this file is a smoke test under `tests/`, it is registered in:

```text
ci/tools-tests.list
```

This keeps the tools-tests manifest guard aligned with the checked-in test
surface.

## What did not change

This PR does not change:

- runtime release behavior
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- release policy
- primary CI release semantics
- Quality Ledger rendering
- break-glass behavior
- shadow-layer authority

## Boundary

This is a test-coverage PR only.

The release-authority center remains unchanged:

- `status.json`
- materialized required gates
- `check_gates.py`
- primary release-gating workflow

The new test only verifies that the materializer produces the expected
`release_decision_v0` artifact behavior from isolated fixture-like inputs.

## Follow-up work

Recommended next PRs:

1. Add schema-validation coverage for generated `release_decision_v0.json`.
2. Add negative fixture coverage for contradictory PASS artifacts.
3. Wire `release_decision_v0.json` into Quality Ledger rendering.
4. Wire release decision materialization into the primary release workflow.
5. Later, add `break_glass_override_v0` as a separate audited governance artifact.

## Checklist

- [ ] `tests/test_release_decision_v0_smoke.py` added
- [ ] `ci/tools-tests.list` updated
- [ ] Stage pass behavior covered
- [ ] Prod pass behavior covered
- [ ] Missing prod release evidence fails closed
- [ ] Stubbed/scaffold status fails release-level pass
- [ ] Non-literal `"true"` fails closed
- [ ] No runtime release behavior changed
- [ ] No gate policy changed
- [ ] No Quality Ledger behavior changed
- [ ] No break-glass behavior changed