### PR TITLE
ci(operator): wire handoff smoke regression into tools manifest

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -27,6 +27,7 @@ tests/test_paradox_diagram_renderer_v0_smoke.py
 tests/test_openai_evals_refusal_smoke_dry_run_smoke.py
 tests/test_render_quality_ledger_tests_list_smoke.py
 tests/test_authority_boundary_repro_smoke.py 
+tests/test_operator_handoff_smoke.py
 tests/test_check_release_authority_manifest_v0.py
 tests/test_build_release_authority_manifest_v0.py
 tests/test_release_authority_manifest_non_interference.py


### PR DESCRIPTION
## Summary

Adds regression coverage for `tools/operator_handoff_smoke.py` and wires it into the tools smoke manifest.

## Scope

Updates:

- `tests/test_operator_handoff_smoke.py`
- `ci/tools-tests.list`

Does not modify:

- workflows
- release policy
- gate semantics
- status producers
- release-decision logic
- ledgers
- manifests
- dashboards
- audit bundles

## Purpose

This is a PULSE-REF RA0 operator-handoff hardening step.

The test locks in the release-authority reconstruction boundary:

- Core handoff may generate a local Core status artifact.
- Custom `--status` paths are honored.
- Release-grade mode must not accept generated Core evidence.
- `--status-source existing` fails closed when the status artifact is missing.

This protects the rule that release-grade reconstruction cannot silently substitute generated Core evidence for archived release-grade evidence.

## Authority boundary

This PR does not change release authority.

The normative decision path remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

This PR only adds regression coverage for the operator handoff path and registers that regression in the tools smoke manifest.