### PR TITLE
fix(release): fail closed on run mode and diagnostic conflicts

### DIFF
--- a/PULSE_safe_pack_v0/tools/check_no_stub_release.py
+++ b/PULSE_safe_pack_v0/tools/check_no_stub_release.py
@@ -21,7 +21,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 
 EXIT_PASS = 0
@@ -30,7 +30,6 @@ EXIT_FAIL = 2
 RELEASE_LANES = {
     "release",
     "release-grade",
-    "release_grade",
     "prod",
     "production",
 }
@@ -40,6 +39,9 @@ NON_RELEASE_LANES = {
     "field",
     "demo",
     "smoke",
+    "scaffold",
+    "shadow",
+    "advisory",
 }
 
 DANGEROUS_STUB_PROFILE_TOKENS = (
@@ -67,35 +69,60 @@ def load_json(path: Path) -> Dict[str, Any]:
 
 
 def normalize_lane(value: str) -> str:
-    return value.strip().lower().replace(" ", "-")
+    text = value.strip().lower().replace("_", "-").replace(" ", "-")
+
+    while "--" in text:
+        text = text.replace("--", "-")
+
+    return text
 
 
 def get_object(value: Any) -> Dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
-def collect_diagnostics(status: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Accept diagnostics from a few known locations so the checker is resilient
-    across current PULSE status variants.
+def safe_repr(value: Any) -> str:
+    try:
+        return json.dumps(value, sort_keys=True)
+    except TypeError:
+        return repr(value)
 
-    Top-level diagnostics wins over nested diagnostics.
+
+def collect_diagnostic_sources(
+    status: Dict[str, Any],
+) -> Tuple[List[Tuple[str, Dict[str, Any]]], List[str]]:
+    """
+    Collect diagnostics from known status locations without masking conflicts.
+
+    Important boundary rule:
+
+    A blocking diagnostic signal from any source must fail release-grade checks.
+    Top-level diagnostics must not silently overwrite nested diagnostics.
     """
 
-    merged: Dict[str, Any] = {}
+    sources: List[Tuple[str, Dict[str, Any]]] = []
+    failures: List[str] = []
+
+    def add_source(path: str, value: Any) -> None:
+        if value is None:
+            return
+
+        if not isinstance(value, dict):
+            failures.append(f"{path} is present but not an object")
+            return
+
+        if value:
+            sources.append((path, value))
 
     meta = get_object(status.get("meta"))
-    meta_diagnostics = get_object(meta.get("diagnostics"))
-    merged.update(meta_diagnostics)
+    add_source("meta.diagnostics", meta.get("diagnostics"))
 
     metrics = get_object(status.get("metrics"))
-    metrics_diagnostics = get_object(metrics.get("diagnostics"))
-    merged.update(metrics_diagnostics)
+    add_source("metrics.diagnostics", metrics.get("diagnostics"))
 
-    top_level_diagnostics = get_object(status.get("diagnostics"))
-    merged.update(top_level_diagnostics)
+    add_source("diagnostics", status.get("diagnostics"))
 
-    return merged
+    return sources, failures
 
 
 def get_run_mode(status: Dict[str, Any]) -> Any:
@@ -112,24 +139,74 @@ def profile_indicates_stub(value: Any) -> bool:
     return any(token in text for token in DANGEROUS_STUB_PROFILE_TOKENS)
 
 
-def require_literal_false(
-    diagnostics: Dict[str, Any],
+def format_source_values(values: List[Tuple[str, Any]]) -> str:
+    return ", ".join(f"{path}={safe_repr(value)}" for path, value in values)
+
+
+def require_consistent_literal_false(
+    diagnostic_sources: List[Tuple[str, Dict[str, Any]]],
     key: str,
     failures: List[str],
 ) -> None:
     """
-    In release-like lanes, absence or non-boolean values are not enough.
+    In release-like lanes, a stub/scaffold flag must be explicitly false.
 
-    A release-grade artifact should explicitly prove that it is not scaffolded
-    or stubbed.
+    If multiple diagnostic sources contain the key, they must not disagree.
+    Any non-false value is blocking.
     """
 
-    if key not in diagnostics:
-        failures.append(f"diagnostics.{key} is missing; release-grade evidence must be explicit")
+    values = [
+        (path, diagnostics[key])
+        for path, diagnostics in diagnostic_sources
+        if key in diagnostics
+    ]
+
+    if not values:
+        failures.append(
+            f"diagnostics.{key} is missing across diagnostic sources; "
+            "release-grade evidence must be explicit"
+        )
         return
 
-    if diagnostics.get(key) is not False:
-        failures.append(f"diagnostics.{key} is not literal false")
+    unique_values = {safe_repr(value) for _, value in values}
+
+    if len(unique_values) > 1:
+        failures.append(
+            f"diagnostics.{key} has conflicting values across diagnostic sources: "
+            f"{format_source_values(values)}"
+        )
+
+    for path, value in values:
+        if value is not False:
+            failures.append(f"{path}.{key} is not literal false")
+
+
+def check_stub_profiles(
+    diagnostic_sources: List[Tuple[str, Dict[str, Any]]],
+    failures: List[str],
+) -> None:
+    values = [
+        (path, diagnostics["stub_profile"])
+        for path, diagnostics in diagnostic_sources
+        if "stub_profile" in diagnostics
+    ]
+
+    if not values:
+        return
+
+    unique_values = {safe_repr(value) for _, value in values}
+
+    if len(unique_values) > 1:
+        failures.append(
+            "diagnostics.stub_profile has conflicting values across diagnostic sources: "
+            f"{format_source_values(values)}"
+        )
+
+    for path, value in values:
+        if profile_indicates_stub(value):
+            failures.append(
+                f"{path}.stub_profile indicates stub/scaffold/smoke profile: {value}"
+            )
 
 
 def require_gate_true(
@@ -144,31 +221,46 @@ def require_gate_true(
 def check_release_boundary(status: Dict[str, Any]) -> List[str]:
     failures: List[str] = []
 
-    gates = status.get("gates")
-    if not isinstance(gates, dict):
-        return ["status.gates is missing or not an object"]
+    gates_value = status.get("gates")
+    if not isinstance(gates_value, dict):
+        failures.append("status.gates is missing or not an object")
+        gates: Dict[str, Any] = {}
+    else:
+        gates = gates_value
 
-    diagnostics = collect_diagnostics(status)
-    if not diagnostics:
-        failures.append("diagnostics object is missing; release-grade evidence must be explicit")
+    diagnostic_sources, diagnostic_shape_failures = collect_diagnostic_sources(status)
+    failures.extend(diagnostic_shape_failures)
+
+    if not diagnostic_sources:
+        failures.append(
+            "diagnostics object is missing or empty; "
+            "release-grade evidence must be explicit"
+        )
+    else:
+        require_consistent_literal_false(
+            diagnostic_sources,
+            "gates_stubbed",
+            failures,
+        )
+        require_consistent_literal_false(
+            diagnostic_sources,
+            "scaffold",
+            failures,
+        )
+        check_stub_profiles(diagnostic_sources, failures)
 
     run_mode = get_run_mode(status)
-    if run_mode is None:
-        failures.append("metrics.run_mode is missing")
+
+    if run_mode is None or str(run_mode).strip() == "":
+        failures.append("run_mode is missing or empty")
     else:
         normalized_run_mode = normalize_lane(str(run_mode))
-        if normalized_run_mode in {"core", "demo", "field", "smoke"}:
-            failures.append(f"metrics.run_mode is non-release: {run_mode}")
 
-    require_literal_false(diagnostics, "gates_stubbed", failures)
-    require_literal_false(diagnostics, "scaffold", failures)
-
-    stub_profile = diagnostics.get("stub_profile")
-    if profile_indicates_stub(stub_profile):
-        failures.append(
-            "diagnostics.stub_profile indicates stub/scaffold/smoke profile: "
-            f"{stub_profile}"
-        )
+        if normalized_run_mode not in RELEASE_LANES:
+            failures.append(
+                "run_mode is not release-like for release boundary check: "
+                f"{run_mode}"
+            )
 
     require_gate_true(gates, "detectors_materialized_ok", failures)
     require_gate_true(gates, "external_summaries_present", failures)


### PR DESCRIPTION
## Summary

Hardens `check_no_stub_release.py` after automated review feedback.

This PR fixes two release-boundary issues:

1. Unknown or non-release `run_mode` values now fail closed during release-grade/prod checks.
2. Diagnostic sources are no longer merged with overwrite semantics.

## Rationale

PULSE release-grade/prod lanes must fail closed when evidence is ambiguous, malformed, contradictory, stubbed, scaffolded, or non-materialized.

The previous checker could allow two unsafe cases:

- `metrics.run_mode` values such as `shadow`, empty strings, or typos could pass release-grade/prod checks if the rest of the artifact appeared valid.
- top-level `diagnostics` could mask blocking nested diagnostics from `meta.diagnostics` or `metrics.diagnostics`.

Both cases weaken the no-stub release boundary.

## Behavior changes

For release-grade/prod checks:

- `run_mode` must be release-like:
  - `release`
  - `release-grade`
  - `prod`
  - `production`
- unknown or non-release run modes fail closed
- diagnostic sources are collected separately
- blocking signals from any diagnostic source fail the check
- conflicting diagnostic values across sources fail the check
- `gates_stubbed` and `scaffold` must be explicit literal `false`
- stub/smoke/scaffold profiles from any source fail the check

## Scope

Checker hardening only.

This PR updates:

- `PULSE_safe_pack_v0/tools/check_no_stub_release.py`

It does not add new fixtures or tests yet. Follow-up fixtures/tests will cover:

- unknown release run mode forbidden
- conflicting diagnostic sources forbidden

## Manual validation

Existing fixture checks:

```text
python PULSE_safe_pack_v0/tools/check_no_stub_release.py tests/fixtures/no_stub_release_boundary/core_scaffold_allowed.json --lane core
```

Expected:

```text
PASS
```

```text
python PULSE_safe_pack_v0/tools/check_no_stub_release.py tests/fixtures/no_stub_release_boundary/release_scaffold_forbidden.json --lane release-grade
```

Expected:

```text
FAIL
```

```text
python PULSE_safe_pack_v0/tools/check_no_stub_release.py tests/fixtures/no_stub_release_boundary/release_real_evidence_allowed.json --lane release-grade
```

Expected:

```text
PASS
```

## Follow-up work

- add `release_unknown_run_mode_forbidden.json`
- add `release_conflicting_diagnostics_forbidden.json`
- add unit tests for the no-stub release boundary
- wire the checker into release-grade/prod CI lanes