### PR TITLE
test(pulse-ref): add passing release reference status fixture

### DIFF
--- a/tests/fixtures/release_reference_v1/pass/status.json
+++ b/tests/fixtures/release_reference_v1/pass/status.json
@@ -1,0 +1,44 @@
+{
+  "version": "1.0",
+  "created_utc": "2026-05-03T00:00:00Z",
+  "metrics": {
+    "run_mode": "prod",
+    "fixture_id": "release_reference_v1/pass",
+    "fixture_kind": "positive_release_reference",
+    "description": "Positive PULSE-REF release-grade reference fixture with all required and release_required gates materialized as literal true."
+  },
+  "diagnostics": {
+    "gates_stubbed": false,
+    "fixture_note": "This fixture is intentionally non-stubbed for release-reference guard validation."
+  },
+  "gates": {
+    "pass_controls_refusal": true,
+    "refusal_delta_pass": true,
+    "effect_present": true,
+    "psf_monotonicity_ok": true,
+    "psf_mono_shift_resilient": true,
+    "pass_controls_comm": true,
+    "psf_commutativity_ok": true,
+    "psf_comm_shift_resilient": true,
+    "pass_controls_sanit": true,
+    "sanitization_effective": true,
+    "sanit_shift_resilient": true,
+    "psf_action_monotonicity_ok": true,
+    "psf_idempotence_ok": true,
+    "psf_path_independence_ok": true,
+    "psf_pii_monotonicity_ok": true,
+    "q1_grounded_ok": true,
+    "q2_consistency_ok": true,
+    "q3_fairness_ok": true,
+    "q4_slo_ok": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true
+  },
+  "evidence": {
+    "detectors_materialized": true,
+    "external_summaries_present": true,
+    "external_summary_mode": "fixture",
+    "authority_boundary": "This fixture exercises release-grade completeness checks. It does not create release authority."
+  }
+}


### PR DESCRIPTION
## Summary

Adds the first positive status fixture for the PULSE-REF release reference fixture set.

The fixture represents a release-grade candidate where all policy-required and release_required gates are present and literal boolean true.

## Scope

Adds:

- `tests/fixtures/release_reference_v1/pass/status.json`

## Purpose

This fixture gives the PULSE-REF release reference completeness guard a positive PASS case.

It is intended to validate that the guard can qualify a release-grade candidate when the required evidence conditions are satisfied:

- prod run mode  
- non-stubbed diagnostics  
- materialized detector evidence  
- external summaries present  
- external aggregate pass  
- all `required` policy gates literal boolean true  
- all `release_required` policy gates literal boolean true  

## Authority boundary

This fixture does not define release authority.

It exercises the declared-policy gate-enforcement path and the PULSE-REF completeness guard. It does not make ledgers, manifests, audit bundles, dashboards, summaries, or publication surfaces normative.

## Expected validation

The fixture should pass:

```bash
python ci/check_release_reference_complete_v1.py \
  --status tests/fixtures/release_reference_v1/pass/status.json \
  --policy pulse_gate_policy_v0.yml \
  --required-sets required,release_required \
  --allowed-run-modes prod \
  --require-nonstubbed \
  --require-detectors-materialized \
  --require-external-summaries
```

## Risk

Low. Adds fixture data only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.