### PR TITLE
docs(field): record no-stub release boundary

### DIFF
--- a/field/decisions/DECISION_001_no_stub_release_boundary.md
+++ b/field/decisions/DECISION_001_no_stub_release_boundary.md
@@ -1,0 +1,36 @@
+# DECISION 001 — No-Stub Release Boundary
+
+## Decision
+
+PULSE may run in scaffold, smoke, demo, or core modes for field exploration and baseline validation.
+
+However, any release-grade or production-authoritative lane must fail closed if the run is based on stubbed gates, scaffold diagnostics, all-true smoke profiles, or missing detector materialization evidence.
+
+## Rule
+
+A PULSE status artifact cannot be treated as release-grade evidence if any of the following are true:
+
+- `diagnostics.gates_stubbed == true`
+- `diagnostics.scaffold == true`
+- `diagnostics.stub_profile` indicates an all-true or smoke profile
+- required release evidence is missing
+- `gates.detectors_materialized_ok` is missing or not literal `true`
+- external detector evidence is required but absent, malformed, or not all-pass
+
+## Rationale
+
+PULSE separates diagnostic observation from release authority.
+
+A scaffold/core pass may prove that the PULSE machinery works. It does not prove that real safety evidence has been materialized.
+
+This distinction prevents dashboards, ledgers, smoke tests, and generated summaries from being confused with actual release authority.
+
+## Non-goals
+
+This decision does not remove scaffold, demo, field, or shadow modes.
+
+Those modes remain important for development and field exploration. The rule only prevents them from being promoted silently into release-grade authority.
+
+## Testable invariant
+
+If a status artifact claims or is checked as release-grade, then stubbed/scaffold/all-true-smoke diagnostics must cause a fail-closed result.


### PR DESCRIPTION
## Summary

Adds `field/decisions/DECISION_001_no_stub_release_boundary.md`.

This records a core PULSE boundary:

- scaffold/demo/core modes may be used for field exploration and baseline validation
- scaffold or stubbed evidence must not be treated as release-grade authority
- release-grade/prod lanes must fail closed when required evidence is stubbed, missing, malformed, or only smoke/all-true material

## Rationale

PULSE separates diagnostic observation from release authority.

A core or scaffold pass can show that the PULSE machinery is functioning, but it must not be confused with materialized release evidence. This decision prevents smoke profiles, dashboards, ledgers, or generated summaries from silently becoming production-authoritative signals.

## Scope

Documentation / field decision only.

This PR does not yet add runtime enforcement, fixtures, CI changes, or ledger rendering changes.

## Follow-up work

Planned follow-ups:

- add a no-stub release boundary checker
- add fixtures for allowed core scaffold and forbidden release scaffold cases
- add tests for the no-stub release boundary
- wire the check into release-grade/prod lanes
- distinguish `CORE-STAGE-PASS` from `RELEASE-GRADE-PASS` in rendered outputs

## Validation

Manual review of the decision document.

No runtime tests were added or changed in this PR.