### PR TITLE
feat(governance): add break-glass override validator

### DIFF
--- a/PULSE_safe_pack_v0/tools/validate_break_glass_override.py
+++ b/PULSE_safe_pack_v0/tools/validate_break_glass_override.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DEFAULT_INPUT = (
+    REPO_ROOT
+    / "PULSE_safe_pack_v0"
+    / "artifacts"
+    / "break_glass_override_v0.json"
+)
+
+DEFAULT_SCHEMA = (
+    REPO_ROOT
+    / "schemas"
+    / "break_glass_override_v0.schema.json"
+)
+
+DEFAULT_RELEASE_DECISION_SCHEMA = (
+    REPO_ROOT
+    / "schemas"
+    / "release_decision_v0.schema.json"
+)
+
+EXPECTED_SCHEMA = "pulse_break_glass_override_v0"
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def _resolve_repo_path(raw: str) -> Path:
+    path = Path(raw)
+    if path.is_absolute():
+        return path
+    return REPO_ROOT / path
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _format_error_path(error: Any) -> str:
+    path = ".".join(str(part) for part in error.path)
+    return path or "<root>"
+
+
+def _validate_with_schema(
+    *,
+    payload: Any,
+    schema_path: Path,
+    label: str,
+) -> list[str]:
+    errors: list[str] = []
+
+    if not schema_path.is_file():
+        return [f"{label}: schema file is missing: {_rel(schema_path)}"]
+
+    try:
+        import jsonschema
+    except Exception as exc:
+        return [f"{label}: jsonschema import failed: {exc}"]
+
+    try:
+        schema = _read_json(schema_path)
+    except Exception as exc:
+        return [f"{label}: schema file could not be read: {exc}"]
+
+    try:
+        jsonschema.Draft202012Validator.check_schema(schema)
+    except Exception as exc:
+        return [f"{label}: schema file is not a valid JSON Schema: {exc}"]
+
+    try:
+        validator = jsonschema.Draft202012Validator(
+            schema,
+            format_checker=jsonschema.FormatChecker(),
+        )
+        validation_errors = sorted(
+            validator.iter_errors(payload),
+            key=lambda e: list(e.path),
+        )
+    except Exception as exc:
+        return [f"{label}: schema validation failed to run: {exc}"]
+
+    for error in validation_errors:
+        errors.append(f"{label}: {_format_error_path(error)}: {error.message}")
+
+    return errors
+
+
+def _semantic_errors(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    schema = payload.get("schema")
+    if schema != EXPECTED_SCHEMA:
+        errors.append(f"schema must be {EXPECTED_SCHEMA!r}, got {schema!r}")
+
+    status = payload.get("status")
+    release_level_before_override = payload.get("release_level_before_override")
+
+    if release_level_before_override != "FAIL":
+        errors.append(
+            "release_level_before_override must be 'FAIL'; "
+            "break-glass must not attach to a passing release decision"
+        )
+
+    if status == "requested":
+        for field in ("review", "risk_acceptance", "expires_utc", "revocation"):
+            if field in payload:
+                errors.append(
+                    f"requested override must not include {field!r}; "
+                    "requested is a pre-review state"
+                )
+
+    elif status == "accepted":
+        review = payload.get("review")
+        if isinstance(review, dict) and review.get("decision") != "accepted":
+            errors.append("accepted override requires review.decision == 'accepted'")
+
+        if payload.get("expires_utc") in (None, ""):
+            errors.append("accepted override requires a non-null expires_utc")
+
+        followups = payload.get("followups")
+        if not isinstance(followups, list) or not followups:
+            errors.append("accepted override requires at least one follow-up")
+
+        if "revocation" in payload:
+            errors.append("accepted override must not include revocation")
+
+    elif status == "rejected":
+        review = payload.get("review")
+        if isinstance(review, dict) and review.get("decision") != "rejected":
+            errors.append("rejected override requires review.decision == 'rejected'")
+
+        if "revocation" in payload:
+            errors.append("rejected override must not include revocation")
+
+    elif status == "expired":
+        review = payload.get("review")
+        if isinstance(review, dict) and review.get("decision") != "accepted":
+            errors.append(
+                "expired override must preserve the original accepted review decision"
+            )
+
+        if payload.get("expires_utc") in (None, ""):
+            errors.append("expired override requires expires_utc")
+
+        followups = payload.get("followups")
+        if not isinstance(followups, list) or not followups:
+            errors.append("expired override requires at least one follow-up")
+
+        if "revocation" in payload:
+            errors.append("expired override must not include revocation")
+
+    elif status == "revoked":
+        review = payload.get("review")
+        if isinstance(review, dict) and review.get("decision") != "accepted":
+            errors.append(
+                "revoked override must preserve the original accepted review decision"
+            )
+
+        followups = payload.get("followups")
+        if not isinstance(followups, list) or not followups:
+            errors.append("revoked override requires at least one follow-up")
+
+        revocation = payload.get("revocation")
+        if not isinstance(revocation, dict):
+            errors.append("revoked override requires a revocation record")
+
+    return errors
+
+
+def _release_decision_reference_errors(
+    *,
+    payload: dict[str, Any],
+    release_decision_path_override: str | None,
+    release_decision_schema_path: Path,
+) -> list[str]:
+    errors: list[str] = []
+
+    raw_path = release_decision_path_override
+    if raw_path is None:
+        raw_path = payload.get("release_decision_path")
+
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return ["release decision reference path is missing or not a string"]
+
+    release_decision_path = _resolve_repo_path(raw_path)
+
+    if not release_decision_path.is_file():
+        return [
+            "referenced release_decision_v0 artifact is missing: "
+            f"{_rel(release_decision_path)}"
+        ]
+
+    expected_sha = payload.get("release_decision_sha256")
+    actual_sha = _sha256(release_decision_path)
+
+    if expected_sha != actual_sha:
+        errors.append(
+            "release_decision_sha256 does not match referenced artifact: "
+            f"expected={expected_sha!r} actual={actual_sha!r}"
+        )
+
+    try:
+        release_decision = _read_json(release_decision_path)
+    except Exception as exc:
+        errors.append(f"referenced release_decision_v0 could not be read: {exc}")
+        return errors
+
+    if not isinstance(release_decision, dict):
+        errors.append("referenced release_decision_v0 root is not an object")
+        return errors
+
+    release_schema_errors = _validate_with_schema(
+        payload=release_decision,
+        schema_path=release_decision_schema_path,
+        label="release_decision_v0",
+    )
+    errors.extend(release_schema_errors)
+
+    expected_level = payload.get("release_level_before_override")
+    actual_level = release_decision.get("release_level")
+
+    if actual_level != expected_level:
+        errors.append(
+            "release_level_before_override does not match referenced "
+            "release_decision_v0.release_level: "
+            f"expected={expected_level!r} actual={actual_level!r}"
+        )
+
+    target = payload.get("target")
+    release_target = release_decision.get("target")
+
+    if isinstance(target, str) and isinstance(release_target, str):
+        if target != release_target:
+            errors.append(
+                "break-glass target does not match referenced release decision target: "
+                f"expected={target!r} actual={release_target!r}"
+            )
+
+    return errors
+
+
+def validate_break_glass_override(
+    *,
+    input_path: Path,
+    schema_path: Path,
+    release_decision_path_override: str | None,
+    release_decision_schema_path: Path,
+    check_release_decision_reference: bool,
+) -> tuple[bool, list[str]]:
+    errors: list[str] = []
+
+    if not input_path.is_file():
+        return False, [f"break-glass override artifact is missing: {_rel(input_path)}"]
+
+    try:
+        payload = _read_json(input_path)
+    except Exception as exc:
+        return False, [f"break-glass override artifact could not be read: {exc}"]
+
+    if not isinstance(payload, dict):
+        return False, ["break-glass override artifact root is not an object"]
+
+    errors.extend(
+        _validate_with_schema(
+            payload=payload,
+            schema_path=schema_path,
+            label="break_glass_override_v0",
+        )
+    )
+
+    errors.extend(_semantic_errors(payload))
+
+    if check_release_decision_reference:
+        errors.extend(
+            _release_decision_reference_errors(
+                payload=payload,
+                release_decision_path_override=release_decision_path_override,
+                release_decision_schema_path=release_decision_schema_path,
+            )
+        )
+
+    return not errors, errors
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate a PULSEmech break_glass_override_v0 artifact."
+    )
+
+    parser.add_argument(
+        "--input",
+        default=str(DEFAULT_INPUT),
+        help="Path to break_glass_override_v0.json.",
+    )
+    parser.add_argument(
+        "--schema",
+        default=str(DEFAULT_SCHEMA),
+        help="Path to schemas/break_glass_override_v0.schema.json.",
+    )
+    parser.add_argument(
+        "--release-decision",
+        default=None,
+        help=(
+            "Optional path to the referenced release_decision_v0.json. "
+            "When omitted, release_decision_path from the override artifact is used."
+        ),
+    )
+    parser.add_argument(
+        "--release-decision-schema",
+        default=str(DEFAULT_RELEASE_DECISION_SCHEMA),
+        help="Path to schemas/release_decision_v0.schema.json.",
+    )
+    parser.add_argument(
+        "--no-release-decision-check",
+        action="store_true",
+        help=(
+            "Validate only the break-glass artifact shape and semantics. "
+            "Do not require or validate the referenced release_decision_v0 artifact."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable validation summary.",
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    input_path = Path(args.input)
+    schema_path = Path(args.schema)
+    release_decision_schema_path = Path(args.release_decision_schema)
+
+    if not input_path.is_absolute():
+        input_path = REPO_ROOT / input_path
+    if not schema_path.is_absolute():
+        schema_path = REPO_ROOT / schema_path
+    if not release_decision_schema_path.is_absolute():
+        release_decision_schema_path = REPO_ROOT / release_decision_schema_path
+
+    ok, errors = validate_break_glass_override(
+        input_path=input_path,
+        schema_path=schema_path,
+        release_decision_path_override=args.release_decision,
+        release_decision_schema_path=release_decision_schema_path,
+        check_release_decision_reference=not args.no_release_decision_check,
+    )
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "ok": ok,
+                    "input": _rel(input_path),
+                    "schema": _rel(schema_path),
+                    "release_decision_check": not args.no_release_decision_check,
+                    "errors": errors,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    elif ok:
+        print(f"OK: break_glass_override_v0 is valid: {_rel(input_path)}")
+    else:
+        print(f"ERROR: break_glass_override_v0 is invalid: {_rel(input_path)}")
+        for error in errors:
+            print(f"- {error}")
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds the first runtime validator for `break_glass_override_v0`.

New file:

```text
PULSE_safe_pack_v0/tools/validate_break_glass_override.py
```

## Why

The break-glass stack now has:

- `docs/BREAK_GLASS_OVERRIDE_v0.md`
- `schemas/break_glass_override_v0.schema.json`

The next step is a validator that checks both schema shape and semantic
constraints.

Break-glass must remain explicit, audited, and separate from normal release
authority.

It must not become a hidden pass or a rewrite of `release_decision_v0`.

## What the validator checks

The validator checks the break-glass override artifact against:

```text
schemas/break_glass_override_v0.schema.json
```

It also performs semantic checks, including:

- break-glass must attach to `release_level_before_override = FAIL`
- requested overrides must not fabricate review/risk/expiry/revocation data
- accepted overrides must preserve accepted review, expiry, and follow-ups
- rejected overrides must preserve rejected review
- expired overrides must preserve original accepted review context
- revoked overrides must include revocation context

By default, the validator also checks the referenced release decision artifact.

## Release decision reference checks

The validator uses:

```text
release_decision_path
release_decision_sha256
release_level_before_override
target
```

to verify the referenced:

```text
release_decision_v0.json
```

It checks:

- referenced artifact exists
- referenced artifact validates against `schemas/release_decision_v0.schema.json`
- SHA-256 matches `release_decision_sha256`
- referenced `release_level` matches `release_level_before_override`
- referenced `target` matches the break-glass target

## CLI

Default validation:

```bash
python PULSE_safe_pack_v0/tools/validate_break_glass_override.py
```

Explicit input:

```bash
python PULSE_safe_pack_v0/tools/validate_break_glass_override.py \
  --input PULSE_safe_pack_v0/artifacts/break_glass_override_v0.json
```

Shape-only validation without checking the referenced release decision:

```bash
python PULSE_safe_pack_v0/tools/validate_break_glass_override.py \
  --input PULSE_safe_pack_v0/artifacts/break_glass_override_v0.json \
  --no-release-decision-check
```

Machine-readable summary:

```bash
python PULSE_safe_pack_v0/tools/validate_break_glass_override.py \
  --input PULSE_safe_pack_v0/artifacts/break_glass_override_v0.json \
  --json
```

## What did not change

This PR does not change:

- `schemas/break_glass_override_v0.schema.json`
- `docs/BREAK_GLASS_OVERRIDE_v0.md`
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- `release_decision_v0` materialization
- Quality Ledger rendering
- CI workflow
- release enforcement behavior
- shadow-layer authority