### PR TITLE
test(pulse-ref): add external summary envelope fixture matrix test

### DIFF
--- a/tests/test_external_summary_envelope_fixture_matrix_v1.py
+++ b/tests/test_external_summary_envelope_fixture_matrix_v1.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+PULSE-REF external summary envelope fixture matrix tests.
+
+These tests execute JSON Schema validation against external_summary_envelope_v1
+fixture cases that contain both:
+
+- envelope.json
+- expected_outcome.json
+
+The tests do not define release authority.
+They verify that fixture expectations match schema-validation outcomes.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_ROOT = ROOT / "tests" / "fixtures" / "external_summary_envelope_v1"
+ENVELOPE_SCHEMA_PATH = ROOT / "schemas" / "external_summary_envelope_v1.schema.json"
+SUMMARY_FIXTURE_PATH = ROOT / "tests" / "fixtures" / "external_summary_v1" / "valid" / "external_summary.json"
+
+
+EXPECTED_ACTIVE_FIXTURES = {
+    "valid",
+    "missing_summary_digest",
+    "missing_signing_identity",
+    "missing_verifier_identity",
+    "unverified_fold_in_allowed",
+    "unverified_fold_in_not_allowed",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def require_jsonschema():
+    try:
+        import jsonschema  # type: ignore
+    except Exception as exc:  # pragma: no cover
+        raise unittest.SkipTest("jsonschema is not available") from exc
+
+    return jsonschema
+
+
+def fixture_dirs() -> list[Path]:
+    if not FIXTURE_ROOT.exists():
+        return []
+
+    dirs: list[Path] = []
+    for path in sorted(FIXTURE_ROOT.iterdir()):
+        if not path.is_dir():
+            continue
+
+        if (path / "envelope.json").exists() and (path / "expected_outcome.json").exists():
+            dirs.append(path)
+
+    return dirs
+
+
+def error_paths(errors: list[Any]) -> list[list[Any]]:
+    return [list(error.path) for error in errors]
+
+
+class TestExternalSummaryEnvelopeFixtureMatrixV1(unittest.TestCase):
+    def setUp(self) -> None:
+        self.jsonschema = require_jsonschema()
+        self.schema = load_json(ENVELOPE_SCHEMA_PATH)
+        self.summary = load_json(SUMMARY_FIXTURE_PATH)
+        self.jsonschema.Draft202012Validator.check_schema(self.schema)
+        self.validator = self.jsonschema.Draft202012Validator(self.schema)
+
+    def assert_digest_binding_if_declared(self, envelope: dict[str, Any], expected: dict[str, Any]) -> None:
+        checks = expected.get("expected_checks", {})
+
+        if checks.get("summary_ref_summary_id_matches_referenced_summary"):
+            self.assertEqual(envelope["summary_ref"]["summary_id"], self.summary["summary_id"])
+
+        if checks.get("summary_digest_matches_referenced_summary"):
+            self.assertIn("summary_digest", envelope)
+            self.assertEqual(envelope["summary_digest"]["value"], self.summary["evidence"]["summary_digest"])
+
+    def assert_verification_before_fold_in_metadata(self, envelope: dict[str, Any], expected: dict[str, Any]) -> None:
+        checks = expected.get("expected_checks", {})
+
+        if "verification_verified" in checks:
+            self.assertEqual(envelope["verification"]["verified"], checks["verification_verified"])
+
+        if "policy_context_fold_in_allowed" in checks:
+            self.assertEqual(
+                envelope["policy_context"]["fold_in_allowed"],
+                checks["policy_context_fold_in_allowed"],
+            )
+
+        if "verification_before_fold_in_satisfied" in checks:
+            satisfied = (
+                envelope["verification"]["verified"] is True
+                or envelope["policy_context"]["fold_in_allowed"] is False
+            )
+            self.assertEqual(satisfied, checks["verification_before_fold_in_satisfied"])
+
+    def assert_isolated_schema_failure(
+        self,
+        *,
+        fixture_dir: Path,
+        expected_path: Path,
+        errors: list[Any],
+        expected_failure: dict[str, Any],
+    ) -> None:
+        """Verify that a negative envelope fixture fails for exactly one intended schema reason."""
+        target_path = expected_failure.get("json_schema_error_path")
+
+        self.assertIsInstance(
+            target_path,
+            list,
+            msg=(
+                "FAIL fixture must declare expected_failure.json_schema_error_path.\n"
+                f"Fixture metadata: {expected_path}"
+            ),
+        )
+
+        self.assertEqual(
+            len(errors),
+            1,
+            msg=(
+                "FAIL fixture must isolate exactly one schema-validation error.\n"
+                f"Fixture: {fixture_dir.name}\n"
+                f"Expected path: {target_path!r}\n"
+                f"Observed paths: {error_paths(errors)!r}\n"
+                f"Messages: {[error.message for error in errors]!r}"
+            ),
+        )
+
+        error = errors[0]
+        observed_path = list(error.path)
+
+        self.assertEqual(
+            observed_path,
+            target_path,
+            msg=(
+                "FAIL fixture produced a schema error at the wrong path.\n"
+                f"Fixture: {fixture_dir.name}\n"
+                f"Expected path: {target_path!r}\n"
+                f"Observed path: {observed_path!r}\n"
+                f"Message: {error.message!r}"
+            ),
+        )
+
+        missing_property = expected_failure.get("missing_property")
+        if missing_property is not None:
+            self.assertEqual(
+                error.validator,
+                "required",
+                msg=(
+                    "Expected a required-property schema failure.\n"
+                    f"Fixture: {fixture_dir.name}\n"
+                    f"Missing property: {missing_property!r}\n"
+                    f"Validator: {error.validator!r}\n"
+                    f"Message: {error.message!r}"
+                ),
+            )
+            self.assertIn(
+                missing_property,
+                error.message,
+                msg=(
+                    "Expected schema error message to mention the missing property.\n"
+                    f"Fixture: {fixture_dir.name}\n"
+                    f"Missing property: {missing_property!r}\n"
+                    f"Message: {error.message!r}"
+                ),
+            )
+            if isinstance(error.validator_value, list):
+                self.assertIn(
+                    missing_property,
+                    error.validator_value,
+                    msg=(
+                        "Missing property should be listed in the schema required list.\n"
+                        f"Fixture: {fixture_dir.name}\n"
+                        f"Missing property: {missing_property!r}\n"
+                        f"Required list: {error.validator_value!r}"
+                    ),
+                )
+
+        if "invalid_value" in expected_failure:
+            invalid_value = expected_failure["invalid_value"]
+            self.assertEqual(
+                error.instance,
+                invalid_value,
+                msg=(
+                    "Expected schema error to be caused by the declared invalid value.\n"
+                    f"Fixture: {fixture_dir.name}\n"
+                    f"Expected invalid value: {invalid_value!r}\n"
+                    f"Observed instance: {error.instance!r}\n"
+                    f"Message: {error.message!r}"
+                ),
+            )
+
+        self.assertTrue(
+            expected_failure.get("non_target_fields_valid"),
+            msg=(
+                "FAIL fixture metadata must declare non_target_fields_valid=true "
+                "to preserve isolated failure-mode semantics.\n"
+                f"Fixture metadata: {expected_path}"
+            ),
+        )
+
+    def test_expected_active_fixture_set_is_present(self) -> None:
+        discovered = {path.name for path in fixture_dirs()}
+
+        self.assertTrue(
+            EXPECTED_ACTIVE_FIXTURES.issubset(discovered),
+            msg=(
+                "Expected all active external summary envelope fixtures to contain both "
+                "envelope.json and expected_outcome.json.\n"
+                f"Expected: {sorted(EXPECTED_ACTIVE_FIXTURES)}\n"
+                f"Discovered: {sorted(discovered)}"
+            ),
+        )
+
+    def test_external_summary_envelope_fixture_matrix_matches_expected_outcomes(self) -> None:
+        fixtures = fixture_dirs()
+        self.assertGreaterEqual(
+            len(fixtures),
+            len(EXPECTED_ACTIVE_FIXTURES),
+            "Expected active external_summary_envelope_v1 fixtures with envelope.json and expected_outcome.json.",
+        )
+
+        for fixture_dir in fixtures:
+            with self.subTest(fixture=fixture_dir.name):
+                envelope_path = fixture_dir / "envelope.json"
+                expected_path = fixture_dir / "expected_outcome.json"
+
+                envelope = load_json(envelope_path)
+                expected = load_json(expected_path)
+
+                expected_fixture_id = f"external_summary_envelope_v1/{fixture_dir.name}"
+                self.assertEqual(expected["fixture_id"], expected_fixture_id)
+                self.assertEqual(expected["expected_schema"], "schemas/external_summary_envelope_v1.schema.json")
+
+                self.assert_digest_binding_if_declared(envelope, expected)
+                self.assert_verification_before_fold_in_metadata(envelope, expected)
+
+                errors = sorted(
+                    self.validator.iter_errors(envelope),
+                    key=lambda error: list(error.path),
+                )
+
+                expected_result = expected["expected_result"]
+
+                if expected_result == "PASS":
+                    self.assertEqual(
+                        errors,
+                        [],
+                        msg=(
+                            "Expected PASS fixture to validate against external_summary_envelope_v1 schema.\n"
+                            f"Fixture: {envelope_path}\n"
+                            f"Errors: {[error.message for error in errors]}"
+                        ),
+                    )
+
+                elif expected_result == "FAIL":
+                    self.assertGreater(
+                        len(errors),
+                        0,
+                        msg=(
+                            "Expected FAIL fixture to produce schema-validation errors.\n"
+                            f"Fixture: {envelope_path}"
+                        ),
+                    )
+
+                    expected_failure = expected.get("expected_failure", {})
+                    self.assert_isolated_schema_failure(
+                        fixture_dir=fixture_dir,
+                        expected_path=expected_path,
+                        errors=errors,
+                        expected_failure=expected_failure,
+                    )
+
+                else:
+                    self.fail(f"Unsupported expected_result: {expected_result!r}")
+
+                self.assertIn("authority_boundary", expected)
+                self.assertIn(
+                    "does not define release authority",
+                    expected["authority_boundary"],
+                )
+
+    def test_expected_outcome_metadata_has_authority_boundary(self) -> None:
+        fixtures = fixture_dirs()
+        self.assertGreaterEqual(len(fixtures), len(EXPECTED_ACTIVE_FIXTURES))
+
+        for fixture_dir in fixtures:
+            with self.subTest(fixture=fixture_dir.name):
+                expected = load_json(fixture_dir / "expected_outcome.json")
+
+                self.assertIn("authority_boundary", expected)
+                self.assertIn(
+                    "does not define release authority",
+                    expected["authority_boundary"],
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a fixture matrix test for the PULSE-REF external summary envelope fixture set.

The test discovers envelope fixture directories that contain both `envelope.json` and `expected_outcome.json`, validates each fixture against `schemas/external_summary_envelope_v1.schema.json`, and checks that the schema-validation result matches the expected outcome metadata.

## Scope

Adds:

- `tests/test_external_summary_envelope_fixture_matrix_v1.py`

## Purpose

This turns the external summary envelope fixture set into an executable regression matrix.

Current active cases include:

- valid envelope;
- missing summary digest;
- missing signing identity;
- missing verifier identity;
- unverified envelope with fold-in allowed;
- unverified envelope with fold-in not allowed.

For negative fixtures, the test enforces failure isolation by requiring exactly one schema-validation error matching the fixture's declared `expected_failure.json_schema_error_path`.

## Verification-before-fold-in

The matrix checks the envelope fixture metadata around:

- `verification.verified`;
- `policy_context.fold_in_allowed`;
- `verification_before_fold_in_satisfied`.

This verifies both sides of the verification-before-fold-in rule:

- unverified + fold-in allowed -> FAIL;
- unverified + fold-in not allowed -> PASS.

## Authority boundary

This test does not define release authority.

It validates external evidence envelope shape against `external_summary_envelope_v1` and compares results to fixture metadata. External summaries and envelopes may become release evidence only through schema, identity, signer, digest, verification, and policy-controlled fold-in to `status.json`.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Testing

Run:

- `python -m py_compile tests/test_external_summary_envelope_fixture_matrix_v1.py`
- `python tests/test_external_summary_envelope_fixture_matrix_v1.py`
- `python tests/test_external_summary_schema_v1.py`
- `python tests/test_external_summary_fixture_matrix_v1.py`
- `python tests/test_release_reference_fixture_matrix_v1.py`

## Risk

Low. Adds tests only. No workflow, schema, policy, fixture data, gate behavior, or release-authority behavior is modified.