### PR TITLE
test(pulse-ref): add unverified non-fold-in envelope fixture

### DIFF
--- a/tests/fixtures/external_summary_envelope_v1/unverified_fold_in_not_allowed/envelope.json
+++ b/tests/fixtures/external_summary_envelope_v1/unverified_fold_in_not_allowed/envelope.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "external_summary_envelope_v1",
+  "envelope_id": "external_summary_envelope_v1_unverified_fold_in_not_allowed_fixture",
+  "summary_ref": {
+    "uri": "tests/fixtures/external_summary_v1/valid/external_summary.json",
+    "schema_version": "external_summary_v1",
+    "summary_id": "external_summary_v1_valid_promptfoo_fixture"
+  },
+  "summary_digest": {
+    "algorithm": "sha256",
+    "value": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  },
+  "signing": {
+    "mode": "sigstore-keyless",
+    "identity": "repo:HKati/pulse-release-gates-0.1:workflow:external-eval",
+    "issuer": "https://token.actions.githubusercontent.com",
+    "bundle_uri": "tests/fixtures/external_summary_envelope_v1/unverified_fold_in_not_allowed/external_summary.sigstore.json",
+    "certificate_subject": "repo:HKati/pulse-release-gates-0.1:workflow:external-eval"
+  },
+  "verification": {
+    "verified": false,
+    "verified_at": "2026-05-03T00:00:00Z",
+    "verifier": {
+      "name": "pulse-external-summary-verifier",
+      "version": "v1"
+    },
+    "result_reason": "This fixture intentionally keeps verification.verified=false while policy_context.fold_in_allowed=false to validate that unverified evidence may be retained only as non-fold-in evidence."
+  },
+  "policy_context": {
+    "signer_policy_ref": "policy/external_signers_v1.yml",
+    "threshold_policy_ref": "policy/external_thresholds_v1.yml",
+    "release_contribution": "diagnostic",
+    "fold_in_allowed": false
+  },
+  "authority_boundary": "This external summary envelope does not define release authority. It records digest, signer, verification, and policy context for external evidence before any policy-controlled fold-in to status.json."
+}

--- a/tests/fixtures/external_summary_envelope_v1/unverified_fold_in_not_allowed/expected_outcome.json
+++ b/tests/fixtures/external_summary_envelope_v1/unverified_fold_in_not_allowed/expected_outcome.json
@@ -1,0 +1,28 @@
+{
+  "fixture_id": "external_summary_envelope_v1/unverified_fold_in_not_allowed",
+  "expected_result": "PASS",
+  "expected_reason": "verification.verified is false and policy_context.fold_in_allowed is false. This fixture validates that unverified external evidence may be retained as non-fold-in diagnostic evidence without becoming release authority.",
+  "expected_schema": "schemas/external_summary_envelope_v1.schema.json",
+  "expected_checks": {
+    "schema_version": "external_summary_envelope_v1",
+    "summary_ref_uri_present": true,
+    "summary_ref_schema_version": "external_summary_v1",
+    "summary_ref_summary_id_matches_referenced_summary": true,
+    "summary_digest_present": true,
+    "summary_digest_algorithm": "sha256",
+    "summary_digest_matches_referenced_summary": true,
+    "summary_digest_valid_sha256": true,
+    "signing_mode_present": true,
+    "signing_identity_present": true,
+    "verification_verified": false,
+    "verification_verified_at_present": true,
+    "verification_verifier_name_present": true,
+    "verification_verifier_version_present": true,
+    "policy_context_signer_policy_ref_present": true,
+    "policy_context_release_contribution": "diagnostic",
+    "policy_context_fold_in_allowed": false,
+    "verification_before_fold_in_satisfied": true,
+    "authority_boundary_present": true
+  },
+  "authority_boundary": "This fixture metadata does not define release authority. It documents an expected PASS schema-validation outcome for unverified external evidence that is explicitly not fold-in eligible."
+}


### PR DESCRIPTION
## Summary

Adds the positive control fixture for unverified external summary envelopes that are not fold-in eligible.

The fixture intentionally sets:

- `verification.verified: false`
- `policy_context.fold_in_allowed: false`
- `policy_context.release_contribution: diagnostic`

The fixture also includes expected outcome metadata so it can be discovered by fixture-matrix validation.

## Scope

Adds:

- `tests/fixtures/external_summary_envelope_v1/unverified_fold_in_not_allowed/envelope.json`
- `tests/fixtures/external_summary_envelope_v1/unverified_fold_in_not_allowed/expected_outcome.json`

## Purpose

This fixture validates the positive counterpart to the verification-before-fold-in failure case.

It demonstrates that unverified external evidence may be retained as diagnostic / non-fold-in evidence, while remaining non-authoritative.

The expected result is PASS because `fold_in_allowed` is false.

## Verification-before-fold-in

This fixture satisfies the schema rule:

```text
if policy_context.fold_in_allowed == true:
    verification.verified must be true
```

Because `fold_in_allowed` is false, `verification.verified=false` is allowed.

## Authority boundary

This fixture does not define release authority.

It is an external evidence verification container only. External summaries and envelopes may become release evidence only through schema, identity, signer, digest, verification, and policy-controlled fold-in to `status.json`.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Risk

Low. Adds fixture data and expected outcome metadata only.

No workflow, schema, policy, gate behavior, or release-authority behavior is modified.