### PR TITLE
ci(tools): include release authority non-interference test

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -29,6 +29,7 @@ tests/test_render_quality_ledger_tests_list_smoke.py
 tests/test_authority_boundary_repro_smoke.py 
 tests/test_check_release_authority_manifest_v0.py
 tests/test_build_release_authority_manifest_v0.py
+tests/test_release_authority_manifest_non_interference.py
 tests/test_release_decision_v0_smoke.py
 tests/test_release_decision_v0_schema_smoke.py
 tests/test_insert_release_decision_ledger_section_smoke.py 


### PR DESCRIPTION
## Summary

Adds the release authority manifest non-interference test to the tools-tests manifest.

## Why

`release_authority_v0.json` is intended to be an audit and traceability surface, not a release-decision engine.

`tests/test_release_authority_manifest_non_interference.py` proves that generating the manifest does not modify `status.json` or change `check_gates.py` outcomes for Core PASS, missing-required-gate FAIL, and failed-required-gate FAIL cases.

This PR wires that test into `ci/tools-tests.list`.

## Change

- Add `tests/test_release_authority_manifest_non_interference.py` to `ci/tools-tests.list`

## Authority boundary

This is a CI manifest-only update.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- checker behavior for existing release gates
- shadow-layer authority

The release authority manifest remains an audit and traceability surface, not a new release-decision engine.