### PR TITLE
fix(governance): normalize PULSE name in README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 **See the latest Quality Ledger (live):** https://hkati.github.io/pulse-release-gates-0.1/
 
 
-# PULSEmech — Release Gates for Safe & Useful AI
+# PULSE — Release Gates for Safe & Useful AI
 
 #### [PULSE is an artifact-defined, deterministic release-governance layer: `status.json`, materialized required gates, and `check_gates.py` define the release decision.](#start-here)
 


### PR DESCRIPTION
## Summary

This PR removes the legacy public-facing `PULSEmech` label from the
README title and restores the canonical project name `PULSE`.

## Why

The repository should present one stable public project name across
reader-facing surfaces.

Mixed naming increases the chance of external misreading and weakens
identity continuity across documentation, citations, and tooling.

## Scope

Changed:
- main H1 title in `README.md`

Not changed:
- workflow behavior
- release gating logic
- schema IDs
- artifact names
- policy / status semantics

## Validation

Checked:
- the README title now shows `PULSE`
- no behavioral or semantic change is introduced