### PR TITLE
feat(topology): add machine-readable summary pointer to space relation map v0

### DIFF
--- a/examples/space_relation_map_v0.manual.json
+++ b/examples/space_relation_map_v0.manual.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "mode": "manual",
   "authority": "descriptive_only",
+  "summary_ref": {
+    "format": "markdown",
+    "path": "reports/topology/space_relation_map_v0_summary.md",
+    "producer": "tools/build_space_relation_map_summary.py"
+  },
   "spaces": [
     {
       "id": "core",


### PR DESCRIPTION
## Summary

This PR adds a machine-readable `summary_ref` pointer to the
manual `space_relation_map_v0` artifact.

In the manual topology artifact, `summary_ref` records:
- `format`
- `path`
- `producer`

## Why

The topology layer already has a canonical rendered summary at:

`reports/topology/space_relation_map_v0_summary.md`

The artifact itself should be able to point to that summary in a stable,
machine-readable way.

This improves discoverability and tooling without making the topology
layer normative.

## Scope of this artifact change

Changed:
- `examples/space_relation_map_v0.manual.json`

Added:
- top-level `summary_ref`

Example value:
- format: `markdown`
- path: `reports/topology/space_relation_map_v0_summary.md`
- producer: `tools/build_space_relation_map_summary.py`

## Important note

This artifact change is intended to land together with the matching
schema/doc updates for `summary_ref`.

On its own, this example change would not be sufficient because the
topology schema currently controls allowed top-level properties.

## Not changed

- topology authority
- release gating logic
- workflow behavior
- CI semantics

## Validation

Checked:
- JSON remains valid
- `summary_ref` matches the current canonical summary path and producer
- the change is descriptive only