### PR TITLE
docs(index): add release-grade reference run entry

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -22,6 +22,7 @@ If you add/rename a doc under `docs/`, please update this index.
 - [GLOSSARY_v0.md](GLOSSARY_v0.md) — Canonical term definitions used across docs.
 - [PULSEMECH_ARCHITECTURE_MAP_v0_1.md](PULSEMECH_ARCHITECTURE_MAP_v0_1.md) — How to read the PULSEmech architecture map and its release-authority boundary.
 - [release_authority_manifest_v0.md](release_authority_manifest_v0.md) — Implemented v0 audit-manifest contract surface for recording the release-authority chain across evidence, policy, evaluator, workflow lane, decision output, and diagnostic context. 
+- [release_grade_reference_run_v0.md](release_grade_reference_run_v0.md) — Operational definition of a non-stubbed release-grade PULSE reference run, including evidence requirements, artifact expectations, authority boundary, and reviewer checklist.
 
 ## Status, ledger & external signals
 


### PR DESCRIPTION
## Summary

Adds the release-grade reference run documentation to the docs index.

## Why

`docs/release_grade_reference_run_v0.md` defines what counts as a non-stubbed release-grade PULSE reference run.

This PR makes that operational reference discoverable from `docs/INDEX.md`.

## Change

- Add `release_grade_reference_run_v0.md` to `docs/INDEX.md`

## Authority boundary

This is a documentation-only index update.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- `check_gates.py` behavior
- primary release-decision authority
- shadow-layer authority