### PR TITLE
chore: ignore Python cache artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 # ```yaml
 # Optional: add a minimal snippet showing how this change runs in CI.
 # ```
+
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
## Summary

Adds standard Python cache artifacts to `.gitignore`.

The PULSE-REF fixture matrix test and syntax checks pass, but Python creates `__pycache__/` during local or CI verification. Ignoring these artifacts keeps the working tree clean after test execution.

## Scope

Updates `.gitignore` only.

Ignored artifacts:

- `__pycache__/`
- `*.py[cod]`

## Authority boundary

This change does not affect release authority.

It does not modify PULSE-REF guard logic, fixture data, policy, schemas, workflows, or release-gate behavior.

## Testing

Run:

- `python -m py_compile tests/test_release_reference_fixture_matrix_v1.py`
- `python tests/test_release_reference_fixture_matrix_v1.py`
- `git status --short`

## Risk

Low. Repository hygiene only.