### PR TITLE
test(pulse-ref): add expected outcome for missing summary digest enve…

### DIFF
--- a/tests/fixtures/external_summary_envelope_v1/missing_summary_digest/expected_outcome.json
+++ b/tests/fixtures/external_summary_envelope_v1/missing_summary_digest/expected_outcome.json
@@ -1,0 +1,32 @@
+{
+  "fixture_id": "external_summary_envelope_v1/missing_summary_digest",
+  "expected_result": "FAIL",
+  "expected_reason": "summary_digest is missing. This fixture isolates a missing summary digest as the only intended external_summary_envelope_v1 schema failure while keeping all non-target fields valid.",
+  "expected_schema": "schemas/external_summary_envelope_v1.schema.json",
+  "expected_failure": {
+    "field": "summary_digest",
+    "json_schema_error_path": [],
+    "missing_property": "summary_digest",
+    "failure_mode": "missing_summary_digest",
+    "non_target_fields_valid": true
+  },
+  "expected_checks": {
+    "schema_version": "external_summary_envelope_v1",
+    "summary_ref_uri_present": true,
+    "summary_ref_schema_version": "external_summary_v1",
+    "summary_ref_summary_id_matches_referenced_summary": true,
+    "summary_digest_present": false,
+    "signing_mode_present": true,
+    "signing_identity_present": true,
+    "verification_verified": true,
+    "verification_verified_at_present": true,
+    "verification_verifier_name_present": true,
+    "verification_verifier_version_present": true,
+    "policy_context_signer_policy_ref_present": true,
+    "policy_context_release_contribution": "required",
+    "policy_context_fold_in_allowed": true,
+    "verification_before_fold_in_satisfied": true,
+    "authority_boundary_present": true
+  },
+  "authority_boundary": "This fixture metadata does not define release authority. It documents an expected fail-closed schema-validation outcome for malformed external evidence before any policy-controlled fold-in to status.json."
+}


### PR DESCRIPTION
## Summary

Adds expected outcome metadata for the malformed PULSE-REF external summary envelope fixture that omits `summary_digest`.

The metadata records that this fixture is expected to fail validation against `schemas/external_summary_envelope_v1.schema.json`.

## Scope

Adds:

- `tests/fixtures/external_summary_envelope_v1/missing_summary_digest/expected_outcome.json`

## Purpose

This expected outcome file makes the missing-summary-digest envelope fixture explicit as a negative schema-validation case.

It records:

- fixture ID;
- expected FAIL result;
- expected schema;
- expected failure field;
- JSON Schema error path;
- missing property;
- non-target field validity;
- verification-before-fold-in state;
- authority-boundary statement.

## Verification-before-fold-in

The fixture keeps:

- `verification.verified: true`
- `policy_context.fold_in_allowed: true`

so the expected failure is isolated to the missing `summary_digest`, not to verification state.

## Authority boundary

This file does not define release authority.

It documents the expected result for a malformed external evidence envelope before any policy-controlled fold-in to `status.json`.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Risk

Low. Adds fixture metadata only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.