### PR TITLE
docs(readme): fix DOI badge markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@
 
 **See the latest Quality Ledger (live):** https://hkati.github.io/pulse-release-gates-0.1/
 
-<  <a href="https://doi.org/10.5281/zenodo.17373002">
+<p>
+  <a href="https://doi.org/10.5281/zenodo.17373002">
     <img src="https://doi.org/badge/DOI/10.5281/zenodo.17373002.svg" alt="DOI">
   </a>
 </p>


### PR DESCRIPTION
## Summary

Fixes the DOI badge markup in the README top block.

## Why

The DOI badge is intentionally visible outside the collapsible badge section, but the current markup contains a stray `<` before the DOI link. That can render as visible noise in the README.

## Change

- Remove the stray markup before the DOI badge
- Restore a valid paragraph wrapper around the DOI link
- Keep the DOI badge in the same location below the live Quality Ledger link

## Authority boundary

This is a documentation-only markup fix.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior
- shadow-layer authority