### PR TITLE
ci(release): materialize release decision artifact

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1195,6 +1195,51 @@ jobs:
 
           echo "OK: artifact postconditions satisfied (IS_RELEASE=$IS_RELEASE)"
 
+      - name: "Release decision v0: materialize artifact"
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PACK_DIR="${{ env.PACK_DIR }}"
+          STATUS_PATH="${PACK_DIR}/artifacts/status.json"
+          OUT_PATH="${PACK_DIR}/artifacts/release_decision_v0.json"
+          TARGET="stage"
+
+          if [[ "${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') }}" == "true" ]]; then
+            TARGET="prod"
+          fi
+
+          echo "release_decision_v0 target=${TARGET}"
+          echo "release_decision_v0 status=${STATUS_PATH}"
+          echo "release_decision_v0 out=${OUT_PATH}"
+
+          set +e
+          python "${PACK_DIR}/tools/materialize_release_decision.py" \
+            --status "${STATUS_PATH}" \
+            --policy pulse_gate_policy_v0.yml \
+            --target "${TARGET}" \
+            --out "${OUT_PATH}" \
+            --status-schema schemas/status/status_v1.schema.json
+          rc=$?
+          set -e
+
+          echo "release_decision_v0 materializer exit code: ${rc}"
+
+          if [[ -f "${OUT_PATH}" ]]; then
+            echo "OK: release_decision_v0 artifact written: ${OUT_PATH}"
+          else
+            echo "::warning::release_decision_v0 artifact was not written"
+          fi
+
+          {
+            echo "### Release decision v0"
+            echo ""
+            echo "- target: \`${TARGET}\`"
+            echo "- materializer exit code: \`${rc}\`"
+            echo "- artifact: \`${OUT_PATH}\`"
+          } >> "${GITHUB_STEP_SUMMARY}
+
       - name: Export JUnit and SARIF from final status
         if: always()
         shell: bash

--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1238,7 +1238,7 @@ jobs:
             echo "- target: \`${TARGET}\`"
             echo "- materializer exit code: \`${rc}\`"
             echo "- artifact: \`${OUT_PATH}\`"
-          } >> "${GITHUB_STEP_SUMMARY}
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Export JUnit and SARIF from final status
         if: always()


### PR DESCRIPTION
## Summary

This PR wires `release_decision_v0` materialization into the primary PULSE CI workflow.

### Modified file

.github/workflows/pulse_ci.yml

The workflow now writes:

PULSE_safe_pack_v0/artifacts/release_decision_v0.json

---

## Why

The `release_decision_v0` stack now has:

- contract docs
- JSON Schema
- materializer tool
- materializer smoke coverage
- schema-validation smoke coverage

The next step is to produce the release decision artifact in CI so it becomes
available as an audit/publication surface.

---

## What changed

A new workflow step runs:

PULSE_safe_pack_v0/tools/materialize_release_decision.py

using:

- PULSE_safe_pack_v0/artifacts/status.json
- pulse_gate_policy_v0.yml
- schemas/status/status_v1.schema.json

and writes:

PULSE_safe_pack_v0/artifacts/release_decision_v0.json

---

## Target selection

The workflow uses:

target=prod

for:

- version tags v*
- version tags V*
- workflow_dispatch with strict_external_evidence=true

Otherwise it uses:

target=stage

---

## Important boundary

This PR does NOT make `release_decision_v0` a new enforcement gate.

The materializer may emit a valid FAIL release decision and return a non-zero
exit code. The workflow captures that exit code and continues so the artifact
can still be uploaded and inspected.

The current release-authority center remains unchanged:

- status.json
- materialized required gates
- check_gates.py
- primary release-gating workflow

---

## What did not change

This PR does NOT change:

- PULSE_safe_pack_v0/tools/materialize_release_decision.py
- schemas/release_decision_v0.schema.json
- status.json
- check_gates.py
- pulse_gate_policy_v0.yml
- primary gate enforcement semantics
- Quality Ledger rendering
- shadow-layer authority
- break-glass behavior

---

## Follow-up work

Next PRs:

- Render release_decision_v0_ledger_section.html in CI
- Compose report_card.with_release_decision.html in CI
- Add CI artifact upload visibility if the existing artifact glob does not already include these outputs

---

## Checklist

- [x] workflow materializes release_decision_v0.json
- [x] target selection distinguishes prod vs stage
- [x] materializer FAIL does not become a new CI gate
- [x] step writes release decision info to Step Summary
- [x] no gate policy changed
- [x] no check_gates.py behavior changed
- [x] no primary release enforcement semantics changed
- [x] no Quality Ledger behavior changed
- [x] no break-glass behavior changed