### PR TITLE
test(fixtures): add missing diagnostics forbidden status

### DIFF
--- a/tests/fixtures/no_stub_release_boundary/release_missing_diagnostics_forbidden.json
+++ b/tests/fixtures/no_stub_release_boundary/release_missing_diagnostics_forbidden.json
@@ -1,0 +1,14 @@
+{
+  "version": "test",
+  "created_utc": "2026-04-25T00:00:00Z",
+  "gates": {
+    "q1_grounded_ok": true,
+    "q4_slo_ok": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true
+  },
+  "metrics": {
+    "run_mode": "prod"
+  }
+}


### PR DESCRIPTION
## Summary

Adds:

- `tests/fixtures/no_stub_release_boundary/release_missing_diagnostics_forbidden.json`

This fixture represents a prod/release-like status artifact with release evidence gates set to true, but with no diagnostics object.

## Rationale

The no-stub release boundary requires release-grade/prod artifacts to explicitly prove that they are not scaffolded, stubbed, smoke-based, or non-materialized.

A status artifact with missing diagnostics must not silently pass release authority.

This fixture anchors that rule.

It is intentionally incomplete:

- `metrics.run_mode == "prod"`
- release evidence gates are literal `true`
- no top-level `diagnostics`
- no nested `meta.diagnostics`
- no nested `metrics.diagnostics`

A release-grade/prod checker must reject this artifact.

## Scope

Fixture only.

This PR does not add tests, CI wiring, or ledger/report changes.

## Manual validation

After `check_no_stub_release.py` is available, this fixture can be checked manually:

```text
python PULSE_safe_pack_v0/tools/check_no_stub_release.py tests/fixtures/no_stub_release_boundary/release_missing_diagnostics_forbidden.json --lane release-grade
```

Expected result:

```text
FAIL
```

The failure should mention missing or empty diagnostics.

## Follow-up work

- add missing materialization forbidden fixture
- add conflicting diagnostics forbidden fixture
- add unknown run mode forbidden fixture
- add unittest coverage for the no-stub release boundary
- wire the checker into release-grade/prod CI lanes