### PR TITLE
test(ledger): cover release decision section insertion

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -26,7 +26,7 @@ tests/test_render_quality_ledger_tests_list_smoke.py
 tests/test_authority_boundary_repro_smoke.py 
 tests/test_release_decision_v0_smoke.py
 tests/test_release_decision_v0_schema_smoke.py
-tests/test_insert_release_decision_ledger_section_smoke.py
+tests/test_insert_release_decision_ledger_section_smoke.py 
 
 tools/operator_handoff_smoke.py
 

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -26,6 +26,7 @@ tests/test_render_quality_ledger_tests_list_smoke.py
 tests/test_authority_boundary_repro_smoke.py 
 tests/test_release_decision_v0_smoke.py
 tests/test_release_decision_v0_schema_smoke.py
+tests/test_insert_release_decision_ledger_section_smoke.py
 
 tools/operator_handoff_smoke.py
 

--- a/tests/test_insert_release_decision_ledger_section_smoke.py
+++ b/tests/test_insert_release_decision_ledger_section_smoke.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (
+    ROOT
+    / "PULSE_safe_pack_v0"
+    / "tools"
+    / "insert_release_decision_ledger_section.py"
+)
+
+
+def _write(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _report_with_body() -> str:
+    return """<!doctype html>
+<html>
+<head>
+  <title>PULSEmech report</title>
+</head>
+<body>
+  <h1>Quality Ledger</h1>
+  <p>Existing report content.</p>
+</body>
+</html>
+"""
+
+
+def _report_without_body() -> str:
+    return """<h1>Quality Ledger</h1>
+<p>Existing report content without body tag.</p>
+"""
+
+
+def _section(level: str = "STAGE-PASS") -> str:
+    return f"""<section id="release-decision-v0" class="release-decision-v0">
+  <h2>Release decision v0</h2>
+  <span>{level}</span>
+</section>
+"""
+
+
+def test_insert_section_before_closing_body() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-insert-release-section-") as tmp:
+        tmp_path = Path(tmp)
+        report = tmp_path / "report_card.html"
+        section = tmp_path / "release_decision_v0_ledger_section.html"
+        out = tmp_path / "report_card.with_release_decision.html"
+
+        _write(report, _report_with_body())
+        _write(section, _section("STAGE-PASS"))
+
+        result = _run(
+            "--report",
+            str(report),
+            "--section",
+            str(section),
+            "--out",
+            str(out),
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert out.exists()
+
+        html = _read(out)
+
+        assert "<!-- PULSE_RELEASE_DECISION_V0_SECTION_START -->" in html
+        assert "<!-- PULSE_RELEASE_DECISION_V0_SECTION_END -->" in html
+        assert "release-decision-v0" in html
+        assert "STAGE-PASS" in html
+        assert html.index("release-decision-v0") < html.lower().index("</body>")
+
+
+def test_append_section_when_report_has_no_body_close() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-insert-release-section-") as tmp:
+        tmp_path = Path(tmp)
+        report = tmp_path / "report_card.html"
+        section = tmp_path / "release_decision_v0_ledger_section.html"
+        out = tmp_path / "report_card.with_release_decision.html"
+
+        _write(report, _report_without_body())
+        _write(section, _section("PROD-PASS"))
+
+        result = _run(
+            "--report",
+            str(report),
+            "--section",
+            str(section),
+            "--out",
+            str(out),
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert out.exists()
+
+        html = _read(out)
+
+        assert "Existing report content without body tag." in html
+        assert "PROD-PASS" in html
+        assert "<!-- PULSE_RELEASE_DECISION_V0_SECTION_START -->" in html
+        assert "mode=append_eof" in result.stdout
+
+
+def test_replace_existing_marked_section() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-insert-release-section-") as tmp:
+        tmp_path = Path(tmp)
+        report = tmp_path / "report_card.html"
+        section = tmp_path / "release_decision_v0_ledger_section.html"
+        out = tmp_path / "report_card.with_release_decision.html"
+
+        old_report = """<!doctype html>
+<html>
+<body>
+  <h1>Quality Ledger</h1>
+
+<!-- PULSE_RELEASE_DECISION_V0_SECTION_START -->
+<section id="release-decision-v0">
+  <span>OLD</span>
+</section>
+<!-- PULSE_RELEASE_DECISION_V0_SECTION_END -->
+
+</body>
+</html>
+"""
+        _write(report, old_report)
+        _write(section, _section("PROD-PASS"))
+
+        result = _run(
+            "--report",
+            str(report),
+            "--section",
+            str(section),
+            "--out",
+            str(out),
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert out.exists()
+
+        html = _read(out)
+
+        assert "OLD" not in html
+        assert "PROD-PASS" in html
+        assert html.count("PULSE_RELEASE_DECISION_V0_SECTION_START") == 1
+        assert html.count("PULSE_RELEASE_DECISION_V0_SECTION_END") == 1
+        assert "mode=replace_existing_marked_section" in result.stdout
+
+
+def test_refuse_duplicate_unmarked_release_decision_section() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-insert-release-section-") as tmp:
+        tmp_path = Path(tmp)
+        report = tmp_path / "report_card.html"
+        section = tmp_path / "release_decision_v0_ledger_section.html"
+        out = tmp_path / "report_card.with_release_decision.html"
+
+        report_with_unmarked_section = """<!doctype html>
+<html>
+<body>
+  <h1>Quality Ledger</h1>
+  <section id="release-decision-v0">
+    <span>Existing unmarked section</span>
+  </section>
+</body>
+</html>
+"""
+        _write(report, report_with_unmarked_section)
+        _write(section, _section("STAGE-PASS"))
+
+        result = _run(
+            "--report",
+            str(report),
+            "--section",
+            str(section),
+            "--out",
+            str(out),
+        )
+
+        assert result.returncode == 1
+        assert not out.exists()
+        assert "refusing to insert a duplicate" in result.stderr
+
+
+def test_missing_section_fails_by_default() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-insert-release-section-") as tmp:
+        tmp_path = Path(tmp)
+        report = tmp_path / "report_card.html"
+        missing_section = tmp_path / "missing_release_decision_v0_ledger_section.html"
+        out = tmp_path / "report_card.with_release_decision.html"
+
+        _write(report, _report_with_body())
+
+        result = _run(
+            "--report",
+            str(report),
+            "--section",
+            str(missing_section),
+            "--out",
+            str(out),
+        )
+
+        assert result.returncode == 1
+        assert not out.exists()
+        assert "release decision section is missing" in result.stderr
+
+
+def test_allow_missing_section_inserts_explicit_missing_placeholder() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-insert-release-section-") as tmp:
+        tmp_path = Path(tmp)
+        report = tmp_path / "report_card.html"
+        missing_section = tmp_path / "missing_release_decision_v0_ledger_section.html"
+        out = tmp_path / "report_card.with_release_decision.html"
+
+        _write(report, _report_with_body())
+
+        result = _run(
+            "--report",
+            str(report),
+            "--section",
+            str(missing_section),
+            "--out",
+            str(out),
+            "--allow-missing-section",
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert out.exists()
+
+        html = _read(out)
+
+        assert "MISSING" in html
+        assert "must not infer" in html
+        assert "STAGE-PASS" in html
+        assert "PROD-PASS" in html
+        assert "<!-- PULSE_RELEASE_DECISION_V0_SECTION_START -->" in html
+
+
+def test_in_place_updates_report_file() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-insert-release-section-") as tmp:
+        tmp_path = Path(tmp)
+        report = tmp_path / "report_card.html"
+        section = tmp_path / "release_decision_v0_ledger_section.html"
+
+        _write(report, _report_with_body())
+        _write(section, _section("STAGE-PASS"))
+
+        result = _run(
+            "--report",
+            str(report),
+            "--section",
+            str(section),
+            "--in-place",
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        html = _read(report)
+
+        assert "STAGE-PASS" in html
+        assert "<!-- PULSE_RELEASE_DECISION_V0_SECTION_START -->" in html
+        assert "out=" in result.stdout
+
+
+def test_partial_marker_pair_fails_closed() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-insert-release-section-") as tmp:
+        tmp_path = Path(tmp)
+        report = tmp_path / "report_card.html"
+        section = tmp_path / "release_decision_v0_ledger_section.html"
+        out = tmp_path / "report_card.with_release_decision.html"
+
+        broken_marked_report = """<!doctype html>
+<html>
+<body>
+  <h1>Quality Ledger</h1>
+  <!-- PULSE_RELEASE_DECISION_V0_SECTION_START -->
+  <section id="release-decision-v0">
+    <span>Broken marker pair</span>
+  </section>
+</body>
+</html>
+"""
+        _write(report, broken_marked_report)
+        _write(section, _section("PROD-PASS"))
+
+        result = _run(
+            "--report",
+            str(report),
+            "--section",
+            str(section),
+            "--out",
+            str(out),
+        )
+
+        assert result.returncode == 1
+        assert not out.exists()
+        assert "both START and END markers are required" in result.stderr
+
+
+def main() -> int:
+    tests = [
+        test_insert_section_before_closing_body,
+        test_append_section_when_report_has_no_body_close,
+        test_replace_existing_marked_section,
+        test_refuse_duplicate_unmarked_release_decision_section,
+        test_missing_section_fails_by_default,
+        test_allow_missing_section_inserts_explicit_missing_placeholder,
+        test_in_place_updates_report_file,
+        test_partial_marker_pair_fails_closed,
+    ]
+
+    for test in tests:
+        try:
+            test()
+        except AssertionError as exc:
+            print(f"ERROR in {test.__name__}: {exc}")
+            return 1
+        except Exception as exc:
+            print(f"ERROR in {test.__name__}: unexpected exception: {exc}")
+            return 1
+
+    print("OK: release decision ledger insertion smoke checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds smoke coverage for the release decision report-card composition
helper.

New file:

```text
tests/test_insert_release_decision_ledger_section_smoke.py
```

Updated file:

```text
ci/tools-tests.list
```

## Why

`PULSE_safe_pack_v0/tools/insert_release_decision_ledger_section.py` was added
as a standalone artifact-composition helper.

It inserts:

```text
PULSE_safe_pack_v0/artifacts/release_decision_v0_ledger_section.html
```

into:

```text
PULSE_safe_pack_v0/artifacts/report_card.html
```

and writes:

```text
PULSE_safe_pack_v0/artifacts/report_card.with_release_decision.html
```

by default.

This PR locks in the safe composition behavior before the helper is wired into
the primary workflow or report generation path.

## What the test covers

### Insert before closing body

When `report_card.html` contains a closing `</body>` tag, the release decision
section is inserted before it.

### Append at EOF

When the report has no closing body tag, the release decision section is
appended at EOF.

### Replace existing marked section

If the report already contains:

```html
<!-- PULSE_RELEASE_DECISION_V0_SECTION_START -->
...
<!-- PULSE_RELEASE_DECISION_V0_SECTION_END -->
```

the tool replaces the marked block instead of appending a duplicate.

### Refuse duplicate unmarked section

If the report already contains:

```html
<section id="release-decision-v0">
```

but no stable markers, the tool fails instead of inserting a duplicate.

### Missing section fails by default

If `release_decision_v0_ledger_section.html` is missing, the tool exits non-zero
by default.

### Explicit missing placeholder mode

With:

```text
--allow-missing-section
```

the tool inserts a visible MISSING placeholder and still does not infer
`STAGE-PASS`, `PROD-PASS`, or any release-level result.

### In-place mode

With:

```text
--in-place
```

the tool overwrites the report path explicitly.

### Partial marker pair fails closed

If only one marker is present, the tool fails closed instead of producing a
corrupted report.

## Manifest registration

Because the new file matches:

```text
tests/test_*_smoke.py
```

it is registered in:

```text
ci/tools-tests.list
```

Recommended nearby block:

```text
tests/test_release_decision_v0_schema_smoke.py
tests/test_render_release_decision_ledger_section_smoke.py
tests/test_insert_release_decision_ledger_section_smoke.py

tools/operator_handoff_smoke.py
```

## What did not change

This PR does not change:

- `PULSE_safe_pack_v0/tools/insert_release_decision_ledger_section.py`
- `PULSE_safe_pack_v0/tools/render_release_decision_ledger_section.py`
- `PULSE_safe_pack_v0/tools/materialize_release_decision.py`
- `schemas/release_decision_v0.schema.json`
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- primary CI release semantics
- main Quality Ledger/report-card integration
- shadow-layer authority
- break-glass behavior

## Boundary

This is a test-only PR.

It verifies the standalone composition helper.

The tool remains an artifact-composition helper only:

```text
release_decision_v0_ledger_section.html
+ report_card.html
→ report_card.with_release_decision.html
```

It does not compute or redefine release decisions.

## Follow-up work

Recommended next PRs:

1. Wire release decision materialization, section rendering, and report insertion into the primary release workflow as uploaded artifacts.
2. Add CI artifact upload coverage for `release_decision_v0.json`, `release_decision_v0_ledger_section.html`, and `report_card.with_release_decision.html`.
3. Later, add `break_glass_override_v0` as a separate audited governance artifact.

## Checklist

- [ ] insertion before `</body>` covered
- [ ] EOF append covered
- [ ] marked replacement covered
- [ ] duplicate unmarked section refusal covered
- [ ] missing section default failure covered
- [ ] `--allow-missing-section` placeholder covered
- [ ] `--in-place` covered
- [ ] partial marker pair failure covered
- [ ] tools-tests manifest updated
- [ ] no runtime release behavior changed
- [ ] no gate policy changed
- [ ] no CI release behavior changed
