### PR TITLE
ci(authority): summarize release authority manifest

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -882,6 +882,36 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
+      - name: Summarize release authority manifest (audit-only)
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          OUT="${{ env.PACK_DIR }}/artifacts/release_authority_v0.json"
+
+          {
+            echo "### Release authority manifest"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Role | Audit / traceability sidecar |"
+            echo "| Authority | Non-normative / non-blocking |"
+            echo "| CI artifact | \`release-authority-v0\` |"
+            echo "| Workspace path | \`$OUT\` |"
+
+            if [[ -f "$OUT" ]]; then
+              echo "| Status | Present |"
+            else
+              echo "| Status | Missing / not produced |"
+            fi
+
+            echo
+            echo "The release authority manifest records the evidence-policy-evaluator chain for audit."
+            echo "It does not change release semantics, gate policy, \`status.json\`, \`check_gates.py\`, or the primary release decision."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+ 
       - name: "ci: enforce gates via check_gates (policy-derived)"
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

Adds a GitHub Step Summary section for the release authority manifest.

## Why

The primary workflow now builds, validates, and uploads `release_authority_v0.json` as the `release-authority-v0` audit artifact.

This PR makes that artifact visible in the workflow Step Summary and records its non-normative authority role.

## Change

- Add a `Summarize release authority manifest (audit-only)` step
- Show whether `release_authority_v0.json` was produced
- Show the dedicated artifact name: `release-authority-v0`
- Show the workspace path
- State that the manifest is audit / traceability only and non-blocking

## Authority boundary

This is a CI summary-only visibility change.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- `check_gates.py` behavior
- primary release-decision authority
- shadow-layer authority

`release_authority_v0.json` remains an audit and traceability surface, not a new release-decision engine.