### PR TITLE
fix(governance): normalize break-glass datetime UTC suffix

### DIFF
--- a/PULSE_safe_pack_v0/tools/validate_break_glass_override.py
+++ b/PULSE_safe_pack_v0/tools/validate_break_glass_override.py
@@ -207,7 +207,8 @@ def _semantic_errors(payload: dict[str, Any]) -> list[str]:
                 "revoked override requires expires_utc from the original accepted override"
             )
 
-        if not _has_nonempty_list(payload, "followups"):
+         followups = payload.get("followups")
+        if not isinstance(followups, list) or not followups:
             errors.append("revoked override requires at least one follow-up")
 
         revocation = payload.get("revocation")
@@ -216,7 +217,15 @@ def _semantic_errors(payload: dict[str, Any]) -> list[str]:
         else:
             expires_utc = _parse_datetime(payload.get("expires_utc"))
             revoked_utc = _parse_datetime(revocation.get("revoked_utc"))
+            if expires_utc is None:
+                errors.append(
+                    "revoked override requires expires_utc to be a parseable date-time"
+                )
 
+            if revoked_utc is None:
+                errors.append(
+                    "revoked override requires revocation.revoked_utc to be a parseable date-time"
+                )
              if expires_utc is None:
                 errors.append(
                     "revoked override requires expires_utc to be a parseable date-time"

--- a/PULSE_safe_pack_v0/tools/validate_break_glass_override.py
+++ b/PULSE_safe_pack_v0/tools/validate_break_glass_override.py
@@ -70,7 +70,7 @@ def _parse_datetime(value: Any) -> dt.datetime | None:
         return None
 
     text = value.strip()
-    if text.endswith("Z"):
+    if text[-1:].lower() == "z":
         text = text[:-1] + "+00:00"
 
     try:
@@ -216,6 +216,16 @@ def _semantic_errors(payload: dict[str, Any]) -> list[str]:
         else:
             expires_utc = _parse_datetime(payload.get("expires_utc"))
             revoked_utc = _parse_datetime(revocation.get("revoked_utc"))
+
+             if expires_utc is None:
+                errors.append(
+                    "revoked override requires expires_utc to be a parseable date-time"
+                )
+
+            if revoked_utc is None:
+                errors.append(
+                    "revoked override requires revocation.revoked_utc to be a parseable date-time"
+                )
 
             if expires_utc is not None and revoked_utc is not None:
                 if revoked_utc >= expires_utc:


### PR DESCRIPTION
## Summary

This PR fixes datetime parsing in the break-glass override validator.

Modified file:

```text
PULSE_safe_pack_v0/tools/validate_break_glass_override.py
```

## Why

Codex correctly flagged that the validator only normalized uppercase UTC suffixes:

```text
Z
```

but not lowercase:

```text
z
```

That meant timestamps such as:

```text
2026-04-21T00:00:00z
```

could fail parser normalization and return `None`.

In the revoked override semantic check, that caused the comparison:

```text
revocation.revoked_utc < expires_utc
```

to be skipped.

That weakens the revoked override audit rule.

## What changed

The datetime parser now normalizes both:

```text
Z
z
```

to:

```text
+00:00
```

The revoked branch also now fails closed if either timestamp cannot be parsed:

```text
expires_utc
revocation.revoked_utc
```

## Revoked override rule preserved

A revoked break-glass override represents:

```text
accepted override
→ active authorization window
→ revoked before expiry
```

The validator now enforces that more reliably:

```text
revocation.revoked_utc must be before expires_utc
```

when both timestamps are present, and reports an error if either timestamp is not
parseable.

## What did not change

This PR does not change:

- `schemas/break_glass_override_v0.schema.json`
- `docs/BREAK_GLASS_OVERRIDE_v0.md`
- CI workflow
- `status.json`
- `check_gates.py`
- `pulse_gate_policy_v0.yml`
- `release_decision_v0` materialization
- Quality Ledger rendering
- release enforcement behavior
- shadow-layer authority
- break-glass runtime behavior

## Boundary

This is a validator fail-closed parsing fix.

Break-glass remains:

- explicit
- audited
- separate from normal release authority
- not a hidden pass
- not a shadow signal
- not a rewrite of `release_decision_v0`

## Checklist

- [ ] lowercase `z` UTC suffix is normalized
- [ ] uppercase `Z` UTC suffix remains supported
- [ ] unparseable `expires_utc` fails revoked validation
- [ ] unparseable `revocation.revoked_utc` fails revoked validation
- [ ] revoked window comparison still requires `revoked_utc < expires_utc`
- [ ] no schema changed
- [ ] no docs changed
- [ ] no CI behavior changed
- [ ] no release behavior changed