### PR TITLE
test(pulse-ref): add empty metrics summary fixture

### DIFF
--- a/tests/fixtures/external_summary_v1/malformed_empty_metrics/external_summary.json
+++ b/tests/fixtures/external_summary_v1/malformed_empty_metrics/external_summary.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "external_summary_v1",
+  "summary_id": "external_summary_v1_malformed_empty_metrics_fixture",
+  "tool": {
+    "name": "promptfoo",
+    "version": "1.0.0",
+    "adapter": "promptfoo_to_summary_v1",
+    "adapter_version": "v1"
+  },
+  "run": {
+    "run_id": "external-summary-empty-metrics-run-001",
+    "generated_at": "2026-05-03T00:00:00Z",
+    "dataset_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "evaluator_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "model_id": "pulse-ref-release-candidate"
+  },
+  "subject": {
+    "kind": "release_candidate",
+    "id": "pulse-ref-release-candidate",
+    "digest_algorithm": "sha256",
+    "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  },
+  "metrics": [],
+  "threshold_ref": {
+    "key": "pulse_ref_external_thresholds_v1",
+    "version": "v1",
+    "uri": "policy/external_thresholds_v1.yml"
+  },
+  "evidence": {
+    "raw_artifact_uri": "tests/fixtures/external_summary_v1/malformed_empty_metrics/raw_promptfoo_result.json",
+    "raw_artifact_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "summary_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  },
+  "signing": {
+    "mode": "sigstore-keyless",
+    "identity": "repo:HKati/pulse-release-gates-0.1:workflow:external-eval",
+    "bundle_path": "tests/fixtures/external_summary_v1/malformed_empty_metrics/external_summary.sigstore.json",
+    "verified": true
+  },
+  "result": {
+    "passed": true,
+    "reason": "This fixture intentionally uses an empty metrics list to validate fail-closed schema behavior.",
+    "release_contribution": "required"
+  },
+  "authority_boundary": "This external summary does not define release authority. It is recorded evidence that may be folded into status.json only after schema, identity, signer, and policy validation."
+}


### PR DESCRIPTION
## Summary

Adds a malformed PULSE-REF external summary fixture with an empty `metrics` list.

The fixture intentionally keeps all non-target fields valid so the schema failure is isolated to the empty metrics array.

## Scope

Adds:

- `tests/fixtures/external_summary_v1/malformed_empty_metrics/external_summary.json`

## Purpose

This fixture validates that `schemas/external_summary_v1.schema.json` rejects external summaries that contain no canonical metrics.

The fixture isolates a single intended schema failure:

- `metrics: []`

All non-target fields remain valid.

## Authority boundary

This fixture does not define release authority.

It is malformed external evidence used for schema validation only. External summaries may become release evidence only through schema, identity, signer, digest, verification, and policy-controlled fold-in to `status.json`.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Expected validation

The fixture should fail validation against:

```text
schemas/external_summary_v1.schema.json
```

Expected failure reason:

```text
metrics must contain at least one item.
```

The existing external summary schema tests and release reference fixture matrix should continue to pass.

## Risk

Low. Adds fixture data only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.