### PR TITLE
ci(tools): include agent orchestration evidence example test

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -36,6 +36,7 @@ tests/test_insert_release_decision_ledger_section_smoke.py
 tests/test_insert_release_authority_manifest_ledger_section.py
 tests/test_check_release_grade_reference_run_v0.py
 tests/test_release_grade_reference_example_package.py
+tests/test_agent_orchestration_evidence_example_package.py
 
 tools/operator_handoff_smoke.py
 


### PR DESCRIPTION
## Summary

Adds the agent orchestration evidence example package test to `ci/tools-tests.list`.

## Why

`tests/test_agent_orchestration_evidence_example_package.py` now guards the example package under `examples/agent_orchestration_evidence_v0/`.

This PR wires that test into the tools-tests manifest so CI executes it through the existing `python "$t"` path.

## Change

- Add `tests/test_agent_orchestration_evidence_example_package.py` to `ci/tools-tests.list`

## Authority boundary

This is a CI manifest-only update.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- `check_gates.py` behavior
- primary release-decision authority
- shadow-layer authority

Agent orchestration evidence remains diagnostic / advisory unless explicitly promoted by policy.