### PR TITLE
test(pulse-ref): add missing external evidence fixture

### DIFF
--- a/tests/fixtures/release_reference_v1/missing_external/status.json
+++ b/tests/fixtures/release_reference_v1/missing_external/status.json
@@ -5,11 +5,11 @@
     "run_mode": "prod",
     "fixture_id": "release_reference_v1/missing_external",
     "fixture_kind": "negative_release_reference",
-    "description": "Negative PULSE-REF release-grade reference fixture where external summaries are missing. Release-grade validation must fail closed."
+    "description": "Negative PULSE-REF release-grade reference fixture where external summaries are missing. Release-grade validation must fail closed on the missing summary presence condition."
   },
   "diagnostics": {
     "gates_stubbed": false,
-    "fixture_note": "This fixture is non-stubbed but intentionally lacks required external summary evidence."
+    "fixture_note": "This fixture is non-stubbed and isolates missing external summary presence as the only intended failing gate."
   },
   "gates": {
     "pass_controls_refusal": true,
@@ -33,12 +33,12 @@
     "q4_slo_ok": true,
     "detectors_materialized_ok": true,
     "external_summaries_present": false,
-    "external_all_pass": false
+    "external_all_pass": true
   },
   "evidence": {
     "detectors_materialized": true,
     "external_summaries_present": false,
-    "external_summary_mode": "missing",
-    "authority_boundary": "This fixture exercises release-grade fail-closed behavior for missing external evidence. It does not create release authority."
+    "external_summary_mode": "missing_presence_fixture",
+    "authority_boundary": "This fixture isolates release-grade fail-closed behavior for missing external summary presence. It does not create release authority."
   }
 }

--- a/tests/fixtures/release_reference_v1/missing_external/status.json
+++ b/tests/fixtures/release_reference_v1/missing_external/status.json
@@ -1,0 +1,44 @@
+{
+  "version": "1.0",
+  "created_utc": "2026-05-03T00:00:00Z",
+  "metrics": {
+    "run_mode": "prod",
+    "fixture_id": "release_reference_v1/missing_external",
+    "fixture_kind": "negative_release_reference",
+    "description": "Negative PULSE-REF release-grade reference fixture where external summaries are missing. Release-grade validation must fail closed."
+  },
+  "diagnostics": {
+    "gates_stubbed": false,
+    "fixture_note": "This fixture is non-stubbed but intentionally lacks required external summary evidence."
+  },
+  "gates": {
+    "pass_controls_refusal": true,
+    "refusal_delta_pass": true,
+    "effect_present": true,
+    "psf_monotonicity_ok": true,
+    "psf_mono_shift_resilient": true,
+    "pass_controls_comm": true,
+    "psf_commutativity_ok": true,
+    "psf_comm_shift_resilient": true,
+    "pass_controls_sanit": true,
+    "sanitization_effective": true,
+    "sanit_shift_resilient": true,
+    "psf_action_monotonicity_ok": true,
+    "psf_idempotence_ok": true,
+    "psf_path_independence_ok": true,
+    "psf_pii_monotonicity_ok": true,
+    "q1_grounded_ok": true,
+    "q2_consistency_ok": true,
+    "q3_fairness_ok": true,
+    "q4_slo_ok": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": false,
+    "external_all_pass": false
+  },
+  "evidence": {
+    "detectors_materialized": true,
+    "external_summaries_present": false,
+    "external_summary_mode": "missing",
+    "authority_boundary": "This fixture exercises release-grade fail-closed behavior for missing external evidence. It does not create release authority."
+  }
+}


### PR DESCRIPTION
## Summary

Adds the first negative PULSE-REF release reference fixture.

The fixture represents a release-grade candidate where external summaries are missing. The expected behavior is fail-closed: missing external evidence must not be converted into release-grade PASS.

## Scope

Adds:

- `tests/fixtures/release_reference_v1/missing_external/status.json`

## Purpose

This fixture validates one of the core PULSE-REF hardening requirements: release-grade paths must not infer PASS from absent external evidence.

The fixture is intentionally non-stubbed and otherwise keeps non-target gates passing. It isolates the missing external summary presence condition by setting:

- `external_summaries_present: false`
- `external_all_pass: true`

This ensures the fixture fails specifically because external summary presence is missing, not because of a second independent aggregate-pass failure.

## Authority boundary

This fixture does not define release authority.

It exercises the declared-policy gate-enforcement path and the PULSE-REF release reference completeness guard. It does not make ledgers, manifests, audit bundles, dashboards, summaries, or publication surfaces normative.

## Expected validation

The fixture should fail:

```bash
python ci/check_release_reference_complete_v1.py \
  --status tests/fixtures/release_reference_v1/missing_external/status.json \
  --policy pulse_gate_policy_v0.yml \
  --required-sets required,release_required \
  --allowed-run-modes prod \
  --require-nonstubbed \
  --require-detectors-materialized \
  --require-external-summaries
```

Expected result: FAIL.

Expected failure reason: `external_summaries_present` is false. The fixture intentionally keeps `external_all_pass` true so the missing-summary presence check is isolated.

## Risk

Low. Adds fixture data only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.