### PR TITLE
feat(governance): add break-glass override v0 schema

### DIFF
--- a/schemas/break_glass_override_v0.schema.json
+++ b/schemas/break_glass_override_v0.schema.json
@@ -1,0 +1,406 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eplabsai.example/schemas/break_glass_override_v0.schema.json",
+  "title": "PULSEmech Break-glass Override v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "version",
+    "created_utc",
+    "override_id",
+    "status",
+    "target",
+    "release_decision_path",
+    "release_decision_sha256",
+    "release_level_before_override",
+    "requested_by",
+    "request_reason"
+  ],
+  "properties": {
+    "schema": {
+      "const": "pulse_break_glass_override_v0"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^0\\.[0-9]+\\.[0-9]+$"
+    },
+    "created_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "override_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^BG-[A-Za-z0-9_.:-]+$"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "requested",
+        "accepted",
+        "rejected",
+        "expired",
+        "revoked"
+      ]
+    },
+    "target": {
+      "type": "string",
+      "enum": [
+        "stage",
+        "prod"
+      ]
+    },
+    "release_decision_path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "release_decision_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "release_level_before_override": {
+      "type": "string",
+      "enum": [
+        "FAIL",
+        "STAGE-PASS",
+        "PROD-PASS"
+      ]
+    },
+    "requested_by": {
+      "type": "string",
+      "minLength": 1
+    },
+    "request_reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "review": {
+      "$ref": "#/$defs/review"
+    },
+    "risk_acceptance": {
+      "$ref": "#/$defs/risk_acceptance"
+    },
+    "expires_utc": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "followups": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/followup"
+      }
+    },
+    "revocation": {
+      "$ref": "#/$defs/revocation"
+    }
+  },
+  "$defs": {
+    "review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reviewed_by",
+        "reviewed_utc",
+        "decision",
+        "decision_reason"
+      ],
+      "properties": {
+        "reviewed_by": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reviewed_utc": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "decision": {
+          "type": "string",
+          "enum": [
+            "accepted",
+            "rejected"
+          ]
+        },
+        "decision_reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "risk_acceptance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scope",
+        "known_risks",
+        "mitigations"
+      ],
+      "properties": {
+        "scope": {
+          "type": "string",
+          "minLength": 1
+        },
+        "known_risks": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        },
+        "mitigations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "followup": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "owner",
+        "due_utc",
+        "action"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "due_utc": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "action": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "revocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "revoked_by",
+        "revoked_utc",
+        "revocation_reason"
+      ],
+      "properties": {
+        "revoked_by": {
+          "type": "string",
+          "minLength": 1
+        },
+        "revoked_utc": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revocation_reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "requested"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            {
+              "required": [
+                "review"
+              ]
+            },
+            {
+              "required": [
+                "risk_acceptance"
+              ]
+            },
+            {
+              "required": [
+                "expires_utc"
+              ]
+            },
+            {
+              "required": [
+                "revocation"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "accepted"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "then": {
+        "required": [
+          "review",
+          "risk_acceptance",
+          "expires_utc",
+          "followups"
+        ],
+        "properties": {
+          "review": {
+            "properties": {
+              "decision": {
+                "const": "accepted"
+              }
+            }
+          },
+          "expires_utc": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "followups": {
+            "minItems": 1
+          }
+        },
+        "not": {
+          "required": [
+            "revocation"
+          ]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "rejected"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "then": {
+        "required": [
+          "review"
+        ],
+        "properties": {
+          "review": {
+            "properties": {
+              "decision": {
+                "const": "rejected"
+              }
+            }
+          },
+          "expires_utc": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "not": {
+          "required": [
+            "revocation"
+          ]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "expired"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "then": {
+        "required": [
+          "review",
+          "risk_acceptance",
+          "expires_utc",
+          "followups"
+        ],
+        "properties": {
+          "review": {
+            "properties": {
+              "decision": {
+                "const": "accepted"
+              }
+            }
+          },
+          "expires_utc": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "followups": {
+            "minItems": 1
+          }
+        },
+        "not": {
+          "required": [
+            "revocation"
+          ]
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "revoked"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "then": {
+        "required": [
+          "review",
+          "risk_acceptance",
+          "revocation",
+          "followups"
+        ],
+        "properties": {
+          "review": {
+            "properties": {
+              "decision": {
+                "const": "accepted"
+              }
+            }
+          },
+          "followups": {
+            "minItems": 1
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds the JSON Schema for `break_glass_override_v0`.

New file:

```text
schemas/break_glass_override_v0.schema.json
```

## Why

`docs/BREAK_GLASS_OVERRIDE_v0.md` now defines the PULSEmech break-glass override
contract.

The next step is to encode that contract as a machine-readable schema.

Break-glass must remain:

- explicit,
- audited,
- temporary when accepted,
- separate from shadow layers,
- separate from normal release authority,
- and never a rewrite of `release_decision_v0`.

## What the schema covers

The schema defines the common break-glass request identity surface:

- `schema`
- `version`
- `created_utc`
- `override_id`
- `status`
- `target`
- `release_decision_path`
- `release_decision_sha256`
- `release_level_before_override`
- `requested_by`
- `request_reason`

It also defines state-specific requirements for:

- `requested`
- `accepted`
- `rejected`
- `expired`
- `revoked`

## State-specific behavior

### requested

Requested overrides are pre-review request artifacts.

They require only the common request identity fields.

They must not include:

- `review`
- `risk_acceptance`
- `expires_utc`
- `revocation`

This prevents the requested state from fabricating reviewer decisions before
review occurs.

### accepted

Accepted overrides require:

- `review`
- `review.decision = accepted`
- `risk_acceptance`
- `expires_utc`
- at least one follow-up

### rejected

Rejected overrides require:

- `review`
- `review.decision = rejected`

### expired

Expired overrides preserve the original accepted override context and require:

- `review`
- `review.decision = accepted`
- `risk_acceptance`
- `expires_utc`
- at least one follow-up

### revoked

Revoked overrides preserve the original accepted override context and require:

- `review`
- `review.decision = accepted`
- `risk_acceptance`
- `revocation`
- at least one follow-up

## What did not change

This PR does not add or modify:

- validator tooling
- renderer tooling
- CI workflow
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- `release_decision_v0`
- Quality Ledger rendering
- release enforcement behavior

## Boundary

This is a schema-contract PR only.

The normal release-authority center remains unchanged:

```text
status.json
+ materialized required gates
+ check_gates.py
+ release_decision_v0.json
```

Break-glass remains a separate audited exception artifact.

It does not turn `FAIL` into `PASS`.

## Follow-up work

Recommended next PRs:

1. Add `PULSE_safe_pack_v0/tools/validate_break_glass_override.py`.
2. Add break-glass schema/validator smoke tests.
3. Add break-glass Ledger rendering.
4. Add CI artifact publication for break-glass artifacts.

## Checklist

- [ ] schema file added under `schemas/`
- [ ] requested state does not require review
- [ ] requested state cannot include review/risk/expiry/revocation
- [ ] accepted state requires review, risk acceptance, expiry, and follow-up
- [ ] rejected state requires review
- [ ] expired state preserves accepted context
- [ ] revoked state requires revocation record
- [ ] no runtime behavior changed
- [ ] no gate policy changed
- [ ] no CI behavior changed
- [ ] no Ledger behavior changed