### PR TITLE
test(pulse-ref): add expected outcome for implicit fallback fixture

### DIFF
--- a/tests/fixtures/release_reference_v1/implicit_fallback_attempt/expected_outcome.json
+++ b/tests/fixtures/release_reference_v1/implicit_fallback_attempt/expected_outcome.json
@@ -1,0 +1,23 @@
+{
+  "fixture_id": "release_reference_v1/implicit_fallback_attempt",
+  "expected_result": "FAIL",
+  "expected_reason": "detectors_materialized_ok is false. This fixture isolates non-materialized detector evidence as the only intended failing condition while keeping all non-target required and release_required gates passing.",
+  "expected_guard": "ci/check_release_reference_complete_v1.py",
+  "expected_checks": {
+    "run_mode": "prod",
+    "gates_stubbed": false,
+    "detectors_materialized_ok": false,
+    "external_summaries_present": true,
+    "external_all_pass": true,
+    "required_gates_literal_true": true,
+    "release_required_gates_literal_true_except_detectors_materialized_ok": true
+  },
+  "expected_failure": {
+    "gate": "detectors_materialized_ok",
+    "value": false,
+    "failure_mode": "non_materialized_detector_evidence",
+    "non_target_required_gates_passing": true,
+    "non_target_release_required_gates_passing": true
+  },
+  "authority_boundary": "This fixture does not define release authority. It exercises fail-closed behavior for non-materialized detector evidence through the declared-policy gate-enforcement path and the PULSE-REF release-grade completeness guard."
+}


### PR DESCRIPTION
## Summary

Adds expected outcome metadata for the negative PULSE-REF `implicit_fallback_attempt` release reference fixture.

The metadata records that this fixture is expected to fail because `detectors_materialized_ok` is false.

## Scope

Adds:

- `tests/fixtures/release_reference_v1/implicit_fallback_attempt/expected_outcome.json`

## Purpose

This expected outcome file documents the intended failure mode for the `implicit_fallback_attempt` fixture.

The fixture isolates non-materialized detector evidence:

- `detectors_materialized_ok: false`
- all non-target required gates passing
- all non-target release_required gates passing
- external summaries present and passing

This avoids masking regressions where materialized-evidence enforcement might stop being checked while another unrelated failing condition still causes the fixture to fail.

## Authority boundary

This file does not define release authority.

It documents the expected result for a fixture that exercises fail-closed behavior through the declared-policy gate-enforcement path and the PULSE-REF release-grade completeness guard.

It does not make ledgers, manifests, audit bundles, dashboards, summaries, or publication surfaces normative.

## Risk

Low. Adds fixture metadata only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.