### PR TITLE
feat(governance): add break-glass override validator

### DIFF
--- a/PULSE_safe_pack_v0/tools/validate_break_glass_override.py
+++ b/PULSE_safe_pack_v0/tools/validate_break_glass_override.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import hashlib
 import json
 import sys
@@ -64,6 +65,25 @@ def _format_error_path(error: Any) -> str:
     return path or "<root>"
 
 
+def _parse_datetime(value: Any) -> dt.datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+
+    try:
+        parsed = dt.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+
+    return parsed.astimezone(dt.timezone.utc)
+
+
 def _validate_with_schema(
     *,
     payload: Any,
@@ -108,6 +128,11 @@ def _validate_with_schema(
     return errors
 
 
+def _has_nonempty_list(payload: dict[str, Any], key: str) -> bool:
+    value = payload.get(key)
+    return isinstance(value, list) and len(value) > 0
+
+
 def _semantic_errors(payload: dict[str, Any]) -> list[str]:
     errors: list[str] = []
 
@@ -140,8 +165,7 @@ def _semantic_errors(payload: dict[str, Any]) -> list[str]:
         if payload.get("expires_utc") in (None, ""):
             errors.append("accepted override requires a non-null expires_utc")
 
-        followups = payload.get("followups")
-        if not isinstance(followups, list) or not followups:
+        if not _has_nonempty_list(payload, "followups"):
             errors.append("accepted override requires at least one follow-up")
 
         if "revocation" in payload:
@@ -165,8 +189,7 @@ def _semantic_errors(payload: dict[str, Any]) -> list[str]:
         if payload.get("expires_utc") in (None, ""):
             errors.append("expired override requires expires_utc")
 
-        followups = payload.get("followups")
-        if not isinstance(followups, list) or not followups:
+        if not _has_nonempty_list(payload, "followups"):
             errors.append("expired override requires at least one follow-up")
 
         if "revocation" in payload:
@@ -179,13 +202,27 @@ def _semantic_errors(payload: dict[str, Any]) -> list[str]:
                 "revoked override must preserve the original accepted review decision"
             )
 
-        followups = payload.get("followups")
-        if not isinstance(followups, list) or not followups:
+        if payload.get("expires_utc") in (None, ""):
+            errors.append(
+                "revoked override requires expires_utc from the original accepted override"
+            )
+
+        if not _has_nonempty_list(payload, "followups"):
             errors.append("revoked override requires at least one follow-up")
 
         revocation = payload.get("revocation")
         if not isinstance(revocation, dict):
             errors.append("revoked override requires a revocation record")
+        else:
+            expires_utc = _parse_datetime(payload.get("expires_utc"))
+            revoked_utc = _parse_datetime(revocation.get("revoked_utc"))
+
+            if expires_utc is not None and revoked_utc is not None:
+                if revoked_utc >= expires_utc:
+                    errors.append(
+                        "revoked override requires revocation.revoked_utc to be "
+                        "before the original expires_utc authorization window"
+                    )
 
     return errors
 


### PR DESCRIPTION
## Summary

This PR adds the first runtime validator for `break_glass_override_v0`.

New file:

```text
PULSE_safe_pack_v0/tools/validate_break_glass_override.py
```

## Why

The break-glass stack now has:

- `docs/BREAK_GLASS_OVERRIDE_v0.md`
- `schemas/break_glass_override_v0.schema.json`

The next step is a validator that checks both schema shape and semantic
constraints.

Break-glass must remain explicit, audited, and separate from normal release
authority.

It must not become a hidden pass or a rewrite of `release_decision_v0`.

## What the validator checks

The validator checks the break-glass override artifact against:

```text
schemas/break_glass_override_v0.schema.json
```

It also performs semantic checks, including:

- break-glass must attach to `release_level_before_override = FAIL`
- requested overrides must not fabricate review/risk/expiry/revocation data
- accepted overrides must preserve accepted review, expiry, and follow-ups
- rejected overrides must preserve rejected review
- expired overrides must preserve original accepted review context
- revoked overrides must include original expiry and revocation context

By default, the validator also checks the referenced release decision artifact.

## Release decision reference checks

The validator uses:

```text
release_decision_path
release_decision_sha256
release_level_before_override
target
```

to verify the referenced:

```text
release_decision_v0.json
```

It checks:

- referenced artifact exists
- referenced artifact validates against `schemas/release_decision_v0.schema.json`
- SHA-256 matches `release_decision_sha256`
- referenced `release_level` matches `release_level_before_override`
- referenced `target` matches the break-glass target

## Revoked override checks

For `status = revoked`, the validator checks that:

- the original review decision is `accepted`
- `expires_utc` is present
- at least one follow-up is present
- a revocation record is present
- `revocation.revoked_utc` is before `expires_utc` when both timestamps are parseable

This preserves the audit chain:

```text
accepted override
→ active authorization window
→ revoked before expiry
```

## CLI

Default validation:

```bash
python PULSE_safe_pack_v0/tools/validate_break_glass_override.py
```

Explicit input:

```bash
python PULSE_safe_pack_v0/tools/validate_break_glass_override.py \
  --input PULSE_safe_pack_v0/artifacts/break_glass_override_v0.json
```

Shape-only validation without checking the referenced release decision:

```bash
python PULSE_safe_pack_v0/tools/validate_break_glass_override.py \
  --input PULSE_safe_pack_v0/artifacts/break_glass_override_v0.json \
  --no-release-decision-check
```

Machine-readable summary:

```bash
python PULSE_safe_pack_v0/tools/validate_break_glass_override.py \
  --input PULSE_safe_pack_v0/artifacts/break_glass_override_v0.json \
  --json
```

## What did not change

This PR does not change:

- `schemas/break_glass_override_v0.schema.json`
- `docs/BREAK_GLASS_OVERRIDE_v0.md`
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- `release_decision_v0` materialization
- Quality Ledger rendering
- CI workflow
- release enforcement behavior
- shadow-layer authority

## Boundary

This is a validator tool introduction.

It does not authorize break-glass.

It does not mutate release decisions.

It does not turn `FAIL` into `PASS`.

Normal release authority remains:

```text
status.json
+ materialized required gates
+ check_gates.py
+ release_decision_v0.json
```

Break-glass remains a separate audited exception artifact.

## Follow-up work

Recommended next PRs:

1. Add `tests/test_break_glass_override_v0_smoke.py`.
2. Register the smoke test in `ci/tools-tests.list`.
3. Add break-glass Ledger rendering.
4. Add CI artifact publication for break-glass artifacts.

## Checklist

- [ ] validator tool added
- [ ] validates break-glass schema
- [ ] checks state-dependent semantics
- [ ] requested override does not require review
- [ ] requested override does not allow fabricated review data
- [ ] accepted override requires audit context
- [ ] revoked override requires expiry context
- [ ] reference release decision hash is checked by default
- [ ] reference release level is checked by default
- [ ] no release behavior changed
- [ ] no gate policy changed
- [ ] no CI behavior changed
- [ ] no Ledger behavior changed