### PR TITLE
fix(topology): allow summary_ref in space relation map schema

### DIFF
--- a/schemas/schemas/space_relation_map_v0.schema.json
+++ b/schemas/schemas/space_relation_map_v0.schema.json
@@ -37,6 +37,9 @@
         "descriptive_only"
       ]
     },
+     "summary_ref": {
+     "$ref": "#/$defs/summary_ref"
+    },
     "spaces": {
       "type": "array",
       "minItems": 1,
@@ -81,6 +84,30 @@
     "nonempty_text": {
       "type": "string",
       "minLength": 1
+    },
+      "summary_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "format",
+        "path"
+      ],
+      "properties": {
+        "format": {
+          "type": "string",
+          "enum": [
+            "markdown"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "producer": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
     },
     "space": {
       "type": "object",


### PR DESCRIPTION
## Summary

This PR updates
`schemas/schemas/space_relation_map_v0.schema.json`
to allow the new top-level `summary_ref` field.

## Why

The manual topology artifact now contains:

- `summary_ref.format`
- `summary_ref.path`
- `summary_ref.producer`

Because the topology schema uses `additionalProperties: false`, the
artifact became invalid until the schema was updated to recognize the
new field.

This PR closes that gap.

## Scope

Changed:
- `schemas/schemas/space_relation_map_v0.schema.json`

Added:
- optional top-level `summary_ref`
- `$defs.summary_ref`

## Design choice

`summary_ref` is intentionally optional in this change.

The goal here is to stabilize the new machine-readable pointer without
yet making it a required contract field.

## Not changed

- topology authority
- validator logic
- renderer logic
- builder logic
- release gating logic
- workflow behavior
- CI semantics

## Validation

Checked:
- the manual artifact validates again against the topology schema
- `tests/test_validate_space_relation_map_tool.py` passes
- tools-tests suite no longer fails on unexpected `summary_ref`