### PR TITLE
fix(authority): reject null manifest sections

### DIFF
--- a/tests/test_check_release_authority_manifest_v0.py
+++ b/tests/test_check_release_authority_manifest_v0.py
@@ -98,3 +98,28 @@ def test_diagnostic_surface_must_not_be_normative(tmp_path: Path) -> None:
 
     assert result.returncode != 0
     assert "normative" in result.stderr
+
+
+def test_non_object_top_level_sections_report_errors(tmp_path: Path) -> None:
+    data = load_fixture("core_pass.json")
+    data["authority"] = "oops"
+
+    path = write_fixture(tmp_path, "non_object_authority.json", data)
+    result = run_checker(path)
+
+    assert result.returncode != 0
+    assert "authority must be an object" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_null_top_level_sections_report_errors(tmp_path: Path) -> None:
+    for section in ("authority", "evaluation", "decision", "diagnostics"):
+        data = load_fixture("core_pass.json")
+        data[section] = None
+
+        path = write_fixture(tmp_path, f"null_{section}.json", data)
+        result = run_checker(path)
+
+        assert result.returncode != 0
+        assert f"{section} must be an object" in result.stderr
+        assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Summary

Rejects explicit null top-level sections in the release authority manifest checker.

## Why

Codex noted that `_object_section()` treated explicit `null` values the same as missing sections.

That meant malformed manifests such as `"authority": null`, `"evaluation": null`, `"decision": null`, or `"diagnostics": null` did not emit the intended `<section> must be an object` semantic error.

## Changes

- Treat explicit `null` top-level sections as malformed
- Keep missing optional sections neutral
- Report `<section> must be an object` for null or non-object sections
- Add regression coverage for null `authority`, `evaluation`, `decision`, and `diagnostics`
- Ensure malformed null sections fail without traceback output

## Authority boundary

This is a checker/test-only robustness fix.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior for existing release gates
- shadow-layer authority