### PR TITLE
test(pulse-ref): add missing authority boundary fixture

### DIFF
--- a/tests/fixtures/external_summary_v1/missing_authority_boundary/external_summary.json
+++ b/tests/fixtures/external_summary_v1/missing_authority_boundary/external_summary.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "external_summary_v1",
+  "summary_id": "external_summary_v1_missing_authority_boundary_fixture",
+  "tool": {
+    "name": "promptfoo",
+    "version": "1.0.0",
+    "adapter": "promptfoo_to_summary_v1",
+    "adapter_version": "v1"
+  },
+  "run": {
+    "run_id": "external-summary-missing-authority-boundary-run-001",
+    "generated_at": "2026-05-03T00:00:00Z",
+    "dataset_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "evaluator_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "model_id": "pulse-ref-release-candidate"
+  },
+  "subject": {
+    "kind": "release_candidate",
+    "id": "pulse-ref-release-candidate",
+    "digest_algorithm": "sha256",
+    "digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  },
+  "metrics": [
+    {
+      "key": "jailbreak_fail_rate",
+      "value": 0.0,
+      "unit": "rate",
+      "threshold": 0.01,
+      "comparator": "lte",
+      "passed": true,
+      "severity": "critical",
+      "notes": "Fixture metric for isolating missing authority_boundary as the only intended schema failure."
+    },
+    {
+      "key": "unsafe_completion_rate",
+      "value": 0.0,
+      "unit": "rate",
+      "threshold": 0.01,
+      "comparator": "lte",
+      "passed": true,
+      "severity": "high",
+      "notes": "Second fixture metric to keep the rest of the summary structurally valid."
+    }
+  ],
+  "threshold_ref": {
+    "key": "pulse_ref_external_thresholds_v1",
+    "version": "v1",
+    "uri": "policy/external_thresholds_v1.yml"
+  },
+  "evidence": {
+    "raw_artifact_uri": "tests/fixtures/external_summary_v1/missing_authority_boundary/raw_promptfoo_result.json",
+    "raw_artifact_digest": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "summary_digest": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  },
+  "signing": {
+    "mode": "sigstore-keyless",
+    "identity": "repo:HKati/pulse-release-gates-0.1:workflow:external-eval",
+    "bundle_path": "tests/fixtures/external_summary_v1/missing_authority_boundary/external_summary.sigstore.json",
+    "verified": true
+  },
+  "result": {
+    "passed": true,
+    "reason": "This fixture intentionally omits authority_boundary to validate fail-closed schema behavior.",
+    "release_contribution": "required"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a malformed PULSE-REF external summary fixture that omits `authority_boundary`.

The fixture intentionally keeps all non-target fields valid so the schema failure is isolated to the missing authority-boundary statement.

## Scope

Adds:

- `tests/fixtures/external_summary_v1/missing_authority_boundary/external_summary.json`

## Purpose

This fixture validates that `schemas/external_summary_v1.schema.json` rejects external summaries that do not explicitly state the authority boundary.

The fixture isolates a single intended schema failure:

- missing `authority_boundary`

All non-target fields remain valid.

## Authority boundary

This fixture intentionally omits the authority-boundary field to test fail-closed schema behavior.

The fixture itself does not define release authority. It is malformed external evidence used for schema validation only.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Expected validation

The fixture should fail validation against:

```text
schemas/external_summary_v1.schema.json
```

Expected failure reason:

```text
authority_boundary is required
```

The existing external summary schema tests and release reference fixture matrix should continue to pass.

## Risk

Low. Adds fixture data only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.