### PR TITLE
feat(topology): add build tool for space relation map summary

### DIFF
--- a/tools/build_space_relation_map_summary.py
+++ b/tools/build_space_relation_map_summary.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = REPO_ROOT / "tools" / "validate_space_relation_map.py"
+RENDERER = REPO_ROOT / "tools" / "render_space_relation_map_summary.py"
+
+DEFAULT_ARTIFACT = REPO_ROOT / "examples" / "space_relation_map_v0.manual.json"
+DEFAULT_OUTPUT = REPO_ROOT / "reports" / "topology" / "space_relation_map_v0_summary.md"
+DEFAULT_SCHEMA_CANDIDATES = [
+    REPO_ROOT / "schemas" / "schemas" / "space_relation_map_v0.schema.json",
+    REPO_ROOT / "schemas" / "space_relation_map_v0.schema.json",
+]
+
+
+def _default_schema_path() -> Path:
+    for candidate in DEFAULT_SCHEMA_CANDIDATES:
+        if candidate.exists():
+            return candidate
+    return DEFAULT_SCHEMA_CANDIDATES[0]
+
+
+def _run(label: str, *args: Path | str) -> None:
+    cp = subprocess.run(
+        [sys.executable, *(str(a) for a in args)],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if cp.returncode != 0:
+        combined = (cp.stdout or "") + (cp.stderr or "")
+        raise SystemExit(f"ERROR: {label} failed\n{combined}".rstrip())
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate and render the PULSE space_relation_map_v0 summary."
+    )
+    parser.add_argument(
+        "--artifact",
+        default=str(DEFAULT_ARTIFACT),
+        help="Path to the space_relation_map_v0 JSON artifact.",
+    )
+    parser.add_argument(
+        "--schema",
+        default=str(_default_schema_path()),
+        help="Path to the JSON Schema for the artifact.",
+    )
+    parser.add_argument(
+        "--out",
+        default=str(DEFAULT_OUTPUT),
+        help="Output path for the rendered markdown summary.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    artifact = Path(args.artifact)
+    schema = Path(args.schema)
+    out = Path(args.out)
+
+    _run(
+        "space relation map validation",
+        VALIDATOR,
+        artifact,
+        "--schema",
+        schema,
+    )
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    _run(
+        "space relation map summary render",
+        RENDERER,
+        artifact,
+        "--out",
+        out,
+    )
+
+    print(f"OK: built space relation map summary: {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds `tools/build_space_relation_map_summary.py`, a small helper
that validates the topology artifact and renders its markdown summary to
a canonical output path.

## Why

The topology layer already has:
- a manual artifact
- a schema
- a validator
- a renderer
- smoke tests
- README/docs entry points

The next natural step is a single build command that produces the
review-facing summary in a stable location.

## What this tool does

- resolves the topology artifact path
- resolves the schema path
- validates the artifact
- renders the markdown summary
- writes it to `reports/topology/space_relation_map_v0_summary.md` by default

## Scope

Added:
- `tools/build_space_relation_map_summary.py`

Not changed:
- topology schema
- validator logic
- renderer logic
- release gating logic
- workflow behavior
- CI semantics

## Validation

Checked:
- the build tool runs successfully on the current topology artifact
- the summary file is written to the expected output path
- validation still occurs before rendering