### PR TITLE
docs(readme): clarify PULSE release-governance positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,6 @@ recorded release evidence
 
 Release gates are the deterministic enforcement mechanism inside the broader PULSE release-governance layer.
 
-
-> 💡 **Continuous expansion**
->
-> PULSE is not a frozen snapshot. The core release gate semantics are stable,
-> but the safe pack, docs and examples are under active, ongoing expansion.
-> Expect new profiles, detectors and ledger views to appear over time.
-
 The normative release path is:
 
 ```text
@@ -70,6 +63,14 @@ release evidence
 ```
 
 > **TL;DR**: Existing systems produce release evidence. PULSE binds that evidence to declared policy, evaluates it deterministically, enforces the release boundary in CI, and records the decision for audit.
+
+---
+
+> 💡 **Continuous expansion**
+>
+> PULSE is not a frozen snapshot. The release-authority core is explicit and versioned,
+> while the safe pack, documentation, examples, profiles, detectors, overlays,
+> and ledger views are under active expansion.
 
 ---
 


### PR DESCRIPTION
## Summary

Clarifies the README positioning around PULSE as a deterministic, fail-closed release-governance layer for LLM applications and AI-enabled systems.

## Why

The current README foregrounded release gates and first-run pack usage, which could under-position PULSE as a small CI utility or simple gate checker.

The preprint and documentation describe the broader architecture more precisely: PULSE is built above existing systems and release pipelines, where it evaluates recorded release evidence against declared policy and emits an auditable release decision record.

## Changes

- Wire the PULSEmech architecture hero into the README
- Preserve the canonical publication title: `PULSE — Release Gates for Safe & Useful AI`
- Add a precise technical subtitle for PULSE as a release-governance layer
- Move all non-DOI badges into a collapsible badge / live-surface section
- Keep the DOI visible outside the collapsible section
- Keep the live Quality Ledger link near the top-level publication / audit surfaces
- Reframe release gates as the deterministic enforcement mechanism inside the broader release-governance layer
- Clarify the release authority boundary:
  - recorded release evidence
  - declared gate policy
  - deterministic evaluator
  - primary CI release workflow
  - auditable release decision record
- Move the Continuous expansion note below the core positioning and before `Start here`

## Authority boundary

This is a documentation-only change.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior
- shadow-layer authority