### PR TITLE
test(pulse-ref): add external summary envelope fixture directories

### DIFF
--- a/tests/fixtures/external_summary_envelope_v1/unverified_fold_in_allowed/.gitkeep
+++ b/tests/fixtures/external_summary_envelope_v1/unverified_fold_in_allowed/.gitkeep
@@ -1,0 +1,1 @@
+# Keep this PULSE-REF external summary envelope fixture directory in Git.


### PR DESCRIPTION
## Summary

Adds the initial directory skeleton for the PULSE-REF external summary envelope fixture set.

These directories correspond to the fixture categories documented in `tests/fixtures/external_summary_envelope_v1/README.md`.

## Scope

Adds placeholder `.gitkeep` files for:

- `valid`
- `missing_summary_digest`
- `missing_signing_identity`
- `missing_verifier_identity`
- `unverified_fold_in_allowed`
- `unverified_fold_in_not_allowed`

## Purpose

The fixture directories prepare the repository for external summary envelope validation cases.

Future commits will populate these directories with concrete envelope artifacts and expected outcome metadata.

The planned cases cover:

- valid envelope;
- missing summary digest;
- missing signing identity;
- missing verifier identity;
- unverified envelope with `fold_in_allowed=true`;
- unverified envelope with `fold_in_allowed=false`.

## Authority boundary

This change does not define release authority.

The fixture directories prepare external evidence verification inputs only. External summaries and envelopes may become release evidence only through schema, identity, signer, digest, verification, and policy-controlled fold-in to `status.json`.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Risk

Low. Directory skeleton only. No workflow, schema, policy, gate behavior, fixture data, or release-authority behavior is modified.