### PR TITLE
test(fixtures): add missing materialization forbidden status

### DIFF
--- a/tests/fixtures/no_stub_release_boundary/release_missing_materialization_forbidden.json
+++ b/tests/fixtures/no_stub_release_boundary/release_missing_materialization_forbidden.json
@@ -1,0 +1,19 @@
+{
+  "version": "test",
+  "created_utc": "2026-04-25T00:00:00Z",
+  "gates": {
+    "q1_grounded_ok": true,
+    "q4_slo_ok": true,
+    "detectors_materialized_ok": false,
+    "external_summaries_present": true,
+    "external_all_pass": true
+  },
+  "metrics": {
+    "run_mode": "prod"
+  },
+  "diagnostics": {
+    "gates_stubbed": false,
+    "scaffold": false,
+    "stub_profile": "materialized_evidence"
+  }
+}


### PR DESCRIPTION
## Summary

Adds:

- `tests/fixtures/no_stub_release_boundary/release_missing_materialization_forbidden.json`

This fixture represents a prod/release-like status artifact with explicit non-scaffold diagnostics, but missing detector materialization.

## Rationale

The no-stub release boundary requires two things in release-grade/prod lanes:

1. the artifact must explicitly prove it is not scaffolded or stubbed  
2. required release evidence must be materialized  

This fixture anchors the second rule.

It is intentionally non-scaffold:

- `metrics.run_mode == "prod"`
- `diagnostics.gates_stubbed == false`
- `diagnostics.scaffold == false`
- `diagnostics.stub_profile == "materialized_evidence"`

But it must still fail because:

- `gates.detectors_materialized_ok == false`

A release-grade/prod checker must reject this artifact.

## Scope

Fixture only.

This PR does not add tests, CI wiring, or ledger/report changes.

## Manual validation

After `check_no_stub_release.py` is available, this fixture can be checked manually:

```text
python PULSE_safe_pack_v0/tools/check_no_stub_release.py tests/fixtures/no_stub_release_boundary/release_missing_materialization_forbidden.json --lane release-grade
```

Expected result:

```text
FAIL
```

The failure should mention `detectors_materialized_ok`.

Also expected:

```text
python PULSE_safe_pack_v0/tools/check_no_stub_release.py tests/fixtures/no_stub_release_boundary/release_missing_materialization_forbidden.json --lane prod
```

Expected result:

```text
FAIL
```

## Follow-up work

- add conflicting diagnostics forbidden fixture
- add unknown run mode forbidden fixture
- add unittest coverage for the no-stub release boundary
- wire the checker into release-grade/prod CI lanes
- update ledger/report wording to distinguish core-stage pass from release-grade pass