### PR TITLE
ci(ledger): render release decision section artifact

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1240,6 +1240,48 @@ jobs:
             echo "- artifact: \`${OUT_PATH}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 
+      - name: "Release decision v0: render ledger section"
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PACK_DIR="${{ env.PACK_DIR }}"
+          INPUT_PATH="${PACK_DIR}/artifacts/release_decision_v0.json"
+          OUT_PATH="${PACK_DIR}/artifacts/release_decision_v0_ledger_section.html"
+          SCHEMA_PATH="schemas/release_decision_v0.schema.json"
+
+          echo "release_decision_v0 ledger input=${INPUT_PATH}"
+          echo "release_decision_v0 ledger out=${OUT_PATH}"
+          echo "release_decision_v0 schema=${SCHEMA_PATH}"
+
+          set +e
+          python "${PACK_DIR}/tools/render_release_decision_ledger_section.py" \
+            --input "${INPUT_PATH}" \
+            --schema "${SCHEMA_PATH}" \
+            --out "${OUT_PATH}"
+          rc=$?
+          set -e
+
+          echo "release_decision_v0 ledger renderer exit code: ${rc}"
+
+          if [[ -f "${OUT_PATH}" ]]; then
+            echo "OK: release_decision_v0 ledger section written: ${OUT_PATH}"
+          else
+            echo "::warning::release_decision_v0 ledger section was not written"
+          fi
+
+          if [[ "${rc}" -ne 0 ]]; then
+            echo "::warning::release_decision_v0 ledger renderer returned ${rc}; artifact may contain INVALID/MISSING output"
+          fi
+
+          {
+            printf '### Release decision v0 Ledger section\n\n'
+            printf -- '- renderer exit code: `%s`\n' "${rc}"
+            printf -- '- input: `%s`\n' "${INPUT_PATH}"
+            printf -- '- output: `%s`\n' "${OUT_PATH}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Export JUnit and SARIF from final status
         if: always()
         shell: bash


### PR DESCRIPTION
## Summary

This PR wires release decision Ledger section rendering into the primary PULSE CI workflow.

Modified file:

```text
.github/workflows/pulse_ci.yml
```

The workflow now writes:

```text
PULSE_safe_pack_v0/artifacts/release_decision_v0_ledger_section.html
```

## Why

The workflow now materializes:

```text
PULSE_safe_pack_v0/artifacts/release_decision_v0.json
```

The next step is to render that artifact into a human-readable Quality Ledger HTML section.

This PR does **not** insert the section into the main report card yet.  
It only publishes the standalone rendered section artifact.

## What changed

A new workflow step runs:

```text
PULSE_safe_pack_v0/tools/render_release_decision_ledger_section.py
```

using:

```text
PULSE_safe_pack_v0/artifacts/release_decision_v0.json
schemas/release_decision_v0.schema.json
```

and writes:

```text
PULSE_safe_pack_v0/artifacts/release_decision_v0_ledger_section.html
```

## Behavior

The renderer may produce one of these section states:

- valid `FAIL`
- valid `STAGE-PASS`
- valid `PROD-PASS`
- `MISSING`
- `INVALID`

The workflow records the renderer exit code in the GitHub Step Summary.

A non-zero renderer exit code is reported as a warning, not as a new release gate.

## Boundary

This PR is artifact publication only.

It does not make the rendered Ledger section part of release enforcement.

The release-authority center remains:

```text
status.json
+ materialized required gates
+ check_gates.py
+ primary release-gating workflow
```

The release decision artifact remains:

```text
release_decision_v0.json
```

The rendered section is a read-only human-facing surface:

```text
release_decision_v0.json
  → release_decision_v0_ledger_section.html
```

## What did not change

This PR does not change:

- `PULSE_safe_pack_v0/tools/render_release_decision_ledger_section.py`
- `PULSE_safe_pack_v0/tools/materialize_release_decision.py`
- `schemas/release_decision_v0.schema.json`
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- primary release enforcement semantics
- main report-card composition
- shadow-layer authority
- break-glass behavior

## Follow-up work

Next PR:

1. Compose `release_decision_v0_ledger_section.html` into `report_card.with_release_decision.html` in CI.

Later:

2. Add CI artifact upload visibility if the existing artifact glob does not already include the new files.
3. Add `break_glass_override_v0` as a separate audited governance artifact.

## Checklist

- [ ] workflow renders `release_decision_v0_ledger_section.html`
- [ ] renderer uses `schemas/release_decision_v0.schema.json`
- [ ] renderer exit code is recorded in Step Summary
- [ ] non-zero renderer exit code is warning-only in this PR
- [ ] no release enforcement semantics changed
- [ ] no gate policy changed
- [ ] no `check_gates.py` behavior changed
- [ ] no materializer behavior changed
- [ ] no break-glass behavior changed