### PR TITLE
docs(readme): anchor pre-materialization gate mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@
 
 PULSE is a deterministic, fail-closed release-governance layer for LLM applications and AI-enabled systems. It is built above existing application, model, evaluation, and deployment pipelines. At the release boundary, PULSE evaluates recorded release evidence against declared gate policy and emits an auditable release decision record.
 
+PULSE implements [pre-materialization gate mechanics](docs/PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md) for release authority: recorded safety, quality, detector, stability, CI, and review evidence is checked under declared policy before unsupported release decisions can materialize.
+
 Release evidence can include safety and consistency invariants, product quality gates, SLO budgets, external detector summaries, run metadata, logs, and release-stability signals. Policy defines which evidence and gates carry release authority. Evaluation is deterministic, explicit, and fail-closed.
 
 The output is a governed release surface:


### PR DESCRIPTION
## Summary

Adds a concise README anchor for PULSE pre-materialization gate mechanics.

## Scope

Updates:

- `README.md`

## Purpose

The README now links the project overview to the pre-materialization gate mechanics foundation:

`docs/PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md`

The added sentence states that recorded safety, quality, detector, stability, CI, and review evidence is checked under declared policy before unsupported release decisions can materialize.

This keeps the concept visible from the project front door without expanding the README into a full conceptual document.

## Authority boundary

This PR is documentation-only.

It does not change:

- release policy;
- gate semantics;
- status producers;
- CI behavior;
- release-decision logic;
- manifests;
- ledgers;
- dashboards;
- audit bundles;
- schemas;
- workflows.