### PR TITLE
fix(governance): require expiry for revoked break-glass overrides

### DIFF
--- a/schemas/break_glass_override_v0.schema.json
+++ b/schemas/break_glass_override_v0.schema.json
@@ -319,7 +319,8 @@
             "type": [
               "null",
               "string"
-            ]
+            ],
+            "format": "date-time"
           }
         },
         "not": {
@@ -385,6 +386,7 @@
         "required": [
           "review",
           "risk_acceptance",
+          "expires_utc",
           "revocation",
           "followups"
         ],
@@ -395,6 +397,10 @@
                 "const": "accepted"
               }
             }
+          },
+          "expires_utc": {
+            "type": "string",
+            "format": "date-time"
           },
           "followups": {
             "minItems": 1


### PR DESCRIPTION
## Summary

This PR replaces:

```text
schemas/break_glass_override_v0.schema.json
```

with a corrected schema that properly requires expiry metadata for revoked
break-glass overrides.

## Why

Codex correctly flagged that the previous schema update only constrained:

```text
expires_utc
```

when the field was present, but did not make it mandatory for:

```text
status = revoked
```

That meant a revoked break-glass override without any expiry timestamp could
still validate.

This is not acceptable for the break-glass audit model.

A revoked override means:

```text
a previously accepted override was withdrawn before expiry
```

Without `expires_utc`, the artifact loses the original accepted authorization
window and auditors cannot verify whether revocation occurred before the
override expired.

## What changed

For:

```text
status = revoked
```

the schema now requires:

```text
review
risk_acceptance
expires_utc
revocation
followups
```

and constrains:

```text
expires_utc
```

to a non-null date-time string.

The key corrected branch now includes:

```json
"required": [
  "review",
  "risk_acceptance",
  "expires_utc",
  "revocation",
  "followups"
]
```

and:

```json
"expires_utc": {
  "type": "string",
  "format": "date-time"
}
```

## Revoked state meaning

A revoked artifact must preserve the original accepted override context:

```text
review.decision = accepted
risk_acceptance
expires_utc
followups
```

and add the revocation record:

```text
revocation
```

This keeps the audit chain reconstructable:

```text
accepted override
→ active authorization window
→ revoked before expiry
```

## What did not change

This PR does not change:

- `docs/BREAK_GLASS_OVERRIDE_v0.md`
- validator tooling
- renderer tooling
- CI workflow
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- `release_decision_v0` materialization
- Quality Ledger rendering
- release enforcement behavior
- shadow-layer authority
- break-glass runtime behavior

## Boundary

This is a schema-contract correction only.

Break-glass remains:

- explicit
- audited
- separate from normal release authority
- not a shadow signal
- not a hidden pass
- not a rewrite of `release_decision_v0`

## Follow-up

A follow-up docs/validator alignment PR should update these surfaces if they do
not already require `expires_utc` for revoked overrides:

```text
docs/BREAK_GLASS_OVERRIDE_v0.md
PULSE_safe_pack_v0/tools/validate_break_glass_override.py
tests/test_break_glass_override_v0_smoke.py
```

## Checklist

- [ ] revoked overrides require `expires_utc`
- [ ] revoked `expires_utc` must be a non-null date-time
- [ ] revoked overrides still require `review`
- [ ] revoked overrides still require `risk_acceptance`
- [ ] revoked overrides still require `revocation`
- [ ] revoked overrides still require `followups`
- [ ] requested override semantics remain unchanged
- [ ] accepted override semantics remain unchanged
- [ ] rejected override semantics remain unchanged
- [ ] expired override semantics remain unchanged
- [ ] no runtime behavior changed
- [ ] no gate policy changed
- [ ] no CI behavior changed
- [ ] no Ledger behavior changed