### PR TITLE
fix(authority): reject null manifest sections

### DIFF
--- a/PULSE_safe_pack_v0/tools/check_release_authority_manifest_v0.py
+++ b/PULSE_safe_pack_v0/tools/check_release_authority_manifest_v0.py
@@ -85,8 +85,11 @@ def _object_section(manifest: dict[str, Any], name: str, errors: list[str]) -> d
 
     Schema validation already rejects non-object sections, but semantic validation
     must not crash before the checker can report normal fail-closed errors.
+
+    Missing optional sections are neutral. Explicit null or other non-object values
+    are malformed and must be reported as validation errors.
     """
-    if name not in manifest or manifest.get(name) is None:
+    if name not in manifest:
         return {}
 
     value = manifest.get(name)


### PR DESCRIPTION
## Summary

Rejects explicit null top-level sections in the release authority manifest checker.

## Why

Codex noted that `_object_section()` treated explicit `null` values the same as missing sections.

That meant malformed manifests such as `"authority": null` or `"decision": null` did not emit the intended `<section> must be an object` semantic error.

## Changes

- Treat explicit `null` top-level sections as malformed
- Keep missing optional sections neutral
- Report `<section> must be an object` for null or non-object sections
- Add regression coverage for null `authority`, `evaluation`, `decision`, and `diagnostics`
- Ensure malformed null sections fail without traceback output

## Authority boundary

This is a checker/test-only robustness fix.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior for existing release gates
- shadow-layer authority