### PR TITLE
fix(governance): normalize PULSE name in break-glass override doc

### DIFF
--- a/docs/BREAK_GLASS_OVERRIDE_v0.md
+++ b/docs/BREAK_GLASS_OVERRIDE_v0.md
@@ -309,7 +309,7 @@ restore missing external evidence
 rerun release-grade detector pipeline
 file post-release incident review
 tighten policy or detector coverage
-re-run PULSEmech release decision after remediation
+re-run PULSE release decision after remediation
 ```
 
 Follow-ups are part of the governance record.


### PR DESCRIPTION
## Summary

This PR removes legacy public-facing `PULSEmech` naming from
`docs/BREAK_GLASS_OVERRIDE_v0.md` and restores the canonical
project name `PULSE`.

## Why

The repository should present one stable public project identity
across documentation and tooling.

Mixed naming increases the chance of external misreading and
weakens continuity across governance surfaces.

## Scope

Changed:
- document title in `docs/BREAK_GLASS_OVERRIDE_v0.md`
- one follow-up example line in the same document

Not changed:
- break-glass artifact structure
- override state rules
- validator behavior
- schema identifiers
- release-decision semantics

## Validation

Checked:
- the document title now shows `PULSE`
- the remediation example now refers to `PULSE`
- no governance or behavioral meaning was changed