### PR TITLE
test(fixtures): add unknown run mode forbidden status

### DIFF
--- a/tests/fixtures/no_stub_release_boundary/release_unknown_run_mode_forbidden.json
+++ b/tests/fixtures/no_stub_release_boundary/release_unknown_run_mode_forbidden.json
@@ -1,0 +1,19 @@
+{
+  "version": "test",
+  "created_utc": "2026-04-25T00:00:00Z",
+  "gates": {
+    "q1_grounded_ok": true,
+    "q4_slo_ok": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true
+  },
+  "metrics": {
+    "run_mode": "shadow"
+  },
+  "diagnostics": {
+    "gates_stubbed": false,
+    "scaffold": false,
+    "stub_profile": "materialized_evidence"
+  }
+}


### PR DESCRIPTION
```markdown
## Summary

Adds:

- `tests/fixtures/no_stub_release_boundary/release_unknown_run_mode_forbidden.json`

This fixture records the fail-closed behavior for unknown or non-release `run_mode` values during release-grade/prod checks.

## Rationale

The no-stub release boundary requires release-like lanes to be explicit.

A status artifact should not pass release-grade/prod checks merely because its gates and diagnostics appear valid. The artifact must also declare a release-like `run_mode`.

This fixture intentionally uses:

- `metrics.run_mode == "shadow"`
- release evidence gates set to literal `true`
- diagnostics explicitly showing non-scaffold / non-stub status

Despite those passing-looking values, this artifact must fail when checked as `release-grade` or `prod`.

## Boundary represented

This fixture anchors the rule:

> Unknown, advisory, shadow, empty, or mistyped run modes must fail closed in release-grade/prod boundary checks.

## Scope

Fixture only.

This PR does not modify the checker, unit tests, CI wiring, or ledger/report rendering.

## Manual validation

Expected check:

```text
python PULSE_safe_pack_v0/tools/check_no_stub_release.py tests/fixtures/no_stub_release_boundary/release_unknown_run_mode_forbidden.json --lane prod
```

Expected result:

```text
FAIL
```

The failure should mention `run_mode`.

## Follow-up work

- add conflicting diagnostics forbidden fixture
- update unit tests to consume explicit regression fixtures directly
- wire no-stub boundary tests into CI

---
