### PR TITLE
test(pulse-ref): add missing signing identity envelope fixture

### DIFF
--- a/tests/fixtures/external_summary_envelope_v1/missing_signing_identity/envelope.json
+++ b/tests/fixtures/external_summary_envelope_v1/missing_signing_identity/envelope.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "external_summary_envelope_v1",
+  "envelope_id": "external_summary_envelope_v1_missing_signing_identity_fixture",
+  "summary_ref": {
+    "uri": "tests/fixtures/external_summary_v1/valid/external_summary.json",
+    "schema_version": "external_summary_v1",
+    "summary_id": "external_summary_v1_valid_promptfoo_fixture"
+  },
+  "summary_digest": {
+    "algorithm": "sha256",
+    "value": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  },
+  "signing": {
+    "mode": "sigstore-keyless",
+    "issuer": "https://token.actions.githubusercontent.com",
+    "bundle_uri": "tests/fixtures/external_summary_envelope_v1/missing_signing_identity/external_summary.sigstore.json",
+    "certificate_subject": "repo:HKati/pulse-release-gates-0.1:workflow:external-eval"
+  },
+  "verification": {
+    "verified": true,
+    "verified_at": "2026-05-03T00:00:00Z",
+    "verifier": {
+      "name": "pulse-external-summary-verifier",
+      "version": "v1"
+    },
+    "result_reason": "This fixture intentionally omits signing.identity to validate fail-closed envelope schema behavior."
+  },
+  "policy_context": {
+    "signer_policy_ref": "policy/external_signers_v1.yml",
+    "threshold_policy_ref": "policy/external_thresholds_v1.yml",
+    "release_contribution": "required",
+    "fold_in_allowed": true
+  },
+  "authority_boundary": "This external summary envelope does not define release authority. It records digest, signer, verification, and policy context for external evidence before any policy-controlled fold-in to status.json."
+}


### PR DESCRIPTION
## Summary

Adds a malformed PULSE-REF external summary envelope fixture that omits `signing.identity`.

The fixture intentionally keeps all non-target fields valid so the schema failure is isolated to the missing signing identity.

## Scope

Adds:

- `tests/fixtures/external_summary_envelope_v1/missing_signing_identity/envelope.json`

## Purpose

This fixture validates that `schemas/external_summary_envelope_v1.schema.json` rejects envelopes that do not identify the signer, workflow, KMS identity, or explicit unsigned identity marker.

The fixture isolates a single intended schema failure:

- missing `signing.identity`

All non-target fields remain valid.

## Verification-before-fold-in

The fixture keeps:

- `verification.verified: true`
- `policy_context.fold_in_allowed: true`

so the expected failure is not caused by verification-before-fold-in. The intended failure is only the missing signer identity.

## Authority boundary

This fixture does not define release authority.

It is malformed external evidence envelope data used for schema validation only. External summaries and envelopes may become release evidence only through schema, identity, signer, digest, verification, and policy-controlled fold-in to `status.json`.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Expected validation

The fixture should fail validation against:

```text
schemas/external_summary_envelope_v1.schema.json
```

Expected failure reason:

```text
signing.identity is required
```

The existing external summary schema tests, external summary fixture matrix, and release reference fixture matrix should continue to pass.

## Risk

Low. Adds fixture data only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.