### PR TITLE
test(pulse-ref): add release reference fixture directory

### DIFF
--- a/tests/fixtures/release_reference_v1/agent_diagnostic_promoted/.gitkeep
+++ b/tests/fixtures/release_reference_v1/agent_diagnostic_promoted/.gitkeep
@@ -1,0 +1,1 @@
+# Keep this PULSE-REF fixture directory in Git.


### PR DESCRIPTION
## Summary

Adds one placeholder `.gitkeep` file for the PULSE-REF release reference fixture directory skeleton.

This directory belongs to the fixture categories documented in `tests/fixtures/release_reference_v1/README.md`.

## Purpose

The fixture directory prepares the repository for release-grade evidence-to-decision test cases.

Future commits will populate this directory with concrete fixture artifacts such as status files, external summaries, manifests, audit traces, publication snapshots, and expected outcomes.

## Authority boundary

This change does not define release authority and does not introduce a second decision path.

The fixture directory will be used to exercise the declared-policy gate-enforcement path and verify that negative evidence cases fail closed.

## Risk

Low. Directory placeholder only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.