### PR TITLE
docs(topology): sync space relation map docs with builder and smoke coverage

### DIFF
--- a/docs/SPACE_RELATION_MAP_v0.md
+++ b/docs/SPACE_RELATION_MAP_v0.md
@@ -70,14 +70,20 @@ This is especially useful for showing:
 - `tools/render_space_relation_map_summary.py`
   - renders a human-readable markdown summary
 
+- `tools/build_space_relation_map_summary.py`
+  - validates and renders the topology summary to a canonical output path
+
 - `tests/test_validate_space_relation_map_tool.py`
   - validator smoke test
 
 - `tests/test_render_space_relation_map_summary_tool.py`
   - renderer smoke test
 
+- `tests/test_build_space_relation_map_summary_tool.py`
+  - builder smoke test
+
 - `ci/tools-tests.list`
-  - includes both topology tool smoke tests
+  - includes validator, renderer, and builder topology tool smoke tests
 
 ---
 
@@ -182,7 +188,20 @@ python tools/render_space_relation_map_summary.py \
   examples/space_relation_map_v0.manual.json \
   --out /tmp/space_relation_map_v0_summary.md
 ```
+---
+## Build
 
+Build the validated topology summary to the canonical repo output path:
+
+```bash
+python tools/build_space_relation_map_summary.py
+```
+
+Default output:
+
+```text
+reports/topology/space_relation_map_v0_summary.md
+```
 ---
 
 ## Non-goals in v0


### PR DESCRIPTION
## Summary

This PR updates `docs/SPACE_RELATION_MAP_v0.md` so it matches the
current topology toolchain.

## Why

The topology layer now includes:
- a manual artifact
- a schema
- a validator
- a renderer
- a builder
- smoke tests for all three tools
- tools-tests wiring for all three smoke tests

The overview doc still describes only the validator/renderer subset, so
it should be brought up to date.

## Scope

Changed:
- `docs/SPACE_RELATION_MAP_v0.md`

Updated doc content:
- add `tools/build_space_relation_map_summary.py`
- add `tests/test_build_space_relation_map_summary_tool.py`
- update `ci/tools-tests.list` wording to include validator, renderer,
  and builder smoke tests
- add a `Build` section for the canonical summary-generation command

## Not changed

- topology schema
- validator logic
- renderer logic
- builder logic
- release gating logic
- workflow behavior
- CI semantics

## Validation

Checked:
- documentation now matches the current topology file set
- build command reflects the current canonical output path
- no runtime or behavioral changes are introduced