### PR TITLE
test(pulse-ref): add valid external summary fixture

### DIFF
--- a/tests/fixtures/external_summary_v1/valid/external_summary.json
+++ b/tests/fixtures/external_summary_v1/valid/external_summary.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "external_summary_v1",
+  "summary_id": "external_summary_v1_valid_promptfoo_fixture",
+  "tool": {
+    "name": "promptfoo",
+    "version": "1.0.0",
+    "adapter": "promptfoo_to_summary_v1",
+    "adapter_version": "v1"
+  },
+  "run": {
+    "run_id": "external-summary-valid-run-001",
+    "generated_at": "2026-05-03T00:00:00Z",
+    "dataset_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "evaluator_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "model_id": "pulse-ref-release-candidate"
+  },
+  "subject": {
+    "kind": "release_candidate",
+    "id": "pulse-ref-release-candidate",
+    "digest_algorithm": "sha256",
+    "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  },
+  "metrics": [
+    {
+      "key": "jailbreak_fail_rate",
+      "value": 0.0,
+      "unit": "rate",
+      "threshold": 0.01,
+      "comparator": "lte",
+      "passed": true,
+      "severity": "critical",
+      "notes": "Fixture metric for validating canonical external summary schema shape."
+    },
+    {
+      "key": "unsafe_completion_rate",
+      "value": 0.0,
+      "unit": "rate",
+      "threshold": 0.01,
+      "comparator": "lte",
+      "passed": true,
+      "severity": "high",
+      "notes": "Second fixture metric to exercise multi-metric summary shape."
+    }
+  ],
+  "threshold_ref": {
+    "key": "pulse_ref_external_thresholds_v1",
+    "version": "v1",
+    "uri": "policy/external_thresholds_v1.yml"
+  },
+  "evidence": {
+    "raw_artifact_uri": "tests/fixtures/external_summary_v1/valid/raw_promptfoo_result.json",
+    "raw_artifact_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "summary_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  },
+  "signing": {
+    "mode": "sigstore-keyless",
+    "identity": "repo:HKati/pulse-release-gates-0.1:workflow:external-eval",
+    "bundle_path": "tests/fixtures/external_summary_v1/valid/external_summary.sigstore.json",
+    "verified": true
+  },
+  "result": {
+    "passed": true,
+    "reason": "All canonical external summary fixture checks passed.",
+    "release_contribution": "required"
+  },
+  "authority_boundary": "This external summary does not define release authority. It is recorded evidence that may be folded into status.json only after schema, identity, signer, and policy validation."
+}


### PR DESCRIPTION
## Summary

Adds the first concrete valid fixture for the PULSE-REF external summary fixture set.

The fixture is a canonical `external_summary_v1` artifact intended to pass `schemas/external_summary_v1.schema.json`.

## Scope

Adds:

- `tests/fixtures/external_summary_v1/valid/external_summary.json`

## Purpose

This fixture establishes the positive external summary case before adding malformed external-summary fixtures.

The fixture includes:

- schema version
- summary ID
- tool name and version
- adapter metadata
- run metadata
- dataset and evaluator digests
- subject binding
- canonical metrics
- threshold reference
- raw evidence artifact reference
- signer / identity information
- aggregate result
- authority-boundary statement

## Authority boundary

This fixture does not define release authority.

It is recorded external evidence shape only. External summaries may become release evidence only through schema, identity, signer, digest, verification, and policy-controlled fold-in to `status.json`.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Expected validation

The fixture should validate against:

```text
schemas/external_summary_v1.schema.json
```

The existing external summary schema tests and release reference fixture matrix should continue to pass.

## Risk

Low. Adds fixture data only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.