### PR TITLE
test(pulse-ref): add missing refusal delta fixture

### DIFF
--- a/tests/fixtures/release_reference_v1/missing_refusal_delta/expected_outcome.json
+++ b/tests/fixtures/release_reference_v1/missing_refusal_delta/expected_outcome.json
@@ -1,0 +1,30 @@
+{
+  "fixture_id": "release_reference_v1/missing_refusal_delta",
+  "expected_result": "FAIL",
+  "expected_reason": "refusal_delta_evidence_present is false. This fixture isolates missing refusal-delta evidence as the intended release-grade evidence-presence failure while keeping refusal_delta_pass=true, external evidence passing, detector evidence materialized, diagnostics.gates_stubbed=false, and all non-target required gates passing.",
+  "expected_guard": "ci/check_release_reference_complete_v1.py",
+  "expected_extra_required_gates": [
+    "refusal_delta_evidence_present"
+  ],
+  "expected_failure": {
+    "gate": "refusal_delta_evidence_present",
+    "value": false,
+    "failure_mode": "missing_refusal_delta_evidence",
+    "non_target_required_gates_passing": true,
+    "non_target_release_required_gates_passing": true
+  },
+  "expected_checks": {
+    "run_mode": "prod",
+    "gates_stubbed": false,
+    "refusal_delta_pass": true,
+    "refusal_delta_evidence_present": false,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true,
+    "required_gates_literal_true": true,
+    "release_required_gates_literal_true": true,
+    "refusal_delta_summary_present": false,
+    "refusal_delta_evidence_mode": "missing"
+  },
+  "authority_boundary": "This fixture does not define release authority. It documents an expected fail-closed release-grade outcome when refusal-delta evidence is missing even though refusal_delta_pass is true."
+}

--- a/tests/fixtures/release_reference_v1/missing_refusal_delta/status.json
+++ b/tests/fixtures/release_reference_v1/missing_refusal_delta/status.json
@@ -1,0 +1,47 @@
+{
+  "version": "1.0",
+  "created_utc": "2026-05-04T00:00:00Z",
+  "metrics": {
+    "run_mode": "prod",
+    "fixture_id": "release_reference_v1/missing_refusal_delta",
+    "fixture_kind": "negative_release_reference",
+    "description": "Negative PULSE-REF release-grade reference fixture where refusal_delta_pass is true but refusal_delta evidence is missing. Release-grade validation must fail closed when refusal_delta_evidence_present is required."
+  },
+  "diagnostics": {
+    "gates_stubbed": false,
+    "fixture_note": "This fixture isolates refusal_delta_evidence_present=false as the intended failing release-grade evidence-presence gate while keeping refusal_delta_pass=true and non-target gates passing."
+  },
+  "gates": {
+    "pass_controls_refusal": true,
+    "refusal_delta_pass": true,
+    "refusal_delta_evidence_present": false,
+    "effect_present": true,
+    "psf_monotonicity_ok": true,
+    "psf_mono_shift_resilient": true,
+    "pass_controls_comm": true,
+    "psf_commutativity_ok": true,
+    "psf_comm_shift_resilient": true,
+    "pass_controls_sanit": true,
+    "sanitization_effective": true,
+    "sanit_shift_resilient": true,
+    "psf_action_monotonicity_ok": true,
+    "psf_idempotence_ok": true,
+    "psf_path_independence_ok": true,
+    "psf_pii_monotonicity_ok": true,
+    "q1_grounded_ok": true,
+    "q2_consistency_ok": true,
+    "q3_fairness_ok": true,
+    "q4_slo_ok": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true
+  },
+  "evidence": {
+    "detectors_materialized": true,
+    "external_summaries_present": true,
+    "refusal_delta_summary_present": false,
+    "refusal_delta_evidence_mode": "missing",
+    "refusal_delta_expected_behavior": "missing refusal-delta evidence must not become implicit release-grade PASS",
+    "authority_boundary": "This fixture does not define release authority. It exercises fail-closed release-grade behavior when refusal_delta_pass is true but refusal-delta evidence is not materialized."
+  }
+}

--- a/tests/test_release_reference_fixture_matrix_v1.py
+++ b/tests/test_release_reference_fixture_matrix_v1.py
@@ -68,6 +68,24 @@ def extract_guard_errors(output: str) -> list[str]:
     return errors
 
 
+def expected_extra_required_gates(expected: dict[str, Any]) -> list[str]:
+    """Return additional fixture-specific release-grade gates."""
+    gates = expected.get("expected_extra_required_gates", [])
+    if gates is None:
+        return []
+
+    if not isinstance(gates, list):
+        raise TypeError("expected_extra_required_gates must be a list when present.")
+
+    out: list[str] = []
+    for gate in gates:
+        if not isinstance(gate, str) or not gate:
+            raise TypeError("expected_extra_required_gates entries must be non-empty strings.")
+        out.append(gate)
+
+    return out
+
+
 class TestReleaseReferenceFixtureMatrixV1(unittest.TestCase):
     def test_fixture_matrix_matches_expected_guard_outcomes(self) -> None:
         fixtures = fixture_dirs()
@@ -103,6 +121,9 @@ class TestReleaseReferenceFixtureMatrixV1(unittest.TestCase):
                     "--require-detectors-materialized",
                     "--require-external-summaries",
                 ]
+
+                for gate in expected_extra_required_gates(expected):
+                    cmd.extend(["--require-gate", gate])
 
                 proc = subprocess.run(
                     cmd,


### PR DESCRIPTION
## Summary

Adds a PULSE-REF release reference fixture for missing refusal-delta evidence and updates the release-reference fixture matrix to support fixture-specific extra required gates.

The fixture represents a release-grade candidate where `refusal_delta_pass=true`, but the underlying refusal-delta evidence is not materialized.

## Scope

Adds:

- `tests/fixtures/release_reference_v1/missing_refusal_delta/status.json`
- `tests/fixtures/release_reference_v1/missing_refusal_delta/expected_outcome.json`

Updates:

- `tests/test_release_reference_fixture_matrix_v1.py`

## Purpose

This fixture validates the evidence-presence policy for refusal-delta evidence.

It demonstrates that release-grade paths must not infer PASS from missing refusal-delta evidence.

The fixture isolates:

- `refusal_delta_evidence_present: false`

while keeping:

- `refusal_delta_pass: true`
- `detectors_materialized_ok: true`
- `external_summaries_present: true`
- `external_all_pass: true`
- `diagnostics.gates_stubbed: false`
- all non-target required gates passing.

## Matrix behavior

The expected outcome metadata declares:

```json
"expected_extra_required_gates": ["refusal_delta_evidence_present"]
```

The matrix test passes this through to the PULSE-REF guard as:

```bash
--require-gate refusal_delta_evidence_present
```

This models the PULSE-REF release-grade evidence-presence requirement without immediately changing the global gate policy.

## Authority boundary

This fixture does not define release authority.

It exercises the declared-policy gate-enforcement path and the PULSE-REF release reference completeness guard. It does not make fixtures, evidence metadata, ledgers, manifests, audit bundles, dashboards, summaries, or publication surfaces normative.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Risk

Low to medium.

This changes test behavior by allowing fixture-specific extra required gates in the release-reference matrix. It does not modify workflow behavior, schema behavior, gate policy, or release-authority behavior.