### PR TITLE
ci(ledger): compose release decision report artifact

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1282,6 +1282,61 @@ jobs:
             printf -- '- output: `%s`\n' "${OUT_PATH}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
+      - name: "Release decision v0: compose report card"
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PACK_DIR="${{ env.PACK_DIR }}"
+          REPORT_PATH="${PACK_DIR}/artifacts/report_card.html"
+          SECTION_PATH="${PACK_DIR}/artifacts/release_decision_v0_ledger_section.html"
+          OUT_PATH="${PACK_DIR}/artifacts/report_card.with_release_decision.html"
+
+          echo "release_decision_v0 report=${REPORT_PATH}"
+          echo "release_decision_v0 section=${SECTION_PATH}"
+          echo "release_decision_v0 composed=${OUT_PATH}"
+
+          if [[ ! -f "${REPORT_PATH}" ]]; then
+            echo "::warning::report_card.html is missing; skipping release decision report composition"
+            {
+              printf '### Release decision v0 composed report\n\n'
+              printf -- '- status: `skipped`\n'
+              printf -- '- reason: `report_card.html missing`\n'
+              printf -- '- expected report: `%s`\n' "${REPORT_PATH}"
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          set +e
+          python "${PACK_DIR}/tools/insert_release_decision_ledger_section.py" \
+            --report "${REPORT_PATH}" \
+            --section "${SECTION_PATH}" \
+            --out "${OUT_PATH}" \
+            --allow-missing-section
+          rc=$?
+          set -e
+
+          echo "release_decision_v0 report composition exit code: ${rc}"
+
+          if [[ -f "${OUT_PATH}" ]]; then
+            echo "OK: composed release decision report written: ${OUT_PATH}"
+          else
+            echo "::warning::composed release decision report was not written"
+          fi
+
+          if [[ "${rc}" -ne 0 ]]; then
+            echo "::warning::release_decision_v0 report composition returned ${rc}; composed report may be unavailable"
+          fi
+
+          {
+            printf '### Release decision v0 composed report\n\n'
+            printf -- '- composer exit code: `%s`\n' "${rc}"
+            printf -- '- report: `%s`\n' "${REPORT_PATH}"
+            printf -- '- section: `%s`\n' "${SECTION_PATH}"
+            printf -- '- output: `%s`\n' "${OUT_PATH}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+      
       - name: Export JUnit and SARIF from final status
         if: always()
         shell: bash


### PR DESCRIPTION
## Summary

This PR wires release-decision report-card composition into the primary PULSE CI workflow.

### Modified file

.github/workflows/pulse_ci.yml

The workflow now writes:

PULSE_safe_pack_v0/artifacts/report_card.with_release_decision.html

---

## Why

The workflow already materializes:

PULSE_safe_pack_v0/artifacts/release_decision_v0.json

and renders:

PULSE_safe_pack_v0/artifacts/release_decision_v0_ledger_section.html

The next step is to compose that rendered section into a report-card artifact,
while keeping the Quality Ledger/report card as a read-only view.

---

## What changed

A new workflow step runs:

PULSE_safe_pack_v0/tools/insert_release_decision_ledger_section.py

using:

- PULSE_safe_pack_v0/artifacts/report_card.html
- PULSE_safe_pack_v0/artifacts/release_decision_v0_ledger_section.html

and writes:

PULSE_safe_pack_v0/artifacts/report_card.with_release_decision.html

---

## Behavior

- If report_card.html is missing, the workflow emits a warning and skips report composition.

- If release_decision_v0_ledger_section.html is missing, the composition helper is invoked with:

  --allow-missing-section

  so the composed report contains an explicit MISSING placeholder rather than silently implying a release pass.

- The composition step records its exit code in the GitHub Step Summary.

- A non-zero composer exit code is warning-only in this PR.

---

## Boundary

This PR is artifact publication only.

It does NOT make the composed report a new release authority source.

### Correct direction

release_decision_v0.json  
→ release_decision_v0_ledger_section.html  
→ report_card.with_release_decision.html  

### Incorrect direction

report_card.with_release_decision.html  
→ release decision  

---

## Release authority remains unchanged

- status.json  
- materialized required gates  
- check_gates.py  
- primary release-gating workflow  

---

## What did not change

This PR does NOT change:

- PULSE_safe_pack_v0/tools/insert_release_decision_ledger_section.py  
- PULSE_safe_pack_v0/tools/render_release_decision_ledger_section.py  
- PULSE_safe_pack_v0/tools/materialize_release_decision.py  
- schemas/release_decision_v0.schema.json  
- status.json  
- check_gates.py  
- pulse_gate_policy_v0.yml  
- primary release enforcement semantics  
- shadow-layer authority  
- break-glass behavior  

---

## Follow-up work

Recommended next PRs:

- Confirm existing artifact upload globs include:
  - release_decision_v0.json  
  - release_decision_v0_ledger_section.html  
  - report_card.with_release_decision.html  

- Add explicit artifact upload paths if needed.

- Add CI summary details for the release decision artifact.

- Later, add break_glass_override_v0 as a separate audited governance artifact.

---

## Checklist

- [x] workflow composes report_card.with_release_decision.html  
- [x] missing report_card.html is warning-only  
- [x] missing release-decision section inserts explicit MISSING placeholder  
- [x] composer exit code is written to Step Summary  
- [x] non-zero composer exit code does not become a new release gate in this PR  
- [x] no release enforcement semantics changed  
- [x] no gate policy changed  
- [x] no check_gates.py behavior changed  
- [x] no materializer behavior changed  
- [x] no renderer behavior changed  
- [x] no break-glass behavior changed  