### PR TITLE
feat(topology): add schema for space relation map v0

### DIFF
--- a/schemas/schemas/space_relation_map_v0.schema.json
+++ b/schemas/schemas/space_relation_map_v0.schema.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eplabsai.example/schemas/space_relation_map_v0.schema.json",
+  "title": "PULSE Space Relation Map v0",
+  "description": "Descriptive-only topology artifact for spaces, elements, placements, relations, and invariants in PULSE.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "version",
+    "mode",
+    "authority",
+    "spaces",
+    "elements",
+    "placements",
+    "relations",
+    "invariants"
+  ],
+  "properties": {
+    "schema": {
+      "const": "pulse_space_relation_map_v0"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "mode": {
+      "type": "string",
+      "enum": [
+        "manual",
+        "generated"
+      ]
+    },
+    "authority": {
+      "type": "string",
+      "enum": [
+        "descriptive_only"
+      ]
+    },
+    "spaces": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/space"
+      }
+    },
+    "elements": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/element"
+      }
+    },
+    "placements": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/placement"
+      }
+    },
+    "relations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/relation"
+      }
+    },
+    "invariants": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/invariant"
+      }
+    }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*$"
+    },
+    "nonempty_text": {
+      "type": "string",
+      "minLength": 1
+    },
+    "space": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "role"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/id"
+        },
+        "role": {
+          "$ref": "#/$defs/nonempty_text"
+        }
+      }
+    },
+    "element": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/id"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "artifact",
+            "policy",
+            "tool",
+            "workflow",
+            "report",
+            "overlay"
+          ]
+        }
+      }
+    },
+    "placement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "element_id",
+        "space_id"
+      ],
+      "properties": {
+        "element_id": {
+          "$ref": "#/$defs/id"
+        },
+        "space_id": {
+          "$ref": "#/$defs/id"
+        }
+      }
+    },
+    "endpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "id"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "element",
+            "space"
+          ]
+        },
+        "id": {
+          "$ref": "#/$defs/id"
+        }
+      }
+    },
+    "relation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type",
+        "from",
+        "to"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/id"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "reads",
+            "writes",
+            "materializes",
+            "enforces",
+            "validates",
+            "renders",
+            "publishes",
+            "observes",
+            "depends_on",
+            "summarizes",
+            "derives_from",
+            "cannot_override",
+            "may_promote_if_policy",
+            "anchors_to",
+            "feeds"
+          ]
+        },
+        "from": {
+          "$ref": "#/$defs/endpoint"
+        },
+        "to": {
+          "$ref": "#/$defs/endpoint"
+        }
+      }
+    },
+    "invariant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "statement"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/id"
+        },
+        "statement": {
+          "$ref": "#/$defs/nonempty_text"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds the first JSON Schema for
`space_relation_map_v0`.

It formalizes the structural shape of the descriptive-only topology
artifact introduced in the manual seed.

## Why

The manual artifact already establishes the initial topology language.
This schema is the next step: it freezes the shape of that language
without yet turning it into a semantic validator or release gate.

## Scope

Added:
- `schemas/space_relation_map_v0.schema.json`

Validated against:
- `examples/space_relation_map_v0.manual.json`

## Design choice

This v0 schema is intentionally structural, not semantic.

It validates:
- required top-level sections
- object shapes
- relation endpoint structure
- relation type vocabulary
- basic identifier format

It does not yet validate:
- cross-reference existence
- duplicate IDs
- placement uniqueness
- authority-boundary semantics

Those belong in a later validator step.

## Not changed

- release gating logic
- status contract
- policy semantics
- workflow behavior
- ledger rendering
- CI enforcement

## Validation

Checked:
- schema is valid Draft 2020-12 JSON Schema
- manual seed artifact validates against the new schema