### PR TITLE
test(pulse-ref): add expected outcome for valid envelope fixture

### DIFF
--- a/tests/fixtures/external_summary_envelope_v1/valid/expected_outcome.json
+++ b/tests/fixtures/external_summary_envelope_v1/valid/expected_outcome.json
@@ -1,0 +1,27 @@
+{
+  "fixture_id": "external_summary_envelope_v1/valid",
+  "expected_result": "PASS",
+  "expected_reason": "The fixture is a valid canonical external_summary_envelope_v1 artifact with summary reference, digest binding, signer identity, verifier identity, verification success, policy context, fold-in eligibility, and authority-boundary statement.",
+  "expected_schema": "schemas/external_summary_envelope_v1.schema.json",
+  "expected_checks": {
+    "schema_version": "external_summary_envelope_v1",
+    "summary_ref_uri_present": true,
+    "summary_ref_schema_version": "external_summary_v1",
+    "summary_ref_summary_id_matches_referenced_summary": true,
+    "summary_digest_algorithm": "sha256",
+    "summary_digest_matches_referenced_summary": true,
+    "summary_digest_valid_sha256": true,
+    "signing_mode_present": true,
+    "signing_identity_present": true,
+    "verification_verified": true,
+    "verification_verified_at_present": true,
+    "verification_verifier_name_present": true,
+    "verification_verifier_version_present": true,
+    "policy_context_signer_policy_ref_present": true,
+    "policy_context_release_contribution": "required",
+    "policy_context_fold_in_allowed": true,
+    "verification_before_fold_in_satisfied": true,
+    "authority_boundary_present": true
+  },
+  "authority_boundary": "This fixture does not define release authority. It validates the canonical external summary envelope shape and verification-before-fold-in state before any policy-controlled fold-in to status.json."
+}


### PR DESCRIPTION
## Summary

Adds expected outcome metadata for the valid PULSE-REF external summary envelope fixture.

The metadata records that `tests/fixtures/external_summary_envelope_v1/valid/envelope.json` is expected to pass validation against `schemas/external_summary_envelope_v1.schema.json`.

## Scope

Adds:

- `tests/fixtures/external_summary_envelope_v1/valid/expected_outcome.json`

## Purpose

This expected outcome file makes the valid external summary envelope fixture explicit as a test case.

It records:

- fixture ID;
- expected PASS result;
- expected schema;
- summary reference checks;
- digest-binding checks;
- signer identity checks;
- verifier identity checks;
- verification-before-fold-in checks;
- authority-boundary statement.

## Verification-before-fold-in

The valid envelope fixture is expected to satisfy:

- `verification.verified: true`
- `policy_context.fold_in_allowed: true`

The envelope digest is also expected to match the referenced external summary fixture’s `evidence.summary_digest`.

## Authority boundary

This file does not define release authority.

It documents the expected result for an external evidence verification container before any policy-controlled fold-in to `status.json`.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Risk

Low. Adds fixture metadata only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.