### PR TITLE
fix(governance): normalize PULSE name in validate_break_glass_overrid…

### DIFF
--- a/PULSE_safe_pack_v0/tools/validate_break_glass_override.py
+++ b/PULSE_safe_pack_v0/tools/validate_break_glass_override.py
@@ -363,7 +363,7 @@ def validate_break_glass_override(
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Validate a PULSEmech break_glass_override_v0 artifact."
+        description="Validate a PULSE break_glass_override_v0 artifact."
     )
 
     parser.add_argument(


### PR DESCRIPTION
## Summary

This PR removes the legacy public-facing `PULSEmech` label from the
CLI help text of
`PULSE_safe_pack_v0/tools/validate_break_glass_override.py`
and restores the canonical project name `PULSE`.

## Why

The repository should present one stable public project name across
reader-facing surfaces.

Mixed naming increases the chance of external misreading and weakens
identity continuity across documentation, schemas, and tool help text.

## Scope

Changed:
- argparse description string in
  `PULSE_safe_pack_v0/tools/validate_break_glass_override.py`

Not changed:
- schema IDs
- file names
- artifact names
- validation logic
- break-glass rules
- release / policy semantics

## Validation

Checked:
- `validate_break_glass_override.py --help` now shows `PULSE`
- no behavioral change in artifact validation