### PR TITLE
Add refusal_delta_evidence_present to release_required and update fixtures/tests

### DIFF
--- a/pulse_gate_policy_v0.yml
+++ b/pulse_gate_policy_v0.yml
@@ -60,6 +60,7 @@ gates:
   # Release-grade evidence / no-stub gates:
   # optional by default, strict when explicitly promoted by workflow/policy selection.
   release_required:
+    - refusal_delta_evidence_present
     - detectors_materialized_ok
     - external_summaries_present
     - external_all_pass

--- a/tests/fixtures/core_baseline_v0/status.normalized.json
+++ b/tests/fixtures/core_baseline_v0/status.normalized.json
@@ -31,7 +31,7 @@
     "RDSI": 0.92,
     "build_time": "1970-01-01T00:00:00Z",
     "gate_policy_path": "pulse_gate_policy_v0.yml",
-    "gate_policy_sha256": "e1cdf26ae7bca113289b8267cbc9db451f0cef40ba08879255db851433ced4a5",
+    "gate_policy_sha256": "88db05c8b3a1af412143f242ae107fb51844b770c95b6e121daabaccb5073196",
     "git_sha": "<GIT_SHA>",
     "hazard_D": 0.0,
     "hazard_E": 0.07999999999999996,
@@ -59,7 +59,6 @@
     "hazard_topology_region": "stably_good",
     "hazard_zone": "GREEN",
     "rdsi_note": "Core CI smoke-run",
-    "run_key": "<RUN_KEY>",
     "run_mode": "core"
   },
   "version": "1.0.0-core"

--- a/tests/test_build_release_authority_manifest_v0.py
+++ b/tests/test_build_release_authority_manifest_v0.py
@@ -173,6 +173,7 @@ def test_builds_required_plus_release_required_manifest(tmp_path: Path) -> None:
         "q2_consistency_ok",
         "q3_fairness_ok",
         "q4_slo_ok",
+        "refusal_delta_evidence_present",
         "detectors_materialized_ok",
         "external_summaries_present",
         "external_all_pass",


### PR DESCRIPTION
### Motivation
- The `refusal_delta_evidence_present` gate was promoted into the `release_required` set and CI started failing due to fixtures and tests not reflecting that promotion. 
- The intent is to keep the promotion while making only minimal changes to tests/fixtures so release-authority behavior remains unchanged.

### Description
- Add `refusal_delta_evidence_present` to `gates.release_required` in `pulse_gate_policy_v0.yml` to reflect the intended policy promotion. 
- Update `tests/fixtures/core_baseline_v0/status.normalized.json` to match the current normalized output (`gate_policy_sha256` and removal of `run_key`) so the core baseline smoke test no longer reports drift. 
- Update `tests/test_build_release_authority_manifest_v0.py` to include `refusal_delta_evidence_present` in the `required_gates` list used for the `required+release_required` prod PASS path so the manifest test reflects the promoted gate. 

### Testing
- Ran the policy assertion `python - <<'PY' ...` which confirmed `refusal_delta_evidence_present` is present in `policy["gates"]["release_required"]` and passed. 
- Ran unit tests including `python -m pytest -q tests/test_core_baseline_v0.py` and `python tests/test_build_release_authority_manifest_v0.py` and the suite passed locally. 
- Executed the release-reference completeness checks with `ci/check_release_reference_complete_v1.py` and observed the expected negative-case FAIL for `tests/fixtures/release_reference_v1/missing_refusal_delta/status.json` and the expected PASS for `tests/fixtures/release_reference_v1/refusal_delta_evidence_present/status.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9468d904832fba71a603ca2a6ec5)