### PR TITLE
fix(release): harden release decision stub guards

### DIFF
--- a/PULSE_safe_pack_v0/tools/materialize_release_decision.py
+++ b/PULSE_safe_pack_v0/tools/materialize_release_decision.py
@@ -86,16 +86,81 @@ def _get_path(obj: Any, dotted: str) -> Any:
     return cur
 
 
-def _is_truthy_path(obj: Any, *paths: str) -> bool:
-    return any(_get_path(obj, path) is True for path in paths)
+STUB_FLAG_PATHS = (
+    "diagnostics.gates_stubbed",
+    "metrics.gates_stubbed",
+    "meta.diagnostics.gates_stubbed",
+)
+
+SCAFFOLD_FLAG_PATHS = (
+    "diagnostics.scaffold",
+    "metrics.scaffold",
+    "meta.diagnostics.scaffold",
+)
+
+STUB_PROFILE_PATHS = (
+    "diagnostics.stub_profile",
+    "metrics.stub_profile",
+    "meta.diagnostics.stub_profile",
+)
+
+NEUTRAL_STUB_PROFILES = {
+    "",
+    "none",
+    "false",
+    "real",
+    "not_stubbed",
+}
 
 
-def _first_present(obj: Any, *paths: str) -> Any:
+def _blocking_flag_present(obj: Any, *paths: str) -> bool:
+    """Return true when any flag path blocks release-level pass.
+
+    Boolean true blocks.
+    Boolean false is neutral.
+    Missing values are neutral.
+    Any present non-boolean value blocks fail-closed because scaffold/stub
+    diagnostics must not be silently ignored when malformed.
+    """
     for path in paths:
         value = _get_path(obj, path)
-        if value is not None:
-            return value
-    return None
+
+        if value is None:
+            continue
+
+        if value is True:
+            return True
+
+        if value is False:
+            continue
+
+        return True
+
+    return False
+
+
+def _stub_profile_blocks(value: Any) -> bool:
+    """Return true when a stub_profile value blocks release-level pass.
+
+    Strings are normalized and compared against the known neutral profiles.
+    Boolean false is neutral.
+    Boolean true blocks.
+    Any other present non-null value blocks fail-closed.
+    """
+    if value is None:
+        return False
+
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        return normalized not in NEUTRAL_STUB_PROFILES
+
+    if value is False:
+        return False
+
+    if value is True:
+        return True
+
+    return True
 
 
 def _value_type(value: Any) -> str:
@@ -185,35 +250,18 @@ def _policy_gate_set(policy: dict[str, Any], name: str) -> list[str]:
 
 
 def _stubbed(status: dict[str, Any]) -> bool:
-    if _is_truthy_path(
-        status,
-        "diagnostics.gates_stubbed",
-        "metrics.gates_stubbed",
-        "meta.diagnostics.gates_stubbed",
-    ):
+    if _blocking_flag_present(status, *STUB_FLAG_PATHS):
         return True
 
-    stub_profile = _first_present(
-        status,
-        "diagnostics.stub_profile",
-        "metrics.stub_profile",
-        "meta.diagnostics.stub_profile",
-    )
-
-    if isinstance(stub_profile, str):
-        normalized = stub_profile.strip().lower()
-        return normalized not in {"", "none", "false", "real", "not_stubbed"}
+    for path in STUB_PROFILE_PATHS:
+        if _stub_profile_blocks(_get_path(status, path)):
+            return True
 
     return False
 
 
 def _scaffold(status: dict[str, Any]) -> bool:
-    return _is_truthy_path(
-        status,
-        "diagnostics.scaffold",
-        "metrics.scaffold",
-        "meta.diagnostics.scaffold",
-    )
+    return _blocking_flag_present(status, *SCAFFOLD_FLAG_PATHS)
 
 
 def _add_reason(reasons: list[str], reason: str) -> None:


### PR DESCRIPTION
## Summary

This PR hardens stub and scaffold detection in:

```text
PULSE_safe_pack_v0/tools/materialize_release_decision.py
```

It addresses the Codex review findings around release-level PASS being possible
when diagnostic stub/scaffold indicators are malformed or conflicting.

## Why

`release_decision_v0` is intended to materialize higher-level release labels:

- `FAIL`
- `STAGE-PASS`
- `PROD-PASS`

A release-level PASS must not be emitted if the status artifact contains
stubbed, scaffolded, or malformed diagnostic evidence.

Codex identified two issues:

1. `stub_profile` was checked with first-present semantics.
2. non-boolean `gates_stubbed` / `scaffold` indicators were treated as clean.

Both cases should fail closed.

## Problem 1: first-present stub_profile handling

The previous logic checked:

```text
diagnostics.stub_profile
metrics.stub_profile
meta.diagnostics.stub_profile
```

but only evaluated the first non-null value.

That meant a status artifact like this could incorrectly pass:

```json
{
  "diagnostics": {
    "stub_profile": "real"
  },
  "metrics": {
    "stub_profile": "all_true_smoke"
  }
}
```

The earlier neutral value hid the later stubbed value.

## Fix

The materializer now checks all supported `stub_profile` sources.

Supported paths:

```text
diagnostics.stub_profile
metrics.stub_profile
meta.diagnostics.stub_profile
```

Neutral values are:

```text
""
"none"
"false"
"real"
"not_stubbed"
```

Any other present value blocks release-level pass.

## Problem 2: malformed boolean diagnostic flags

The previous logic only treated literal boolean `true` as blocking for:

```text
gates_stubbed
scaffold
```

That meant malformed values such as:

```json
{
  "diagnostics": {
    "scaffold": "true"
  }
}
```

or:

```json
{
  "diagnostics": {
    "gates_stubbed": 1
  }
}
```

could be silently treated as clean.

## Fix

The materializer now treats supported diagnostic flags as follows:

- missing value: neutral
- boolean `false`: neutral
- boolean `true`: blocks release-level pass
- any present non-boolean value: blocks release-level pass fail-closed

Supported `gates_stubbed` paths:

```text
diagnostics.gates_stubbed
metrics.gates_stubbed
meta.diagnostics.gates_stubbed
```

Supported `scaffold` paths:

```text
diagnostics.scaffold
metrics.scaffold
meta.diagnostics.scaffold
```

## Release behavior impact

This PR changes the release decision materializer's diagnostic handling to be
more fail-closed.

It prevents `STAGE-PASS` or `PROD-PASS` from being produced when the status
artifact contains:

- conflicting stub profile sources,
- non-real stub profiles in any supported location,
- malformed `gates_stubbed` indicators,
- malformed `scaffold` indicators.

## What did not change

This PR does not change:

- `status.json` contract
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- primary CI gate policy
- existing required gate sets
- Quality Ledger rendering
- break-glass behavior
- shadow-layer authority

## Boundary

This is a fail-closed correctness fix for the release decision materializer.

The release-authority center remains:

```text
status.json
+ materialized required gates
+ check_gates.py
+ primary release-gating workflow
```

The materializer remains an artifact-producing layer that writes:

```text
PULSE_safe_pack_v0/artifacts/release_decision_v0.json
```

## Expected blocked cases

The following must no longer be able to produce `STAGE-PASS` or `PROD-PASS`.

### Conflicting stub profiles

```json
{
  "diagnostics": {
    "stub_profile": "real"
  },
  "metrics": {
    "stub_profile": "all_true_smoke"
  }
}
```

### Malformed scaffold flag

```json
{
  "diagnostics": {
    "scaffold": "true"
  }
}
```

### Malformed gates_stubbed flag

```json
{
  "diagnostics": {
    "gates_stubbed": 1
  }
}
```

## Follow-up

A separate test PR should cover:

- later stub profile source blocks even if earlier source is neutral,
- malformed `scaffold` blocks fail-closed,
- malformed `gates_stubbed` blocks fail-closed.

## Checklist

- [ ] all supported `stub_profile` sources are checked
- [ ] first-present stub profile behavior removed
- [ ] non-real stub profiles block release-level pass
- [ ] non-boolean `gates_stubbed` values block release-level pass
- [ ] non-boolean `scaffold` values block release-level pass
- [ ] no gate policy changed
- [ ] no `check_gates.py` behavior changed
- [ ] no `status.json` contract changed
- [ ] no Quality Ledger behavior changed
- [ ] no break-glass behavior changed
