### PR TITLE
ci(pages): serialize GitHub Pages deployments

### DIFF
--- a/.github/workflows/publish_report_pages.yml
+++ b/.github/workflows/publish_report_pages.yml
@@ -24,7 +24,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "github-pages"
+  group: github-pages
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

Updates the GitHub Pages deployment workflow to use a stable workflow-level concurrency group for Pages deployments.

Recent Pages deployments failed because a new deployment request was created while a previous Pages deployment was still in progress.

## Scope

Updates:

- `.github/workflows/publish_report_pages.yml`

Concurrency setting:

```yaml
concurrency:
  group: github-pages
  cancel-in-progress: false
```

## Purpose

This serializes GitHub Pages deployments and reduces deployment conflicts caused by rapid successive merges or publish runs.

## Authority boundary

This change does not affect PULSE release authority.

It does not modify schemas, fixtures, status artifacts, gate policy, `check_gates.py`, release-reference guards, or release-decision behavior.

Pages remains a publication surface only and does not define release authority.

## Testing

Verified that:

- only the Pages deployment workflow using `actions/deploy-pages` was inspected;
- the intended concurrency block is present at workflow level;
- no release-authority behavior was modified.

## Risk

Low. CI / deployment hygiene only.