### PR TITLE
test(operator): cover release-grade existing-status handoff

### DIFF
--- a/tests/test_operator_handoff_smoke.py
+++ b/tests/test_operator_handoff_smoke.py
@@ -211,7 +211,7 @@ def test_release_grade_accepts_existing_release_reference_status() -> None:
 
         status_source = payload["status_source"]
         assert status_source["mode"] == "existing"
-        assert status_source["status_path"] == str(fixture_status)
+        assert status_source["status_path"] ==  expected_status_path
         assert status_source["status_exists_before_run"] is True
         assert status_source["status_exists_after_generation"] is True
         assert status_source["status_exists_after_run"] is True

--- a/tests/test_operator_handoff_smoke.py
+++ b/tests/test_operator_handoff_smoke.py
@@ -175,6 +175,7 @@ def test_existing_missing_status_fails_closed() -> None:
             for warning in payload["warnings"]
         )
 
+
 def test_release_grade_accepts_existing_release_reference_status() -> None:
     fixture_status = (
         ROOT
@@ -184,6 +185,9 @@ def test_release_grade_accepts_existing_release_reference_status() -> None:
         / "refusal_delta_evidence_present"
         / "status.json"
     )
+    expected_status_path = str(fixture_status.relative_to(ROOT))
+
+    assert fixture_status.exists(), f"missing release-reference fixture: {fixture_status}"
 
     with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
         tmp_path = Path(tmp)
@@ -211,7 +215,7 @@ def test_release_grade_accepts_existing_release_reference_status() -> None:
 
         status_source = payload["status_source"]
         assert status_source["mode"] == "existing"
-        assert status_source["status_path"] ==  expected_status_path
+        assert status_source["status_path"] == expected_status_path
         assert status_source["status_exists_before_run"] is True
         assert status_source["status_exists_after_generation"] is True
         assert status_source["status_exists_after_run"] is True
@@ -227,6 +231,7 @@ def test_release_grade_accepts_existing_release_reference_status() -> None:
         assert "materialize_release_required" in command_names
         assert "check_gates_release-grade" in command_names
         assert "check_shadow_layer_registry" in command_names
+
 
 def main() -> int:
     try:

--- a/tests/test_operator_handoff_smoke.py
+++ b/tests/test_operator_handoff_smoke.py
@@ -175,12 +175,65 @@ def test_existing_missing_status_fails_closed() -> None:
             for warning in payload["warnings"]
         )
 
+def test_release_grade_accepts_existing_release_reference_status() -> None:
+    fixture_status = (
+        ROOT
+        / "tests"
+        / "fixtures"
+        / "release_reference_v1"
+        / "refusal_delta_evidence_present"
+        / "status.json"
+    )
+
+    with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
+        tmp_path = Path(tmp)
+        report_path = tmp_path / "operator_handoff_smoke.release_grade.pass.json"
+
+        result = _run(
+            "--gate-mode",
+            "release-grade",
+            "--status-source",
+            "existing",
+            "--status",
+            str(fixture_status),
+            "--out",
+            str(report_path),
+        )
+
+        _assert_returncode(result, 0)
+
+        assert report_path.exists()
+
+        payload = _read_json(report_path)
+
+        assert payload["ok"] is True
+        assert payload["gate_mode"] == "release-grade"
+
+        status_source = payload["status_source"]
+        assert status_source["mode"] == "existing"
+        assert status_source["status_path"] == str(fixture_status)
+        assert status_source["status_exists_before_run"] is True
+        assert status_source["status_exists_after_generation"] is True
+        assert status_source["status_exists_after_run"] is True
+
+        assert "required" in payload["materialized_gate_sets"]
+        assert "release_required" in payload["materialized_gate_sets"]
+
+        assert "refusal_delta_evidence_present" in payload["effective_required_gates"]
+
+        command_names = [command["name"] for command in payload["commands"]]
+
+        assert "materialize_required" in command_names
+        assert "materialize_release_required" in command_names
+        assert "check_gates_release-grade" in command_names
+        assert "check_shadow_layer_registry" in command_names
 
 def main() -> int:
     try:
         test_generate_core_honors_custom_status_path()
         test_release_grade_rejects_generate_core_status()
         test_existing_missing_status_fails_closed()
+        test_release_grade_accepts_existing_release_reference_status()
     except AssertionError as exc:
         print(f"ERROR: {exc}")
         return 1


### PR DESCRIPTION
## Summary

Adds positive release-grade operator handoff coverage for an existing release-reference status artifact.

## Scope

Updates:

- `tests/test_operator_handoff_smoke.py`

## Purpose

This extends the PULSE-REF RA0 operator-handoff regression coverage.

The existing tests cover negative authority boundaries:

- release-grade mode rejects generated Core evidence;
- `--status-source existing` fails closed when the status artifact is missing.

This PR adds the positive release-grade path:

- `--gate-mode release-grade`
- `--status-source existing`
- existing release-reference status fixture
- required + release_required gates materialize
- `check_gates` passes
- `refusal_delta_evidence_present` is included in the effective required gate set.

## Authority boundary

This PR does not change release authority.

It only adds regression coverage proving that release-grade operator handoff can accept an archived, existing release-grade status artifact when the declared required and release_required gates are satisfied.

No release policy, gate semantics, status producer, workflow, release-decision engine, ledger, manifest, dashboard, or audit-bundle behavior is changed.