### PR TITLE
fix(governance): normalize PULSE name in break-glass override schema title

### DIFF
--- a/schemas/break_glass_override_v0.schema.json
+++ b/schemas/break_glass_override_v0.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://eplabsai.example/schemas/break_glass_override_v0.schema.json",
-  "title": "PULSE Release Decision v0",
+  "title": "PULSE Break-glass Override v0",
   "type": "object",
   "additionalProperties": false,
   "required": [


### PR DESCRIPTION
## Summary

This PR removes the legacy public-facing `PULSEmech` label from the
human-readable `title` field of
`schemas/break_glass_override_v0.schema.json`
and restores the canonical project name `PULSE`.

## Why

The repository should present one stable public project identity across
documentation, schemas, and tooling.

Mixed naming increases the chance of external misreading and weakens
continuity across governance surfaces.

## Scope

Changed:
- `title` field in `schemas/break_glass_override_v0.schema.json`

Not changed:
- `$id`
- `schema` const
- file name
- artifact structure
- validation logic
- break-glass semantics

## Validation

Checked:
- the schema title now shows `PULSE`
- no machine-readable identifiers were changed
- no behavioral or semantic change was introduced