### PR TITLE
test(pulse-ref): add implicit fallback attempt fixture

### DIFF
--- a/tests/fixtures/release_reference_v1/implicit_fallback_attempt/status.json
+++ b/tests/fixtures/release_reference_v1/implicit_fallback_attempt/status.json
@@ -1,0 +1,44 @@
+{
+  "version": "1.0",
+  "created_utc": "2026-05-03T00:00:00Z",
+  "metrics": {
+    "run_mode": "prod",
+    "fixture_id": "release_reference_v1/implicit_fallback_attempt",
+    "fixture_kind": "negative_release_reference",
+    "description": "Negative PULSE-REF release-grade reference fixture where detector evidence is not materialized while other gates appear passing. Release-grade validation must fail closed and must not infer PASS from fallback-looking state."
+  },
+  "diagnostics": {
+    "gates_stubbed": false,
+    "fixture_note": "This fixture isolates detectors_materialized_ok=false as the intended failing condition while keeping non-target gates passing."
+  },
+  "gates": {
+    "pass_controls_refusal": true,
+    "refusal_delta_pass": true,
+    "effect_present": true,
+    "psf_monotonicity_ok": true,
+    "psf_mono_shift_resilient": true,
+    "pass_controls_comm": true,
+    "psf_commutativity_ok": true,
+    "psf_comm_shift_resilient": true,
+    "pass_controls_sanit": true,
+    "sanitization_effective": true,
+    "sanit_shift_resilient": true,
+    "psf_action_monotonicity_ok": true,
+    "psf_idempotence_ok": true,
+    "psf_path_independence_ok": true,
+    "psf_pii_monotonicity_ok": true,
+    "q1_grounded_ok": true,
+    "q2_consistency_ok": true,
+    "q3_fairness_ok": true,
+    "q4_slo_ok": true,
+    "detectors_materialized_ok": false,
+    "external_summaries_present": true,
+    "external_all_pass": true
+  },
+  "evidence": {
+    "detectors_materialized": false,
+    "external_summaries_present": true,
+    "external_summary_mode": "fixture",
+    "authority_boundary": "This fixture isolates release-grade fail-closed behavior for non-materialized detector evidence. It does not create release authority."
+  }
+}


### PR DESCRIPTION
## Summary

Adds the negative PULSE-REF `implicit_fallback_attempt` release reference fixture.

The fixture represents a release-grade candidate where detector evidence is not materialized while other gates appear passing. The expected behavior is fail-closed: non-materialized detector evidence must not be converted into release-grade PASS.

## Scope

Adds:

- `tests/fixtures/release_reference_v1/implicit_fallback_attempt/status.json`

## Purpose

This fixture validates a core PULSE-REF hardening requirement: release-grade paths must not infer PASS from missing, non-materialized, or fallback-looking evidence.

The fixture intentionally isolates:

- `detectors_materialized_ok: false`

as the intended failing condition.

All non-target gates remain passing.

## Authority boundary

This fixture does not define release authority.

It exercises the declared-policy gate-enforcement path and the PULSE-REF release reference completeness guard. It does not make ledgers, manifests, audit bundles, dashboards, summaries, or publication surfaces normative.

## Expected validation

The fixture should fail:

```bash
python ci/check_release_reference_complete_v1.py \
  --status tests/fixtures/release_reference_v1/implicit_fallback_attempt/status.json \
  --policy pulse_gate_policy_v0.yml \
  --required-sets required,release_required \
  --allowed-run-modes prod \
  --require-nonstubbed \
  --require-detectors-materialized \
  --require-external-summaries
```

Expected result: FAIL.

Expected failure reason: `detectors_materialized_ok` is false. Non-target gates remain passing so the non-materialized detector evidence check is isolated.

## Risk

Low. Adds fixture data only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.