### PR TITLE
fix(authority): run builder test from tools manifest

### DIFF
--- a/tests/test_build_release_authority_manifest_v0.py
+++ b/tests/test_build_release_authority_manifest_v0.py
@@ -198,3 +198,8 @@ def test_builds_required_plus_release_required_manifest(tmp_path: Path) -> None:
 
     check = run_checker(tmp_path / "release_authority_v0.json")
     assert check.returncode == 0, check.stderr
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

Adds a top-level pytest runner to `tests/test_build_release_authority_manifest_v0.py`.

## Why

Codex noted that `ci/tools-tests.list` entries are executed with `python "$t"`.

`tests/test_build_release_authority_manifest_v0.py` was pytest-style only, so direct execution could exit successfully without running assertions.

## Change

- Add a `__main__` pytest runner to `tests/test_build_release_authority_manifest_v0.py`

## Authority boundary

This is a test-runner fix.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- existing release gate checker behavior
- shadow-layer authority