### PR TITLE
test(pulse-ref): add false required gate fixture

### DIFF
--- a/tests/fixtures/release_reference_v1/false_gate/status.json
+++ b/tests/fixtures/release_reference_v1/false_gate/status.json
@@ -1,0 +1,44 @@
+{
+  "version": "1.0",
+  "created_utc": "2026-05-03T00:00:00Z",
+  "metrics": {
+    "run_mode": "prod",
+    "fixture_id": "release_reference_v1/false_gate",
+    "fixture_kind": "negative_release_reference",
+    "description": "Negative PULSE-REF release-grade reference fixture where one policy-required gate is false. Release-grade validation must fail closed on non-true required gates."
+  },
+  "diagnostics": {
+    "gates_stubbed": false,
+    "fixture_note": "This fixture isolates one required gate set to false as the only intended failing condition."
+  },
+  "gates": {
+    "pass_controls_refusal": false,
+    "refusal_delta_pass": true,
+    "effect_present": true,
+    "psf_monotonicity_ok": true,
+    "psf_mono_shift_resilient": true,
+    "pass_controls_comm": true,
+    "psf_commutativity_ok": true,
+    "psf_comm_shift_resilient": true,
+    "pass_controls_sanit": true,
+    "sanitization_effective": true,
+    "sanit_shift_resilient": true,
+    "psf_action_monotonicity_ok": true,
+    "psf_idempotence_ok": true,
+    "psf_path_independence_ok": true,
+    "psf_pii_monotonicity_ok": true,
+    "q1_grounded_ok": true,
+    "q2_consistency_ok": true,
+    "q3_fairness_ok": true,
+    "q4_slo_ok": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true
+  },
+  "evidence": {
+    "detectors_materialized": true,
+    "external_summaries_present": true,
+    "external_summary_mode": "fixture",
+    "authority_boundary": "This fixture isolates fail-closed behavior for a false policy-required gate. It does not create release authority."
+  }
+}


### PR DESCRIPTION
## Summary

Adds the negative PULSE-REF `false_gate` release reference fixture.

The fixture represents a release-grade candidate where one policy-required gate is literal boolean false while all other required and release_required gates remain literal boolean true.

## Scope

Adds:

- `tests/fixtures/release_reference_v1/false_gate/status.json`

## Purpose

This fixture validates strict fail-closed gate semantics for release-grade reference validation.

The fixture intentionally isolates:

- `pass_controls_refusal: false`

as the only intended failing condition.

All non-target gates remain passing.

## Authority boundary

This fixture does not define release authority.

It exercises the declared-policy gate-enforcement path and the PULSE-REF release reference completeness guard. It does not make ledgers, manifests, audit bundles, dashboards, summaries, or publication surfaces normative.

## Expected validation

The fixture should fail:

```bash
python ci/check_release_reference_complete_v1.py \
  --status tests/fixtures/release_reference_v1/false_gate/status.json \
  --policy pulse_gate_policy_v0.yml \
  --required-sets required,release_required \
  --allowed-run-modes prod \
  --require-nonstubbed \
  --require-detectors-materialized \
  --require-external-summaries
```

Expected result: FAIL.

Expected failure reason: `pass_controls_refusal` is a policy-required gate and is literal boolean false. Non-target gates remain passing so the required-gate fail-closed check is isolated.

## Risk

Low. Adds fixture data only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.