### PR TITLE
test(pulse-ref): enforce isolated fixture failures

### DIFF
--- a/tests/test_release_reference_fixture_matrix_v1.py
+++ b/tests/test_release_reference_fixture_matrix_v1.py
@@ -46,7 +46,9 @@ def fixture_dirs() -> list[Path]:
 
     return dirs
 
+
 def extract_guard_errors(output: str) -> list[str]:
+    """Extract bullet error lines emitted by the PULSE-REF guard."""
     errors: list[str] = []
     in_errors = False
 
@@ -131,27 +133,25 @@ class TestReleaseReferenceFixtureMatrixV1(unittest.TestCase):
 
                     expected_failure = expected.get("expected_failure", {})
                     target = expected_failure.get("gate") or expected_failure.get("field")
-                                      self.assertIsInstance(
+
+                    self.assertIsInstance(
                         target,
                         str,
                         msg=(
-                            "Expected FAIL fixtures to set expected_failure.gate or "
-                            f"expected_failure.field.\nFixture: {fixture_dir.name}"
+                            "FAIL fixture must declare expected_failure.gate "
+                            f"or expected_failure.field: {expected_path}"
                         ),
                     )
                     self.assertTrue(
                         target,
-                        msg=(
-                            "Expected FAIL fixtures to set a non-empty expected_failure.gate or "
-                            f"expected_failure.field.\nFixture: {fixture_dir.name}"
-                        ),
+                        msg=f"FAIL fixture expected failure target must be non-empty: {expected_path}",
                     )
 
                     errors = extract_guard_errors(output)
                     self.assertGreater(
                         len(errors),
                         0,
-                        msg=f"Expected FAIL guard output to include Errors entries.\nOutput:\n{output}",
+                        msg=f"Expected guard output to include structured error lines.\nOutput:\n{output}",
                     )
 
                     matching_errors = [error for error in errors if target in error]
@@ -161,17 +161,21 @@ class TestReleaseReferenceFixtureMatrixV1(unittest.TestCase):
                         len(matching_errors),
                         0,
                         msg=(
-                            "Expected at least one guard error to mention the intended failing "
-                            f"target {target!r}.\nErrors:\n" + "\n".join(errors)
+                            "Expected guard errors to mention the intended failing gate/field "
+                            f"{target!r}.\nErrors:\n{errors}\nOutput:\n{output}"
                         ),
                     )
+
                     self.assertEqual(
                         unexpected_errors,
                         [],
                         msg=(
-                            "Expected FAIL fixture guard errors to be isolated to the intended "
-                            f"target {target!r}, but found unrelated errors:\n"
-                            + "\n".join(unexpected_errors)
+                            "FAIL fixture produced unrelated guard errors. "
+                            "Each negative fixture must isolate one expected failure mode.\n"
+                            f"Expected target: {target!r}\n"
+                            f"Unexpected errors: {unexpected_errors}\n"
+                            f"All errors: {errors}\n"
+                            f"Output:\n{output}"
                         ),
                     )
 

--- a/tests/test_release_reference_fixture_matrix_v1.py
+++ b/tests/test_release_reference_fixture_matrix_v1.py
@@ -46,6 +46,25 @@ def fixture_dirs() -> list[Path]:
 
     return dirs
 
+def extract_guard_errors(output: str) -> list[str]:
+    errors: list[str] = []
+    in_errors = False
+
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+
+        if line == "Errors:":
+            in_errors = True
+            continue
+
+        if in_errors and line.startswith("Result:"):
+            break
+
+        if in_errors and line.startswith("- "):
+            errors.append(line[2:])
+
+    return errors
+
 
 class TestReleaseReferenceFixtureMatrixV1(unittest.TestCase):
     def test_fixture_matrix_matches_expected_guard_outcomes(self) -> None:
@@ -112,15 +131,49 @@ class TestReleaseReferenceFixtureMatrixV1(unittest.TestCase):
 
                     expected_failure = expected.get("expected_failure", {})
                     target = expected_failure.get("gate") or expected_failure.get("field")
-                    if target:
-                        self.assertIn(
-                            target,
-                            output,
-                            msg=(
-                                "Expected guard output to mention the intended failing gate/field "
-                                f"{target!r}.\nOutput:\n{output}"
-                            ),
-                        )
+                                      self.assertIsInstance(
+                        target,
+                        str,
+                        msg=(
+                            "Expected FAIL fixtures to set expected_failure.gate or "
+                            f"expected_failure.field.\nFixture: {fixture_dir.name}"
+                        ),
+                    )
+                    self.assertTrue(
+                        target,
+                        msg=(
+                            "Expected FAIL fixtures to set a non-empty expected_failure.gate or "
+                            f"expected_failure.field.\nFixture: {fixture_dir.name}"
+                        ),
+                    )
+
+                    errors = extract_guard_errors(output)
+                    self.assertGreater(
+                        len(errors),
+                        0,
+                        msg=f"Expected FAIL guard output to include Errors entries.\nOutput:\n{output}",
+                    )
+
+                    matching_errors = [error for error in errors if target in error]
+                    unexpected_errors = [error for error in errors if target not in error]
+
+                    self.assertGreater(
+                        len(matching_errors),
+                        0,
+                        msg=(
+                            "Expected at least one guard error to mention the intended failing "
+                            f"target {target!r}.\nErrors:\n" + "\n".join(errors)
+                        ),
+                    )
+                    self.assertEqual(
+                        unexpected_errors,
+                        [],
+                        msg=(
+                            "Expected FAIL fixture guard errors to be isolated to the intended "
+                            f"target {target!r}, but found unrelated errors:\n"
+                            + "\n".join(unexpected_errors)
+                        ),
+                    )
 
                 else:
                     self.fail(f"Unsupported expected_result: {expected_result!r}")


### PR DESCRIPTION
## Summary

Strengthens the PULSE-REF release reference fixture matrix test so negative fixtures only pass when the guard fails for the expected isolated failure condition.

Previously, FAIL fixtures required a non-zero guard exit and the expected gate/field to appear somewhere in the output. That could mask regressions where a fixture also failed for unrelated gates.

## Scope

Updates:

- `tests/test_release_reference_fixture_matrix_v1.py`

Adds:

- `extract_guard_errors(output: str)`
- stricter FAIL-fixture assertions

## Behavior

For FAIL fixtures, the matrix test now checks that:

- the guard exits non-zero;
- output contains `Result: FAIL`;
- `expected_failure.gate` or `expected_failure.field` is declared;
- at least one parsed guard error mentions the expected target;
- every parsed guard error mentions the expected target.

This preserves isolated failure-mode validation while allowing duplicate guard errors about the same intended target.

## Authority boundary

This test does not define release authority.

It verifies that fixture expectations match the PULSE-REF completeness guard outcome. It does not modify `check_gates.py`, `pulse_gate_policy_v0.yml`, workflows, schemas, status artifacts, or release-authority behavior.

## Testing

Run:

- `python -m py_compile tests/test_release_reference_fixture_matrix_v1.py`
- `python tests/test_release_reference_fixture_matrix_v1.py`

## Risk

Low. Test-only hardening. No release-authority behavior modified.