### PR TITLE
test(topology): add space relation map validator smoke test to tools-…

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -17,6 +17,7 @@ tests/test_check_external_summaries_present.py
 tests/test_augment_status_smoke.py
 tests/test_run_all_mode_contract.py
 tests/test_validate_status_schema_tool.py
+tests/test_validate_space_relation_map_tool.py
 tests/test_no_legacy_status_schema_refs_smoke.py
 tests/test_pack_tools_compile.py
 tests/test_paradox_diagram_example_v0_smoke.py


### PR DESCRIPTION
## Summary

This PR adds `tests/test_validate_space_relation_map_tool.py` to
`ci/tools-tests.list`.

## Why

The topology layer now has:
- a manual seed artifact
- a schema
- a validator
- a smoke test

The next step is to keep that smoke test inside the existing tools-test
execution path so it remains visible and regularly exercised.

## Scope

Changed:
- `ci/tools-tests.list`

Added to suite:
- `tests/test_validate_space_relation_map_tool.py`

## Not changed

- topology schema
- manual topology artifact
- validator logic
- release gating logic
- workflow semantics
- CI policy semantics

## Validation

Checked:
- the smoke test passes standalone
- the manifest includes the new test exactly once
- this change only extends the existing tools-tests suite