### PR TITLE
docs(schema): add release authority manifest v0 schema

### DIFF
--- a/schemas/release_authority_v0.schema.json
+++ b/schemas/release_authority_v0.schema.json
@@ -264,6 +264,14 @@
           },
           "default": []
         },
+        "advisory_gates_present": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/gate_id"
+          },
+          "default": []
+        },
         "publication_surfaces_present": {
           "type": "array",
           "items": {

--- a/schemas/release_authority_v0.schema.json
+++ b/schemas/release_authority_v0.schema.json
@@ -1,0 +1,348 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/HKati/pulse-release-gates-0.1/schemas/release_authority_v0.schema.json",
+  "title": "PULSE Release Authority Manifest v0",
+  "description": "Audit manifest for recording the PULSE release-authority chain for one run. This schema validates the manifest shape; it does not define release semantics.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "created_utc",
+    "run_identity",
+    "inputs",
+    "authority",
+    "evaluation",
+    "decision"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "release_authority_v0"
+    },
+    "created_utc": {
+      "type": "string",
+      "minLength": 1,
+      "description": "UTC timestamp for manifest creation."
+    },
+    "run_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "run_mode",
+        "workflow_name",
+        "event_name",
+        "ref",
+        "git_sha"
+      ],
+      "properties": {
+        "run_mode": {
+          "type": "string",
+          "enum": [
+            "demo",
+            "core",
+            "prod"
+          ]
+        },
+        "workflow_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "event_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "git_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{40}$"
+        },
+        "run_id": {
+          "type": [
+            "string",
+            "integer"
+          ],
+          "minLength": 1
+        },
+        "attempt": {
+          "type": [
+            "string",
+            "integer"
+          ],
+          "minLength": 1
+        },
+        "actor": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status_json",
+        "gate_policy",
+        "gate_registry"
+      ],
+      "properties": {
+        "status_json": {
+          "$ref": "#/$defs/artifact_ref"
+        },
+        "gate_policy": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/artifact_ref"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "policy_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "version": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          ]
+        },
+        "gate_registry": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/artifact_ref"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "version": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          ]
+        },
+        "evaluator": {
+          "$ref": "#/$defs/artifact_ref"
+        }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "policy_set",
+        "effective_required_gates",
+        "release_required_materialized"
+      ],
+      "properties": {
+        "policy_set": {
+          "type": "string",
+          "enum": [
+            "core_required",
+            "required",
+            "release_required",
+            "required+release_required",
+            "custom"
+          ]
+        },
+        "effective_required_gates": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/gate_id"
+          }
+        },
+        "release_required_materialized": {
+          "type": "boolean"
+        },
+        "advisory_gates": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/gate_id"
+          }
+        }
+      }
+    },
+    "evaluation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evaluator",
+        "required_gate_results",
+        "failed_required_gates",
+        "missing_required_gates"
+      ],
+      "properties": {
+        "evaluator": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evaluator_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "required_gate_results": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "propertyNames": {
+            "$ref": "#/$defs/gate_id"
+          }
+        },
+        "failed_required_gates": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/gate_id"
+          }
+        },
+        "missing_required_gates": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/gate_id"
+          }
+        }
+      }
+    },
+    "decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "fail_closed"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": [
+            "PASS",
+            "FAIL",
+            "STAGE-PASS",
+            "PROD-PASS",
+            "UNKNOWN"
+          ]
+        },
+        "fail_closed": {
+          "type": "boolean",
+          "const": true
+        }
+      }
+    },
+    "diagnostics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "shadow_surfaces_non_normative"
+      ],
+      "properties": {
+        "shadow_surfaces_present": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/diagnostic_surface"
+          },
+          "default": []
+        },
+        "shadow_surfaces_non_normative": {
+          "type": "boolean",
+          "const": true
+        },
+        "status_meta_foldins": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "publication_surfaces_present": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/diagnostic_surface"
+          },
+          "default": []
+        }
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$"
+    },
+    "gate_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.:-]+$",
+      "minLength": 1
+    },
+    "artifact_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "sha256"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "policy_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "diagnostic_surface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "role"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "shadow",
+            "diagnostic",
+            "publication",
+            "guardrail",
+            "auxiliary"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "normative": {
+          "type": "boolean",
+          "const": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the JSON Schema for the proposed `release_authority_v0.json` audit manifest.

## Why

`docs/release_authority_manifest_v0.md` specifies a future manifest for recording the PULSE release-authority chain across evidence, policy, evaluator, workflow lane, and decision output.

This PR adds the first machine-readable contract surface for that manifest.

## Change

- Add `schemas/release_authority_v0.schema.json`

## Authority boundary

This schema validates the shape of the proposed audit manifest.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior
- shadow-layer authority

The manifest remains an audit and traceability surface, not a new release-decision engine.