### PR TITLE
test(fixtures): add release authority core pass fixture

### DIFF
--- a/tests/fixtures/release_authority_v0/core_pass.json
+++ b/tests/fixtures/release_authority_v0/core_pass.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "release_authority_v0",
+  "created_utc": "2026-04-27T00:00:00Z",
+  "run_identity": {
+    "run_mode": "core",
+    "workflow_name": "PULSE CI",
+    "event_name": "pull_request",
+    "ref": "refs/pull/1/merge",
+    "git_sha": "0000000000000000000000000000000000000000"
+  },
+  "inputs": {
+    "status_json": {
+      "path": "PULSE_safe_pack_v0/artifacts/status.json",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "gate_policy": {
+      "path": "pulse_gate_policy_v0.yml",
+      "policy_id": "pulse-gate-policy-v0",
+      "version": "0.1.3",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "gate_registry": {
+      "path": "pulse_gate_registry_v0.yml",
+      "version": "gate_registry_v0",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    "evaluator": {
+      "path": "PULSE_safe_pack_v0/tools/check_gates.py",
+      "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    }
+  },
+  "authority": {
+    "policy_set": "core_required",
+    "effective_required_gates": [
+      "pass_controls_refusal",
+      "pass_controls_sanit",
+      "sanitization_effective",
+      "q1_grounded_ok",
+      "q4_slo_ok"
+    ],
+    "release_required_materialized": false,
+    "advisory_gates": [
+      "external_summaries_present",
+      "external_all_pass"
+    ]
+  },
+  "evaluation": {
+    "evaluator": "PULSE_safe_pack_v0/tools/check_gates.py",
+    "evaluator_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "required_gate_results": {
+      "pass_controls_refusal": true,
+      "pass_controls_sanit": true,
+      "sanitization_effective": true,
+      "q1_grounded_ok": true,
+      "q4_slo_ok": true
+    },
+    "failed_required_gates": [],
+    "missing_required_gates": []
+  },
+  "decision": {
+    "state": "PASS",
+    "fail_closed": true
+  },
+  "diagnostics": {
+    "shadow_surfaces_present": [],
+    "shadow_surfaces_non_normative": true,
+    "status_meta_foldins": [],
+    "advisory_gates_present": [
+      "external_summaries_present",
+      "external_all_pass"
+    ],
+    "publication_surfaces_present": []
+  }
+}


### PR DESCRIPTION
## Summary

Adds the first canonical valid fixture for the release authority manifest v0 schema.

## Why

`schemas/release_authority_v0.schema.json` now defines the machine-readable shape for the proposed `release_authority_v0.json` audit manifest.

This fixture records a minimal Core-lane PASS example and gives future schema/checker tests a stable positive example.

## Change

- Add `tests/fixtures/release_authority_v0/core_pass.json`

## Authority boundary

This is a fixture-only change.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior
- shadow-layer authority

The fixture models an audit manifest shape; it does not create a new release-decision engine.