### PR TITLE
fix(pulse-ref): read canonical policy gate sets

### DIFF
--- a/ci/check_release_reference_complete_v1.py
+++ b/ci/check_release_reference_complete_v1.py
@@ -75,36 +75,60 @@ def get_nested_bool(data: dict[str, Any], path: list[str]) -> Any:
         cur = cur.get(key)
     return cur
 
+def _normalize_gate_list(candidate: Any) -> list[str]:
+    """Normalize a gate-list candidate into a list of gate names."""
+    if not isinstance(candidate, list):
+        return []
+
+    gates: list[str] = []
+    for item in candidate:
+        if isinstance(item, str):
+            gates.append(item)
+        elif isinstance(item, dict):
+            for key in ("name", "gate", "id"):
+                value = item.get(key)
+                if isinstance(value, str):
+                    gates.append(value)
+                    break
+
+    return gates
+
 
 def extract_gate_set(policy: dict[str, Any], set_name: str) -> list[str]:
     """
-    Extract a gate set from common policy layouts.
+    Extract a gate set from supported policy layouts.
 
     Supported shapes include:
-    - {"required": [...]}
-    - {"release_required": [...]}
-    - {"gate_sets": {"required": [...]}}
-    - {"sets": {"required": [...]}}
+        - {"gates": {"required": [...]}}              # canonical PULSE format
+    - {"gates": {"release_required": [...]}}      # canonical PULSE format
+    - {"required": [...]}                         # simple / legacy format
+    - {"release_required": [...]}                 # simple / legacy format
+    - {"gate_sets": {"required": [...]}}          # alternate format
+    - {"sets": {"required": [...]}}               # alternate format
     """
 
     candidates: list[Any] = []
 
+    # Canonical PULSE policy format:
+    # gates.required / gates.release_required
+    gates_container = policy.get("gates")
+    if isinstance(gates_container, dict) and set_name in gates_container:
+        candidates.append(gates_container.get(set_name))
+
+    # Simple / legacy top-level format.
+    
     if set_name in policy:
         candidates.append(policy.get(set_name))
 
+    # Alternate nested formats.
     for container_key in ("gate_sets", "sets"):
         container = policy.get(container_key)
         if isinstance(container, dict) and set_name in container:
             candidates.append(container.get(set_name))
 
     for candidate in candidates:
-        if isinstance(candidate, list):
-            gates: list[str] = []
-            for item in candidate:
-                if isinstance(item, str):
-                    gates.append(item)
-                elif isinstance(item, dict) and isinstance(item.get("name"), str):
-                    gates.append(item["name"])
+          gates = _normalize_gate_list(candidate)
+        if gates:
             return gates
 
     return []

--- a/ci/check_release_reference_complete_v1.py
+++ b/ci/check_release_reference_complete_v1.py
@@ -75,59 +75,49 @@ def get_nested_bool(data: dict[str, Any], path: list[str]) -> Any:
         cur = cur.get(key)
     return cur
 
-def _normalize_gate_list(candidate: Any) -> list[str]:
-    """Normalize a gate-list candidate into a list of gate names."""
-    if not isinstance(candidate, list):
-        return []
-
-    gates: list[str] = []
-    for item in candidate:
-        if isinstance(item, str):
-            gates.append(item)
-        elif isinstance(item, dict):
-            for key in ("name", "gate", "id"):
-                value = item.get(key)
-                if isinstance(value, str):
-                    gates.append(value)
-                    break
-
-    return gates
-
 
 def extract_gate_set(policy: dict[str, Any], set_name: str) -> list[str]:
     """
-    Extract a gate set from supported policy layouts.
+    Extract a gate set from common policy layouts.
 
     Supported shapes include:
-        - {"gates": {"required": [...]}}              # canonical PULSE format
-    - {"gates": {"release_required": [...]}}      # canonical PULSE format
-    - {"required": [...]}                         # simple / legacy format
-    - {"release_required": [...]}                 # simple / legacy format
-    - {"gate_sets": {"required": [...]}}          # alternate format
-    - {"sets": {"required": [...]}}               # alternate format
+    - {"gates": {"required": [...]}}
+    - {"required": [...]}
+    - {"gate_sets": {"required": [...]}}
+    - {"sets": {"required": [...]}}
     """
+    def _normalize_gate_list(candidate: Any) -> list[str]:
+        if not isinstance(candidate, list):
+            return []
+
+        gates: list[str] = []
+        for item in candidate:
+            if isinstance(item, str):
+                gates.append(item)
+            elif isinstance(item, dict):
+                for key in ("name", "gate", "id"):
+                    value = item.get(key)
+                    if isinstance(value, str):
+                        gates.append(value)
+                        break
+        return gates
 
     candidates: list[Any] = []
 
-    # Canonical PULSE policy format:
-    # gates.required / gates.release_required
     gates_container = policy.get("gates")
     if isinstance(gates_container, dict) and set_name in gates_container:
         candidates.append(gates_container.get(set_name))
 
-    # Simple / legacy top-level format.
-    
     if set_name in policy:
         candidates.append(policy.get(set_name))
 
-    # Alternate nested formats.
     for container_key in ("gate_sets", "sets"):
         container = policy.get(container_key)
         if isinstance(container, dict) and set_name in container:
             candidates.append(container.get(set_name))
 
     for candidate in candidates:
-          gates = _normalize_gate_list(candidate)
+        gates = _normalize_gate_list(candidate)
         if gates:
             return gates
 


### PR DESCRIPTION
## Summary

Fixes `ci/check_release_reference_complete_v1.py` so the PULSE-REF release reference completeness guard reads gate sets from the canonical PULSE gate policy structure.

The canonical `pulse_gate_policy_v0.yml` stores gate sets under `gates.required` and `gates.release_required`. The previous extraction logic only checked top-level keys and alternate `gate_sets` / `sets` containers, which caused the guard to report valid canonical gate sets as missing.

## Scope

Updates gate-set extraction only.

Supported policy layouts now include:

- `policy["gates"][set_name]`
- `policy[set_name]`
- `policy["gate_sets"][set_name]`
- `policy["sets"][set_name]`

Also normalizes gate list entries that are either strings or dictionaries with a `name`, `gate`, or `id` field.

## Authority boundary

This change does not create release authority.

It does not replace `check_gates.py`.

It does not modify `pulse_gate_policy_v0.yml`.

It does not make release-authority manifests, audit bundles, ledgers, dashboards, summaries, or publication surfaces normative.

The guard remains a release-grade completeness check for PULSE-REF reference artifacts.

## Testing

Run:

- `python -m py_compile ci/check_release_reference_complete_v1.py`
- `python ci/check_release_reference_complete_v1.py --help`
- extraction check for `required` and `release_required` against `pulse_gate_policy_v0.yml`

## Risk

Low. This is a parser compatibility fix for canonical policy layout. No workflow, schema, policy, gate semantics, or release-authority behavior is modified.