### PR TITLE
docs(index): add orchestration evidence bridge entry

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,6 +31,7 @@ If you add/rename a doc under `docs/`, please update this index.
 - [refusal_delta_gate.md](refusal_delta_gate.md) — Refusal-delta summary format + fail-closed semantics.
 - [EXTERNAL_DETECTORS.md](EXTERNAL_DETECTORS.md) — External detectors policy & modes (gating vs advisory).
 - [external_detector_summaries.md](external_detector_summaries.md) — Folding external detector summaries into status/ledger.
+- [AGENT_ORCHESTRATION_EVIDENCE_BRIDGE_v0.md](AGENT_ORCHESTRATION_EVIDENCE_BRIDGE_v0.md) — Boundary for treating agent-orchestration proof-of-work as diagnostic release evidence without granting release authority.
 
 ## Paradox field & edges
 


### PR DESCRIPTION
## Summary

Adds the agent orchestration evidence bridge document to `docs/INDEX.md`.

## Why

`docs/AGENT_ORCHESTRATION_EVIDENCE_BRIDGE_v0.md` defines how agent-orchestration proof-of-work can be treated as diagnostic release evidence without granting release authority.

This PR makes that bridge document discoverable from the documentation index.

## Change

- Add `AGENT_ORCHESTRATION_EVIDENCE_BRIDGE_v0.md` to `docs/INDEX.md`

## Authority boundary

This is a documentation-only index update.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- `check_gates.py` behavior
- primary release-decision authority
- shadow-layer authority

Agent orchestration evidence remains diagnostic / advisory unless explicitly promoted by policy.