### PR TITLE
fix(governance): require expiry for revoked break-glass overrides

### DIFF
--- a/schemas/break_glass_override_v0.schema.json
+++ b/schemas/break_glass_override_v0.schema.json
@@ -396,6 +396,10 @@
               }
             }
           },
+           "expires_utc": {
+            "type": "string",
+            "format": "date-time"
+          },
           "followups": {
             "minItems": 1
           }


### PR DESCRIPTION
## Summary

This PR fixes the `revoked` state contract for `break_glass_override_v0`.

Modified files:

```text
schemas/break_glass_override_v0.schema.json
docs/BREAK_GLASS_OVERRIDE_v0.md
```

If the validator is part of this PR, also updated:

```text
PULSE_safe_pack_v0/tools/validate_break_glass_override.py
```

## Why

Codex correctly flagged that the `revoked` state did not require `expires_utc`.

A revoked break-glass override represents a previously accepted override that
was withdrawn before expiry.

Without `expires_utc`, the artifact loses the original accepted authorization
window. That weakens auditability because reviewers cannot verify whether the
revocation occurred before the override expired.

## What changed

For:

```text
status = revoked
```

the schema now requires:

- `review`
- `risk_acceptance`
- `expires_utc`
- `revocation`
- `followups`

and constrains:

```text
expires_utc
```

to be a non-null date-time string.

## Contract meaning

A revoked artifact must preserve the original accepted override context.

That includes:

```text
review.decision = accepted
risk_acceptance
expires_utc
followups
revocation
```

The `revocation` block records the withdrawal.

The `expires_utc` field preserves the original authorization window.

## What did not change

This PR does not change:

- release enforcement behavior
- gate policy
- `status.json`
- `check_gates.py`
- `release_decision_v0` materialization
- Quality Ledger rendering
- CI release behavior
- shadow-layer authority
- break-glass runtime behavior

## Boundary

This is a contract correction.

Break-glass remains:

- explicit
- audited
- separate from normal release authority
- never a rewrite of `release_decision_v0`
- never a hidden pass

## Checklist

- [ ] revoked overrides require `expires_utc`
- [ ] revoked `expires_utc` must be a non-null date-time
- [ ] docs updated to match schema
- [ ] validator updated if present in this PR
- [ ] no runtime release behavior changed
- [ ] no gate policy changed
- [ ] no CI behavior changed
- [ ] no Ledger behavior changed