### PR TITLE
fix(ledger): validate release decision before rendering

### DIFF
--- a/PULSE_safe_pack_v0/tools/render_release_decision_ledger_section.py
+++ b/PULSE_safe_pack_v0/tools/render_release_decision_ledger_section.py
@@ -24,14 +24,7 @@ DEFAULT_OUT = (
     / "release_decision_v0_ledger_section.html"
 )
 
-EXPECTED_SCHEMA = "pulse_release_decision_v0"
-
-VALID_RELEASE_LEVELS = {
-    "FAIL",
-    "STAGE-PASS",
-    "PROD-PASS",
-}
-
+DEFAULT_SCHEMA = REPO_ROOT / "schemas" / "release_decision_v0.schema.json"
 
 def _rel(path: Path) -> str:
     try:
@@ -302,17 +295,52 @@ def _render_invalid(input_path: Path, error: str) -> str:
 """.strip()
 
 
-def _basic_artifact_error(payload: Any) -> str | None:
+def _release_decision_artifact_error(payload: Any, schema_path: Path) -> str | None:
     if not isinstance(payload, dict):
         return "release decision artifact root is not an object"
 
-    schema = payload.get("schema")
-    if schema != EXPECTED_SCHEMA:
-        return f"unexpected schema value: {schema!r}"
+    if not schema_path.exists():
+        return f"release decision schema is missing: {_rel(schema_path)}"
 
-    level = payload.get("release_level")
-    if level not in VALID_RELEASE_LEVELS:
-        return f"unexpected release_level value: {level!r}"
+    try:
+        import jsonschema
+    except Exception as exc:
+        return f"jsonschema import failed: {exc}"
+
+    try:
+        schema_payload = _read_json(schema_path)
+    except Exception as exc:
+        return f"release decision schema could not be read: {exc}"
+
+    try:
+        jsonschema.Draft202012Validator.check_schema(schema_payload)
+    except Exception as exc:
+        return f"release decision schema is not a valid JSON Schema: {exc}"
+
+    try:
+        validator = jsonschema.Draft202012Validator(
+            schema_payload,
+            format_checker=jsonschema.FormatChecker(),
+        )
+        errors = sorted(validator.iter_errors(payload), key=lambda e: list(e.path))
+    except Exception as exc:
+        return f"release decision artifact schema validation failed to run: {exc}"
+
+    if errors:
+        rendered_errors = []
+        for error in errors[:5]:
+            path = ".".join(str(part) for part in error.path) or "<root>"
+            rendered_errors.append(f"{path}: {error.message}")
+
+        suffix = ""
+        if len(errors) > 5:
+            suffix = f" (+{len(errors) - 5} more)"
+
+        return (
+            "release decision artifact failed schema validation: "
+            + "; ".join(rendered_errors)
+            + suffix
+        )
 
     return None
 
@@ -387,7 +415,9 @@ def _render_release_decision(input_path: Path, payload: dict[str, Any]) -> str:
 """.strip()
 
 
-def render_release_decision_section(input_path: Path) -> tuple[str, int]:
+def render_release_decision_section(
+    input_path: Path, schema_path: Path = DEFAULT_SCHEMA
+) -> tuple[str, int]:
     if not input_path.exists():
         return _render_missing(input_path), 0
 
@@ -396,7 +426,7 @@ def render_release_decision_section(input_path: Path) -> tuple[str, int]:
     except Exception as exc:
         return _render_invalid(input_path, str(exc)), 1
 
-    error = _basic_artifact_error(payload)
+    error = _release_decision_artifact_error(payload, schema_path)
     if error is not None:
         return _render_invalid(input_path, error), 1
 
@@ -422,6 +452,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Path to write the rendered HTML fragment.",
     )
     parser.add_argument(
+        "--schema",
+        default=str(DEFAULT_SCHEMA),
+        help="Path to schemas/release_decision_v0.schema.json.",
+    )
+    parser.add_argument(
         "--strict-missing",
         action="store_true",
         help="Return exit code 1 when the release decision artifact is missing.",
@@ -435,13 +470,16 @@ def main(argv: list[str] | None = None) -> int:
 
     input_path = Path(args.input)
     out_path = Path(args.out)
+    schema_path = Path(args.schema)
 
     if not input_path.is_absolute():
         input_path = REPO_ROOT / input_path
     if not out_path.is_absolute():
         out_path = REPO_ROOT / out_path
+    if not schema_path.is_absolute():
+        schema_path = REPO_ROOT / schema_path
 
-    rendered, rc = render_release_decision_section(input_path)
+    rendered, rc = render_release_decision_section(input_path, schema_path)
 
     if args.strict_missing and not input_path.exists():
         rc = 1


### PR DESCRIPTION
## Summary

This PR makes the release decision Ledger renderer validate
`release_decision_v0.json` against the release-decision schema before rendering
it as a release-level section.

Affected file:

```text
PULSE_safe_pack_v0/tools/render_release_decision_ledger_section.py
```

The renderer now checks artifacts against:

```text
schemas/release_decision_v0.schema.json
```

before allowing `FAIL`, `STAGE-PASS`, or `PROD-PASS` rendering.

## Why

Codex correctly flagged that the renderer only checked:

- `schema`
- `release_level`

That meant a truncated artifact like this could render as a credible PASS:

```json
{
  "schema": "pulse_release_decision_v0",
  "release_level": "PROD-PASS"
}
```

That is not acceptable for a fail-safe Ledger surface.

The Quality Ledger must not display broken release-decision evidence as a valid
release decision.

## What changed

The renderer now:

- loads the release-decision schema,
- checks that the schema itself is valid JSON Schema,
- validates the release-decision artifact against that schema,
- renders schema-invalid artifacts as `INVALID`,
- only renders release-level pills for schema-valid artifacts.

A new optional CLI argument is added:

```text
--schema
```

Default:

```text
schemas/release_decision_v0.schema.json
```

## Behavior

### Missing artifact

If `release_decision_v0.json` is missing:

```text
MISSING
```

is rendered.

The Ledger does not infer PASS.

### Invalid artifact

If `release_decision_v0.json` exists but is malformed, truncated, tampered, or
schema-invalid:

```text
INVALID
```

is rendered.

The Ledger does not infer PASS.

### Valid artifact

Only schema-valid release-decision artifacts can render:

- `FAIL`
- `STAGE-PASS`
- `PROD-PASS`

## What did not change

This PR does not change:

- `PULSE_safe_pack_v0/tools/materialize_release_decision.py`
- `schemas/release_decision_v0.schema.json`
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- primary CI release semantics
- break-glass behavior
- shadow-layer authority

## Boundary

This is a fail-safe renderer fix.

The Ledger remains read-only:

```text
release_decision_v0.json → Quality Ledger section
```

It must not become:

```text
Quality Ledger section → release decision
```

## Checklist

- [ ] renderer validates artifact against `schemas/release_decision_v0.schema.json`
- [ ] truncated PASS artifact renders as INVALID
- [ ] schema-invalid artifact renders as INVALID
- [ ] missing artifact still renders as MISSING
- [ ] valid artifact still renders normally
- [ ] no release semantics changed
- [ ] no gate policy changed
- [ ] no materializer behavior changed