### PR TITLE
docs(ledger): remove duplicate release authority heading

### DIFF
--- a/docs/quality_ledger.md
+++ b/docs/quality_ledger.md
@@ -47,7 +47,6 @@ A top-level `decision` field, when present, is descriptive only and is not the s
 ---
 
 ## 2. Release authority manifest section
-## 2. Release authority manifest section
 
 The Quality Ledger may include a `Release authority manifest` section when
 `release_authority_v0.json` is available for the run.


### PR DESCRIPTION
## Summary

Removes a duplicated `Release authority manifest section` heading from `docs/quality_ledger.md`.

## Why

The focused end-to-end verification pass for the `release_authority_v0` stack found one remaining documentation issue: a duplicated heading in the Quality Ledger documentation.

## Change

- Remove the duplicate `## Release authority manifest section` heading from `docs/quality_ledger.md`

## Verification

The focused verification pass confirmed the release authority stack is otherwise aligned across:

- docs
- schema
- builder
- checker
- fixtures
- tests
- tools-test manifest wiring
- workflow integration
- Quality Ledger insertion
- artifact upload
- audit bundle upload

## Authority boundary

This is a documentation-only cleanup.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- `check_gates.py` behavior
- primary release-decision authority
- shadow-layer authority

The Quality Ledger remains a reader / renderer. `release_authority_v0.json` remains an audit and traceability surface, not a release-decision engine.