### PR TITLE
ci(tools): include release authority manifest checker test

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -27,6 +27,7 @@ tests/test_paradox_diagram_renderer_v0_smoke.py
 tests/test_openai_evals_refusal_smoke_dry_run_smoke.py
 tests/test_render_quality_ledger_tests_list_smoke.py
 tests/test_authority_boundary_repro_smoke.py 
+tests/test_check_release_authority_manifest_v0.py
 tests/test_release_decision_v0_smoke.py
 tests/test_release_decision_v0_schema_smoke.py
 tests/test_insert_release_decision_ledger_section_smoke.py 


### PR DESCRIPTION
## Summary

Adds the release authority manifest checker regression test to the tools-tests manifest.

## Why

`PULSE_safe_pack_v0/tools/check_release_authority_manifest_v0.py` and its regression tests are now part of the release-authority audit-manifest tooling.

This PR wires the test into `ci/tools-tests.list` so the tools-tests CI job covers it.

## Change

- Add `tests/test_check_release_authority_manifest_v0.py` to `ci/tools-tests.list`

## Authority boundary

This is a CI manifest-only update.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- checker behavior for existing release gates
- shadow-layer authority