### PR TITLE
ci(authority): pin release authority artifact upload action

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -875,7 +875,7 @@ jobs:
       - name: Upload release authority manifest (audit-only)
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-authority-v0
           path: ${{ env.PACK_DIR }}/artifacts/release_authority_v0.json


### PR DESCRIPTION
## Summary

Pins the release authority manifest upload action to an immutable commit SHA.

## Why

Codex noted that the new release authority artifact upload step used:

```yaml
actions/upload-artifact@v4
```

That is a mutable tag. The rest of `pulse_ci.yml` follows a pinned-action trust model, so this step should use an immutable commit SHA as well.

## Change

Replace:

```yaml
actions/upload-artifact@v4
```

with the pinned v4.6.2 commit SHA:

```yaml
actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
```

## Authority boundary

This is a CI supply-chain hardening change.

It does not change:

- release semantics  
- gate policy  
- status.json semantics  
- check_gates.py behavior  
- primary release-decision authority  
- shadow-layer authority  

`release_authority_v0.json` remains an audit and traceability surface, not a new release-decision engine.