### PR TITLE
test(pulse-ref): add refusal delta evidence present fixture

### DIFF
--- a/tests/fixtures/release_reference_v1/refusal_delta_evidence_present/expected_outcome.json
+++ b/tests/fixtures/release_reference_v1/refusal_delta_evidence_present/expected_outcome.json
@@ -1,0 +1,23 @@
+{
+  "fixture_id": "release_reference_v1/refusal_delta_evidence_present",
+  "expected_result": "PASS",
+  "expected_reason": "refusal_delta_evidence_present is true and refusal_delta_pass is true. This fixture is the positive control for refusal-delta evidence presence under release-grade validation.",
+  "expected_guard": "ci/check_release_reference_complete_v1.py",
+  "expected_extra_required_gates": [
+    "refusal_delta_evidence_present"
+  ],
+  "expected_checks": {
+    "run_mode": "prod",
+    "gates_stubbed": false,
+    "refusal_delta_pass": true,
+    "refusal_delta_evidence_present": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true,
+    "required_gates_literal_true": true,
+    "release_required_gates_literal_true": true,
+    "refusal_delta_summary_present": true,
+    "refusal_delta_evidence_mode": "materialized_fixture"
+  },
+  "authority_boundary": "This fixture does not define release authority. It documents an expected PASS release-grade outcome when refusal-delta evidence is materialized, explicit, and required."
+}

--- a/tests/fixtures/release_reference_v1/refusal_delta_evidence_present/status.json
+++ b/tests/fixtures/release_reference_v1/refusal_delta_evidence_present/status.json
@@ -1,0 +1,47 @@
+{
+  "version": "1.0",
+  "created_utc": "2026-05-04T00:00:00Z",
+  "metrics": {
+    "run_mode": "prod",
+    "fixture_id": "release_reference_v1/refusal_delta_evidence_present",
+    "fixture_kind": "positive_release_reference",
+    "description": "Positive PULSE-REF release-grade reference fixture where refusal_delta_pass is true and materialized refusal-delta evidence is explicitly present."
+  },
+  "diagnostics": {
+    "gates_stubbed": false,
+    "fixture_note": "This fixture validates the positive control for refusal_delta_evidence_present=true while all required and release_required gates pass."
+  },
+  "gates": {
+    "pass_controls_refusal": true,
+    "refusal_delta_pass": true,
+    "refusal_delta_evidence_present": true,
+    "effect_present": true,
+    "psf_monotonicity_ok": true,
+    "psf_mono_shift_resilient": true,
+    "pass_controls_comm": true,
+    "psf_commutativity_ok": true,
+    "psf_comm_shift_resilient": true,
+    "pass_controls_sanit": true,
+    "sanitization_effective": true,
+    "sanit_shift_resilient": true,
+    "psf_action_monotonicity_ok": true,
+    "psf_idempotence_ok": true,
+    "psf_path_independence_ok": true,
+    "psf_pii_monotonicity_ok": true,
+    "q1_grounded_ok": true,
+    "q2_consistency_ok": true,
+    "q3_fairness_ok": true,
+    "q4_slo_ok": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true
+  },
+  "evidence": {
+    "detectors_materialized": true,
+    "external_summaries_present": true,
+    "refusal_delta_summary_present": true,
+    "refusal_delta_evidence_mode": "materialized_fixture",
+    "refusal_delta_expected_behavior": "materialized refusal-delta evidence may satisfy release-grade evidence-presence requirements when refusal_delta_pass is also true",
+    "authority_boundary": "This fixture does not define release authority. It exercises the positive release-grade evidence-presence case where refusal-delta evidence is materialized and refusal_delta_pass is true."
+  }
+}


### PR DESCRIPTION
## Summary

Adds the positive PULSE-REF release-reference fixture for materialized refusal-delta evidence.

This fixture is the positive control for the no-implicit-PASS refusal-delta evidence-presence work.

## Scope

Adds:

- `tests/fixtures/release_reference_v1/refusal_delta_evidence_present/status.json`
- `tests/fixtures/release_reference_v1/refusal_delta_evidence_present/expected_outcome.json`

## Purpose

The existing `missing_refusal_delta` fixture proves that this state fails release-grade validation:

```text
refusal_delta_pass = true
refusal_delta_evidence_present = false
```

This new fixture proves the positive counterpart:

```text
refusal_delta_pass = true
refusal_delta_evidence_present = true
```

The expected result is PASS when the fixture matrix passes `refusal_delta_evidence_present` through as a fixture-specific extra required gate.

## Matrix behavior

The expected outcome metadata declares:

```json
"expected_extra_required_gates": ["refusal_delta_evidence_present"]
```

The release-reference matrix passes this through to the PULSE-REF completeness guard as:

```bash
--require-gate refusal_delta_evidence_present
```

## Authority boundary

This fixture does not define release authority.

It exercises the existing PULSE-REF completeness guard and release-reference fixture matrix. It does not modify `pulse_gate_policy_v0.yml`, `check_gates.py`, schemas, workflows, or release-decision behavior.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Risk

Low. Adds fixture data and expected outcome metadata only. No workflow, schema, policy, gate behavior, or release-authority behavior is modified.