### PR TITLE
docs(readme): fix architecture hero rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,22 @@
-
-<!-- HERO / architecture orientation map -->
-<img
-  alt="PULSEmech architecture map: artifact-first governance, shadow diagnostics, normative release authority, traceability, and release output."
-  src="hero_pulsemech_architecture_map_v0_1.svg"
-  width="100%"
->
+![PULSEmech architecture map: artifact-first governance, shadow diagnostics, normative release authority, traceability, and release output.](hero_pulsemech_architecture_map_v0_1.svg)
 
 <details>
   <summary><strong>Project badges and live release surfaces</strong></summary>
 
-  <p align="center">
-    <img src="pulse_grail.svg" width="90" alt="Pulse Holy Grail" />
-  </p>
+<p align="center">
+  <img src="pulse_grail.svg" width="90" alt="Pulse Holy Grail">
+</p>
 
-  <p align="center">
-    <img
-      src="https://img.shields.io/badge/PULSE-HOLY%20GRAIL-%237DF9FF?style=for-the-badge&logo=codesandbox&logoColor=white"
-      alt="Pulse Holy Grail badge"
-    >
-    <a href="https://hkati.github.io/pulse-release-gates-0.1/">
-      <img src="badges/pulse_status.svg" alt="PULSE status">
-    </a>
-    <a href="https://hkati.github.io/pulse-release-gates-0.1/status.json">
-      <img src="badges/rdsi.svg" alt="RDSI">
-    </a>
-    <a href="https://hkati.github.io/pulse-release-gates-0.1/#quality-ledger">
-      <img src="badges/q_ledger.svg" alt="Q-Ledger">
-    </a>
-  </p>
+<p align="center">
+  <img src="https://img.shields.io/badge/PULSE-HOLY%20GRAIL-%237DF9FF?style=for-the-badge&logo=codesandbox&logoColor=white" alt="Pulse Holy Grail badge">
+  <a href="https://hkati.github.io/pulse-release-gates-0.1/"><img src="badges/pulse_status.svg" alt="PULSE status"></a>
+  <a href="https://hkati.github.io/pulse-release-gates-0.1/status.json"><img src="badges/rdsi.svg" alt="RDSI"></a>
+  <a href="https://hkati.github.io/pulse-release-gates-0.1/#quality-ledger"><img src="badges/q_ledger.svg" alt="Q-Ledger"></a>
+</p>
 
 - **Quality Ledger:** https://hkati.github.io/pulse-release-gates-0.1/
 - **Status JSON:** https://hkati.github.io/pulse-release-gates-0.1/status.json
+
 </details>
 
 # PULSE — Release Gates for Safe & Useful AI


### PR DESCRIPTION
## Summary

Fixes rendering of the new PULSEmech architecture hero in the README.

## Why

The README top block used a multiline HTML `<img>` tag for the hero. GitHub rendered that tag as visible text instead of displaying the SVG.

## Changes

- Replace the multiline hero HTML with Markdown image syntax
- Keep the PULSEmech architecture map as the README hero
- Keep non-DOI badges inside the collapsible badge / live-surface section
- Keep the DOI badge visible outside the collapsible section using standard Markdown badge syntax

## Result

The README top block should now render in the intended order:

1. PULSEmech architecture hero
2. collapsible project badges and live release surfaces
3. canonical PULSE title
4. release-governance subtitle
5. live Quality Ledger link
6. DOI badge
7. release-governance positioning text

## Authority boundary

This is a documentation-only rendering fix.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior
- shadow-layer authority