### PR TITLE
docs(index): add PULSEmech architecture map entry

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -20,6 +20,7 @@ If you add/rename a doc under `docs/`, please update this index.
 - [STATUS_CONTRACT.md](STATUS_CONTRACT.md) — Contract for `status.json` shape and semantics.
 - [GATE_SETS.md](GATE_SETS.md) — Human-readable matrix of the current `core_required` and `required` policy sets.
 - [GLOSSARY_v0.md](GLOSSARY_v0.md) — Canonical term definitions used across docs.
+- [PULSEMECH_ARCHITECTURE_MAP_v0_1.md](PULSEMECH_ARCHITECTURE_MAP_v0_1.md) — How to read the PULSEmech architecture map and its release-authority boundary.
 
 ## Status, ledger & external signals
 


### PR DESCRIPTION
## Summary

Adds the PULSEmech architecture map documentation to the docs index.

## Why

`docs/PULSEMECH_ARCHITECTURE_MAP_v0_1.md` now documents how to read the PULSEmech architecture map and its release-authority boundary. This PR makes that page discoverable from `docs/INDEX.md`.

## Change

- Add `PULSEMECH_ARCHITECTURE_MAP_v0_1.md` to the `Orientation & contracts` section of `docs/INDEX.md`

## Authority boundary

This is a documentation-only index update.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior
- shadow-layer authority