### PR TITLE
fix(release): block null diagnostic stub flags

### DIFF
--- a/PULSE_safe_pack_v0/tools/materialize_release_decision.py
+++ b/PULSE_safe_pack_v0/tools/materialize_release_decision.py
@@ -20,6 +20,34 @@ DEFAULT_STATUS = REPO_ROOT / "PULSE_safe_pack_v0" / "artifacts" / "status.json"
 DEFAULT_POLICY = REPO_ROOT / "pulse_gate_policy_v0.yml"
 DEFAULT_OUT = REPO_ROOT / "PULSE_safe_pack_v0" / "artifacts" / "release_decision_v0.json"
 
+_MISSING = object()
+
+STUB_FLAG_PATHS = (
+    "diagnostics.gates_stubbed",
+    "metrics.gates_stubbed",
+    "meta.diagnostics.gates_stubbed",
+)
+
+SCAFFOLD_FLAG_PATHS = (
+    "diagnostics.scaffold",
+    "metrics.scaffold",
+    "meta.diagnostics.scaffold",
+)
+
+STUB_PROFILE_PATHS = (
+    "diagnostics.stub_profile",
+    "metrics.stub_profile",
+    "meta.diagnostics.stub_profile",
+)
+
+NEUTRAL_STUB_PROFILES = {
+    "",
+    "none",
+    "false",
+    "real",
+    "not_stubbed",
+}
+
 
 def _utc_now() -> str:
     return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
@@ -78,78 +106,72 @@ def _git_sha() -> str | None:
 
 
 def _get_path(obj: Any, dotted: str) -> Any:
+    """Return a dotted path value, using None for both missing and explicit null.
+
+    Use _get_path_or_missing when the distinction between missing and explicit
+    JSON null matters.
+    """
+    value = _get_path_or_missing(obj, dotted)
+    if value is _MISSING:
+        return None
+    return value
+
+
+def _get_path_or_missing(obj: Any, dotted: str) -> Any:
+    """Return a dotted path value or _MISSING when any component is absent.
+
+    This intentionally preserves explicit JSON null as None, so callers can
+    distinguish a missing diagnostic flag from a present-but-null malformed flag.
+    """
     cur = obj
     for part in dotted.split("."):
         if not isinstance(cur, dict) or part not in cur:
-            return None
+            return _MISSING
         cur = cur[part]
     return cur
 
 
-STUB_FLAG_PATHS = (
-    "diagnostics.gates_stubbed",
-    "metrics.gates_stubbed",
-    "meta.diagnostics.gates_stubbed",
-)
-
-SCAFFOLD_FLAG_PATHS = (
-    "diagnostics.scaffold",
-    "metrics.scaffold",
-    "meta.diagnostics.scaffold",
-)
-
-STUB_PROFILE_PATHS = (
-    "diagnostics.stub_profile",
-    "metrics.stub_profile",
-    "meta.diagnostics.stub_profile",
-)
-
-NEUTRAL_STUB_PROFILES = {
-    "",
-    "none",
-    "false",
-    "real",
-    "not_stubbed",
-}
-
-
 def _blocking_flag_present(obj: Any, *paths: str) -> bool:
-    """Return true when any flag path blocks release-level pass.
+    """Return true when any diagnostic flag blocks release-level pass.
 
-    Boolean true blocks.
-    Boolean false is neutral.
     Missing values are neutral.
-    Any present non-boolean value blocks fail-closed because scaffold/stub
-    diagnostics must not be silently ignored when malformed.
+
+    Boolean false is neutral.
+    Boolean true blocks.
+
+    Any present non-boolean value, including explicit JSON null, blocks
+    fail-closed. Diagnostic scaffold/stub flags must not be silently ignored
+    when malformed.
     """
     for path in paths:
-        value = _get_path(obj, path)
+        value = _get_path_or_missing(obj, path)
 
-        if value is None:
+        if value is _MISSING:
+            continue
+
+        if value is False:
             continue
 
         if value is True:
             return True
 
-        if value is False:
-            continue
-
+        # Present but malformed: null, string, number, array, object, etc.
         return True
 
     return False
 
 
 def _stub_profile_blocks(value: Any) -> bool:
-    """Return true when a stub_profile value blocks release-level pass.
+    """Return true when a present stub_profile value blocks release-level pass.
 
-    Strings are normalized and compared against the known neutral profiles.
+    Missing values must be handled by the caller.
+
+    Strings are normalized and compared against known neutral profiles.
     Boolean false is neutral.
     Boolean true blocks.
-    Any other present non-null value blocks fail-closed.
+    Explicit null and any other present non-string/non-boolean value block
+    fail-closed.
     """
-    if value is None:
-        return False
-
     if isinstance(value, str):
         normalized = value.strip().lower()
         return normalized not in NEUTRAL_STUB_PROFILES
@@ -160,7 +182,26 @@ def _stub_profile_blocks(value: Any) -> bool:
     if value is True:
         return True
 
+    # Present but malformed, including explicit JSON null.
     return True
+
+
+def _stubbed(status: dict[str, Any]) -> bool:
+    if _blocking_flag_present(status, *STUB_FLAG_PATHS):
+        return True
+
+    for path in STUB_PROFILE_PATHS:
+        value = _get_path_or_missing(status, path)
+        if value is _MISSING:
+            continue
+        if _stub_profile_blocks(value):
+            return True
+
+    return False
+
+
+def _scaffold(status: dict[str, Any]) -> bool:
+    return _blocking_flag_present(status, *SCAFFOLD_FLAG_PATHS)
 
 
 def _value_type(value: Any) -> str:
@@ -247,21 +288,6 @@ def _policy_gate_set(policy: dict[str, Any], name: str) -> list[str]:
         out.append(item)
 
     return out
-
-
-def _stubbed(status: dict[str, Any]) -> bool:
-    if _blocking_flag_present(status, *STUB_FLAG_PATHS):
-        return True
-
-    for path in STUB_PROFILE_PATHS:
-        if _stub_profile_blocks(_get_path(status, path)):
-            return True
-
-    return False
-
-
-def _scaffold(status: dict[str, Any]) -> bool:
-    return _blocking_flag_present(status, *SCAFFOLD_FLAG_PATHS)
 
 
 def _add_reason(reasons: list[str], reason: str) -> None:
@@ -441,7 +467,7 @@ def _materialize_decision(
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Materialize the PULSE release_decision_v0 artifact."
+        description="Materialize the PULSEmech release_decision_v0 artifact."
     )
 
     parser.add_argument(
@@ -528,7 +554,10 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(json.dumps(decision, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_path.write_text(
+        json.dumps(decision, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 
     print(json.dumps(decision, indent=2, sort_keys=True))
 


### PR DESCRIPTION
## Summary

This PR fixes a fail-closed edge case in:

```text
PULSE_safe_pack_v0/tools/materialize_release_decision.py
```

Codex correctly flagged that explicit JSON `null` diagnostic flags were being
treated the same as missing fields.

That allowed malformed status artifacts such as:

```json
{
  "diagnostics": {
    "scaffold": null
  }
}
```

or:

```json
{
  "diagnostics": {
    "gates_stubbed": null
  }
}
```

to behave as neutral instead of blocking release-level pass.

## Why

Missing diagnostic data and explicitly malformed diagnostic data are not the
same thing.

For release-level materialization:

- missing diagnostic flag = neutral
- present flag with boolean `false` = neutral
- present flag with boolean `true` = blocking
- present flag with `null` = malformed, blocking
- present flag with string/number/object/array = malformed, blocking

The previous helper returned `None` for both missing paths and explicit JSON
`null`, so the materializer could not tell those cases apart.

## What changed

This PR introduces:

```python
_MISSING = object()
```

and a new helper:

```python
_get_path_or_missing(...)
```

so the materializer can distinguish:

```text
missing path
```

from:

```text
present path with null
```

## Updated fail-closed behavior

Supported `gates_stubbed` paths:

```text
diagnostics.gates_stubbed
metrics.gates_stubbed
meta.diagnostics.gates_stubbed
```

Supported `scaffold` paths:

```text
diagnostics.scaffold
metrics.scaffold
meta.diagnostics.scaffold
```

These now behave as follows:

| Value | Behavior |
|---|---|
| missing | neutral |
| `false` | neutral |
| `true` | blocks release-level pass |
| `null` | blocks fail-closed |
| `"true"` | blocks fail-closed |
| `1` | blocks fail-closed |
| `{}` | blocks fail-closed |
| `[]` | blocks fail-closed |

## Stub profile behavior

This PR preserves the previous hardening for `stub_profile`.

All supported stub profile paths are checked:

```text
diagnostics.stub_profile
metrics.stub_profile
meta.diagnostics.stub_profile
```

A neutral earlier value can no longer hide a later stub profile.

Neutral profiles remain:

```text
""
"none"
"false"
"real"
"not_stubbed"
```

Any other present value blocks release-level pass.

Explicit `null` in a present `stub_profile` path also blocks fail-closed.

## What did not change

This PR does not change:

- `status.json` contract
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- primary CI release semantics
- Quality Ledger rendering
- break-glass behavior
- shadow-layer authority
- release-decision schema

## Boundary

This is a fail-closed correctness fix for the release decision materializer.

The release-authority center remains unchanged:

```text
status.json
+ materialized required gates
+ check_gates.py
+ primary release-gating workflow
```

The materializer remains an artifact-producing layer that writes:

```text
PULSE_safe_pack_v0/artifacts/release_decision_v0.json
```

## Expected blocked cases

The following must not produce `STAGE-PASS` or `PROD-PASS`.

### Explicit null scaffold

```json
{
  "diagnostics": {
    "scaffold": null
  }
}
```

### Explicit null gates_stubbed

```json
{
  "diagnostics": {
    "gates_stubbed": null
  }
}
```

### Malformed scaffold string

```json
{
  "diagnostics": {
    "scaffold": "true"
  }
}
```

### Malformed gates_stubbed number

```json
{
  "diagnostics": {
    "gates_stubbed": 1
  }
}
```

### Conflicting stub profiles

```json
{
  "diagnostics": {
    "stub_profile": "real"
  },
  "metrics": {
    "stub_profile": "all_true_smoke"
  }
}
```

## Checklist

- [ ] missing diagnostic flags remain neutral
- [ ] explicit `null` diagnostic flags block fail-closed
- [ ] non-boolean `gates_stubbed` values block fail-closed
- [ ] non-boolean `scaffold` values block fail-closed
- [ ] all supported `stub_profile` paths are checked
- [ ] no gate policy changed
- [ ] no `status.json` contract changed
- [ ] no `check_gates.py` behavior changed
- [ ] no CI release semantics changed
- [ ] no Quality Ledger behavior changed
- [ ] no break-glass behavior changed
