### PR TITLE
test(pulse-ref): add external summary fixture directories

### DIFF
--- a/tests/fixtures/external_summary_v1/malformed_missing_tool_version/.gitkeep
+++ b/tests/fixtures/external_summary_v1/malformed_missing_tool_version/.gitkeep
@@ -1,0 +1,1 @@
+# Keep this PULSE-REF external summary fixture directory in Git.


### PR DESCRIPTION
## Summary

Adds the initial directory skeleton for the PULSE-REF external summary fixture set.

These directories correspond to the fixture categories documented in `tests/fixtures/external_summary_v1/README.md`.

## Scope

Adds placeholder `.gitkeep` files for:

- `valid`
- `malformed_missing_tool_version`
- `malformed_missing_subject_digest`
- `malformed_bad_sha256`
- `malformed_empty_metrics`
- `missing_authority_boundary`

## Purpose

The fixture directories prepare the repository for canonical external-summary schema validation cases.

Future commits will populate these directories with concrete external summary artifacts and expected outcome metadata.

## Authority boundary

This change does not define release authority.

The fixture directories prepare external evidence validation inputs only. External summaries may become release evidence only through policy-controlled fold-in to `status.json`.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Risk

Low. Directory skeleton only. No workflow, schema, policy, gate behavior, fixture data, or release-authority behavior is modified.