### PR TITLE
ci(tools): include release authority builder test

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -28,6 +28,7 @@ tests/test_openai_evals_refusal_smoke_dry_run_smoke.py
 tests/test_render_quality_ledger_tests_list_smoke.py
 tests/test_authority_boundary_repro_smoke.py 
 tests/test_check_release_authority_manifest_v0.py
+tests/test_build_release_authority_manifest_v0.py
 tests/test_release_decision_v0_smoke.py
 tests/test_release_decision_v0_schema_smoke.py
 tests/test_insert_release_decision_ledger_section_smoke.py 


### PR DESCRIPTION
## Summary

Adds the release authority manifest builder regression test to the tools-tests manifest.

## Why

`tests/test_build_release_authority_manifest_v0.py` now covers the builder for the proposed `release_authority_v0.json` audit manifest.

This PR wires that test into `ci/tools-tests.list` so the tools-tests CI job covers the builder path.

## Change

- Add `tests/test_build_release_authority_manifest_v0.py` to `ci/tools-tests.list`

## Authority boundary

This is a CI manifest-only update.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- checker behavior for existing release gates
- shadow-layer authority

The release authority manifest remains an audit and traceability surface, not a new release-decision engine.