### PR TITLE
docs(index): update release authority manifest status

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,7 +21,7 @@ If you add/rename a doc under `docs/`, please update this index.
 - [GATE_SETS.md](GATE_SETS.md) — Human-readable matrix of the current `core_required` and `required` policy sets.
 - [GLOSSARY_v0.md](GLOSSARY_v0.md) — Canonical term definitions used across docs.
 - [PULSEMECH_ARCHITECTURE_MAP_v0_1.md](PULSEMECH_ARCHITECTURE_MAP_v0_1.md) — How to read the PULSEmech architecture map and its release-authority boundary.
-- [release_authority_manifest_v0.md](release_authority_manifest_v0.md) — Proposed audit manifest for recording the release-authority chain across evidence, policy, evaluator, workflow lane, and decision output.
+- [release_authority_manifest_v0.md](release_authority_manifest_v0.md) — Implemented v0 audit-manifest contract surface for recording the release-authority chain across evidence, policy, evaluator, workflow lane, decision output, and diagnostic context. 
 
 ## Status, ledger & external signals
 


### PR DESCRIPTION
## Summary

Updates the `docs/INDEX.md` entry for `release_authority_manifest_v0.md`.

## Why

The release authority manifest documentation now states that `release_authority_v0` is an implemented v0 contract surface.

Codex’s second focused verification found one remaining documentation mismatch: `docs/INDEX.md` still described the manifest as “proposed.”

## Change

- Replace “Proposed audit manifest” with “Implemented v0 audit-manifest contract surface”
- Keep the entry in the orientation / contract documentation area
- Preserve the non-normative audit-surface framing

## Authority boundary

This is a documentation-only index update.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- CI behavior
- checker behavior for existing release gates
- shadow-layer authority