### PR TITLE
test(pulse-ref): add valid external summary envelope fixture

### DIFF
--- a/tests/fixtures/external_summary_envelope_v1/valid/envelope.json
+++ b/tests/fixtures/external_summary_envelope_v1/valid/envelope.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "external_summary_envelope_v1",
+  "envelope_id": "external_summary_envelope_v1_valid_fixture",
+  "summary_ref": {
+    "uri": "tests/fixtures/external_summary_v1/valid/external_summary.json",
+    "schema_version": "external_summary_v1",
+    "summary_id": "external_summary_v1_valid_promptfoo_fixture"
+  },
+  "summary_digest": {
+    "algorithm": "sha256",
+    "value": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+  },
+  "signing": {
+    "mode": "sigstore-keyless",
+    "identity": "repo:HKati/pulse-release-gates-0.1:workflow:external-eval",
+    "issuer": "https://token.actions.githubusercontent.com",
+    "bundle_uri": "tests/fixtures/external_summary_envelope_v1/valid/external_summary.sigstore.json",
+    "certificate_subject": "repo:HKati/pulse-release-gates-0.1:workflow:external-eval"
+  },
+  "verification": {
+    "verified": true,
+    "verified_at": "2026-05-03T00:00:00Z",
+    "verifier": {
+      "name": "pulse-external-summary-verifier",
+      "version": "v1"
+    },
+    "result_reason": "Fixture envelope is verification-positive and fold-in eligible under declared signer policy."
+  },
+  "policy_context": {
+    "signer_policy_ref": "policy/external_signers_v1.yml",
+    "threshold_policy_ref": "policy/external_thresholds_v1.yml",
+    "release_contribution": "required",
+    "fold_in_allowed": true
+  },
+  "authority_boundary": "This external summary envelope does not define release authority. It records digest, signer, verification, and policy context for external evidence before any policy-controlled fold-in to status.json."
+}

--- a/tests/fixtures/external_summary_envelope_v1/valid/envelope.json
+++ b/tests/fixtures/external_summary_envelope_v1/valid/envelope.json
@@ -8,7 +8,7 @@
   },
   "summary_digest": {
     "algorithm": "sha256",
-    "value": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    "value": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
   },
   "signing": {
     "mode": "sigstore-keyless",


### PR DESCRIPTION
## Summary

Adds the first concrete valid fixture for the PULSE-REF external summary envelope fixture set.

The fixture is a canonical `external_summary_envelope_v1` artifact intended to pass `schemas/external_summary_envelope_v1.schema.json`.

## Scope

Adds:

- `tests/fixtures/external_summary_envelope_v1/valid/envelope.json`

## Purpose

This fixture establishes the positive external summary envelope case before adding malformed / unverified envelope fixtures.

The fixture includes:

- envelope schema version;
- envelope ID;
- reference to a canonical `external_summary_v1` artifact;
- summary digest;
- signing mode and identity;
- verifier identity;
- verification result;
- signer policy reference;
- release contribution mode;
- fold-in eligibility;
- authority-boundary statement.

## Verification-before-fold-in

The fixture intentionally sets:

```text
verification.verified = true
policy_context.fold_in_allowed = true
```

This satisfies the envelope schema condition that fold-in eligibility requires successful verification.

## Authority boundary

This fixture does not define release authority.

It is an external evidence verification container only. External summaries and envelopes may become release evidence only through schema, identity, signer, digest, verification, and policy-controlled fold-in to `status.json`.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Expected validation

The fixture should validate against:

```text
schemas/external_summary_envelope_v1.schema.json
```

The existing external summary schema tests, external summary fixture matrix, and release reference fixture matrix should continue to pass.

## Risk

Low. Adds fixture data only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.