### PR TITLE
test(pulse-ref): add expected outcome for false gate fixture

### DIFF
--- a/tests/fixtures/release_reference_v1/false_gate/expected_outcome.json
+++ b/tests/fixtures/release_reference_v1/false_gate/expected_outcome.json
@@ -1,0 +1,24 @@
+{
+  "fixture_id": "release_reference_v1/false_gate",
+  "expected_result": "FAIL",
+  "expected_reason": "pass_controls_refusal is false. This fixture isolates a false policy-required gate as the only intended failing condition while keeping all non-target required and release_required gates passing.",
+  "expected_guard": "ci/check_release_reference_complete_v1.py",
+  "expected_checks": {
+    "run_mode": "prod",
+    "gates_stubbed": false,
+    "pass_controls_refusal": false,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true,
+    "required_gates_literal_true_except_pass_controls_refusal": true,
+    "release_required_gates_literal_true": true
+  },
+  "expected_failure": {
+    "gate": "pass_controls_refusal",
+    "value": false,
+    "failure_mode": "false_policy_required_gate",
+    "non_target_required_gates_passing": true,
+    "non_target_release_required_gates_passing": true
+  },
+  "authority_boundary": "This fixture does not define release authority. It exercises fail-closed behavior for a false policy-required gate through the declared-policy gate-enforcement path and the PULSE-REF release-grade completeness guard."
+}


### PR DESCRIPTION
## Summary

Adds expected outcome metadata for the negative PULSE-REF `false_gate` release reference fixture.

The metadata records that this fixture is expected to fail because `pass_controls_refusal` is false.

## Scope

Adds:

- `tests/fixtures/release_reference_v1/false_gate/expected_outcome.json`

## Purpose

This expected outcome file documents the intended failure mode for the `false_gate` fixture.

The fixture isolates a single false policy-required gate:

- `pass_controls_refusal: false`
- all non-target required gates passing
- all release_required gates passing

This avoids masking regressions where strict required-gate enforcement might stop being checked while another unrelated failing condition still causes the fixture to fail.

## Authority boundary

This file does not define release authority.

It documents the expected result for a fixture that exercises fail-closed behavior through the declared-policy gate-enforcement path and the PULSE-REF release-grade completeness guard.

It does not make ledgers, manifests, audit bundles, dashboards, summaries, or publication surfaces normative.

## Risk

Low. Adds fixture metadata only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.