### PR TITLE
test(authority): cover release authority manifest checker

### DIFF
--- a/tests/test_check_release_authority_manifest_v0.py
+++ b/tests/test_check_release_authority_manifest_v0.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "PULSE_safe_pack_v0" / "tools" / "check_release_authority_manifest_v0.py"
+SCHEMA = ROOT / "schemas" / "release_authority_v0.schema.json"
+FIXTURES = ROOT / "tests" / "fixtures" / "release_authority_v0"
+
+
+def run_checker(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(TOOL),
+            "--manifest",
+            str(path),
+            "--schema",
+            str(SCHEMA),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def write_fixture(tmp_path: Path, name: str, data: dict) -> Path:
+    out = tmp_path / name
+    out.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return out
+
+
+def test_core_pass_fixture_validates() -> None:
+    result = run_checker(FIXTURES / "core_pass.json")
+    assert result.returncode == 0, result.stderr
+
+
+def test_core_fail_missing_gate_fixture_validates() -> None:
+    result = run_checker(FIXTURES / "core_fail_missing_gate.json")
+    assert result.returncode == 0, result.stderr
+
+
+def test_missing_required_gate_must_be_recorded(tmp_path: Path) -> None:
+    data = load_fixture("core_fail_missing_gate.json")
+    data["evaluation"]["missing_required_gates"] = []
+
+    path = write_fixture(tmp_path, "missing_not_recorded.json", data)
+    result = run_checker(path)
+
+    assert result.returncode != 0
+    assert "not listed in missing_required_gates" in result.stderr
+
+
+def test_missing_required_gate_must_fail_decision(tmp_path: Path) -> None:
+    data = load_fixture("core_fail_missing_gate.json")
+    data["decision"]["state"] = "PASS"
+
+    path = write_fixture(tmp_path, "missing_but_pass.json", data)
+    result = run_checker(path)
+
+    assert result.returncode != 0
+    assert "decision.state must be FAIL" in result.stderr
+
+
+def test_false_required_gate_must_be_listed_as_failed(tmp_path: Path) -> None:
+    data = load_fixture("core_pass.json")
+    data["evaluation"]["required_gate_results"]["q4_slo_ok"] = False
+
+    path = write_fixture(tmp_path, "false_not_failed.json", data)
+    result = run_checker(path)
+
+    assert result.returncode != 0
+    assert "not listed in failed_required_gates" in result.stderr
+
+
+def test_diagnostic_surface_must_not_be_normative(tmp_path: Path) -> None:
+    data = load_fixture("core_pass.json")
+    data["diagnostics"]["shadow_surfaces_present"] = [
+        {
+            "name": "relational_gain_shadow",
+            "role": "shadow",
+            "path": "PULSE_safe_pack_v0/artifacts/relational_gain_shadow_v0.json",
+            "normative": True,
+        }
+    ]
+
+    path = write_fixture(tmp_path, "normative_shadow.json", data)
+    result = run_checker(path)
+
+    assert result.returncode != 0
+    assert "normative" in result.stderr


### PR DESCRIPTION
## Summary

Adds regression tests for the release authority manifest v0 checker.

## Why

The release authority manifest checker validates both schema shape and minimal fail-closed consistency for the proposed audit manifest. This PR adds test coverage for the canonical valid fixtures and key invalid audit-manifest states.

## Changes

- Add `tests/test_check_release_authority_manifest_v0.py`
- Validate `tests/fixtures/release_authority_v0/core_pass.json`
- Validate `tests/fixtures/release_authority_v0/core_fail_missing_gate.json`
- Add negative regression coverage for:
  - missing required gates not listed in `missing_required_gates`
  - missing required gates with non-FAIL decisions
  - false required gates not listed in `failed_required_gates`
  - shadow diagnostic surfaces marked normative

## Authority boundary

This is a test-only change.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior for existing release gates
- shadow-layer authority