### PR TITLE
fix(authority): run checker test from tools manifest

### DIFF
--- a/tests/test_check_release_authority_manifest_v0.py
+++ b/tests/test_check_release_authority_manifest_v0.py
@@ -123,3 +123,8 @@ def test_null_top_level_sections_report_errors(tmp_path: Path) -> None:
         assert result.returncode != 0
         assert f"{section} must be an object" in result.stderr
         assert "Traceback" not in result.stderr
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

Adds a top-level pytest runner to `tests/test_check_release_authority_manifest_v0.py`.

## Why

`ci/tools-tests.list` entries are executed with `python "$t"`.

`tests/test_check_release_authority_manifest_v0.py` is pytest-style, so direct execution needs a `__main__` pytest runner to ensure its assertions actually run under the tools-tests manifest.

## Change

- Add a `__main__` pytest runner to `tests/test_check_release_authority_manifest_v0.py`

## Authority boundary

This is a test-runner fix.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- existing release gate checker behavior
- shadow-layer authority