### PR TITLE
test(pulse-ref): add expected outcome for stubbed fixture

### DIFF
--- a/tests/fixtures/release_reference_v1/stubbed/expected_outcome.json
+++ b/tests/fixtures/release_reference_v1/stubbed/expected_outcome.json
@@ -1,0 +1,23 @@
+{
+  "fixture_id": "release_reference_v1/stubbed",
+  "expected_result": "FAIL",
+  "expected_reason": "diagnostics.gates_stubbed is true. This fixture isolates stubbed diagnostics as the only intended failing condition while keeping all required and release_required gates passing.",
+  "expected_guard": "ci/check_release_reference_complete_v1.py",
+  "expected_checks": {
+    "run_mode": "prod",
+    "gates_stubbed": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true,
+    "required_gates_literal_true": true,
+    "release_required_gates_literal_true": true
+  },
+  "expected_failure": {
+    "field": "diagnostics.gates_stubbed",
+    "value": true,
+    "failure_mode": "stubbed_release_grade_evidence",
+    "non_target_required_gates_passing": true,
+    "non_target_release_required_gates_passing": true
+  },
+  "authority_boundary": "This fixture does not define release authority. It exercises fail-closed behavior for stubbed diagnostics through the declared-policy gate-enforcement path and the PULSE-REF release-grade completeness guard."
+}


### PR DESCRIPTION
## Summary

Adds expected outcome metadata for the negative PULSE-REF `stubbed` release reference fixture.

The metadata records that this fixture is expected to fail because `diagnostics.gates_stubbed` is true.

## Scope

Adds:

- `tests/fixtures/release_reference_v1/stubbed/expected_outcome.json`

## Purpose

This expected outcome file documents the intended failure mode for the `stubbed` fixture.

The fixture isolates stubbed diagnostics:

- `diagnostics.gates_stubbed: true`
- all required gates passing
- all release_required gates passing

This avoids masking regressions where stubbed-state enforcement might stop being checked while another independent failing gate still causes the fixture to fail.

## Authority boundary

This file does not define release authority.

It documents the expected result for a fixture that exercises fail-closed behavior through the declared-policy gate-enforcement path and the PULSE-REF release-grade completeness guard.

It does not make ledgers, manifests, audit bundles, dashboards, summaries, or publication surfaces normative.

## Risk

Low. Adds fixture metadata only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.