### PR TITLE
docs(index): add release authority manifest entry

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,6 +21,7 @@ If you add/rename a doc under `docs/`, please update this index.
 - [GATE_SETS.md](GATE_SETS.md) — Human-readable matrix of the current `core_required` and `required` policy sets.
 - [GLOSSARY_v0.md](GLOSSARY_v0.md) — Canonical term definitions used across docs.
 - [PULSEMECH_ARCHITECTURE_MAP_v0_1.md](PULSEMECH_ARCHITECTURE_MAP_v0_1.md) — How to read the PULSEmech architecture map and its release-authority boundary.
+- [release_authority_manifest_v0.md](release_authority_manifest_v0.md) — Proposed audit manifest for recording the release-authority chain across evidence, policy, evaluator, workflow lane, and decision output.
 
 ## Status, ledger & external signals
 


### PR DESCRIPTION
## Summary

Adds the release authority manifest specification to the documentation index.

## Why

`docs/release_authority_manifest_v0.md` specifies the proposed `release_authority_v0.json` audit manifest. This PR makes that specification discoverable from `docs/INDEX.md`.

## Change

- Add `release_authority_manifest_v0.md` to the `Orientation & contracts` section of `docs/INDEX.md`

## Authority boundary

This is a documentation-only index update.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior
- shadow-layer authority