### PR TITLE
test(pulse-ref): add malformed summary release fixture

### DIFF
--- a/tests/fixtures/release_reference_v1/malformed_summary/expected_outcome.json
+++ b/tests/fixtures/release_reference_v1/malformed_summary/expected_outcome.json
@@ -1,0 +1,25 @@
+{
+  "fixture_id": "release_reference_v1/malformed_summary",
+  "expected_result": "FAIL",
+  "expected_reason": "external_all_pass is false. This fixture isolates a release-grade external evidence contract failure while keeping external_summaries_present=true, detectors_materialized_ok=true, diagnostics.gates_stubbed=false, and all non-target required gates passing.",
+  "expected_guard": "ci/check_release_reference_complete_v1.py",
+  "expected_failure": {
+    "gate": "external_all_pass",
+    "value": false,
+    "failure_mode": "malformed_external_summary_contract",
+    "non_target_required_gates_passing": true,
+    "non_target_release_required_gates_passing": true
+  },
+  "expected_checks": {
+    "run_mode": "prod",
+    "gates_stubbed": false,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": false,
+    "required_gates_literal_true": true,
+    "release_required_gates_literal_true_except_external_all_pass": true,
+    "external_summary_contract_result": "fail",
+    "external_summary_contract_failure_mode": "malformed_summary"
+  },
+  "authority_boundary": "This fixture does not define release authority. It documents an expected fail-closed release-grade outcome when external evidence fails the external summary contract before policy-controlled release authorization."
+}

--- a/tests/fixtures/release_reference_v1/malformed_summary/status.json
+++ b/tests/fixtures/release_reference_v1/malformed_summary/status.json
@@ -1,0 +1,48 @@
+{
+  "version": "1.0",
+  "created_utc": "2026-05-04T00:00:00Z",
+  "metrics": {
+    "run_mode": "prod",
+    "fixture_id": "release_reference_v1/malformed_summary",
+    "fixture_kind": "negative_release_reference",
+    "description": "Negative PULSE-REF release-grade reference fixture where external summaries are present but fail the external evidence contract. Release-grade validation must fail closed through external_all_pass=false."
+  },
+  "diagnostics": {
+    "gates_stubbed": false,
+    "fixture_note": "This fixture isolates external_all_pass=false as the intended failing release-required gate while keeping external_summaries_present=true and non-target gates passing."
+  },
+  "gates": {
+    "pass_controls_refusal": true,
+    "refusal_delta_pass": true,
+    "effect_present": true,
+    "psf_monotonicity_ok": true,
+    "psf_mono_shift_resilient": true,
+    "pass_controls_comm": true,
+    "psf_commutativity_ok": true,
+    "psf_comm_shift_resilient": true,
+    "pass_controls_sanit": true,
+    "sanitization_effective": true,
+    "sanit_shift_resilient": true,
+    "psf_action_monotonicity_ok": true,
+    "psf_idempotence_ok": true,
+    "psf_path_independence_ok": true,
+    "psf_pii_monotonicity_ok": true,
+    "q1_grounded_ok": true,
+    "q2_consistency_ok": true,
+    "q3_fairness_ok": true,
+    "q4_slo_ok": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": false
+  },
+  "evidence": {
+    "detectors_materialized": true,
+    "external_summaries_present": true,
+    "external_summary_mode": "fixture",
+    "external_summary_contract_result": "fail",
+    "external_summary_contract_failure_mode": "malformed_summary",
+    "external_summary_fixture_ref": "tests/fixtures/external_summary_v1/malformed_missing_tool_version/external_summary.json",
+    "external_summary_expected_outcome_ref": "tests/fixtures/external_summary_v1/malformed_missing_tool_version/expected_outcome.json",
+    "authority_boundary": "This fixture does not define release authority. It exercises fail-closed release-grade behavior when external evidence exists but fails the external summary contract."
+  }
+}


### PR DESCRIPTION
## Summary

Adds a negative PULSE-REF release reference fixture for malformed external summary evidence.

The fixture represents a release-grade candidate where external summaries are present, detector evidence is materialized, and all non-target required gates pass, but the external evidence contract fails. The release-grade path must fail closed through `external_all_pass=false`.

## Scope

Adds:

- `tests/fixtures/release_reference_v1/malformed_summary/status.json`
- `tests/fixtures/release_reference_v1/malformed_summary/expected_outcome.json`

## Purpose

This fixture integrates the external summary contract layer back into the release-reference fixture matrix.

It validates that malformed external evidence cannot be converted into release-grade PASS.

The fixture isolates:

- `external_all_pass: false`

while keeping:

- `external_summaries_present: true`
- `detectors_materialized_ok: true`
- `diagnostics.gates_stubbed: false`
- all non-target required gates passing.

## Authority boundary

This fixture does not define release authority.

It exercises the declared-policy gate-enforcement path and the PULSE-REF release reference completeness guard. External summaries, envelopes, signer policies, fixtures, ledgers, manifests, audit bundles, dashboards, summaries, and publication surfaces do not create a second release-decision path.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Expected validation

The fixture should fail:

```bash
python ci/check_release_reference_complete_v1.py \
  --status tests/fixtures/release_reference_v1/malformed_summary/status.json \
  --policy pulse_gate_policy_v0.yml \
  --required-sets required,release_required \
  --allowed-run-modes prod \
  --require-nonstubbed \
  --require-detectors-materialized \
  --require-external-summaries
```

Expected result: FAIL.

Expected failure reason: `external_all_pass` is false because the external summary contract failed.

## Risk

Low. Adds fixture data and expected outcome metadata only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.