### PR TITLE
fix(topology): correct indentation in space relation map summary builder

### DIFF
--- a/tools/build_space_relation_map_summary.py
+++ b/tools/build_space_relation_map_summary.py
@@ -71,7 +71,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
 
-     artifact = _repo_path(args.artifact)
+    artifact = _repo_path(args.artifact)
     schema = _repo_path(args.schema)
     out = _repo_path(args.out)
 


### PR DESCRIPTION
## Summary

This PR fixes an indentation regression in
`tools/build_space_relation_map_summary.py`.

A single misindented assignment line in `main()` caused the script to
fail at parse time with `IndentationError`, making the summary builder
unusable.

## Why

An earlier review suggested the indentation issue might be stale or
already resolved, but the failure turned out to be real.

This PR is a focused follow-up that restores executable Python structure
without changing the intended behavior of the tool.

## Scope

Changed:
- `tools/build_space_relation_map_summary.py`

Specifically:
- restore correct indentation of the repo-path assignment in `main()`

## Not changed

- topology semantics
- repo-relative path normalization behavior
- validation logic
- renderer logic
- release gating logic
- workflow behavior
- CI semantics

## Validation

Checked:
- `python -m py_compile tools/build_space_relation_map_summary.py`
- `python tools/build_space_relation_map_summary.py`
- non-repo working directory invocation with relative `--out`