### PR TITLE
docs(ledger): remove duplicate reader guidance heading

### DIFF
--- a/docs/quality_ledger.md
+++ b/docs/quality_ledger.md
@@ -326,7 +326,7 @@ Recommended reading order:
 
 ---
 
-## 6. How humans should read the ledger
+## 7. Keeping this document aligned
 
 Keep this document aligned with the actual renderer.
 


### PR DESCRIPTION
## Summary

Removes a duplicated `How humans should read the ledger` heading from `docs/quality_ledger.md`.

## Why

The focused verification pass found one remaining documentation issue in the current checkout: `docs/quality_ledger.md` contained a duplicated heading.

The rest of the release authority manifest, Quality Ledger, audit bundle, workflow, schema, checker, builder, fixtures, tests, and tools-test wiring was reported as present in the local checkout.

## Change

- Remove the duplicate `## 6. How humans should read the ledger` heading from `docs/quality_ledger.md`

## Authority boundary

This is a documentation-only cleanup.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- `check_gates.py` behavior
- primary release-decision authority
- shadow-layer authority

The Quality Ledger remains a reader / renderer. `release_authority_v0.json` remains an audit and traceability surface, not a release-decision engine.