### PR TITLE
fix(topology): normalize repo-relative paths in space relation map build tool

### DIFF
--- a/tools/build_space_relation_map_summary.py
+++ b/tools/build_space_relation_map_summary.py
@@ -25,6 +25,7 @@ def _default_schema_path() -> Path:
             return candidate
     return DEFAULT_SCHEMA_CANDIDATES[0]
 
+
 def _repo_path(value: str) -> Path:
     path = Path(value)
     if path.is_absolute():

--- a/tools/build_space_relation_map_summary.py
+++ b/tools/build_space_relation_map_summary.py
@@ -25,6 +25,12 @@ def _default_schema_path() -> Path:
             return candidate
     return DEFAULT_SCHEMA_CANDIDATES[0]
 
+def _repo_path(value: str) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return REPO_ROOT / path
+
 
 def _run(label: str, *args: Path | str) -> None:
     cp = subprocess.run(
@@ -64,9 +70,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
-    artifact = Path(args.artifact)
-    schema = Path(args.schema)
-    out = Path(args.out)
+     artifact = _repo_path(args.artifact)
+    schema = _repo_path(args.schema)
+    out = _repo_path(args.out)
 
     _run(
         "space relation map validation",


### PR DESCRIPTION
## Summary

This PR normalizes CLI-provided artifact, schema, and output paths
against `REPO_ROOT` in
`tools/build_space_relation_map_summary.py`.

## Why

The build tool creates the output parent directory locally, but runs the
renderer subprocess with `cwd=REPO_ROOT`.

With a relative `--out`, that could create directories in the caller’s
current working directory while the renderer writes the file somewhere
else.

Normalizing paths once at the start makes path handling consistent and
prevents stray directories outside the repo.

## Scope

Changed:
- `tools/build_space_relation_map_summary.py`

Specifically:
- add repo-relative path normalization helper
- normalize `artifact`, `schema`, and `out` before mkdir and subprocess calls

## Not changed

- topology schema
- validator logic
- renderer logic
- topology semantics
- release gating logic
- workflow behavior

## Validation

Checked:
- normal build still succeeds
- relative `--out` is now resolved consistently against `REPO_ROOT`
- output is written to the expected repo-local path