### PR TITLE
test(release): cover fail-closed diagnostic stub flags

### DIFF
--- a/tests/test_release_decision_v0_smoke.py
+++ b/tests/test_release_decision_v0_smoke.py
@@ -202,6 +202,88 @@ def test_stage_fails_when_status_is_stubbed() -> None:
     assert decision["conditions"]["stubbed"] is True
     assert any("stubbed diagnostics are present" in reason for reason in decision["blocking_reasons"])
 
+def test_stage_fails_when_later_stub_profile_source_is_stubbed() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-release-decision-") as tmp:
+        status = _status(
+            {
+                "pass_controls_refusal": True,
+                "q1_grounded_ok": True,
+                "detectors_materialized_ok": True
+            },
+            run_mode="prod",
+            diagnostics={
+                "stub_profile": "real"
+            },
+        )
+        status["metrics"]["stub_profile"] = "all_true_smoke"
+
+        result, decision = _run(
+            Path(tmp),
+            target="stage",
+            status=status,
+        )
+
+    assert result.returncode == 1
+    assert decision["release_level"] == "FAIL"
+    assert decision["conditions"]["stubbed"] is True
+    assert any(
+        "stubbed diagnostics are present" in reason
+        for reason in decision["blocking_reasons"]
+    )
+
+
+def test_stage_fails_closed_on_malformed_scaffold_indicator() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-release-decision-") as tmp:
+        result, decision = _run(
+            Path(tmp),
+            target="stage",
+            status=_status(
+                {
+                    "pass_controls_refusal": True,
+                    "q1_grounded_ok": True,
+                    "detectors_materialized_ok": True
+                },
+                run_mode="prod",
+                diagnostics={
+                    "scaffold": "true"
+                },
+            ),
+        )
+
+    assert result.returncode == 1
+    assert decision["release_level"] == "FAIL"
+    assert decision["conditions"]["scaffold"] is True
+    assert any(
+        "scaffold diagnostics are present" in reason
+        for reason in decision["blocking_reasons"]
+    )
+
+
+def test_stage_fails_closed_on_malformed_gates_stubbed_indicator() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-release-decision-") as tmp:
+        result, decision = _run(
+            Path(tmp),
+            target="stage",
+            status=_status(
+                {
+                    "pass_controls_refusal": True,
+                    "q1_grounded_ok": True,
+                    "detectors_materialized_ok": True
+                },
+                run_mode="prod",
+                diagnostics={
+                    "gates_stubbed": 1
+                },
+            ),
+        )
+
+    assert result.returncode == 1
+    assert decision["release_level"] == "FAIL"
+    assert decision["conditions"]["stubbed"] is True
+    assert any(
+        "stubbed diagnostics are present" in reason
+        for reason in decision["blocking_reasons"]
+    )
 
 def test_non_literal_true_gate_fails_closed() -> None:
     with tempfile.TemporaryDirectory(prefix="pulse-release-decision-") as tmp:
@@ -235,6 +317,9 @@ def main() -> int:
         test_prod_pass_requires_required_and_release_required,
         test_prod_fails_when_release_required_evidence_is_missing,
         test_stage_fails_when_status_is_stubbed,
+        test_stage_fails_when_later_stub_profile_source_is_stubbed,
+        test_stage_fails_closed_on_malformed_scaffold_indicator,
+        test_stage_fails_closed_on_malformed_gates_stubbed_indicator,
         test_non_literal_true_gate_fails_closed,
     ]
 


### PR DESCRIPTION
## Summary

This PR updates:

```text
tests/test_release_decision_v0_smoke.py
```

to cover the fail-closed diagnostic stub/scaffold behavior recently added to:

```text
PULSE_safe_pack_v0/tools/materialize_release_decision.py
```

## Why

The release decision materializer now treats malformed diagnostic stub/scaffold
signals as release-blocking.

The test suite should lock in that behavior so future changes cannot
accidentally allow malformed diagnostic evidence to produce:

- `STAGE-PASS`
- `PROD-PASS`

## Background

The materializer now distinguishes:

```text
missing diagnostic path
```

from:

```text
present diagnostic path with JSON null
```

This matters because missing diagnostic data and malformed diagnostic data are
not equivalent.

The intended behavior is:

| Diagnostic value | Meaning |
|---|---|
| missing | neutral |
| `false` | neutral |
| `true` | blocks |
| `null` | malformed, blocks |
| `"true"` | malformed, blocks |
| `1` | malformed, blocks |
| `{}` | malformed, blocks |
| `[]` | malformed, blocks |

## What changed

This PR adds or updates smoke coverage for the following cases.

### Explicit null scaffold blocks

A status artifact like this must not produce `STAGE-PASS` or `PROD-PASS`:

```json
{
  "diagnostics": {
    "scaffold": null
  }
}
```

Expected result:

```text
release_level = FAIL
conditions.scaffold = true
blocking_reasons includes scaffold diagnostics
```

### Explicit null gates_stubbed blocks

A status artifact like this must not produce `STAGE-PASS` or `PROD-PASS`:

```json
{
  "diagnostics": {
    "gates_stubbed": null
  }
}
```

Expected result:

```text
release_level = FAIL
conditions.stubbed = true
blocking_reasons includes stubbed diagnostics
```

### Malformed scaffold blocks

A status artifact like this must fail closed:

```json
{
  "diagnostics": {
    "scaffold": "true"
  }
}
```

Expected result:

```text
release_level = FAIL
conditions.scaffold = true
```

### Malformed gates_stubbed blocks

A status artifact like this must fail closed:

```json
{
  "diagnostics": {
    "gates_stubbed": 1
  }
}
```

Expected result:

```text
release_level = FAIL
conditions.stubbed = true
```

### Conflicting stub_profile sources block

A neutral earlier source must not hide a later stub source.

This must fail:

```json
{
  "diagnostics": {
    "stub_profile": "real"
  },
  "metrics": {
    "stub_profile": "all_true_smoke"
  }
}
```

Expected result:

```text
release_level = FAIL
conditions.stubbed = true
```

### Explicit null stub_profile blocks

A present-but-null stub profile must be treated as malformed diagnostic evidence:

```json
{
  "diagnostics": {
    "stub_profile": null
  }
}
```

Expected result:

```text
release_level = FAIL
conditions.stubbed = true
```

## What did not change

This PR does not change:

- `PULSE_safe_pack_v0/tools/materialize_release_decision.py`
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- CI release semantics
- Quality Ledger rendering
- break-glass behavior
- shadow-layer authority

## Boundary

This is a test-only PR.

It verifies the intended behavior of the already-updated materializer.

The release-authority center remains unchanged:

```text
status.json
+ materialized required gates
+ check_gates.py
+ primary release-gating workflow
```

## Expected result

The smoke suite should prove that malformed diagnostic stub/scaffold evidence
cannot result in `STAGE-PASS` or `PROD-PASS`.

## Checklist

- [ ] explicit null `diagnostics.scaffold` is covered
- [ ] explicit null `diagnostics.gates_stubbed` is covered
- [ ] malformed string scaffold value is covered
- [ ] malformed numeric gates_stubbed value is covered
- [ ] conflicting stub_profile sources are covered
- [ ] explicit null stub_profile is covered
- [ ] no runtime release behavior changed
- [ ] no gate policy changed
- [ ] no CI release semantics changed
- [ ] no Quality Ledger behavior changed
- [ ] no break-glass behavior changed