### PR TITLE
test(topology): add space relation map summary builder smoke test to tools-tests suite

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -19,6 +19,7 @@ tests/test_run_all_mode_contract.py
 tests/test_validate_status_schema_tool.py
 tests/test_validate_space_relation_map_tool.py
 tests/test_render_space_relation_map_summary_tool.py
+tests/test_build_space_relation_map_summary_tool.py
 tests/test_no_legacy_status_schema_refs_smoke.py
 tests/test_pack_tools_compile.py
 tests/test_paradox_diagram_example_v0_smoke.py


### PR DESCRIPTION
## Summary

This PR adds `tests/test_build_space_relation_map_summary_tool.py` to
`ci/tools-tests.list`.

## Why

The topology layer now has:
- a manual artifact
- a schema
- a validator
- a renderer
- a builder
- smoke tests for all three tools

The next step is to keep the builder smoke test inside the existing
tools-test execution path so it remains visible and regularly exercised.

## Scope

Changed:
- `ci/tools-tests.list`

Added to suite:
- `tests/test_build_space_relation_map_summary_tool.py`

## Not changed

- topology schema
- topology validator
- topology renderer
- topology builder logic
- release gating logic
- workflow behavior
- CI policy semantics

## Validation

Checked:
- the builder smoke test passes standalone
- the manifest includes the new test exactly once
- this change only extends the existing tools-tests suite