### PR TITLE
fix(release): reject malformed diagnostics sections

### DIFF
--- a/PULSE_safe_pack_v0/tools/check_release_grade_reference_run_v0.py
+++ b/PULSE_safe_pack_v0/tools/check_release_grade_reference_run_v0.py
@@ -69,13 +69,12 @@ def _check_status(status: dict[str, Any], errors: list[str]) -> None:
     if run_mode != "prod":
         errors.append(f"status.metrics.run_mode must be 'prod' for a release-grade reference run (got {run_mode!r})")
 
-    diagnostics = status.get("diagnostics") or {}
-    if diagnostics is not None and not isinstance(diagnostics, dict):
-        errors.append("status.diagnostics must be an object when present")
-        diagnostics = {}
-
-    if diagnostics.get("gates_stubbed") is True:
-        errors.append("status.diagnostics.gates_stubbed must not be true for a release-grade reference run")
+        if "diagnostics" in status:
+        diagnostics = status.get("diagnostics")
+        if not isinstance(diagnostics, dict):
+            errors.append("status.diagnostics must be an object when present")
+        elif diagnostics.get("gates_stubbed") is True:
+            errors.append("status.diagnostics.gates_stubbed must not be true for a release-grade reference run")
 
     for gate in RELEASE_REQUIRED_GATES:
         _gate_true(gates, gate, errors)
@@ -143,13 +142,14 @@ def _check_manifest(manifest: dict[str, Any], errors: list[str]) -> None:
     if decision.get("fail_closed") is not True:
         errors.append("manifest.decision.fail_closed must be true")
 
-    diagnostics = manifest.get("diagnostics") or {}
-    if diagnostics is not None and not isinstance(diagnostics, dict):
-        errors.append("manifest.diagnostics must be an object when present")
-        diagnostics = {}
-
-    if diagnostics and diagnostics.get("shadow_surfaces_non_normative") is not True:
-        errors.append("manifest.diagnostics.shadow_surfaces_non_normative must be true when diagnostics is present")
+        if "diagnostics" in manifest:
+        diagnostics = manifest.get("diagnostics")
+        if not isinstance(diagnostics, dict):
+            errors.append("manifest.diagnostics must be an object when present")
+        elif diagnostics.get("shadow_surfaces_non_normative") is not True:
+            errors.append(
+                "manifest.diagnostics.shadow_surfaces_non_normative must be true when diagnostics is present"
+            )
 
 
 def _check_optional_file(path: Path | None, label: str, errors: list[str]) -> None:

--- a/PULSE_safe_pack_v0/tools/check_release_grade_reference_run_v0.py
+++ b/PULSE_safe_pack_v0/tools/check_release_grade_reference_run_v0.py
@@ -69,7 +69,7 @@ def _check_status(status: dict[str, Any], errors: list[str]) -> None:
     if run_mode != "prod":
         errors.append(f"status.metrics.run_mode must be 'prod' for a release-grade reference run (got {run_mode!r})")
 
-        if "diagnostics" in status:
+    if "diagnostics" in status:
         diagnostics = status.get("diagnostics")
         if not isinstance(diagnostics, dict):
             errors.append("status.diagnostics must be an object when present")
@@ -142,14 +142,13 @@ def _check_manifest(manifest: dict[str, Any], errors: list[str]) -> None:
     if decision.get("fail_closed") is not True:
         errors.append("manifest.decision.fail_closed must be true")
 
-        if "diagnostics" in manifest:
+    if "diagnostics" in manifest:
         diagnostics = manifest.get("diagnostics")
         if not isinstance(diagnostics, dict):
             errors.append("manifest.diagnostics must be an object when present")
         elif diagnostics.get("shadow_surfaces_non_normative") is not True:
-            errors.append(
-                "manifest.diagnostics.shadow_surfaces_non_normative must be true when diagnostics is present"
-            )
+            errors.append("manifest.diagnostics.shadow_surfaces_non_normative must be true when diagnostics is present")
+            
 
 
 def _check_optional_file(path: Path | None, label: str, errors: list[str]) -> None:


### PR DESCRIPTION
## Summary

Rejects malformed diagnostics sections in the release-grade reference run checker.

## Why

Codex noted that the checker used `get(... ) or {}` for `status.diagnostics` and `manifest.diagnostics`.

That masked falsy non-object values such as:

- `[]`
- `false`
- `""`
- `0`

and allowed malformed diagnostics sections to pass instead of failing the release-grade reference qualification check.

## Changes

- Validate `status.diagnostics` only when explicitly present
- Reject non-object `status.diagnostics`
- Validate `manifest.diagnostics` only when explicitly present
- Reject non-object `manifest.diagnostics`
- Require `manifest.diagnostics.shadow_surfaces_non_normative=true` whenever manifest diagnostics are present
- Ensure an explicitly empty diagnostics object does not bypass the non-normative invariant

## Authority boundary

This is a checker-only robustness fix.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- `check_gates.py` behavior
- primary release-decision authority
- shadow-layer authority

`check_release_grade_reference_run_v0.py` remains a reference-run qualification checker, not a release-decision engine.