### PR TITLE
test(pulse-ref): add expected outcome for bad SHA-256 fixture

### DIFF
--- a/tests/fixtures/external_summary_v1/malformed_bad_sha256/expected_outcome.json
+++ b/tests/fixtures/external_summary_v1/malformed_bad_sha256/expected_outcome.json
@@ -1,0 +1,35 @@
+{
+  "fixture_id": "external_summary_v1/malformed_bad_sha256",
+  "expected_result": "FAIL",
+  "expected_reason": "subject.digest is present but is not a valid 64-character SHA-256 hex digest. This fixture isolates an invalid subject digest as the only intended external_summary_v1 schema failure while keeping all non-target fields valid.",
+  "expected_schema": "schemas/external_summary_v1.schema.json",
+  "expected_failure": {
+    "field": "subject.digest",
+    "json_schema_error_path": [
+      "subject",
+      "digest"
+    ],
+    "invalid_value": "not-a-sha256",
+    "failure_mode": "invalid_subject_digest_sha256",
+    "non_target_fields_valid": true
+  },
+  "expected_checks": {
+    "schema_version": "external_summary_v1",
+    "tool_name_present": true,
+    "tool_version_present": true,
+    "subject_kind_present": true,
+    "subject_id_present": true,
+    "subject_digest_algorithm": "sha256",
+    "subject_digest_present": true,
+    "subject_digest_valid_sha256": false,
+    "metrics_min_items": 1,
+    "metrics_require_key_value_passed": true,
+    "threshold_ref_key_present": true,
+    "raw_artifact_uri_present": true,
+    "signing_mode_present": true,
+    "signing_identity_present": true,
+    "result_passed": true,
+    "authority_boundary_present": true
+  },
+  "authority_boundary": "This fixture does not define release authority. It validates fail-closed schema behavior for malformed external evidence before any policy-controlled fold-in to status.json."
+}


### PR DESCRIPTION
## Summary

Adds expected outcome metadata for the malformed PULSE-REF external summary fixture with an invalid `subject.digest`.

The metadata records that this fixture is expected to fail validation against `schemas/external_summary_v1.schema.json`.

## Scope

Adds:

- `tests/fixtures/external_summary_v1/malformed_bad_sha256/expected_outcome.json`

## Purpose

This expected outcome file makes the malformed bad-SHA-256 fixture explicit as a negative schema-validation case.

It records:

- fixture ID;
- expected FAIL result;
- expected schema;
- expected failure field;
- JSON Schema error path;
- invalid digest value;
- non-target field validity;
- authority-boundary statement.

## Authority boundary

This file does not define release authority.

It documents the expected result for a malformed external evidence fixture before any policy-controlled fold-in to `status.json`.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Risk

Low. Adds fixture metadata only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.