### PR TITLE
ci(release): upload release decision artifacts

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1337,6 +1337,18 @@ jobs:
             printf -- '- output: `%s`\n' "${OUT_PATH}"
           } >> "${GITHUB_STEP_SUMMARY}"
       
+      - name: "Upload release decision v0 artifact bundle"
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        with:
+          name: release-decision-v0
+          if-no-files-found: warn
+          path: |
+            ${{ env.PACK_DIR }}/artifacts/status.json
+            ${{ env.PACK_DIR }}/artifacts/release_decision_v0.json
+            ${{ env.PACK_DIR }}/artifacts/release_decision_v0_ledger_section.html
+            ${{ env.PACK_DIR }}/artifacts/report_card.with_release_decision.html
+      
       - name: Export JUnit and SARIF from final status
         if: always()
         shell: bash


### PR DESCRIPTION
## Summary

This PR adds an explicit CI artifact upload for the `release_decision_v0` bundle.

Modified file:

```text
.github/workflows/pulse_ci.yml
```

The workflow now uploads these files under the artifact name:

```text
release-decision-v0
```

Included paths:

```text
PULSE_safe_pack_v0/artifacts/release_decision_v0.json
PULSE_safe_pack_v0/artifacts/release_decision_v0_ledger_section.html
PULSE_safe_pack_v0/artifacts/report_card.with_release_decision.html
```

## Why

The primary workflow now materializes and renders the release-decision chain:

```text
status.json
→ release_decision_v0.json
→ release_decision_v0_ledger_section.html
→ report_card.with_release_decision.html
```

This PR makes those outputs explicitly available as a named CI artifact bundle.

That improves auditability and makes review easier.

## What changed

Added an `actions/upload-artifact@v4` step:

```yaml
name: release-decision-v0
```

with:

```yaml
if-no-files-found: warn
```

so missing files are visible as warnings but do not create a new release gate.

## Boundary

This is artifact publication only.

It does not make `release_decision_v0` a new enforcement source.

The release-authority center remains unchanged:

```text
status.json
+ materialized required gates
+ check_gates.py
+ primary release-gating workflow
```

## What did not change

This PR does not change:

- `PULSE_safe_pack_v0/tools/materialize_release_decision.py`
- `PULSE_safe_pack_v0/tools/render_release_decision_ledger_section.py`
- `PULSE_safe_pack_v0/tools/insert_release_decision_ledger_section.py`
- `schemas/release_decision_v0.schema.json`
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- primary release enforcement semantics
- shadow-layer authority
- break-glass behavior

## Follow-up work

Recommended next PRs:

1. Add a concise GitHub Step Summary section that links or summarizes the uploaded artifact.
2. Later, add `break_glass_override_v0` as a separate audited governance artifact.

## Checklist

- [ ] uploads `release_decision_v0.json`
- [ ] uploads `release_decision_v0_ledger_section.html`
- [ ] uploads `report_card.with_release_decision.html`
- [ ] artifact name is `release-decision-v0`
- [ ] missing files warn instead of becoming a new gate
- [ ] no release enforcement semantics changed
- [ ] no gate policy changed
- [ ] no `check_gates.py` behavior changed
- [ ] no break-glass behavior changed
```
