### PR TITLE
docs(topology): add README start-here link for space relation map v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Choose one path first:
 - **Triage / operational path** → [`docs/RUNBOOK.md`](docs/RUNBOOK.md)  
   Start here when CI is red and you need the shortest path to diagnosis.
 
+- **Topology / authority-boundary path** → [`docs/SPACE_RELATION_MAP_v0.md`](docs/SPACE_RELATION_MAP_v0.md)
+  Use this when you need the machine-readable topology view of PULSE:
+  spaces, elements, placements, relations, and invariants.
+  This layer is descriptive-only. It clarifies authority boundaries
+  but does not define shipping decisions.
+
 - **Topology / Paradox / EPF / overlays** → [`docs/OPTIONAL_LAYERS.md`](docs/OPTIONAL_LAYERS.md)  
   Use this after the core path. It maps diagnostic overlays, shadow workflows, and external companion surfaces such as Parameter Golf v0. These layers remain non-normative unless explicitly promoted into the required gate set. 
 


### PR DESCRIPTION
## Summary

This PR adds a dedicated README Start-here link for
`docs/SPACE_RELATION_MAP_v0.md`.

## Why

The topology layer now has:
- a manual artifact
- a schema
- a validator
- a renderer
- smoke tests
- an overview document

The README should expose that layer directly so readers can find the
authority-boundary map without having to infer it from broader optional
layers documentation.

## Scope

Changed:
- `README.md`

Added:
- a dedicated Start-here path for `docs/SPACE_RELATION_MAP_v0.md`

## Not changed

- topology schema
- topology validator
- topology renderer
- release gating logic
- workflow behavior
- CI semantics

## Validation

Checked:
- the README now exposes the topology layer directly
- the new wording keeps the artifact descriptive-only
- no normative authority is added