### PR TITLE
test(pulse-ref): add expected outcome for missing subject digest fixture

### DIFF
--- a/tests/fixtures/external_summary_v1/malformed_missing_subject_digest/expected_outcome.json
+++ b/tests/fixtures/external_summary_v1/malformed_missing_subject_digest/expected_outcome.json
@@ -1,0 +1,33 @@
+{
+  "fixture_id": "external_summary_v1/malformed_missing_subject_digest",
+  "expected_result": "FAIL",
+  "expected_reason": "subject.digest is missing. This fixture isolates a missing subject digest as the only intended external_summary_v1 schema failure while keeping all non-target fields valid.",
+  "expected_schema": "schemas/external_summary_v1.schema.json",
+  "expected_failure": {
+    "field": "subject.digest",
+    "json_schema_error_path": [
+      "subject"
+    ],
+    "missing_property": "digest",
+    "failure_mode": "missing_subject_digest",
+    "non_target_fields_valid": true
+  },
+  "expected_checks": {
+    "schema_version": "external_summary_v1",
+    "tool_name_present": true,
+    "tool_version_present": true,
+    "subject_kind_present": true,
+    "subject_id_present": true,
+    "subject_digest_algorithm": "sha256",
+    "subject_digest_present": false,
+    "metrics_min_items": 1,
+    "metrics_require_key_value_passed": true,
+    "threshold_ref_key_present": true,
+    "raw_artifact_uri_present": true,
+    "signing_mode_present": true,
+    "signing_identity_present": true,
+    "result_passed": true,
+    "authority_boundary_present": true
+  },
+  "authority_boundary": "This fixture does not define release authority. It validates fail-closed schema behavior for malformed external evidence before any policy-controlled fold-in to status.json."
+}


### PR DESCRIPTION
## Summary

Adds expected outcome metadata for the malformed PULSE-REF external summary fixture that omits `subject.digest`.

The metadata records that this fixture is expected to fail validation against `schemas/external_summary_v1.schema.json`.

## Scope

Adds:

- `tests/fixtures/external_summary_v1/malformed_missing_subject_digest/expected_outcome.json`

## Purpose

This expected outcome file makes the malformed missing-subject-digest fixture explicit as a negative schema-validation case.

It records:

- fixture ID;
- expected FAIL result;
- expected schema;
- expected failure field;
- JSON Schema error path;
- missing property;
- non-target field validity;
- authority-boundary statement.

## Authority boundary

This file does not define release authority.

It documents the expected result for a malformed external evidence fixture before any policy-controlled fold-in to `status.json`.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Risk

Low. Adds fixture metadata only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.