### PR TITLE
docs(topology): document summary_ref in space relation map overview

### DIFF
--- a/docs/SPACE_RELATION_MAP_v0.md
+++ b/docs/SPACE_RELATION_MAP_v0.md
@@ -87,6 +87,23 @@ This is especially useful for showing:
 
 ---
 
+## Summary pointer
+
+The topology artifact may include a machine-readable `summary_ref`
+pointer to its canonical rendered summary.
+
+Current convention:
+
+- format: `markdown`
+- path: `reports/topology/space_relation_map_v0_summary.md`
+- producer: `tools/build_space_relation_map_summary.py`
+
+This pointer is descriptive only.
+It helps tools and readers locate the canonical rendered summary, but it
+does not add release authority.
+
+---
+
 ## Core concepts
 
 ### Spaces


### PR DESCRIPTION
## Summary

This PR updates `docs/SPACE_RELATION_MAP_v0.md` to document the new
machine-readable `summary_ref` pointer in the topology artifact.

## Why

The topology artifact now supports a descriptive pointer to its canonical
rendered summary.

The overview doc should explain:
- what `summary_ref` is
- what values it currently uses
- and what it does *not* mean

That keeps the topology docs aligned with the current artifact and
schema.

## Scope

Changed:
- `docs/SPACE_RELATION_MAP_v0.md`

Added:
- a `Summary pointer` section describing:
  - `format`
  - `path`
  - `producer`

## Important clarification

`summary_ref` is descriptive only.

It helps tools and readers locate the canonical rendered summary, but it
does not add release authority, create a new decision surface, or change
shipping semantics.

## Not changed

- topology schema
- topology validator
- topology renderer
- topology builder logic
- release gating logic
- workflow behavior
- CI semantics

## Validation

Checked:
- the docs now reflect the current `summary_ref` convention
- wording keeps the topology layer descriptive-only
- no behavioral or semantic change is introduced