### PR TITLE
ci(authority): insert release authority section into ledger

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -911,7 +911,42 @@ jobs:
             echo "It does not change release semantics, gate policy, \`status.json\`, \`check_gates.py\`, or the primary release decision."
           } >> "$GITHUB_STEP_SUMMARY"
 
- 
+      - name: Insert release authority manifest section into Quality Ledger (audit-only)
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          REPORT="${{ env.PACK_DIR }}/artifacts/report_card.html"
+          MANIFEST="${{ env.PACK_DIR }}/artifacts/release_authority_v0.json"
+          TOOL="${{ env.PACK_DIR }}/tools/insert_release_authority_manifest_ledger_section.py"
+
+          if [[ ! -f "$REPORT" ]]; then
+            echo "::warning::release authority ledger section skipped: report_card.html not found at $REPORT"
+            exit 0
+          fi
+
+          if [[ ! -f "$TOOL" ]]; then
+            echo "::warning::release authority ledger section skipped: inserter tool not found at $TOOL"
+            exit 0
+          fi
+
+          set +e
+          python "$TOOL" \
+            --report "$REPORT" \
+            --manifest "$MANIFEST" \
+            --href "release_authority_v0.json"
+
+          INSERT_RC=$?
+          set -e
+
+          if [[ "$INSERT_RC" -ne 0 ]]; then
+            echo "::warning::release authority ledger section insertion failed; Quality Ledger left unchanged"
+            exit 0
+          fi
+
+          echo "OK: release authority manifest section inserted into Quality Ledger"
+
       - name: "ci: enforce gates via check_gates (policy-derived)"
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

Adds the release authority manifest section to the Quality Ledger during the primary workflow.

## Why

The workflow now builds, validates, uploads, and summarizes `release_authority_v0.json`.

This PR connects that audit sidecar to the human-readable Quality Ledger by running the tested ledger-section inserter against `report_card.html`.

## Changes

- Add a workflow step to run `insert_release_authority_manifest_ledger_section.py`
- Insert a `Release authority manifest` section into `report_card.html`
- Link to `release_authority_v0.json`
- Keep the step non-blocking
- Preserve missing-report / missing-tool cases as warnings

## Authority boundary

This is a CI visibility / renderer post-processing change.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- `check_gates.py` behavior
- primary release-decision authority
- shadow-layer authority

The Quality Ledger remains a reader / renderer. `release_authority_v0.json` remains an audit and traceability surface, not a release-decision engine.