### PR TITLE
docs(governance): align revoked break-glass expiry contract

### DIFF
--- a/docs/BREAK_GLASS_OVERRIDE_v0.md
+++ b/docs/BREAK_GLASS_OVERRIDE_v0.md
@@ -233,7 +233,10 @@ status records that the accepted override is no longer active
 For `status = revoked`:
 
 ```text
-review or revocation record is required
+review is required from the original accepted override
+risk_acceptance is required
+expires_utc is required and must preserve the original accepted override expiry
+revocation is required
 status records that the accepted override was withdrawn before expiry
 ```
 


### PR DESCRIPTION
## Summary

This PR updates the break-glass override documentation to align the `revoked`
state with the schema contract.

Modified file:

```text
docs/BREAK_GLASS_OVERRIDE_v0.md
```

## Why

The schema now requires `expires_utc` for:

```text
status = revoked
```

That is the correct behavior because a revoked override represents:

```text
a previously accepted break-glass authorization withdrawn before expiry
```

Without preserving the original expiry timestamp, downstream auditors cannot
verify whether the revocation occurred inside the original authorization window.

The documentation should say the same thing as the schema.

## What changed

The `revoked` state documentation now requires:

```text
review is required from the original accepted override
risk_acceptance is required
expires_utc is required and must preserve the original accepted override expiry
revocation is required
followups is required and must contain at least one item
status records that the accepted override was withdrawn before expiry
```

The review/expiry/audit language is also aligned so revoked artifacts preserve
enough context to reconstruct:

```text
accepted override
→ active authorization window
→ revoked before expiry
```

## Revoked state meaning

A revoked break-glass artifact must preserve the original accepted override
context:

```text
review.decision = accepted
risk_acceptance
expires_utc
followups
```

and add:

```text
revocation
```

The `expires_utc` field is not a new revocation timestamp. It preserves the
original accepted authorization window.

The revocation timestamp remains in:

```text
revocation.revoked_utc
```

## What did not change

This PR does not change:

- `schemas/break_glass_override_v0.schema.json`
- validator tooling
- renderer tooling
- CI workflow
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- `release_decision_v0` materialization
- Quality Ledger rendering
- release enforcement behavior
- shadow-layer authority
- break-glass runtime behavior

## Boundary

This is a docs-only contract alignment PR.

Break-glass remains:

- explicit
- audited
- separate from normal release authority
- not a shadow signal
- not a hidden pass
- not a rewrite of `release_decision_v0`

## Follow-up

If not already done, follow-up validator/test work should ensure revoked
overrides require:

```text
expires_utc
```

and reject revoked artifacts that omit the original accepted expiry timestamp.

## Checklist

- [ ] revoked docs require `expires_utc`
- [ ] docs clarify `expires_utc` preserves original accepted override expiry
- [ ] docs clarify `revocation.revoked_utc` records withdrawal time
- [ ] docs remain aligned with `schemas/break_glass_override_v0.schema.json`
- [ ] no schema changed
- [ ] no runtime behavior changed
- [ ] no gate policy changed
- [ ] no CI behavior changed
- [ ] no Ledger behavior changed