### PR TITLE
test(fixtures): add allowed release evidence status

### DIFF
--- a/tests/fixtures/no_stub_release_boundary/release_real_evidence_allowed.json
+++ b/tests/fixtures/no_stub_release_boundary/release_real_evidence_allowed.json
@@ -1,0 +1,19 @@
+{
+  "version": "test",
+  "created_utc": "2026-04-25T00:00:00Z",
+  "gates": {
+    "q1_grounded_ok": true,
+    "q4_slo_ok": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true
+  },
+  "metrics": {
+    "run_mode": "prod"
+  },
+  "diagnostics": {
+    "gates_stubbed": false,
+    "scaffold": false,
+    "stub_profile": "materialized_evidence"
+  }
+}


### PR DESCRIPTION
```markdown
## Summary

Adds:

- `tests/fixtures/no_stub_release_boundary/release_real_evidence_allowed.json`

This fixture represents the passing prod/release-like case for the no-stub release boundary.

## Rationale

The no-stub release boundary needs both forbidden and allowed examples.

Existing forbidden fixtures cover cases where release-like artifacts must fail because evidence is scaffolded, diagnostics are missing, or materialization is absent.

This fixture anchors the allowed release case.

It is intentionally explicit:

- `metrics.run_mode == "prod"`
- `diagnostics.gates_stubbed == false`
- `diagnostics.scaffold == false`
- `diagnostics.stub_profile == "materialized_evidence"`
- `gates.detectors_materialized_ok == true`
- `gates.external_summaries_present == true`
- `gates.external_all_pass == true`

A release-grade/prod checker should accept this artifact.

## Boundary represented

This fixture records that release authority is allowed only when:

- the lane is release-like
- diagnostics explicitly prove non-scaffold / non-stub status
- required detector and external evidence gates are literal `true`
- no smoke, scaffold, or stub profile is present

## Scope

Fixture only.

This PR does not add:

- unit tests
- CI wiring
- ledger/report rendering changes

## Manual validation

Expected manual check:

```text
python PULSE_safe_pack_v0/tools/check_no_stub_release.py tests/fixtures/no_stub_release_boundary/release_real_evidence_allowed.json --lane release-grade
```

Expected result:

```text
PASS
```

Also expected:

```text
python PULSE_safe_pack_v0/tools/check_no_stub_release.py tests/fixtures/no_stub_release_boundary/release_real_evidence_allowed.json --lane prod
```

Expected result:

```text
PASS
```

## Follow-up work

- add conflicting diagnostics forbidden fixture
- add unknown run mode forbidden fixture
- add unit tests for the no-stub release boundary
- wire the checker into release-grade/prod CI lanes
- update ledger/report wording to distinguish core-stage pass from release-grade pass
```