### PR TITLE
test(pulse-ref): add expected outcome for missing verifier identity

### DIFF
--- a/tests/fixtures/external_summary_envelope_v1/missing_verifier_identity/expected_outcome.json
+++ b/tests/fixtures/external_summary_envelope_v1/missing_verifier_identity/expected_outcome.json
@@ -1,0 +1,21 @@
+{
+  "fixture_id": "external_summary_envelope_v1_missing_verifier_identity",
+  "expected_result": "fail",
+  "expected_schema": "schemas/external_summary_envelope_v1.schema.json",
+  "expected_failure": {
+    "field": "verification.verifier.name",
+    "json_schema_error_path": [
+      "verification",
+      "verifier"
+    ],
+    "missing_property": "name",
+    "non_target_fields_valid": true
+  },
+  "expected_checks": {
+    "schema_validation": "fail",
+    "failure_isolated_to_target_field": true,
+    "verification_before_fold_in_not_target": true,
+    "authority_boundary_preserved": true
+  },
+  "authority_boundary": "This fixture does not define release authority. It is malformed external evidence envelope data used for schema validation only. External summaries and envelopes may become release evidence only through schema, identity, signer, digest, verification, and policy-controlled fold-in to status.json. The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome."
+}


### PR DESCRIPTION
## Summary

Adds expected outcome metadata for the malformed PULSE-REF external summary envelope fixture that omits `verification.verifier.name`.

Codex noted that the new `missing_verifier_identity` fixture directory contained only `envelope.json`. The fixture-matrix pattern expects each active fixture to include `expected_outcome.json` so the harness can discover the case and assert the intended pass/fail behavior.

## Scope

Adds:

- `tests/fixtures/external_summary_envelope_v1/missing_verifier_identity/expected_outcome.json`

## Purpose

This companion metadata file records the intended isolated schema failure for the malformed envelope fixture:

```text
missing verification.verifier.name
```

It ensures the fixture is tracked by discovery-based validation and cannot silently become an unasserted negative case.

## Expected validation

The fixture should fail validation against:

```text
schemas/external_summary_envelope_v1.schema.json
```

Expected failure reason:

```text
verification.verifier.name is required
```

The expected outcome metadata records that:

- schema validation should fail;
- the failure should be isolated to `verification.verifier.name`;
- the verification-before-fold-in condition is not the target failure;
- the authority boundary remains preserved.

## Authority boundary

This fixture and expected outcome metadata do not define release authority.

They are malformed external evidence envelope fixture metadata used for schema-validation coverage only. External summaries and envelopes may become release evidence only through schema, identity, signer, digest, verification, and policy-controlled fold-in to `status.json`.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Risk

Low. Adds fixture metadata only. No workflow, schema, policy, gate behavior, CI behavior, or release-authority behavior is modified.