### PR TITLE
test(pulse-ref): prepare release fixtures for refusal delta evidence …

### DIFF
--- a/tests/fixtures/release_reference_v1/implicit_fallback_attempt/status.json
+++ b/tests/fixtures/release_reference_v1/implicit_fallback_attempt/status.json
@@ -14,6 +14,7 @@
   "gates": {
     "pass_controls_refusal": true,
     "refusal_delta_pass": true,
+    "refusal_delta_evidence_present": true,  
     "effect_present": true,
     "psf_monotonicity_ok": true,
     "psf_mono_shift_resilient": true,


### PR DESCRIPTION
## Summary

Prepares existing PULSE-REF release-reference fixtures for future promotion of `refusal_delta_evidence_present` as a release-grade evidence-presence gate.

This adds `refusal_delta_evidence_present: true` to non-target release-reference fixtures so they remain valid when refusal-delta evidence presence becomes globally release-required.

## Scope

Updates release-reference fixture status files only.

Adds `refusal_delta_evidence_present: true` to non-target fixtures:

- `pass`
- `missing_external`
- `stubbed`
- `false_gate`
- `implicit_fallback_attempt`
- `malformed_summary`
- `unsigned_summary`

Does not change:

- `missing_refusal_delta`, where `refusal_delta_evidence_present` is intentionally false;
- `refusal_delta_evidence_present`, where it is already true.

## Purpose

This is a fixture-readiness step before any global policy promotion.

The current no-implicit-PASS proof already shows:

```text
refusal_delta_pass=true
refusal_delta_evidence_present=false
-> release-grade FAIL
```

This change ensures that existing non-target fixtures do not fail for unrelated refusal-delta evidence presence when the gate is later promoted.

## Authority boundary

This change does not define release authority.

It does not modify `pulse_gate_policy_v0.yml`, `check_gates.py`, schemas, workflows, or release-decision behavior.

The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

## Risk

Low. Fixture data only. No policy, workflow, schema, gate behavior, or release-authority behavior is modified.