### PR TITLE
ci(tools): include release authority ledger section test

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -33,6 +33,7 @@ tests/test_release_authority_manifest_non_interference.py
 tests/test_release_decision_v0_smoke.py
 tests/test_release_decision_v0_schema_smoke.py
 tests/test_insert_release_decision_ledger_section_smoke.py 
+tests/test_insert_release_authority_manifest_ledger_section.py
 
 tools/operator_handoff_smoke.py
 


### PR DESCRIPTION
## Summary

Adds the release authority manifest ledger section inserter test to `ci/tools-tests.list`.

## Why

`tests/test_insert_release_authority_manifest_ledger_section.py` now covers the Quality Ledger post-processor for release authority manifest visibility.

This PR wires that test into the tools-tests manifest so CI executes it through the existing `python "$t"` path.

## Change

- Add `tests/test_insert_release_authority_manifest_ledger_section.py` to `ci/tools-tests.list`

## Authority boundary

This is a CI manifest-only update.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- `check_gates.py` behavior
- primary release-decision authority
- shadow-layer authority

The ledger inserter remains a renderer/post-processing visibility tool.