### PR TITLE
docs(assets): add PULSEmech architecture hero v0.1

### DIFF
--- a/hero_pulsemech_architecture_map_v0_1.svg
+++ b/hero_pulsemech_architecture_map_v0_1.svg
@@ -1,0 +1,191 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080" viewBox="0 0 1920 1080">
+<defs><linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#02070e"/><stop offset="0.6" stop-color="#06111d"/><stop offset="1" stop-color="#02070e"/></linearGradient><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="#25a9ff"/></marker></defs><rect width="1920" height="1080" fill="url(#bg)"/>
+<text x="960" y="60" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="54" font-weight="700" fill="#fff" text-anchor="end" letter-spacing="8">PULSE</text>
+<text x="960" y="60" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="54" font-weight="700" fill="#25a9ff" text-anchor="start" letter-spacing="0">mech</text>
+<text x="960" y="100" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="24" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">Artifact-first Mechanical Governance &amp; Knowledge System</text>
+<text x="960" y="132" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#25a9ff" text-anchor="middle" letter-spacing="0">Discover → Interpret → Prove → Protect → Improve</text>
+<rect x="40" y="70" width="310" height="390" rx="12" fill="#071927" stroke="#5d7f99" stroke-width="2"/>
+<text x="195" y="105" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="22" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">1. INPUT LAYER</text>
+<text x="195" y="130" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="14" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">All sources, all signals</text>
+<rect x="65" y="155" width="260" height="58" rx="8" fill="#071623" stroke="#25a9ff" stroke-width="2"/>
+<text x="81" y="183" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Code / Config</text>
+<text x="81" y="203" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">repo, workflows, scripts</text>
+<rect x="65" y="223" width="260" height="58" rx="8" fill="#071623" stroke="#47d85a" stroke-width="2"/>
+<text x="81" y="251" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Metrics / Measurements</text>
+<text x="81" y="271" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">json, logs, time-series</text>
+<rect x="65" y="291" width="260" height="58" rx="8" fill="#071623" stroke="#b06cff" stroke-width="2"/>
+<text x="81" y="319" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Documents</text>
+<text x="81" y="339" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">md, pdf, schema</text>
+<rect x="65" y="359" width="260" height="58" rx="8" fill="#071623" stroke="#f6c84d" stroke-width="2"/>
+<text x="81" y="387" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Events</text>
+<text x="81" y="407" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">CI runs, failures, hints</text>
+<rect x="65" y="427" width="260" height="58" rx="8" fill="#071623" stroke="#25a9ff" stroke-width="2"/>
+<text x="81" y="455" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Human Signals</text>
+<text x="81" y="475" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">notes, intuition, context</text>
+<rect x="40" y="610" width="310" height="330" rx="12" fill="#071927" stroke="#47d85a" stroke-width="2"/>
+<text x="195" y="645" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="20" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">7. CONTINUOUS IMPROVEMENT</text>
+<text x="195" y="670" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="14" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">Learn, evolve, get better</text>
+<rect x="65" y="695" width="260" height="58" rx="8" fill="#071623" stroke="#f6c84d" stroke-width="2"/>
+<text x="81" y="723" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Feedback Ingestion</text>
+<text x="81" y="743" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">what worked / what did not</text>
+<rect x="65" y="760" width="260" height="58" rx="8" fill="#071623" stroke="#f6c84d" stroke-width="2"/>
+<text x="81" y="788" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">New Hypotheses</text>
+<text x="81" y="808" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">from field &amp; evidence</text>
+<rect x="65" y="825" width="260" height="58" rx="8" fill="#071623" stroke="#47d85a" stroke-width="2"/>
+<text x="81" y="853" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Experiments &amp; Samples</text>
+<text x="81" y="873" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">controlled exploration</text>
+<rect x="65" y="890" width="260" height="58" rx="8" fill="#071623" stroke="#47d85a" stroke-width="2"/>
+<text x="81" y="918" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Knowledge Growth</text>
+<text x="81" y="938" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">improving the system</text>
+<rect x="390" y="155" width="1040" height="330" rx="12" fill="#071927" stroke="#5d7f99" stroke-width="2"/>
+<text x="910" y="193" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="23" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="1">2. INTERPRETIVE &amp; DIAGNOSTIC LAYER (SHADOW LAYER)</text>
+<text x="910" y="218" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="14" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">Understand the field. Not normative. Not deciding.</text>
+<circle cx="910" cy="335" r="100" fill="none" stroke="#25a9ff" stroke-width="2" opacity="0.18"/>
+<circle cx="910" cy="335" r="76" fill="none" stroke="#25a9ff" stroke-width="2" opacity="0.25"/>
+<circle cx="910" cy="335" r="52" fill="none" stroke="#25a9ff" stroke-width="2" opacity="0.35"/>
+<circle cx="910" cy="335" r="50" fill="#0a2133" stroke="#25a9ff" stroke-width="3"/>
+<text x="910" y="327" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="24" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">FIELD</text>
+<text x="910" y="357" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="24" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">MODEL</text>
+<text x="910" y="381" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="14" font-weight="700" fill="#25a9ff" text-anchor="middle" letter-spacing="0">(FSM)</text>
+<rect x="430" y="235" width="320" height="62" rx="8" fill="#071623" stroke="#b06cff" stroke-width="2"/>
+<text x="444" y="261" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#b06cff" text-anchor="start" letter-spacing="0">2.1 PARADOX DETECTOR</text>
+<text x="444" y="281" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">tensions, contradictions,</text>
+<text x="444" y="295" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">anomalies</text>
+<rect x="430" y="310" width="320" height="62" rx="8" fill="#071623" stroke="#47d85a" stroke-width="2"/>
+<text x="444" y="336" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#47d85a" text-anchor="start" letter-spacing="0">2.2 FIELD READER</text>
+<text x="444" y="356" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">patterns, trends, structures</text>
+<rect x="430" y="385" width="320" height="62" rx="8" fill="#071623" stroke="#25a9ff" stroke-width="2"/>
+<text x="444" y="411" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#25a9ff" text-anchor="start" letter-spacing="0">2.3 STABILITY &amp; EPF</text>
+<text x="444" y="431" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">robustness, stability,</text>
+<text x="444" y="445" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">boundaries</text>
+<rect x="1070" y="235" width="320" height="62" rx="8" fill="#071623" stroke="#f6c84d" stroke-width="2"/>
+<text x="1084" y="261" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#f6c84d" text-anchor="start" letter-spacing="0">2.4 HYPOTHESIS GENERATOR</text>
+<text x="1084" y="281" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">explanations and experiments</text>
+<rect x="1070" y="310" width="320" height="62" rx="8" fill="#071623" stroke="#ff9a3e" stroke-width="2"/>
+<text x="1084" y="336" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#ff9a3e" text-anchor="start" letter-spacing="0">2.5 EVIDENCE EVALUATOR</text>
+<text x="1084" y="356" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">quality, confidence, consistency</text>
+<rect x="1070" y="385" width="320" height="62" rx="8" fill="#071623" stroke="#13d4c8" stroke-width="2"/>
+<text x="1084" y="411" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#13d4c8" text-anchor="start" letter-spacing="0">2.6 REASONING ENGINE</text>
+<text x="1084" y="431" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">recommendations, non-normative</text>
+<line x1="750" y1="266" x2="850" y2="335" stroke="#b06cff" stroke-width="3" marker-end="url(#arrow)"/>
+<line x1="750" y1="341" x2="850" y2="335" stroke="#47d85a" stroke-width="3" marker-end="url(#arrow)"/>
+<line x1="750" y1="416" x2="850" y2="335" stroke="#25a9ff" stroke-width="3" marker-end="url(#arrow)"/>
+<line x1="1070" y1="266" x2="970" y2="335" stroke="#f6c84d" stroke-width="3" marker-end="url(#arrow)"/>
+<line x1="1070" y1="341" x2="970" y2="335" stroke="#ff9a3e" stroke-width="3" marker-end="url(#arrow)"/>
+<line x1="1070" y1="416" x2="970" y2="335" stroke="#13d4c8" stroke-width="3" marker-end="url(#arrow)"/>
+<line x1="350" y1="330" x2="390" y2="330" stroke="#25a9ff" stroke-width="3" marker-end="url(#arrow)"/>
+<line x1="1430" y1="330" x2="1510" y2="330" stroke="#25a9ff" stroke-width="3" marker-end="url(#arrow)"/>
+<rect x="390" y="520" width="1040" height="175" rx="12" fill="#071927" stroke="#5d7f99" stroke-width="2"/>
+<text x="910" y="558" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="23" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="1">3. NORMATIVE GOVERNANCE LAYER (AUTHORITY LAYER)</text>
+<text x="910" y="582" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="14" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">The only place where release decisions are made.</text>
+<rect x="420" y="615" width="140" height="68" rx="8" fill="#071623" stroke="#25a9ff" stroke-width="2"/>
+<text x="490.0" y="642" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">status.json</text>
+<text x="490.0" y="665" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">state &amp; context</text>
+<line x1="560" y1="649" x2="585" y2="649" stroke="#a7b7c8" stroke-width="3" marker-end="url(#arrow)"/>
+<rect x="585" y="615" width="160" height="68" rx="8" fill="#071623" stroke="#25a9ff" stroke-width="2"/>
+<text x="665.0" y="642" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">Policy Gate Set</text>
+<text x="665.0" y="665" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">required gates</text>
+<line x1="745" y1="649" x2="770" y2="649" stroke="#a7b7c8" stroke-width="3" marker-end="url(#arrow)"/>
+<rect x="770" y="615" width="150" height="68" rx="8" fill="#071623" stroke="#5d7f99" stroke-width="2"/>
+<text x="845.0" y="642" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">check_gates.py</text>
+<text x="845.0" y="665" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">true-only eval</text>
+<line x1="920" y1="649" x2="945" y2="649" stroke="#a7b7c8" stroke-width="3" marker-end="url(#arrow)"/>
+<rect x="945" y="615" width="220" height="68" rx="8" fill="#071623" stroke="#ff4b4b" stroke-width="2"/>
+<text x="1055.0" y="642" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#ff4b4b" text-anchor="middle" letter-spacing="0">release_decision_v0</text>
+<text x="1055.0" y="665" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">Materialized decision artifact</text>
+<text x="1055.0" y="679" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="11" font-weight="400" fill="#eef5ff" text-anchor="middle" letter-spacing="0">FAIL / STAGE-PASS / PROD-PASS</text>
+<line x1="1165" y1="649" x2="1190" y2="649" stroke="#a7b7c8" stroke-width="3" marker-end="url(#arrow)"/>
+<rect x="1190" y="615" width="170" height="68" rx="8" fill="#071623" stroke="#5d7f99" stroke-width="2"/>
+<text x="1275.0" y="642" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">Ledger Render</text>
+<text x="1275.0" y="665" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">read-only view</text>
+<line x1="910" y1="485" x2="910" y2="520" stroke="#a7b7c8" stroke-width="3" marker-end="url(#arrow)"/>
+<line x1="1430" y1="620" x2="1510" y2="620" stroke="#13d4c8" stroke-width="3" marker-end="url(#arrow)"/>
+<rect x="390" y="725" width="1040" height="145" rx="12" fill="#071927" stroke="#f6c84d" stroke-width="2"/>
+<text x="910" y="762" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="23" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="1">4. EXCEPTION &amp; OVERRIDE LAYER (BREAK-GLASS)</text>
+<text x="910" y="786" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="14" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">For rare critical situations. Separate from normal flow.</text>
+<rect x="430" y="815" width="205" height="56" rx="8" fill="#071623" stroke="#f6c84d" stroke-width="2" stroke-dasharray="8 6"/>
+<text x="532" y="838" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">Break-glass v0</text>
+<text x="532" y="860" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="11" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">audited exception request</text>
+<line x1="635" y1="843" x2="675" y2="843" stroke="#f6c84d" stroke-width="3" marker-end="url(#arrow)"/>
+<rect x="675" y="815" width="205" height="56" rx="8" fill="#071623" stroke="#f6c84d" stroke-width="2" stroke-dasharray="8 6"/>
+<text x="777" y="838" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">Human Review</text>
+<text x="777" y="860" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="11" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">justification required</text>
+<line x1="880" y1="843" x2="920" y2="843" stroke="#f6c84d" stroke-width="3" marker-end="url(#arrow)"/>
+<rect x="920" y="815" width="205" height="56" rx="8" fill="#071623" stroke="#f6c84d" stroke-width="2" stroke-dasharray="8 6"/>
+<text x="1022" y="838" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">Exception Decision</text>
+<text x="1022" y="860" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="11" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">approve / reject with reason</text>
+<line x1="1125" y1="843" x2="1165" y2="843" stroke="#f6c84d" stroke-width="3" marker-end="url(#arrow)"/>
+<rect x="1165" y="815" width="205" height="56" rx="8" fill="#071623" stroke="#f6c84d" stroke-width="2" stroke-dasharray="8 6"/>
+<text x="1267" y="838" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">Exception Ledger</text>
+<text x="1267" y="860" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="11" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">audited record, never PASS rewrite</text>
+<line x1="1055" y1="725" x2="1055" y2="695" stroke="#ff4b4b" stroke-width="3" marker-end="url(#arrow)"/>
+<rect x="1510" y="70" width="350" height="395" rx="12" fill="#071927" stroke="#5d7f99" stroke-width="2"/>
+<text x="1685" y="102" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">6. OUTPUT &amp; CONSUMPTION</text>
+<text x="1685" y="124" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">LAYER</text>
+<text x="1685" y="148" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="13" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">Make it useful, visible, actionable</text>
+<rect x="1538" y="165" width="300" height="57" rx="8" fill="#071623" stroke="#eef5ff" stroke-width="2"/>
+<text x="1554" y="193" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Reports</text>
+<text x="1554" y="213" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">interpreted views</text>
+<rect x="1538" y="232" width="300" height="57" rx="8" fill="#071623" stroke="#f6c84d" stroke-width="2"/>
+<text x="1554" y="260" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Artifacts</text>
+<text x="1554" y="280" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">json, ledger, packs</text>
+<rect x="1538" y="299" width="300" height="57" rx="8" fill="#071623" stroke="#47d85a" stroke-width="2"/>
+<text x="1554" y="327" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Quality Views</text>
+<text x="1554" y="347" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">scores, ledgers, status</text>
+<rect x="1538" y="366" width="300" height="57" rx="8" fill="#071623" stroke="#25a9ff" stroke-width="2"/>
+<text x="1554" y="394" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Visualizations</text>
+<text x="1554" y="414" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">charts, graphs, maps</text>
+<rect x="1538" y="433" width="300" height="57" rx="8" fill="#071623" stroke="#eef5ff" stroke-width="2"/>
+<text x="1554" y="461" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Next Steps</text>
+<text x="1554" y="481" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">actionable guidance</text>
+<rect x="1510" y="500" width="350" height="315" rx="12" fill="#071927" stroke="#5d7f99" stroke-width="2"/>
+<text x="1685" y="532" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">5. TRACKING &amp; TRACEABILITY</text>
+<text x="1685" y="554" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">LAYER</text>
+<text x="1685" y="578" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="13" font-weight="400" fill="#a7b7c8" text-anchor="middle" letter-spacing="0">Nothing disappears.</text>
+<rect x="1538" y="600" width="300" height="57" rx="8" fill="#071623" stroke="#eef5ff" stroke-width="2"/>
+<text x="1554" y="628" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Evidence Ledger</text>
+<text x="1554" y="648" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">everything is recorded</text>
+<rect x="1538" y="665" width="300" height="57" rx="8" fill="#071623" stroke="#f6c84d" stroke-width="2"/>
+<text x="1554" y="693" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Change Ledger</text>
+<text x="1554" y="713" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">who changed what, when</text>
+<rect x="1538" y="730" width="300" height="57" rx="8" fill="#071623" stroke="#eef5ff" stroke-width="2"/>
+<text x="1554" y="758" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Decision Trace</text>
+<text x="1554" y="778" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">why, how, under what</text>
+<rect x="1538" y="795" width="300" height="57" rx="8" fill="#071623" stroke="#eef5ff" stroke-width="2"/>
+<text x="1554" y="823" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#eef5ff" text-anchor="start" letter-spacing="0">Time Travel</text>
+<text x="1554" y="843" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#a7b7c8" text-anchor="start" letter-spacing="0">replay and inspect</text>
+<rect x="1510" y="845" width="350" height="140" rx="12" fill="#071927" stroke="#5d7f99" stroke-width="2"/>
+<text x="1685" y="878" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17" font-weight="700" fill="#eef5ff" text-anchor="middle" letter-spacing="0">PRINCIPLES</text>
+<text x="1540" y="910" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17" font-weight="700" fill="#a7b7c8" text-anchor="start" letter-spacing="0">•</text>
+<text x="1560" y="910" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">Interpret, don&#x27;t decide (in shadow)</text>
+<text x="1540" y="930" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17" font-weight="700" fill="#a7b7c8" text-anchor="start" letter-spacing="0">•</text>
+<text x="1560" y="930" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">Decide once, materialize always</text>
+<text x="1540" y="950" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17" font-weight="700" fill="#a7b7c8" text-anchor="start" letter-spacing="0">•</text>
+<text x="1560" y="950" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">Audit everything, trust nothing</text>
+<text x="1540" y="970" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17" font-weight="700" fill="#a7b7c8" text-anchor="start" letter-spacing="0">•</text>
+<text x="1560" y="970" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">Break-glass is audited, not hidden</text>
+<text x="1540" y="990" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="17" font-weight="700" fill="#a7b7c8" text-anchor="start" letter-spacing="0">•</text>
+<text x="1560" y="990" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">Artifact-first, never UI-first</text>
+<rect x="390" y="910" width="1040" height="70" rx="12" fill="#071927" stroke="#5d7f99" stroke-width="2"/>
+<text x="430" y="940" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#25a9ff" text-anchor="start" letter-spacing="0">DISCOVER</text>
+<text x="430" y="962" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">see the field</text>
+<text x="630" y="940" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#47d85a" text-anchor="start" letter-spacing="0">INTERPRET</text>
+<text x="630" y="962" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">understand patterns</text>
+<text x="830" y="940" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#b06cff" text-anchor="start" letter-spacing="0">PROVE</text>
+<text x="830" y="962" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">build &amp; evaluate evidence</text>
+<text x="1030" y="940" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#f6c84d" text-anchor="start" letter-spacing="0">PROTECT</text>
+<text x="1030" y="962" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">make decisions with integrity</text>
+<text x="1230" y="940" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="700" fill="#25a9ff" text-anchor="start" letter-spacing="0">IMPROVE</text>
+<text x="1230" y="962" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="start" letter-spacing="0">learn and evolve</text>
+<rect x="40" y="965" width="310" height="60" rx="12" fill="#071927" stroke="#5d7f99" stroke-width="2"/>
+<text x="80" y="1000" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700" fill="#25a9ff" text-anchor="start" letter-spacing="0">PULSEmech =</text>
+<text x="238" y="990" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="middle" letter-spacing="0">artifact-first mechanical</text>
+<text x="238" y="1010" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="400" fill="#eef5ff" text-anchor="middle" letter-spacing="0">governance &amp; knowledge system</text>
+<rect x="1510" y="1000" width="350" height="60" rx="12" fill="#071927" stroke="#5d7f99" stroke-width="2"/>
+<text x="1660" y="1037" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="26" font-weight="700" fill="#fff" text-anchor="end" letter-spacing="3">PULSE</text>
+<text x="1660" y="1037" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="26" font-weight="700" fill="#25a9ff" text-anchor="start" letter-spacing="0">mech</text>
+<text x="1840" y="1028" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="13" font-weight="400" fill="#eef5ff" text-anchor="end" letter-spacing="0">v0.1</text>
+<text x="1840" y="1047" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="13" font-weight="400" fill="#a7b7c8" text-anchor="end" letter-spacing="0">2026</text>
+<line x1="195" y1="610" x2="195" y2="460" stroke="#f6c84d" stroke-width="3" marker-end="url(#arrow)"/>
+<line x1="320" y1="750" x2="390" y2="750" stroke="#f6c84d" stroke-width="3" marker-end="url(#arrow)"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds the versioned PULSEmech architecture map as a new hero asset.

## Why

The current public README hero under-positions PULSE as a simple release-gate utility. The new architecture map better reflects the direction described by the preprint and documentation: PULSE as an artifact-first release-governance layer for LLM applications and AI-enabled systems.

The image presents the current release-authority core together with the expanding diagnostic, traceability, and governance layers.

## Change

- Add `hero_pulsemech_architecture_map_v0_1.svg`

## Authority boundary

This PR adds a visual orientation asset only.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior
- shadow-layer authority

## Follow-up

A follow-up PR can wire this asset into the README hero and update the top-level README positioning around PULSE as a release-governance layer.