### PR TITLE
fix(governance): normalize PULSE name in materialize_release_decision…

### DIFF
--- a/PULSE_safe_pack_v0/tools/materialize_release_decision.py
+++ b/PULSE_safe_pack_v0/tools/materialize_release_decision.py
@@ -467,7 +467,7 @@ def _materialize_decision(
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Materialize the PULSEmech release_decision_v0 artifact."
+        description="Materialize the PULSE release_decision_v0 artifact."
     )
 
     parser.add_argument(


### PR DESCRIPTION
## Summary

This PR removes the legacy public-facing `PULSEmech` label from the
CLI help text of `PULSE_safe_pack_v0/tools/materialize_release_decision.py`
and restores the canonical project name `PULSE`.

## Why

The repository should present one stable public project name across
reader-facing surfaces.

Mixed naming increases the chance of external misreading and weakens
identity continuity across documentation, tooling help text, and review
surfaces.

## Scope

Changed:
- argparse description string in
  `PULSE_safe_pack_v0/tools/materialize_release_decision.py`

Not changed:
- schema IDs
- file names
- artifact names
- release gating logic
- status / policy semantics

## Validation

Checked:
- `materialize_release_decision.py --help` now shows `PULSE`
- no behavioral change in release decision generation