### PR TITLE
fix(operator): require prod run mode for release-grade handoff

### DIFF
--- a/tests/test_operator_handoff_smoke.py
+++ b/tests/test_operator_handoff_smoke.py
@@ -522,6 +522,72 @@ def test_release_grade_existing_stubbed_status_fails_closed() -> None:
             for error in payload["errors"]
         )
 
+def test_release_grade_existing_non_prod_run_mode_fails_closed() -> None:
+    source_status = (
+        ROOT
+        / "tests"
+        / "fixtures"
+        / "release_reference_v1"
+        / "refusal_delta_evidence_present"
+        / "status.json"
+    )
+
+    assert source_status.exists(), f"missing release-reference fixture: {source_status}"
+
+    with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
+        tmp_path = Path(tmp)
+        status_path = tmp_path / "operator_handoff_status.non_prod.json"
+        report_path = tmp_path / "operator_handoff_smoke.release_grade.non_prod.json"
+
+        status_obj = _read_json(source_status)
+        metrics = status_obj.setdefault("metrics", {})
+        metrics["run_mode"] = "core"
+
+        status_path.write_text(
+            json.dumps(status_obj, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        result = _run(
+            "--gate-mode",
+            "release-grade",
+            "--status-source",
+            "existing",
+            "--status",
+            str(status_path),
+            "--out",
+            str(report_path),
+        )
+
+        _assert_returncode(result, 1)
+
+        assert report_path.exists()
+
+        payload = _read_json(report_path)
+
+        assert payload["ok"] is False
+        assert payload["gate_mode"] == "release-grade"
+
+        status_source = payload["status_source"]
+        assert status_source["mode"] == "existing"
+        assert status_source["status_path"] == str(status_path)
+        assert status_source["status_exists_before_run"] is True
+        assert status_source["status_exists_after_generation"] is True
+        assert status_source["status_exists_after_run"] is True
+
+        assert payload["commands"] == []
+        assert payload["materialized_gate_sets"] == {}
+        assert payload["effective_required_gates"] == []
+
+        assert any(
+            "metrics.run_mode=prod" in error
+            for error in payload["errors"]
+        )
+        assert any(
+            "found 'core'" in error
+            for error in payload["errors"]
+        )
+
 def main() -> int:
     try:
         test_generate_core_honors_custom_status_path()
@@ -532,6 +598,7 @@ def main() -> int:
         test_release_grade_existing_external_evidence_failures_fail_closed()
         test_release_grade_existing_missing_external_summary_fails_closed()
         test_release_grade_existing_stubbed_status_fails_closed()
+        test_release_grade_existing_non_prod_run_mode_fails_closed()
     except AssertionError as exc:
         print(f"ERROR: {exc}")
         return 1

--- a/tools/operator_handoff_smoke.py
+++ b/tools/operator_handoff_smoke.py
@@ -282,6 +282,15 @@ def main(argv: list[str] | None = None) -> int:
         if status_obj is None:
             errors.append(f"status artifact is not a JSON object: {_rel(status_path)}")
         else:
+            metrics = status_obj.get("metrics")
+            run_mode = metrics.get("run_mode") if isinstance(metrics, dict) else None
+
+            if run_mode != "prod":
+                errors.append(
+                    "release-grade gate-mode requires metrics.run_mode=prod; "
+                    f"found {run_mode!r}."
+                )
+         
             diagnostics = status_obj.get("diagnostics")
             gates_stubbed = (
                 isinstance(diagnostics, dict)


### PR DESCRIPTION
## Summary

Requires `metrics.run_mode=prod` for release-grade operator handoff.

## Scope

Updates:

- `tools/operator_handoff_smoke.py`
- `tests/test_operator_handoff_smoke.py`

## Purpose

This is a PULSE-REF RA0 operator-handoff hardening step.

Release-grade operator handoff must not treat a non-prod or Core status artifact as release-grade evidence, even if individual gate booleans appear to pass.

This PR adds a fail-closed precondition:

`--gate-mode release-grade` + `metrics.run_mode != "prod"` -> fail closed before gate materialization.

The regression mutates the positive release-reference fixture to `run_mode=core` and verifies that release-grade handoff rejects it before materializing gate sets.

## Authority boundary

This PR does not change release authority.

It hardens the operator handoff precondition for release-grade reconstruction. The normative release decision remains declared-policy gate enforcement over materialized evidence and CI outcome.

No release policy, gate semantics, status producer, workflow, release-decision engine, ledger, manifest, dashboard, schema, or audit-bundle behavior is changed.