### PR TITLE
docs(release): record reference qualification workflow step

### DIFF
--- a/docs/release_grade_reference_run_v0.md
+++ b/docs/release_grade_reference_run_v0.md
@@ -36,6 +36,8 @@ authority.
 - checker: PULSE_safe_pack_v0/tools/check_release_grade_reference_run_v0.py  
 - test coverage: tests/test_check_release_grade_reference_run_v0.py  
 - tools-test coverage: ci/tools-tests.list  
+- primary workflow advisory qualification: present  
+- primary workflow authority role: non-normative / non-blocking  
 
 The reference run definition describes how to produce and review a release-grade
 PULSE run. It does not create a new gate and does not promote any diagnostic
@@ -356,6 +358,56 @@ check_release_grade_reference_run_v0.py = release-grade reference qualification 
 
 The checker can reject a candidate reference run as insufficient for reference
 purposes without redefining the underlying release decision.
+
+---
+
+## Primary workflow visibility
+
+The primary PULSE workflow runs the release-grade reference qualification checker
+as an advisory visibility step for release-grade runs.
+
+Workflow surface:
+
+```text
+.github/workflows/pulse_ci.yml
+```
+
+The workflow step checks the candidate run using:
+
+```text
+PULSE_safe_pack_v0/tools/check_release_grade_reference_run_v0.py
+```
+
+and reports the result in the GitHub Step Summary.
+
+This step is:
+
+- advisory  
+- non-normative  
+- non-blocking  
+- release-grade only  
+
+If the checker fails, the workflow emits a warning and records the result as
+Not qualified, but the normal release outcome is still determined by the
+existing release-authority path:
+
+```text
+status.json
++ declared gate policy
++ workflow-effective required gate set
++ check_gates.py
++ primary CI workflow
+```
+
+The qualification step answers a different question:
+
+Does this run satisfy the documented release-grade reference-run criteria?
+
+It does not answer:
+
+Should this release pass?
+
+That decision remains with the normal PULSE release-authority path.
 
 ---
 


### PR DESCRIPTION
## Summary

Records the release-grade reference qualification workflow step in the release-grade reference documentation.

## Why

The primary PULSE workflow now runs `check_release_grade_reference_run_v0.py` as an advisory visibility step for release-grade runs.

The documentation should reflect that workflow integration while preserving the authority boundary: the checker qualifies candidate reference runs but does not decide release outcomes.

## Changes

- Update the `Status` block in `docs/release_grade_reference_run_v0.md`
- Add a `Primary workflow visibility` section
- Document that `.github/workflows/pulse_ci.yml` runs the checker for release-grade runs
- Clarify that the step is advisory, non-normative, and non-blocking
- Clarify the difference between release decision authority and reference-run qualification

## Authority boundary

This is a documentation-only status alignment.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- `check_gates.py` behavior
- primary release-decision authority
- shadow-layer authority

`check_gates.py` remains the release authority evaluator. `check_release_grade_reference_run_v0.py` remains a reference-run qualification checker, not a release-decision engine.