### PR TITLE
test(pulse-ref): add expected outcome for missing external fixture

### DIFF
--- a/tests/fixtures/release_reference_v1/missing_external/expected_outcome.json
+++ b/tests/fixtures/release_reference_v1/missing_external/expected_outcome.json
@@ -1,0 +1,22 @@
+{
+  "fixture_id": "release_reference_v1/missing_external",
+  "expected_result": "FAIL",
+  "expected_reason": "external_summaries_present is false. This fixture isolates the missing external summary presence condition while keeping non-target gates passing.",
+  "expected_guard": "ci/check_release_reference_complete_v1.py",
+  "expected_checks": {
+    "run_mode": "prod",
+    "gates_stubbed": false,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": false,
+    "external_all_pass": true,
+    "required_gates_literal_true": true,
+    "release_required_gates_literal_true_except_external_summaries_present": true
+  },
+  "expected_failure": {
+    "gate": "external_summaries_present",
+    "value": false,
+    "failure_mode": "missing_external_summary_presence",
+    "non_target_release_required_gates_passing": true
+  },
+  "authority_boundary": "This fixture does not define release authority. It exercises fail-closed behavior for missing external summary presence through the declared-policy gate-enforcement path and the PULSE-REF release-grade completeness guard."
+}


### PR DESCRIPTION
## Summary

Adds expected outcome metadata for the negative PULSE-REF `missing_external` release reference fixture.

The metadata records that this fixture is expected to fail because `external_summaries_present` is false.

## Scope

Adds:

- `tests/fixtures/release_reference_v1/missing_external/expected_outcome.json`

## Purpose

This expected outcome file documents the intended failure mode for the `missing_external` fixture.

The fixture isolates missing external summary presence:

- `external_summaries_present: false`
- `external_all_pass: true`
- all non-target required and release_required gates passing

This avoids masking regressions where the presence check might stop being enforced while another independent failing gate still causes the fixture to fail.

## Authority boundary

This file does not define release authority.

It documents the expected result for a fixture that exercises fail-closed behavior through the declared-policy gate-enforcement path and the PULSE-REF release-grade completeness guard.

It does not make ledgers, manifests, audit bundles, dashboards, summaries, or publication surfaces normative.

## Risk

Low. Adds fixture metadata only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.