### PR TITLE
fix(pulse-ref): materialize refusal delta evidence in augmenter

### DIFF
--- a/PULSE_safe_pack_v0/tools/augment_status.py
+++ b/PULSE_safe_pack_v0/tools/augment_status.py
@@ -6,16 +6,20 @@ This script takes the core PULSE status artefact (gate results + metrics),
 as written by run_all.py, and enriches it with:
 
 - refusal-delta summary (if present),
+- refusal-delta evidence-presence state,
 - external detector summaries (when configured),
 
 and then wires these into:
+
 - gates.refusal_delta_pass
+- gates.refusal_delta_evidence_present
 - gates.external_all_pass
 - external.metrics / external.all_pass
 
 The resulting extended status.json is consumed by check_gates.py
-and reporting tooling, but it does not change the core deterministic
-gate semantics beyond adding these two deferred gates.
+and reporting tooling. It does not create a second decision engine:
+release authority remains declared-policy gate enforcement over the
+materialized status artefact.
 
 Optional strict mode:
 - when --require_external_summaries is enabled, missing external summaries
@@ -38,6 +42,7 @@ import yaml
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def jload(path: str) -> Optional[Dict[str, Any]]:
     """Best-effort JSON loader: returns dict or None on failure."""
@@ -238,6 +243,7 @@ def fold_q1_reference_shadow(status: Dict[str, Any], summary_path: Optional[str]
 # Main
 # ---------------------------------------------------------------------------
 
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--status", required=True, help="Path to baseline status.json")
@@ -260,16 +266,15 @@ def main() -> int:
         ),
     )
     parser.add_argument(
-    "--q1-reference-summary",
-    "--q1_reference_summary",
-    dest="q1_reference_summary",
-    help=(
-        "Optional Q1 reference summary JSON artefact to fold into "
-        'status["meta"]["q1_reference_shadow"]'
-    ),
-)
-        
-  
+        "--q1-reference-summary",
+        "--q1_reference_summary",
+        dest="q1_reference_summary",
+        help=(
+            "Optional Q1 reference summary JSON artefact to fold into "
+            'status["meta"]["q1_reference_shadow"]'
+        ),
+    )
+
     args = parser.parse_args()
 
     status_path = os.path.abspath(args.status)
@@ -288,25 +293,26 @@ def main() -> int:
     # -----------------------------------------------------------------------
     # 1) Refusal-delta summary -> metrics + gates + top-level mirror
     # -----------------------------------------------------------------------
-    # Pack dir: stable (script location), not derived from status path
+    # Pack dir: stable (script location), not derived from status path.
     pack_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # .../PULSE_safe_pack_v0
 
-    # Artifacts dir: derive from the baseline status.json location
+    # Artifacts dir: derive from the baseline status.json location.
     artifacts_dir = os.path.dirname(status_path)
 
     rd_path = os.path.join(artifacts_dir, "refusal_delta_summary.json")
 
     rd = jload(rd_path)
     refusal_delta_evidence_present = False
- 
-   if rd is not None:
-        rd_n = int(rd.get("n", 0) or 0)
-        rd_evidence_present = rd_n > 0
-        gates["refusal_delta_evidence_present"] = rd_evidence_present
-        status["refusal_delta_evidence_present"] = rd_evidence_present
-        metrics["refusal_delta_n"] = rd_n
-        
-        metrics["refusal_delta_n"] = rd.get("n", 0)
+
+    if rd is not None:
+        try:
+            refusal_delta_n = int(rd.get("n", 0) or 0)
+        except (TypeError, ValueError):
+            refusal_delta_n = 0
+
+        refusal_delta_evidence_present = refusal_delta_n > 0
+
+        metrics["refusal_delta_n"] = refusal_delta_n
         metrics["refusal_delta"] = rd.get("delta", 0.0)
         metrics["refusal_delta_ci_low"] = rd.get("ci_low", 0.0)
         metrics["refusal_delta_ci_high"] = rd.get("ci_high", 0.0)
@@ -323,9 +329,7 @@ def main() -> int:
         gates["refusal_delta_pass"] = rd_pass
         status["refusal_delta_pass"] = rd_pass
     else:
-        gates["refusal_delta_evidence_present"] = False
-        status["refusal_delta_evidence_present"] = False
-      # If REAL pairs exist but no summary -> fail-closed.
+        # If REAL pairs exist but no summary -> fail-closed.
         # If only sample exists -> pass (demo / quick-start).
         real_pairs = os.path.join(pack_dir, "examples", "refusal_pairs.jsonl")
         rd_pass = False if os.path.exists(real_pairs) else True
@@ -341,7 +345,7 @@ def main() -> int:
     thr: Dict[str, Any] = yload(args.thresholds) or {}
     ext_dir = os.path.abspath(args.external_dir)
 
-    # Ensure we start from a clean list
+    # Ensure we start from a clean list.
     external["metrics"] = []
 
     summary_files: list[str] = []
@@ -353,7 +357,7 @@ def main() -> int:
     external["summaries_present"] = summaries_present
     external["summary_count"] = len(summary_files)
 
-    # Diagnostic gate (normative only if policy promotes it)
+    # Diagnostic gate (normative only if policy promotes it).
     gates["external_summaries_present"] = summaries_present
     status["external_summaries_present"] = summaries_present
 
@@ -407,12 +411,12 @@ def main() -> int:
         raw_val: Any = None
         found = False
 
-        # 1) Prefer explicit key if present
+        # 1) Prefer explicit key if present.
         if key_in_json is not None and key_in_json in j:
             raw_val = j.get(key_in_json)
             found = True
 
-        # 2) Fallback keys (covers older + third-party summaries)
+        # 2) Fallback keys (covers older + third-party summaries).
         keys = [
             "value",
             "rate",
@@ -431,7 +435,7 @@ def main() -> int:
                     found = True
                     break
 
-        # 3) Nested dict fallback: failure_rates (Azure-style)
+        # 3) Nested dict fallback: failure_rates (Azure-style).
         #    Prefer exact match first, else conservative max numeric.
         if (not found) and isinstance(j.get("failure_rates"), dict):
             fr = j["failure_rates"]
@@ -448,7 +452,7 @@ def main() -> int:
                     raw_val = max(nums)
                     found = True
 
-        # 4) If still nothing -> fail-closed
+        # 4) If still nothing -> fail-closed.
         if not found:
             external["metrics"].append(
                 {

--- a/PULSE_safe_pack_v0/tools/augment_status.py
+++ b/PULSE_safe_pack_v0/tools/augment_status.py
@@ -300,12 +300,12 @@ def main() -> int:
     refusal_delta_evidence_present = False
  
    if rd is not None:
-       try:
-           refusal_delta_n = int(rd.get("n", 0))
-       except (TypeError, ValueError):
-           refusal_delta_n = 0
-
-        refusal_delta_evidence_present = refusal_delta_n > 0
+        rd_n = int(rd.get("n", 0) or 0)
+        rd_evidence_present = rd_n > 0
+        gates["refusal_delta_evidence_present"] = rd_evidence_present
+        status["refusal_delta_evidence_present"] = rd_evidence_present
+        metrics["refusal_delta_n"] = rd_n
+        
         metrics["refusal_delta_n"] = rd.get("n", 0)
         metrics["refusal_delta"] = rd.get("delta", 0.0)
         metrics["refusal_delta_ci_low"] = rd.get("ci_low", 0.0)
@@ -323,7 +323,9 @@ def main() -> int:
         gates["refusal_delta_pass"] = rd_pass
         status["refusal_delta_pass"] = rd_pass
     else:
-        # If REAL pairs exist but no summary -> fail-closed.
+        gates["refusal_delta_evidence_present"] = False
+        status["refusal_delta_evidence_present"] = False
+      # If REAL pairs exist but no summary -> fail-closed.
         # If only sample exists -> pass (demo / quick-start).
         real_pairs = os.path.join(pack_dir, "examples", "refusal_pairs.jsonl")
         rd_pass = False if os.path.exists(real_pairs) else True

--- a/PULSE_safe_pack_v0/tools/augment_status.py
+++ b/PULSE_safe_pack_v0/tools/augment_status.py
@@ -297,8 +297,15 @@ def main() -> int:
     rd_path = os.path.join(artifacts_dir, "refusal_delta_summary.json")
 
     rd = jload(rd_path)
+    refusal_delta_evidence_present = False
+ 
+   if rd is not None:
+       try:
+           refusal_delta_n = int(rd.get("n", 0))
+       except (TypeError, ValueError):
+           refusal_delta_n = 0
 
-    if rd is not None:
+        refusal_delta_evidence_present = refusal_delta_n > 0
         metrics["refusal_delta_n"] = rd.get("n", 0)
         metrics["refusal_delta"] = rd.get("delta", 0.0)
         metrics["refusal_delta_ci_low"] = rd.get("ci_low", 0.0)
@@ -322,6 +329,9 @@ def main() -> int:
         rd_pass = False if os.path.exists(real_pairs) else True
         gates["refusal_delta_pass"] = rd_pass
         status["refusal_delta_pass"] = rd_pass
+
+    gates["refusal_delta_evidence_present"] = bool(refusal_delta_evidence_present)
+    status["refusal_delta_evidence_present"] = bool(refusal_delta_evidence_present)
 
     # -----------------------------------------------------------------------
     # 2) External detectors fold-in -> external.metrics + gates + top-level mirror

--- a/pulse_gate_registry_v0.yml
+++ b/pulse_gate_registry_v0.yml
@@ -114,6 +114,11 @@ gates:
     intent: "Refusal-delta meets configured thresholds (computed by refusal_delta_calc and injected during status augmentation)."
     stability: stable
 
+  refusal_delta_evidence_present:
+    category: controls
+    intent: "Materialized refusal-delta evidence is present and usable for release-grade validation."
+    stability: stable
+
   external_all_pass:
     category: external
     intent: "All external detector summaries meet configured thresholds (computed from artifacts/external by augment_status.py)."

--- a/tests/test_augment_status_smoke.py
+++ b/tests/test_augment_status_smoke.py
@@ -232,9 +232,8 @@ def test_parse_error_marks_metric_and_fails(tmp_path: Path) -> None:
     assert m.get("parse_error") is True
     assert m["pass"] is False
 
-def test_refusal_delta_evidence_present_false_when_summary_missing(tmp_path: Path) -> None:
+def test_refusal_delta_evidence_missing_is_materialized_false(tmp_path: Path) -> None:
     tmp_path.mkdir(parents=True, exist_ok=True)
-
     status = tmp_path / "status.json"
     thresholds = tmp_path / "external_thresholds.yaml"
     ext = tmp_path / "external"
@@ -242,17 +241,15 @@ def test_refusal_delta_evidence_present_false_when_summary_missing(tmp_path: Pat
 
     _write_json(status, {"gates": {}, "metrics": {}})
     _write_text(thresholds, "external_overall_policy: all\n")
-
     _run_augment(status, thresholds, ext)
 
     out = _load_status(status)
-
     assert out["gates"]["refusal_delta_evidence_present"] is False
+    assert out["refusal_delta_evidence_present"] is False
 
 
-def test_refusal_delta_evidence_present_true_when_summary_materialized(tmp_path: Path) -> None:
+def test_refusal_delta_evidence_materialized_n_gt_zero_is_true(tmp_path: Path) -> None:
     tmp_path.mkdir(parents=True, exist_ok=True)
-
     status = tmp_path / "status.json"
     thresholds = tmp_path / "external_thresholds.yaml"
     ext = tmp_path / "external"
@@ -260,31 +257,15 @@ def test_refusal_delta_evidence_present_true_when_summary_materialized(tmp_path:
 
     _write_json(status, {"gates": {}, "metrics": {}})
     _write_text(thresholds, "external_overall_policy: all\n")
-
     _write_json(
         tmp_path / "refusal_delta_summary.json",
-        {
-            "n": 3,
-            "delta": 0.2,
-            "ci_low": 0.1,
-            "ci_high": 0.3,
-            "policy": "balanced",
-            "delta_min": 0.1,
-            "delta_strict": 0.1,
-            "p_mcnemar": 0.01,
-            "pass_min": True,
-            "pass_strict": True,
-            "pass": True,
-        },
+        {"n": 3, "delta": 0.25, "pass": True, "pass_min": True, "pass_strict": True},
     )
-
     _run_augment(status, thresholds, ext)
 
     out = _load_status(status)
-
     assert out["gates"]["refusal_delta_evidence_present"] is True
-    assert out["gates"]["refusal_delta_pass"] is True
-    assert out["metrics"]["refusal_delta_n"] == 3
+    assert out["refusal_delta_evidence_present"] is True
 
 def main() -> int:
     # Standalone runner (CI calls this file directly via subprocess).
@@ -295,8 +276,10 @@ def main() -> int:
         test_azure_prefers_named_scalar_over_rate(base / "t2")
         test_azure_fallback_to_rate_when_named_missing(base / "t3")
         test_parse_error_marks_metric_and_fails(base / "t4")
-
-    print("augment_status smoke tests: OK")
+        test_refusal_delta_evidence_missing_is_materialized_false(base / "t5")
+        test_refusal_delta_evidence_materialized_n_gt_zero_is_true(base / "t6")
+ 
+  print("augment_status smoke tests: OK")
     return 0
 
 

--- a/tests/test_augment_status_smoke.py
+++ b/tests/test_augment_status_smoke.py
@@ -10,6 +10,9 @@ Goals:
 - Specifically validate Azure behavior:
   - prefer azure_indirect_jailbreak_rate over generic rate/value when both exist
   - fallback to rate when the named scalar is missing
+- Validate refusal-delta evidence-presence materialization:
+  - missing refusal_delta_summary.json -> refusal_delta_evidence_present=false
+  - materialized refusal_delta_summary.json with n > 0 -> refusal_delta_evidence_present=true
 """
 
 from __future__ import annotations
@@ -39,7 +42,8 @@ def _run_augment(status_path: Path, thresholds_path: Path, external_dir: Path) -
     root = _repo_root()
     script = root / "PULSE_safe_pack_v0" / "tools" / "augment_status.py"
     print(
-        f"[smoke] augment_status.py={script} sha256={__import__('hashlib').sha256(script.read_bytes()).hexdigest()}",
+        f"[smoke] augment_status.py={script} "
+        f"sha256={__import__('hashlib').sha256(script.read_bytes()).hexdigest()}",
         flush=True,
     )
 
@@ -98,18 +102,22 @@ def test_external_all_pass_true_with_valid_summaries(tmp_path: Path) -> None:
         ),
     )
 
-    # JSON with canonical-ish keys
+    # JSON with canonical-ish keys.
     _write_json(ext / "llamaguard_summary.json", {"violation_rate": 0.10})
     _write_json(ext / "promptguard_summary.json", {"attack_detect_rate": 0.05})
     _write_json(ext / "garak_summary.json", {"new_critical": 0})
 
-    # Azure: provide both named scalar and rate (should still pass under lenient threshold)
+    # Azure: provide both named scalar and rate.
     _write_json(
         ext / "azure_eval_summary.json",
-        {"azure_indirect_jailbreak_rate": 0.01, "rate": 0.19, "failure_rates": {"x": 0.01}},
+        {
+            "azure_indirect_jailbreak_rate": 0.01,
+            "rate": 0.19,
+            "failure_rates": {"x": 0.01},
+        },
     )
 
-    # JSONL (common in pipelines)
+    # JSONL, common in pipelines.
     _write_text(ext / "promptfoo_summary.jsonl", '{"fail_rate": 0.02}\n')
     _write_text(ext / "deepeval_summary.jsonl", '{"fail_rate": 0.03}\n')
 
@@ -134,8 +142,8 @@ def test_azure_prefers_named_scalar_over_rate(tmp_path: Path) -> None:
     _write_json(status, {"gates": {}, "metrics": {}})
 
     # Strict enough to demonstrate preference:
-    # - named scalar is 0.07 (should FAIL)
-    # - rate is 0.01 (would PASS if incorrectly used)
+    # - named scalar is 0.07, should FAIL
+    # - rate is 0.01, would PASS if incorrectly used
     _write_text(
         thresholds,
         "\n".join(
@@ -187,7 +195,7 @@ def test_azure_fallback_to_rate_when_named_missing(tmp_path: Path) -> None:
         ),
     )
 
-    # No named scalar -> should fall back to rate (=0.03) and PASS
+    # No named scalar -> should fall back to rate (=0.03) and PASS.
     _write_json(ext / "azure_eval_summary.json", {"rate": 0.03, "failure_rates": {"x": 0.03}})
 
     _run_augment(status, thresholds, ext)
@@ -220,7 +228,7 @@ def test_parse_error_marks_metric_and_fails(tmp_path: Path) -> None:
         ),
     )
 
-    # Invalid JSON -> parse_error True, pass False, external_all_pass False
+    # Invalid JSON -> parse_error True, pass False, external_all_pass False.
     _write_text(ext / "llamaguard_summary.json", "{not json")
 
     _run_augment(status, thresholds, ext)
@@ -232,8 +240,10 @@ def test_parse_error_marks_metric_and_fails(tmp_path: Path) -> None:
     assert m.get("parse_error") is True
     assert m["pass"] is False
 
+
 def test_refusal_delta_evidence_missing_is_materialized_false(tmp_path: Path) -> None:
     tmp_path.mkdir(parents=True, exist_ok=True)
+
     status = tmp_path / "status.json"
     thresholds = tmp_path / "external_thresholds.yaml"
     ext = tmp_path / "external"
@@ -241,6 +251,7 @@ def test_refusal_delta_evidence_missing_is_materialized_false(tmp_path: Path) ->
 
     _write_json(status, {"gates": {}, "metrics": {}})
     _write_text(thresholds, "external_overall_policy: all\n")
+
     _run_augment(status, thresholds, ext)
 
     out = _load_status(status)
@@ -250,6 +261,7 @@ def test_refusal_delta_evidence_missing_is_materialized_false(tmp_path: Path) ->
 
 def test_refusal_delta_evidence_materialized_n_gt_zero_is_true(tmp_path: Path) -> None:
     tmp_path.mkdir(parents=True, exist_ok=True)
+
     status = tmp_path / "status.json"
     thresholds = tmp_path / "external_thresholds.yaml"
     ext = tmp_path / "external"
@@ -259,16 +271,27 @@ def test_refusal_delta_evidence_materialized_n_gt_zero_is_true(tmp_path: Path) -
     _write_text(thresholds, "external_overall_policy: all\n")
     _write_json(
         tmp_path / "refusal_delta_summary.json",
-        {"n": 3, "delta": 0.25, "pass": True, "pass_min": True, "pass_strict": True},
+        {
+            "n": 3,
+            "delta": 0.25,
+            "pass": True,
+            "pass_min": True,
+            "pass_strict": True,
+        },
     )
+
     _run_augment(status, thresholds, ext)
 
     out = _load_status(status)
     assert out["gates"]["refusal_delta_evidence_present"] is True
     assert out["refusal_delta_evidence_present"] is True
+    assert out["gates"]["refusal_delta_pass"] is True
+    assert out["refusal_delta_pass"] is True
+    assert out["metrics"]["refusal_delta_n"] == 3
+
 
 def main() -> int:
-    # Standalone runner (CI calls this file directly via subprocess).
+    # Standalone runner; CI calls this file directly via subprocess.
     with tempfile.TemporaryDirectory() as d:
         base = Path(d)
 
@@ -278,8 +301,8 @@ def main() -> int:
         test_parse_error_marks_metric_and_fails(base / "t4")
         test_refusal_delta_evidence_missing_is_materialized_false(base / "t5")
         test_refusal_delta_evidence_materialized_n_gt_zero_is_true(base / "t6")
- 
-  print("augment_status smoke tests: OK")
+
+    print("augment_status smoke tests: OK")
     return 0
 
 

--- a/tests/test_augment_status_smoke.py
+++ b/tests/test_augment_status_smoke.py
@@ -232,6 +232,59 @@ def test_parse_error_marks_metric_and_fails(tmp_path: Path) -> None:
     assert m.get("parse_error") is True
     assert m["pass"] is False
 
+def test_refusal_delta_evidence_present_false_when_summary_missing(tmp_path: Path) -> None:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+
+    status = tmp_path / "status.json"
+    thresholds = tmp_path / "external_thresholds.yaml"
+    ext = tmp_path / "external"
+    ext.mkdir(parents=True, exist_ok=True)
+
+    _write_json(status, {"gates": {}, "metrics": {}})
+    _write_text(thresholds, "external_overall_policy: all\n")
+
+    _run_augment(status, thresholds, ext)
+
+    out = _load_status(status)
+
+    assert out["gates"]["refusal_delta_evidence_present"] is False
+
+
+def test_refusal_delta_evidence_present_true_when_summary_materialized(tmp_path: Path) -> None:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+
+    status = tmp_path / "status.json"
+    thresholds = tmp_path / "external_thresholds.yaml"
+    ext = tmp_path / "external"
+    ext.mkdir(parents=True, exist_ok=True)
+
+    _write_json(status, {"gates": {}, "metrics": {}})
+    _write_text(thresholds, "external_overall_policy: all\n")
+
+    _write_json(
+        tmp_path / "refusal_delta_summary.json",
+        {
+            "n": 3,
+            "delta": 0.2,
+            "ci_low": 0.1,
+            "ci_high": 0.3,
+            "policy": "balanced",
+            "delta_min": 0.1,
+            "delta_strict": 0.1,
+            "p_mcnemar": 0.01,
+            "pass_min": True,
+            "pass_strict": True,
+            "pass": True,
+        },
+    )
+
+    _run_augment(status, thresholds, ext)
+
+    out = _load_status(status)
+
+    assert out["gates"]["refusal_delta_evidence_present"] is True
+    assert out["gates"]["refusal_delta_pass"] is True
+    assert out["metrics"]["refusal_delta_n"] == 3
 
 def main() -> int:
     # Standalone runner (CI calls this file directly via subprocess).


### PR DESCRIPTION
## Summary

Materializes `refusal_delta_evidence_present` in the refusal-delta augmentation path and adds smoke coverage for the new evidence-presence gate.

## Scope

Updates:

- `PULSE_safe_pack_v0/tools/augment_status.py`
- `tests/test_augment_status_smoke.py`

## Purpose

Release-grade paths must not infer PASS from missing refusal-delta evidence.

The intended behavior is:

```text
materialized refusal-delta evidence present -> refusal_delta_evidence_present=true
missing or unusable refusal-delta evidence -> refusal_delta_evidence_present=false
```

This separates `refusal_delta_pass` from evidence presence.

## Authority boundary

This change does not define release authority.

It materializes evidence-presence state into `status.json` and updates smoke coverage. The normative release decision remains produced by declared-policy gate enforcement and recorded through the CI outcome.

This PR does not modify `pulse_gate_policy_v0.yml`, `check_gates.py`, schemas, workflows, or release-decision behavior.

## Risk

Low to medium.

This prepares the producer path for future release-required policy promotion.