### PR TITLE
ci(authority): upload release authority manifest artifact

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -872,6 +872,16 @@ jobs:
 
           echo "OK: release authority manifest audit sidecar ready at $OUT"
     
+      - name: Upload release authority manifest (audit-only)
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-authority-v0
+          path: ${{ env.PACK_DIR }}/artifacts/release_authority_v0.json
+          if-no-files-found: warn
+          retention-days: 30
+
       - name: "ci: enforce gates via check_gates (policy-derived)"
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

Uploads `release_authority_v0.json` as an explicit audit-only CI artifact.

## Why

The primary PULSE workflow now builds and validates the release authority manifest as a non-normative sidecar.

This PR makes that sidecar visible as a dedicated CI artifact named `release-authority-v0`, instead of relying only on the broader artifacts directory.

## Change

- Add an explicit upload step for `PULSE_safe_pack_v0/artifacts/release_authority_v0.json`
- Publish it as `release-authority-v0`
- Keep the upload step non-blocking
- Use `if-no-files-found: warn`

## Authority boundary

This is a CI artifact publication change.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- `check_gates.py` behavior
- primary release-decision authority
- shadow-layer authority

`release_authority_v0.json` remains an audit and traceability surface, not a new release-decision engine.