### PR TITLE
fix(authority): omit empty policy version in manifest builder

### DIFF
--- a/PULSE_safe_pack_v0/tools/build_release_authority_manifest_v0.py
+++ b/PULSE_safe_pack_v0/tools/build_release_authority_manifest_v0.py
@@ -312,6 +312,15 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
     if not isinstance(registry_version, str):
         registry_version = str(registry_version)
 
+    gate_policy_ref = {
+        "path": str(policy_path),
+        "policy_id": str(policy_meta.get("id") or "pulse-gate-policy-v0"),
+        "sha256": _sha256(policy_path),
+    }
+    policy_version = policy_meta.get("version")
+    if policy_version:
+        gate_policy_ref["version"] = str(policy_version)
+
     manifest = {
         "schema_version": "release_authority_v0",
         "created_utc": args.created_utc or _utc_now(),
@@ -327,12 +336,7 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
                 "path": str(status_path),
                 "sha256": _sha256(status_path),
             },
-            "gate_policy": {
-                "path": str(policy_path),
-                "policy_id": str(policy_meta.get("id") or "pulse-gate-policy-v0"),
-                "version": str(policy_meta.get("version") or ""),
-                "sha256": _sha256(policy_path),
-            },
+            "gate_policy": gate_policy_ref,
             "gate_registry": {
                 "path": str(registry_path),
                 "version": registry_version,


### PR DESCRIPTION
## Summary

Omits `inputs.gate_policy.version` from the release authority manifest when `policy.version` is unavailable.

## Why

Codex noted that the builder always emitted `inputs.gate_policy.version`.

When the policy file did not define `policy.version`, the builder wrote an empty string:

    "version": ""

The schema treats `version` as optional, but if present it must satisfy `minLength: 1`. This produced schema-invalid manifests for otherwise valid minimal policies.

## Change

- Build the `gate_policy` input reference incrementally
- Preserve `policy_id`
- Preserve `sha256`
- Add `version` only when a non-empty policy version is available

## Authority boundary

This is a builder-only schema-alignment fix.

It does **not** change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior for existing release gates
- shadow-layer authority

The release authority manifest remains an audit and traceability surface, not a new release-decision engine.