### PR TITLE
docs(governance): align revoked break-glass followups contract

### DIFF
--- a/docs/BREAK_GLASS_OVERRIDE_v0.md
+++ b/docs/BREAK_GLASS_OVERRIDE_v0.md
@@ -237,6 +237,7 @@ review is required from the original accepted override
 risk_acceptance is required
 expires_utc is required and must preserve the original accepted override expiry
 revocation is required
+followups is required and must contain at least one item
 status records that the accepted override was withdrawn before expiry
 ```
 


### PR DESCRIPTION
## Summary

This PR aligns the `revoked` break-glass documentation with the schema.

Modified file:

```text
docs/BREAK_GLASS_OVERRIDE_v0.md
```

## Why

Codex correctly flagged that the `status = revoked` documentation still omitted:

```text
followups
```

even though the schema requires revoked overrides to include followups with at
least one item.

Because the affected section is the state-specific required-field checklist, the
documentation must match the schema exactly.

## What changed

For:

```text
status = revoked
```

the docs now require:

```text
review is required from the original accepted override
risk_acceptance is required
expires_utc is required and must preserve the original accepted override expiry
revocation is required
followups is required and must contain at least one item
status records that the accepted override was withdrawn before expiry
```

## Contract meaning

A revoked break-glass artifact preserves the original accepted override context:

```text
review.decision = accepted
risk_acceptance
expires_utc
followups
```

and adds:

```text
revocation
```

The `followups` list remains required because revocation does not remove the
need to preserve remediation/audit obligations associated with the accepted
override.

## What did not change

This PR does not change:

- `schemas/break_glass_override_v0.schema.json`
- validator tooling
- renderer tooling
- CI workflow
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- `release_decision_v0` materialization
- Quality Ledger rendering
- release enforcement behavior
- shadow-layer authority
- break-glass runtime behavior

## Boundary

This is a docs-only schema-alignment fix.

Break-glass remains:

- explicit
- audited
- separate from normal release authority
- not a hidden pass
- not a rewrite of `release_decision_v0`

## Checklist

- [ ] revoked docs require `followups`
- [ ] revoked docs state `followups` must contain at least one item
- [ ] docs match `schemas/break_glass_override_v0.schema.json`
- [ ] no schema changed
- [ ] no runtime behavior changed
- [ ] no CI behavior changed
- [ ] no Ledger behavior changed