### PR TITLE
test(fixtures): add forbidden release scaffold status

### DIFF
--- a/tests/fixtures/no_stub_release_boundary/release_scaffold_forbidden.json
+++ b/tests/fixtures/no_stub_release_boundary/release_scaffold_forbidden.json
@@ -1,0 +1,19 @@
+{
+  "version": "test",
+  "created_utc": "2026-04-25T00:00:00Z",
+  "gates": {
+    "q1_grounded_ok": true,
+    "q4_slo_ok": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true
+  },
+  "metrics": {
+    "run_mode": "prod"
+  },
+  "diagnostics": {
+    "gates_stubbed": true,
+    "scaffold": true,
+    "stub_profile": "all_true_smoke"
+  }
+}


### PR DESCRIPTION
## Summary

Adds:

- `tests/fixtures/no_stub_release_boundary/release_scaffold_forbidden.json`

This fixture represents a prod/release-like status artifact where release evidence gates are true, but diagnostics show scaffold/stub evidence.

## Rationale

Decision 001 defines the no-stub release boundary:

- scaffold/demo/core runs may support field exploration and baseline validation
- scaffold/stub evidence must not be treated as release-grade authority
- release-grade/prod lanes must fail closed when evidence is stubbed, scaffolded, or only smoke/all-true material

This fixture anchors the forbidden release side of that boundary.

It is intentionally contradictory:

- `gates.detectors_materialized_ok == true`
- `gates.external_summaries_present == true`
- `gates.external_all_pass == true`
- but `diagnostics.gates_stubbed == true`
- and `diagnostics.scaffold == true`
- and `diagnostics.stub_profile == "all_true_smoke"`

A release-grade/prod checker must reject this artifact.

## Scope

Fixture only.

This PR does not add tests, CI wiring, or ledger/report changes.

## Manual validation

After `check_no_stub_release.py` is available, this fixture can be checked manually:

```text
python PULSE_safe_pack_v0/tools/check_no_stub_release.py tests/fixtures/no_stub_release_boundary/release_scaffold_forbidden.json --lane release-grade
```

Expected result:

```text
FAIL
```

The failure should mention stub, scaffold, smoke, or release-grade evidence boundary violations.

## Follow-up work

- add missing diagnostics forbidden fixture
- add missing materialization forbidden fixture
- add real release evidence allowed fixture
- add unittest coverage for the no-stub release boundary
- wire the checker into release-grade/prod CI lanes