### PR TITLE
test(pulse-ref): add malformed external summary fixture

### DIFF
--- a/tests/fixtures/external_summary_v1/malformed_missing_tool_version/external_summary.json
+++ b/tests/fixtures/external_summary_v1/malformed_missing_tool_version/external_summary.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "external_summary_v1",
+  "summary_id": "external_summary_v1_malformed_missing_tool_version_fixture",
+  "tool": {
+    "name": "promptfoo",
+    "adapter": "promptfoo_to_summary_v1",
+    "adapter_version": "v1"
+  },
+  "run": {
+    "run_id": "external-summary-missing-tool-version-run-001",
+    "generated_at": "2026-05-03T00:00:00Z",
+    "dataset_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "evaluator_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "model_id": "pulse-ref-release-candidate"
+  },
+  "subject": {
+    "kind": "release_candidate",
+    "id": "pulse-ref-release-candidate",
+    "digest_algorithm": "sha256",
+    "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  },
+  "metrics": [
+    {
+      "key": "jailbreak_fail_rate",
+      "value": 0.0,
+      "unit": "rate",
+      "threshold": 0.01,
+      "comparator": "lte",
+      "passed": true,
+      "severity": "critical",
+      "notes": "Fixture metric for isolating missing tool.version as the only intended schema failure."
+    },
+    {
+      "key": "unsafe_completion_rate",
+      "value": 0.0,
+      "unit": "rate",
+      "threshold": 0.01,
+      "comparator": "lte",
+      "passed": true,
+      "severity": "high",
+      "notes": "Second fixture metric to keep the rest of the summary structurally valid."
+    }
+  ],
+  "threshold_ref": {
+    "key": "pulse_ref_external_thresholds_v1",
+    "version": "v1",
+    "uri": "policy/external_thresholds_v1.yml"
+  },
+  "evidence": {
+    "raw_artifact_uri": "tests/fixtures/external_summary_v1/malformed_missing_tool_version/raw_promptfoo_result.json",
+    "raw_artifact_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "summary_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  },
+  "signing": {
+    "mode": "sigstore-keyless",
+    "identity": "repo:HKati/pulse-release-gates-0.1:workflow:external-eval",
+    "bundle_path": "tests/fixtures/external_summary_v1/malformed_missing_tool_version/external_summary.sigstore.json",
+    "verified": true
+  },
+  "result": {
+    "passed": true,
+    "reason": "This fixture intentionally omits tool.version to validate fail-closed schema behavior.",
+    "release_contribution": "required"
+  },
+  "authority_boundary": "This external summary does not define release authority. It is recorded evidence that may be folded into status.json only after schema, identity, signer, and policy validation."
+}


### PR DESCRIPTION
## Summary

Adds the first malformed PULSE-REF external summary fixture.

The fixture intentionally omits `tool.version` while keeping the rest of the external summary structurally valid.

## Scope

Adds:

- `tests/fixtures/external_summary_v1/malformed_missing_tool_version/external_summary.json`

## Purpose

This fixture validates that `schemas/external_summary_v1.schema.json` rejects external summaries that do not identify the producing tool version.

The fixture isolates a single intended schema failure:

- missing `tool.version`

All non-target fields remain valid.

## Authority boundary

This fixture does not define release authority.

It is malformed external evidence used for schema validation only. External summaries may become release evidence only through schema, identity, signer, digest, verification, and policy-controlled fold-in to `status.json`.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Expected validation

The fixture should fail validation against:

```text
schemas/external_summary_v1.schema.json