### PR TITLE
feat(ledger): insert release decision section into report

### DIFF
--- a/PULSE_safe_pack_v0/tools/insert_release_decision_ledger_section.py
+++ b/PULSE_safe_pack_v0/tools/insert_release_decision_ledger_section.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DEFAULT_REPORT = (
+    REPO_ROOT
+    / "PULSE_safe_pack_v0"
+    / "artifacts"
+    / "report_card.html"
+)
+
+DEFAULT_SECTION = (
+    REPO_ROOT
+    / "PULSE_safe_pack_v0"
+    / "artifacts"
+    / "release_decision_v0_ledger_section.html"
+)
+
+DEFAULT_OUT = (
+    REPO_ROOT
+    / "PULSE_safe_pack_v0"
+    / "artifacts"
+    / "report_card.with_release_decision.html"
+)
+
+START_MARKER = "<!-- PULSE_RELEASE_DECISION_V0_SECTION_START -->"
+END_MARKER = "<!-- PULSE_RELEASE_DECISION_V0_SECTION_END -->"
+
+RELEASE_SECTION_ID_RE = re.compile(
+    r"""id\s*=\s*["']release-decision-v0["']""",
+    flags=re.IGNORECASE,
+)
+
+CLOSING_BODY_RE = re.compile(
+    r"</body\s*>",
+    flags=re.IGNORECASE,
+)
+
+
+class ComposeResult(NamedTuple):
+    html: str
+    mode: str
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _wrap_section(section_html: str) -> str:
+    return (
+        f"{START_MARKER}\n"
+        f"{section_html.rstrip()}\n"
+        f"{END_MARKER}"
+    )
+
+
+def _missing_section_html(section_path: Path) -> str:
+    return f"""
+<section id="release-decision-v0" class="release-decision-v0">
+  <h2>Release decision v0</h2>
+  <p>
+    <strong>MISSING</strong>
+  </p>
+  <p>
+    The rendered release decision Ledger section was not available at
+    <code>{_rel(section_path)}</code>.
+  </p>
+  <p>
+    This composition helper must not infer <code>STAGE-PASS</code>,
+    <code>PROD-PASS</code>, or any release-level result from a missing
+    release-decision section.
+  </p>
+</section>
+""".strip()
+
+
+def _has_release_decision_section(html: str) -> bool:
+    return RELEASE_SECTION_ID_RE.search(html) is not None
+
+
+def _replace_existing_marked_section(report_html: str, wrapped_section: str) -> str | None:
+    start = report_html.find(START_MARKER)
+    end = report_html.find(END_MARKER)
+
+    if start == -1 and end == -1:
+        return None
+
+    if start == -1 or end == -1:
+        raise ValueError(
+            "report contains only one release-decision marker; "
+            "both START and END markers are required"
+        )
+
+    if end < start:
+        raise ValueError(
+            "release-decision END marker appears before START marker"
+        )
+
+    end_after = end + len(END_MARKER)
+
+    return (
+        report_html[:start].rstrip()
+        + "\n\n"
+        + wrapped_section
+        + "\n\n"
+        + report_html[end_after:].lstrip()
+    )
+
+
+def _insert_before_closing_body(report_html: str, wrapped_section: str) -> ComposeResult:
+    match = None
+    for match in CLOSING_BODY_RE.finditer(report_html):
+        pass
+
+    if match is None:
+        return ComposeResult(
+            html=report_html.rstrip() + "\n\n" + wrapped_section + "\n",
+            mode="append_eof",
+        )
+
+    insert_at = match.start()
+
+    composed = (
+        report_html[:insert_at].rstrip()
+        + "\n\n"
+        + wrapped_section
+        + "\n\n"
+        + report_html[insert_at:].lstrip()
+    )
+
+    return ComposeResult(html=composed, mode="insert_before_body_close")
+
+
+def compose_report_with_release_decision_section(
+    *,
+    report_html: str,
+    section_html: str,
+) -> ComposeResult:
+    wrapped_section = _wrap_section(section_html)
+
+    replaced = _replace_existing_marked_section(report_html, wrapped_section)
+    if replaced is not None:
+        return ComposeResult(html=replaced, mode="replace_existing_marked_section")
+
+    if _has_release_decision_section(report_html):
+        raise ValueError(
+            "report already contains a release-decision section but no "
+            "PULSE_RELEASE_DECISION_V0 markers; refusing to insert a duplicate"
+        )
+
+    return _insert_before_closing_body(report_html, wrapped_section)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Insert the rendered release_decision_v0 Quality Ledger section "
+            "into a report_card.html artifact."
+        )
+    )
+
+    parser.add_argument(
+        "--report",
+        default=str(DEFAULT_REPORT),
+        help="Path to the existing report_card.html artifact.",
+    )
+    parser.add_argument(
+        "--section",
+        default=str(DEFAULT_SECTION),
+        help="Path to release_decision_v0_ledger_section.html.",
+    )
+    parser.add_argument(
+        "--out",
+        default=str(DEFAULT_OUT),
+        help=(
+            "Path to write the composed report. Ignored when --in-place is used."
+        ),
+    )
+    parser.add_argument(
+        "--in-place",
+        action="store_true",
+        help="Overwrite --report instead of writing --out.",
+    )
+    parser.add_argument(
+        "--allow-missing-section",
+        action="store_true",
+        help=(
+            "Insert an explicit MISSING placeholder when the rendered release "
+            "decision section is absent. Without this flag, missing section input "
+            "is an error."
+        ),
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    report_path = Path(args.report)
+    section_path = Path(args.section)
+    out_path = report_path if args.in_place else Path(args.out)
+
+    if not report_path.is_absolute():
+        report_path = REPO_ROOT / report_path
+    if not section_path.is_absolute():
+        section_path = REPO_ROOT / section_path
+    if not out_path.is_absolute():
+        out_path = REPO_ROOT / out_path
+
+    if not report_path.exists():
+        print(
+            f"ERROR: report artifact is missing: {_rel(report_path)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        report_html = _read_text(report_path)
+    except Exception as exc:
+        print(
+            f"ERROR: could not read report artifact {_rel(report_path)}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if section_path.exists():
+        try:
+            section_html = _read_text(section_path)
+        except Exception as exc:
+            print(
+                f"ERROR: could not read release decision section "
+                f"{_rel(section_path)}: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+
+        if not section_html.strip():
+            print(
+                f"ERROR: release decision section is empty: {_rel(section_path)}",
+                file=sys.stderr,
+            )
+            return 1
+    else:
+        if not args.allow_missing_section:
+            print(
+                f"ERROR: release decision section is missing: {_rel(section_path)}",
+                file=sys.stderr,
+            )
+            print(
+                "Hint: run render_release_decision_ledger_section.py first, "
+                "or pass --allow-missing-section to insert an explicit MISSING "
+                "placeholder.",
+                file=sys.stderr,
+            )
+            return 1
+
+        section_html = _missing_section_html(section_path)
+
+    try:
+        result = compose_report_with_release_decision_section(
+            report_html=report_html,
+            section_html=section_html,
+        )
+    except Exception as exc:
+        print(f"ERROR: could not compose report: {exc}", file=sys.stderr)
+        return 1
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(result.html, encoding="utf-8")
+
+    print(
+        "OK: inserted release decision Ledger section "
+        f"mode={result.mode} report={_rel(report_path)} out={_rel(out_path)}"
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds a small Quality Ledger/report-card composition helper.

New file:

```text
PULSE_safe_pack_v0/tools/insert_release_decision_ledger_section.py
```

The tool inserts the rendered release decision Ledger section into an existing
report card artifact.

Input artifacts:

```text
PULSE_safe_pack_v0/artifacts/report_card.html
PULSE_safe_pack_v0/artifacts/release_decision_v0_ledger_section.html
```

Default output:

```text
PULSE_safe_pack_v0/artifacts/report_card.with_release_decision.html
```

## Why

The `release_decision_v0` stack now has:

- release decision contract docs
- JSON Schema
- materializer tool
- materializer smoke coverage
- schema-validation smoke coverage
- standalone release decision Ledger section renderer
- renderer smoke coverage

The next step is to compose the rendered section into a report-card artifact
without making the report renderer compute or redefine release semantics.

This helper keeps that boundary explicit.

## What the tool does

The tool:

1. reads an existing `report_card.html`,
2. reads `release_decision_v0_ledger_section.html`,
3. wraps the section in stable markers,
4. inserts the section before `</body>` when available,
5. appends the section at EOF when no closing body tag exists,
6. replaces an existing marked release-decision section on repeated runs,
7. refuses to insert a duplicate if an unmarked `id="release-decision-v0"`
   section already exists.

Stable markers:

```html
<!-- PULSE_RELEASE_DECISION_V0_SECTION_START -->
<!-- PULSE_RELEASE_DECISION_V0_SECTION_END -->
```

## CLI

Default usage:

```bash
python PULSE_safe_pack_v0/tools/insert_release_decision_ledger_section.py
```

Explicit paths:

```bash
python PULSE_safe_pack_v0/tools/insert_release_decision_ledger_section.py \
  --report PULSE_safe_pack_v0/artifacts/report_card.html \
  --section PULSE_safe_pack_v0/artifacts/release_decision_v0_ledger_section.html \
  --out PULSE_safe_pack_v0/artifacts/report_card.with_release_decision.html
```

In-place mode:

```bash
python PULSE_safe_pack_v0/tools/insert_release_decision_ledger_section.py \
  --in-place
```

Missing-section placeholder mode:

```bash
python PULSE_safe_pack_v0/tools/insert_release_decision_ledger_section.py \
  --allow-missing-section
```

## Missing section behavior

If `release_decision_v0_ledger_section.html` is missing, the tool fails by
default.

This prevents silently publishing a report that appears complete while lacking
the release-decision section.

If explicitly invoked with:

```text
--allow-missing-section
```

the tool inserts a visible MISSING placeholder.

The placeholder explicitly states that the tool must not infer:

- `STAGE-PASS`
- `PROD-PASS`
- any release-level result

from a missing release-decision section.

## Authority boundary

This tool is an artifact-composition helper.

It does not:

- compute `STAGE-PASS`
- compute `PROD-PASS`
- reinterpret `FAIL`
- mutate `status.json`
- call or replace `check_gates.py`
- alter `pulse_gate_policy_v0.yml`
- promote any shadow layer
- treat missing release-decision evidence as pass

Correct direction:

```text
release_decision_v0.json
  → release_decision_v0_ledger_section.html
  → report_card.with_release_decision.html
```

Incorrect direction:

```text
report_card.with_release_decision.html
  → release decision
```

## What did not change

This PR does not change:

- `PULSE_safe_pack_v0/tools/materialize_release_decision.py`
- `PULSE_safe_pack_v0/tools/render_release_decision_ledger_section.py`
- `schemas/release_decision_v0.schema.json`
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- primary CI release semantics
- shadow-layer authority
- break-glass behavior

## Boundary

This is a standalone helper PR.

It adds a safe composition step but does not yet wire the tool into the primary
release workflow.

The release-authority center remains unchanged:

```text
status.json
+ materialized required gates
+ check_gates.py
+ primary release-gating workflow
```

The release-level artifact remains:

```text
release_decision_v0.json
```

The rendered release-decision section remains:

```text
release_decision_v0_ledger_section.html
```

This PR only adds a tool to insert that rendered section into a report artifact.

## Follow-up work

Recommended next PRs:

1. Add smoke coverage for `insert_release_decision_ledger_section.py`.
2. Register the new smoke test in `ci/tools-tests.list`.
3. Wire release decision materialization, section rendering, and report insertion into the primary release workflow as uploaded artifacts.
4. Later, add `break_glass_override_v0` as a separate audited governance artifact.

## Checklist

- [ ] `PULSE_safe_pack_v0/tools/insert_release_decision_ledger_section.py` added
- [ ] tool reads `report_card.html`
- [ ] tool reads `release_decision_v0_ledger_section.html`
- [ ] tool writes `report_card.with_release_decision.html` by default
- [ ] tool supports `--in-place`
- [ ] tool supports `--allow-missing-section`
- [ ] tool uses stable insertion markers
- [ ] tool avoids duplicate unmarked release-decision sections
- [ ] tool does not compute release semantics
- [ ] no gate policy changed
- [ ] no `check_gates.py` behavior changed
- [ ] no `status.json` behavior changed
- [ ] no CI release semantics changed
- [ ] no break-glass behavior changed