### PR TITLE
fix(operator): reject stubbed release-grade handoff

### DIFF
--- a/tests/test_operator_handoff_smoke.py
+++ b/tests/test_operator_handoff_smoke.py
@@ -464,6 +464,64 @@ def test_release_grade_existing_missing_external_summary_fails_closed() -> None:
             for error in payload["errors"]
         )
 
+
+def test_release_grade_existing_stubbed_status_fails_closed() -> None:
+    fixture_status = (
+        ROOT
+        / "tests"
+        / "fixtures"
+        / "release_reference_v1"
+        / "stubbed"
+        / "status.json"
+    )
+    expected_status_path = str(fixture_status.relative_to(ROOT))
+
+    assert fixture_status.exists(), f"missing release-reference fixture: {fixture_status}"
+
+    with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
+        tmp_path = Path(tmp)
+        report_path = tmp_path / "operator_handoff_smoke.release_grade.stubbed.json"
+
+        result = _run(
+            "--gate-mode",
+            "release-grade",
+            "--status-source",
+            "existing",
+            "--status",
+            str(fixture_status),
+            "--out",
+            str(report_path),
+        )
+
+        _assert_returncode(result, 1)
+
+        assert report_path.exists()
+
+        payload = _read_json(report_path)
+
+        assert payload["ok"] is False
+        assert payload["gate_mode"] == "release-grade"
+
+        status_source = payload["status_source"]
+        assert status_source["mode"] == "existing"
+        assert status_source["status_path"] == expected_status_path
+        assert status_source["status_exists_before_run"] is True
+        assert status_source["status_exists_after_generation"] is True
+        assert status_source["status_exists_after_run"] is True
+
+        assert payload["commands"] == []
+        assert payload["materialized_gate_sets"] == {}
+        assert payload["effective_required_gates"] == []
+
+        assert any(
+            "diagnostics.gates_stubbed=false" in error
+            for error in payload["errors"]
+        )
+        assert any(
+            "stubbed status evidence" in error
+            for error in payload["errors"]
+        )
+
 def main() -> int:
     try:
         test_generate_core_honors_custom_status_path()
@@ -473,6 +531,7 @@ def main() -> int:
         test_release_grade_existing_missing_refusal_delta_fails_closed()
         test_release_grade_existing_external_evidence_failures_fail_closed()
         test_release_grade_existing_missing_external_summary_fails_closed()
+        test_release_grade_existing_stubbed_status_fails_closed()
     except AssertionError as exc:
         print(f"ERROR: {exc}")
         return 1

--- a/tools/operator_handoff_smoke.py
+++ b/tools/operator_handoff_smoke.py
@@ -144,6 +144,13 @@ def _file_inventory(paths: list[Path]) -> list[dict[str, Any]]:
 
     return out
 
+def _load_status_artifact(path: Path) -> dict[str, Any] | None:
+    try:
+        obj = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+    return obj if isinstance(obj, dict) else None
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -268,6 +275,23 @@ def main(argv: list[str] | None = None) -> int:
     if not status_path.exists():
         errors.append(f"status artifact missing: {_rel(status_path)}")
 
+        if not errors and args.gate_mode == "release-grade":
+        status_obj = _load_status_artifact(status_path)
+        if status_obj is None:
+            errors.append(f"status artifact is not a JSON object: {_rel(status_path)}")
+        else:
+            diagnostics = status_obj.get("diagnostics")
+            gates_stubbed = (
+                isinstance(diagnostics, dict)
+                and diagnostics.get("gates_stubbed") is True
+            )
+
+            if gates_stubbed:
+                errors.append(
+                    "release-grade gate-mode requires diagnostics.gates_stubbed=false; "
+                    "stubbed status evidence must not be treated as release-grade evidence."
+                )
+   
     materialized_gate_sets: dict[str, list[str]] = {}
 
     if not errors:

--- a/tools/operator_handoff_smoke.py
+++ b/tools/operator_handoff_smoke.py
@@ -144,6 +144,7 @@ def _file_inventory(paths: list[Path]) -> list[dict[str, Any]]:
 
     return out
 
+
 def _load_status_artifact(path: Path) -> dict[str, Any] | None:
     try:
         obj = json.loads(path.read_text(encoding="utf-8"))
@@ -151,6 +152,7 @@ def _load_status_artifact(path: Path) -> dict[str, Any] | None:
         return None
 
     return obj if isinstance(obj, dict) else None
+
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -275,7 +277,7 @@ def main(argv: list[str] | None = None) -> int:
     if not status_path.exists():
         errors.append(f"status artifact missing: {_rel(status_path)}")
 
-        if not errors and args.gate_mode == "release-grade":
+    if not errors and args.gate_mode == "release-grade":
         status_obj = _load_status_artifact(status_path)
         if status_obj is None:
             errors.append(f"status artifact is not a JSON object: {_rel(status_path)}")
@@ -291,7 +293,7 @@ def main(argv: list[str] | None = None) -> int:
                     "release-grade gate-mode requires diagnostics.gates_stubbed=false; "
                     "stubbed status evidence must not be treated as release-grade evidence."
                 )
-   
+
     materialized_gate_sets: dict[str, list[str]] = {}
 
     if not errors:


### PR DESCRIPTION
## Summary

Rejects stubbed status artifacts in release-grade operator handoff.

## Scope

Updates:

- `tools/operator_handoff_smoke.py`
- `tests/test_operator_handoff_smoke.py`

## Purpose

This is a PULSE-REF RA0 operator-handoff hardening step.

The existing release-grade handoff tests cover:

- valid existing release-reference status passing;
- missing refusal-delta evidence failing closed;
- malformed / unsigned external evidence failing closed;
- missing external summaries failing closed.

This PR adds the stubbed-status boundary:

- `--gate-mode release-grade`
- `--status-source existing`
- existing `stubbed` release-reference fixture
- `diagnostics.gates_stubbed=true`
- operator handoff fails closed before gate materialization

Stubbed status evidence must not become release-grade evidence merely because individual gate booleans appear to pass.

## Authority boundary

This PR does not change release authority.

It hardens the operator handoff precondition for release-grade reconstruction. The normative release decision remains declared-policy gate enforcement over materialized evidence and CI outcome.

No release policy, gate semantics, status producer, workflow, release-decision engine, ledger, manifest, dashboard, schema, or audit-bundle behavior is changed.