### PR TITLE
test(fixtures): add release authority missing gate fixture

### DIFF
--- a/tests/fixtures/release_authority_v0/core_fail_missing_gate.json
+++ b/tests/fixtures/release_authority_v0/core_fail_missing_gate.json
@@ -11,22 +11,22 @@
   "inputs": {
     "status_json": {
       "path": "PULSE_safe_pack_v0/artifacts/status.json",
-      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      "sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
     },
     "gate_policy": {
       "path": "pulse_gate_policy_v0.yml",
       "policy_id": "pulse-gate-policy-v0",
       "version": "0.1.3",
-      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      "sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     },
     "gate_registry": {
       "path": "pulse_gate_registry_v0.yml",
       "version": "gate_registry_v0",
-      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      "sha256": "1111111111111111111111111111111111111111111111111111111111111111"
     },
     "evaluator": {
       "path": "PULSE_safe_pack_v0/tools/check_gates.py",
-      "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      "sha256": "2222222222222222222222222222222222222222222222222222222222222222"
     }
   },
   "authority": {
@@ -46,19 +46,20 @@
   },
   "evaluation": {
     "evaluator": "PULSE_safe_pack_v0/tools/check_gates.py",
-    "evaluator_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "evaluator_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
     "required_gate_results": {
       "pass_controls_refusal": true,
       "pass_controls_sanit": true,
       "sanitization_effective": true,
-      "q1_grounded_ok": true,
-      "q4_slo_ok": true
+      "q1_grounded_ok": true
     },
     "failed_required_gates": [],
-    "missing_required_gates": []
+    "missing_required_gates": [
+      "q4_slo_ok"
+    ]
   },
   "decision": {
-    "state": "PASS",
+    "state": "FAIL",
     "fail_closed": true
   },
   "diagnostics": {

--- a/tests/fixtures/release_authority_v0/core_fail_missing_gate.json
+++ b/tests/fixtures/release_authority_v0/core_fail_missing_gate.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "release_authority_v0",
+  "created_utc": "2026-04-27T00:00:00Z",
+  "run_identity": {
+    "run_mode": "core",
+    "workflow_name": "PULSE CI",
+    "event_name": "pull_request",
+    "ref": "refs/pull/1/merge",
+    "git_sha": "0000000000000000000000000000000000000000"
+  },
+  "inputs": {
+    "status_json": {
+      "path": "PULSE_safe_pack_v0/artifacts/status.json",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "gate_policy": {
+      "path": "pulse_gate_policy_v0.yml",
+      "policy_id": "pulse-gate-policy-v0",
+      "version": "0.1.3",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "gate_registry": {
+      "path": "pulse_gate_registry_v0.yml",
+      "version": "gate_registry_v0",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    "evaluator": {
+      "path": "PULSE_safe_pack_v0/tools/check_gates.py",
+      "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    }
+  },
+  "authority": {
+    "policy_set": "core_required",
+    "effective_required_gates": [
+      "pass_controls_refusal",
+      "pass_controls_sanit",
+      "sanitization_effective",
+      "q1_grounded_ok",
+      "q4_slo_ok"
+    ],
+    "release_required_materialized": false,
+    "advisory_gates": [
+      "external_summaries_present",
+      "external_all_pass"
+    ]
+  },
+  "evaluation": {
+    "evaluator": "PULSE_safe_pack_v0/tools/check_gates.py",
+    "evaluator_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "required_gate_results": {
+      "pass_controls_refusal": true,
+      "pass_controls_sanit": true,
+      "sanitization_effective": true,
+      "q1_grounded_ok": true,
+      "q4_slo_ok": true
+    },
+    "failed_required_gates": [],
+    "missing_required_gates": []
+  },
+  "decision": {
+    "state": "PASS",
+    "fail_closed": true
+  },
+  "diagnostics": {
+    "shadow_surfaces_present": [],
+    "shadow_surfaces_non_normative": true,
+    "status_meta_foldins": [],
+    "advisory_gates_present": [
+      "external_summaries_present",
+      "external_all_pass"
+    ],
+    "publication_surfaces_present": []
+  }
+}


### PR DESCRIPTION
## Summary

Adds a canonical missing-required-gate fixture for the release authority manifest v0 schema.

## Why

The release authority manifest must represent fail-closed outcomes when a required gate is missing.

This fixture records a Core-lane FAIL example where `q4_slo_ok` is part of the effective required gate set but is absent from `required_gate_results` and listed under `missing_required_gates`.

## Change

- Add `tests/fixtures/release_authority_v0/core_fail_missing_gate.json`

## Authority boundary

This is a fixture-only change.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior
- shadow-layer authority

The fixture models an audit manifest shape for an existing fail-closed condition; it does not create a new release-decision engine.