### PR TITLE
fix(authority): preserve numeric policy versions

### DIFF
--- a/PULSE_safe_pack_v0/tools/build_release_authority_manifest_v0.py
+++ b/PULSE_safe_pack_v0/tools/build_release_authority_manifest_v0.py
@@ -318,8 +318,10 @@ def build_manifest(args: argparse.Namespace) -> dict[str, Any]:
         "sha256": _sha256(policy_path),
     }
     policy_version = policy_meta.get("version")
-    if policy_version:
-        gate_policy_ref["version"] = str(policy_version)
+    if policy_version is not None:
+        policy_version_s = str(policy_version).strip()
+        if policy_version_s:
+            gate_policy_ref["version"] = policy_version_s
 
     manifest = {
         "schema_version": "release_authority_v0",


### PR DESCRIPTION
## Summary

Preserves numeric `policy.version` values in the release authority manifest builder.

## Why

Codex noted that the builder checked `policy.version` by truthiness before serializing it.

That dropped numeric zero values such as:

    policy:
      version: 0

because `0` is falsy, even though it should serialize to the valid non-empty string `"0"`.

## Change

- Normalize `policy.version` to string before checking emptiness  
- Preserve numeric zero as `"0"`  
- Omit only missing, empty, or whitespace-only policy versions  

## Authority boundary

This is a builder-only schema-alignment fix.

It does **not** change:

- release semantics  
- gate policy  
- `status.json` semantics  
- CI behavior  
- checker behavior for existing release gates  
- shadow-layer authority  