### PR TITLE
ci(release): summarize release decision artifact

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1349,6 +1349,143 @@ jobs:
             ${{ env.PACK_DIR }}/artifacts/release_decision_v0_ledger_section.html
             ${{ env.PACK_DIR }}/artifacts/report_card.with_release_decision.html
       
+      - name: "Release decision v0: summarize artifact"
+        if: always()
+        shell: bash
+        env:
+          RELEASE_DECISION_PATH: ${{ env.PACK_DIR }}/artifacts/release_decision_v0.json
+        run: |
+          set -euo pipefail
+
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          from pathlib import Path
+          from typing import Any
+
+
+          decision_path = Path(os.environ["RELEASE_DECISION_PATH"])
+          summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
+
+
+          def _safe_text(value: Any) -> str:
+              if value is None:
+                  return "missing"
+              text = str(value)
+              return text.replace("\n", " ").replace("\r", " ").strip()
+
+
+          def _list_text(value: Any) -> str:
+              if isinstance(value, list):
+                  if not value:
+                      return "none"
+                  return ", ".join(_safe_text(item) for item in value)
+              if value is None:
+                  return "missing"
+              return _safe_text(value)
+
+
+          def _write_summary(markdown: str) -> None:
+              with summary_path.open("a", encoding="utf-8") as f:
+                  f.write(markdown.rstrip() + "\n")
+
+
+          lines: list[str] = []
+          lines.append("### Release decision v0 summary")
+          lines.append("")
+
+          if not decision_path.exists():
+              print(f"::warning::release_decision_v0 artifact missing: {decision_path}")
+              lines.append("- status: `missing`")
+              lines.append(f"- artifact: `{decision_path}`")
+              lines.append("")
+              lines.append("The workflow did not find a materialized release decision artifact.")
+              _write_summary("\n".join(lines))
+              raise SystemExit(0)
+
+          try:
+              payload = json.loads(decision_path.read_text(encoding="utf-8"))
+          except Exception as exc:
+              print(f"::warning::release_decision_v0 artifact is not valid JSON: {exc}")
+              lines.append("- status: `invalid-json`")
+              lines.append(f"- artifact: `{decision_path}`")
+              lines.append(f"- error: `{_safe_text(exc)}`")
+              _write_summary("\n".join(lines))
+              raise SystemExit(0)
+
+          if not isinstance(payload, dict):
+              print("::warning::release_decision_v0 artifact root is not an object")
+              lines.append("- status: `invalid-root`")
+              lines.append(f"- artifact: `{decision_path}`")
+              _write_summary("\n".join(lines))
+              raise SystemExit(0)
+
+          conditions = payload.get("conditions")
+          if not isinstance(conditions, dict):
+              conditions = {}
+
+          blocking_reasons = payload.get("blocking_reasons")
+          if not isinstance(blocking_reasons, list):
+              blocking_reasons = []
+
+          decision_basis = payload.get("decision_basis")
+          if not isinstance(decision_basis, list):
+              decision_basis = []
+
+          release_level = _safe_text(payload.get("release_level"))
+          target = _safe_text(payload.get("target"))
+          run_mode = _safe_text(payload.get("run_mode"))
+          required_gates_passed = _safe_text(payload.get("required_gates_passed"))
+
+          lines.append(f"- artifact: `{decision_path}`")
+          lines.append(f"- release level: `{release_level}`")
+          lines.append(f"- target: `{target}`")
+          lines.append(f"- run mode: `{run_mode}`")
+          lines.append(f"- active gate sets: `{_list_text(payload.get('active_gate_sets'))}`")
+          lines.append(f"- required gates passed: `{required_gates_passed}`")
+          lines.append(
+              f"- external evidence mode: "
+              f"`{_safe_text(conditions.get('external_evidence_mode'))}`"
+          )
+          lines.append(f"- detectors materialized: `{_safe_text(conditions.get('detectors_materialized_ok'))}`")
+          lines.append(f"- external summaries present: `{_safe_text(conditions.get('external_summaries_present'))}`")
+          lines.append(f"- external all pass: `{_safe_text(conditions.get('external_all_pass'))}`")
+          lines.append(f"- stubbed: `{_safe_text(conditions.get('stubbed'))}`")
+          lines.append(f"- scaffold: `{_safe_text(conditions.get('scaffold'))}`")
+          lines.append("")
+
+          if blocking_reasons:
+              lines.append("#### Blocking reasons")
+              lines.append("")
+              for reason in blocking_reasons[:10]:
+                  lines.append(f"- {_safe_text(reason)}")
+              if len(blocking_reasons) > 10:
+                  lines.append(f"- ... {len(blocking_reasons) - 10} more")
+              lines.append("")
+          else:
+              lines.append("Blocking reasons: `none`")
+              lines.append("")
+
+          if decision_basis:
+              lines.append("#### Decision basis")
+              lines.append("")
+              for item in decision_basis[:8]:
+                  lines.append(f"- {_safe_text(item)}")
+              if len(decision_basis) > 8:
+                  lines.append(f"- ... {len(decision_basis) - 8} more")
+              lines.append("")
+
+          lines.append(
+              "> This summary is read-only. It does not replace `status.json`, "
+              "`check_gates.py`, the materialized required gate set, or the primary "
+              "release-gating workflow."
+          )
+
+          _write_summary("\n".join(lines))
+          PY
+      
       - name: Export JUnit and SARIF from final status
         if: always()
         shell: bash


### PR DESCRIPTION
## Summary

This PR adds a GitHub Step Summary section for the materialized
`release_decision_v0` artifact.

Modified file:

```text
.github/workflows/pulse_ci.yml
```

The summary reads:

```text
PULSE_safe_pack_v0/artifacts/release_decision_v0.json
```

and displays a concise human-readable overview.

## Why

The workflow now produces and uploads the release decision artifact chain:

```text
release_decision_v0.json
release_decision_v0_ledger_section.html
report_card.with_release_decision.html
```

This PR makes the key release decision state visible directly in the GitHub
Actions Step Summary.

That helps reviewers quickly see:

- whether the materialized release decision is `FAIL`, `STAGE-PASS`, or `PROD-PASS`,
- which target was evaluated,
- whether external evidence was advisory or required,
- whether stub/scaffold diagnostics blocked the release level,
- what blocking reasons were recorded.

## What changed

A new workflow step reads:

```text
PULSE_safe_pack_v0/artifacts/release_decision_v0.json
```

and appends a Markdown summary to:

```text
GITHUB_STEP_SUMMARY
```

The summary includes:

- artifact path
- release level
- target
- run mode
- active gate sets
- required gate pass state
- external evidence mode
- detector/external condition state
- stubbed/scaffold state
- blocking reasons
- decision basis

## Missing or invalid artifact behavior

If the release decision artifact is missing, the step writes a warning and
records a `missing` summary.

If the artifact is not valid JSON, the step writes a warning and records an
`invalid-json` summary.

These conditions do not turn this summary step into a new release gate.

## Boundary

This PR is visibility-only.

It does not make the GitHub Step Summary a release-authority source.

The release-authority center remains:

```text
status.json
+ materialized required gates
+ check_gates.py
+ primary release-gating workflow
```

The Step Summary is a read-only consumer of:

```text
release_decision_v0.json
```

## What did not change

This PR does not change:

- `PULSE_safe_pack_v0/tools/materialize_release_decision.py`
- `PULSE_safe_pack_v0/tools/render_release_decision_ledger_section.py`
- `PULSE_safe_pack_v0/tools/insert_release_decision_ledger_section.py`
- `schemas/release_decision_v0.schema.json`
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- primary release enforcement semantics
- artifact upload behavior
- shadow-layer authority
- break-glass behavior

## Follow-up work

Recommended next step:

1. Begin `break_glass_override_v0` as a separate audited governance artifact.

## Checklist

- [ ] Step Summary reads `release_decision_v0.json`
- [ ] release level appears in summary
- [ ] target appears in summary
- [ ] blocking reasons appear when present
- [ ] missing artifact is warning-only
- [ ] invalid JSON artifact is warning-only
- [ ] summary does not become release authority
- [ ] no release enforcement semantics changed
- [ ] no gate policy changed
- [ ] no break-glass behavior changed