### PR TITLE
test(fixtures): add core scaffold allowed status

### DIFF
--- a/tests/fixtures/no_stub_release_boundary/core_scaffold_allowed.json
+++ b/tests/fixtures/no_stub_release_boundary/core_scaffold_allowed.json
@@ -1,0 +1,16 @@
+{
+  "version": "test",
+  "created_utc": "2026-04-25T00:00:00Z",
+  "gates": {
+    "q1_grounded_ok": true,
+    "q4_slo_ok": true
+  },
+  "metrics": {
+    "run_mode": "core"
+  },
+  "diagnostics": {
+    "gates_stubbed": true,
+    "scaffold": true,
+    "stub_profile": "all_true_smoke"
+  }
+}


### PR DESCRIPTION
## Summary

Adds:

- `tests/fixtures/no_stub_release_boundary/core_scaffold_allowed.json`

This fixture represents a core-lane status artifact with scaffold/stub diagnostics.

## Rationale

Decision 001 defines the no-stub release boundary:

- scaffold/demo/core runs may support field exploration and baseline validation
- scaffold/stub evidence must not be treated as release-grade authority

This fixture anchors the allowed side of that boundary.

It is intentionally scaffolded:

- `diagnostics.gates_stubbed == true`
- `diagnostics.scaffold == true`
- `diagnostics.stub_profile == "all_true_smoke"`
- `metrics.run_mode == "core"`

That should be acceptable for a non-release lane.

## Scope

Fixture only.

This PR does not add tests, forbidden release fixtures, CI wiring, or ledger/report changes.

## Manual validation

After `check_no_stub_release.py` is available, this fixture can be checked manually:

```text
python PULSE_safe_pack_v0/tools/check_no_stub_release.py tests/fixtures/no_stub_release_boundary/core_scaffold_allowed.json --lane core
```

Expected result:

```text
PASS
```

## Follow-up work

- add release scaffold forbidden fixture
- add missing diagnostics forbidden fixture
- add missing materialization forbidden fixture
- add real release evidence allowed fixture
- add unittest coverage for the no-stub release boundary