### PR TITLE
fix(schema): align agent evidence required fields

### DIFF
--- a/schemas/agent_orchestration_evidence_v0.schema.json
+++ b/schemas/agent_orchestration_evidence_v0.schema.json
@@ -47,9 +47,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "task_id",
-        "tracker",
-        "title"
+        "task_id"
       ],
       "properties": {
         "task_id": {
@@ -165,8 +163,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "human_accepted",
-        "reviewer_notes"
+        "human_accepted"
       ],
       "properties": {
         "human_accepted": {


### PR DESCRIPTION
## Summary

Aligns the agent orchestration evidence schema with the bridge documentation.

## Why

Codex noted that `schemas/agent_orchestration_evidence_v0.schema.json` required metadata fields that the bridge documentation describes as optional.

Specifically, the schema required:

- `task.tracker`
- `task.title`
- `human_review.reviewer_notes`

The bridge contract allows minimal payloads where only the core task identity and human acceptance state are present.

## Changes

- Require only `task.task_id` in the `task` object
- Keep `task.tracker`, `task.title`, and `task.task_url` optional
- Require only `human_review.human_accepted`
- Keep `human_review.reviewer_notes` optional

## Authority boundary

This only relaxes optional descriptive metadata.

It does not relax the authority-boundary invariants:

- `evidence_role = diagnostic`
- `normative = false`
- `release_authority = false`
- `pulse_ingestion.gate_promotion = false`
- `pulse_ingestion.release_decision_claim = none`
- `pulse_ingestion.recommended_fold_in_target = status.meta.agent_work_evidence`

This is a schema-only contract alignment.

It does not change:

- release semantics
- gate policy
- `status.json` semantics
- `check_gates.py` behavior
- primary release-decision authority
- shadow-layer authority

Agent orchestration evidence remains diagnostic / advisory unless explicitly promoted by policy.