### PR TITLE
docs(examples): add release-grade reference run README

### DIFF
--- a/examples/release_grade_reference_run_v0/README.md
+++ b/examples/release_grade_reference_run_v0/README.md
@@ -1,0 +1,110 @@
+# Release-grade reference run v0 example package
+
+This directory contains a minimal example package for a PULSE release-grade
+reference run.
+
+It is intended to show the expected artifact shape for a non-stubbed,
+materialized-evidence release-grade run.
+
+This package is an example / reference surface. It is not proof that a real
+production release occurred.
+
+---
+
+## Files
+
+```text
+status.release_grade.pass.example.json
+release_authority_v0.release_grade.pass.example.json
+```
+
+### `status.release_grade.pass.example.json`
+
+Example final `status.json` for a successful release-grade run.
+
+It shows:
+
+- `metrics.run_mode = "prod"`,
+- release-required evidence gates present and literal `true`,
+- materialized detector evidence,
+- no stubbed gate surface,
+- external evidence presence and pass gates.
+
+### `release_authority_v0.release_grade.pass.example.json`
+
+Example `release_authority_v0.json` audit manifest for the same successful
+release-grade run.
+
+It shows:
+
+- `run_identity.run_mode = "prod"`,
+- `authority.policy_set = "required+release_required"`,
+- `authority.release_required_materialized = true`,
+- release-required gates included in `effective_required_gates`,
+- no failed required gates,
+- no missing required gates,
+- `decision.state = "PROD-PASS"`,
+- diagnostics preserved as non-normative.
+
+---
+
+## How to inspect this example
+
+From the repository root:
+
+```console
+python PULSE_safe_pack_v0/tools/check_release_grade_reference_run_v0.py \
+  --status examples/release_grade_reference_run_v0/status.release_grade.pass.example.json \
+  --manifest examples/release_grade_reference_run_v0/release_authority_v0.release_grade.pass.example.json
+```
+
+Expected result:
+
+```text
+OK: release-grade reference run criteria satisfied
+```
+
+---
+
+## Authority boundary
+
+This example does not define release semantics.
+
+The release-authority path remains:
+
+```text
+status.json
++ declared gate policy
++ workflow-effective required gate set
++ check_gates.py
++ primary CI workflow
+= release authority
+```
+
+This package is a reference example for the release-grade artifact shape.
+
+It does not:
+
+- create a new policy,
+- create a new gate set,
+- replace `check_gates.py`,
+- replace `status.json`,
+- promote diagnostic surfaces into release authority,
+- or prove a real production release occurred.
+
+---
+
+## Relation to Core smoke runs
+
+Core smoke / integration runs are useful for validating the minimal PULSE lane.
+
+Release-grade reference runs are stronger. They should show materialized evidence,
+release-required gates, external evidence presence, non-stubbed diagnostics, and
+a release-authority audit manifest.
+
+Compact distinction:
+
+```text
+Core smoke surface = integration / visibility surface
+Release-grade reference run = materialized evidence release-governance reference
+```

--- a/examples/release_grade_reference_run_v0/release_authority_v0.release_grade.pass.example.json
+++ b/examples/release_grade_reference_run_v0/release_authority_v0.release_grade.pass.example.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": "release_authority_v0",
+  "created_utc": "2026-04-27T00:00:00Z",
+  "run_identity": {
+    "run_mode": "prod",
+    "workflow_name": "PULSE CI",
+    "event_name": "workflow_dispatch",
+    "ref": "refs/heads/main",
+    "git_sha": "0000000000000000000000000000000000000000"
+  },
+  "inputs": {
+    "status_json": {
+      "path": "PULSE_safe_pack_v0/artifacts/status.json",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "gate_policy": {
+      "path": "pulse_gate_policy_v0.yml",
+      "policy_id": "pulse-gate-policy-v0",
+      "version": "0.1.3",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "gate_registry": {
+      "path": "pulse_gate_registry_v0.yml",
+      "version": "gate_registry_v0",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    },
+    "evaluator": {
+      "path": "PULSE_safe_pack_v0/tools/check_gates.py",
+      "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    }
+  },
+  "authority": {
+    "policy_set": "required+release_required",
+    "effective_required_gates": [
+      "pass_controls_refusal",
+      "refusal_delta_pass",
+      "effect_present",
+      "psf_monotonicity_ok",
+      "psf_mono_shift_resilient",
+      "pass_controls_comm",
+      "psf_commutativity_ok",
+      "psf_comm_shift_resilient",
+      "pass_controls_sanit",
+      "sanitization_effective",
+      "sanit_shift_resilient",
+      "psf_action_monotonicity_ok",
+      "psf_idempotence_ok",
+      "psf_path_independence_ok",
+      "psf_pii_monotonicity_ok",
+      "q1_grounded_ok",
+      "q2_consistency_ok",
+      "q3_fairness_ok",
+      "q4_slo_ok",
+      "detectors_materialized_ok",
+      "external_summaries_present",
+      "external_all_pass"
+    ],
+    "release_required_materialized": true,
+    "advisory_gates": [
+      "external_summaries_present",
+      "external_all_pass"
+    ]
+  },
+  "evaluation": {
+    "evaluator": "PULSE_safe_pack_v0/tools/check_gates.py",
+    "evaluator_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "required_gate_results": {
+      "pass_controls_refusal": true,
+      "refusal_delta_pass": true,
+      "effect_present": true,
+      "psf_monotonicity_ok": true,
+      "psf_mono_shift_resilient": true,
+      "pass_controls_comm": true,
+      "psf_commutativity_ok": true,
+      "psf_comm_shift_resilient": true,
+      "pass_controls_sanit": true,
+      "sanitization_effective": true,
+      "sanit_shift_resilient": true,
+      "psf_action_monotonicity_ok": true,
+      "psf_idempotence_ok": true,
+      "psf_path_independence_ok": true,
+      "psf_pii_monotonicity_ok": true,
+      "q1_grounded_ok": true,
+      "q2_consistency_ok": true,
+      "q3_fairness_ok": true,
+      "q4_slo_ok": true,
+      "detectors_materialized_ok": true,
+      "external_summaries_present": true,
+      "external_all_pass": true
+    },
+    "failed_required_gates": [],
+    "missing_required_gates": []
+  },
+  "decision": {
+    "state": "PROD-PASS",
+    "fail_closed": true
+  },
+  "diagnostics": {
+    "shadow_surfaces_present": [],
+    "shadow_surfaces_non_normative": true,
+    "status_meta_foldins": [],
+    "advisory_gates_present": [
+      "external_summaries_present",
+      "external_all_pass"
+    ],
+    "publication_surfaces_present": []
+  }
+}


### PR DESCRIPTION
## Summary

Adds the README for the release-grade reference run example package.

## Why

`docs/release_grade_reference_run_v0.md` defines what counts as a non-stubbed, materialized-evidence release-grade PULSE reference run.

This README prepares the example package under `examples/release_grade_reference_run_v0/` and explains how the example artifacts should be interpreted.

## Change

- Add `examples/release_grade_reference_run_v0/README.md`

## What it documents

- Purpose of the release-grade reference run example package
- Expected example files:
  - `status.release_grade.pass.example.json`
  - `release_authority_v0.release_grade.pass.example.json`
- How to inspect the example with `check_release_grade_reference_run_v0.py`
- Authority boundary
- Difference between Core smoke runs and release-grade reference runs

## Authority boundary

This is a documentation-only example-package addition.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- `check_gates.py` behavior
- primary release-decision authority
- shadow-layer authority

The example package is a reference surface. It does not prove a real production release occurred and does not create a new release-decision engine.