### PR TITLE
docs(readme): link PULSEmech hero to architecture map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![PULSEmech architecture map: artifact-first governance, shadow diagnostics, normative release authority, traceability, and release output.](hero_pulsemech_architecture_map_v0_1.svg)
+[![PULSEmech architecture map: artifact-first governance, shadow diagnostics, normative release authority, traceability, and release output.](hero_pulsemech_architecture_map_v0_1.svg)](docs/PULSEMECH_ARCHITECTURE_MAP_v0_1.md)
 
 <details>
   <summary><strong>Project badges and live release surfaces</strong></summary>


### PR DESCRIPTION
## Summary

Links the README PULSEmech architecture hero to the dedicated architecture map documentation.

## Why

`docs/PULSEMECH_ARCHITECTURE_MAP_v0_1.md` now explains how to read the PULSEmech map as an orientation surface without changing the PULSE release-authority boundary.

This PR makes the README hero clickable so readers can move directly from the visual map to the canonical explanatory document.

## Change

- Update the README hero image link to point to `docs/PULSEMECH_ARCHITECTURE_MAP_v0_1.md`

## Authority boundary

This is a documentation-only navigation change.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior
- shadow-layer authority