### PR TITLE
fix(schema): allow empty required gate results

### DIFF
--- a/schemas/release_authority_v0.schema.json
+++ b/schemas/release_authority_v0.schema.json
@@ -189,7 +189,6 @@
         },
         "required_gate_results": {
           "type": "object",
-          "minProperties": 1,
           "additionalProperties": {
             "type": "boolean"
           },


### PR DESCRIPTION
## Summary

Allows `evaluation.required_gate_results` to be empty in the release authority manifest schema.

## Why

Codex noted that when all effective required gates are missing from `status.json`, the builder can correctly emit:

- `evaluation.required_gate_results: {}`
- all effective required gates under `evaluation.missing_required_gates`
- `decision.state: FAIL`

That is a valid fail-closed audit state, but the schema previously rejected it because `required_gate_results` required at least one property.

## Change

- Permit an empty `evaluation.required_gate_results` object in `schemas/release_authority_v0.schema.json`

## Authority boundary

This is a schema-only audit-manifest fix.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior for existing release gates
- shadow-layer authority

The release authority manifest remains an audit and traceability surface, not a new release-decision engine.