### PR TITLE
docs(examples): add release-grade status example

### DIFF
--- a/examples/release_grade_reference_run_v0/status.release_grade.pass.example.json
+++ b/examples/release_grade_reference_run_v0/status.release_grade.pass.example.json
@@ -1,0 +1,54 @@
+{
+  "version": "release-grade-reference-v0",
+  "created_utc": "2026-04-27T00:00:00Z",
+  "metrics": {
+    "run_mode": "prod"
+  },
+  "gates": {
+    "pass_controls_refusal": true,
+    "refusal_delta_pass": true,
+    "effect_present": true,
+    "psf_monotonicity_ok": true,
+    "psf_mono_shift_resilient": true,
+    "pass_controls_comm": true,
+    "psf_commutativity_ok": true,
+    "psf_comm_shift_resilient": true,
+    "pass_controls_sanit": true,
+    "sanitization_effective": true,
+    "sanit_shift_resilient": true,
+    "psf_action_monotonicity_ok": true,
+    "psf_idempotence_ok": true,
+    "psf_path_independence_ok": true,
+    "psf_pii_monotonicity_ok": true,
+    "q1_grounded_ok": true,
+    "q2_consistency_ok": true,
+    "q3_fairness_ok": true,
+    "q4_slo_ok": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true
+  },
+  "external": {
+    "summaries_present": true,
+    "all_pass": true,
+    "summary_count": 2,
+    "metrics": [
+      {
+        "name": "example_external_safety_summary",
+        "value": 1.0,
+        "threshold": 1.0,
+        "pass": true
+      },
+      {
+        "name": "example_external_quality_summary",
+        "value": 1.0,
+        "threshold": 1.0,
+        "pass": true
+      }
+    ]
+  },
+  "diagnostics": {
+    "gates_stubbed": false,
+    "stub_profile": null
+  }
+}


### PR DESCRIPTION
## Summary

Adds the missing `status.release_grade.pass.example.json` file for the release-grade reference run example package.

## Why

`examples/release_grade_reference_run_v0/README.md` references two JSON artifacts:

- `status.release_grade.pass.example.json`
- `release_authority_v0.release_grade.pass.example.json`

The authority manifest example is present, but the status example was missing. As a result, the documented inspection command failed with a missing status file instead of returning the expected OK result.

## Change

- Add `examples/release_grade_reference_run_v0/status.release_grade.pass.example.json`

## What the example shows

- `metrics.run_mode = "prod"`
- materialized detector evidence
- release-required external evidence gates
- no stubbed gate surface
- release-grade PASS-style status evidence for the example package

## Authority boundary

This is an example-only addition.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- `check_gates.py` behavior
- primary release-decision authority
- shadow-layer authority

The package illustrates the release-grade artifact shape; it does not prove a real production release occurred and does not create a new release-decision engine.