### PR TITLE
test(operator): cover malformed release-grade status handoff

### DIFF
--- a/tests/test_operator_handoff_smoke.py
+++ b/tests/test_operator_handoff_smoke.py
@@ -588,6 +588,59 @@ def test_release_grade_existing_non_prod_run_mode_fails_closed() -> None:
             for error in payload["errors"]
         )
 
+def test_release_grade_existing_malformed_status_fails_closed() -> None:
+    cases = [
+        ("malformed_json", "{not json\n"),
+        ("json_array", "[]\n"),
+    ]
+
+    for case_id, status_text in cases:
+        with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
+            tmp_path = Path(tmp)
+            status_path = tmp_path / f"operator_handoff_status.{case_id}.json"
+            report_path = (
+                tmp_path
+                / f"operator_handoff_smoke.release_grade.{case_id}.json"
+            )
+
+            status_path.write_text(status_text, encoding="utf-8")
+
+            result = _run(
+                "--gate-mode",
+                "release-grade",
+                "--status-source",
+                "existing",
+                "--status",
+                str(status_path),
+                "--out",
+                str(report_path),
+            )
+
+            _assert_returncode(result, 1)
+
+            assert report_path.exists()
+
+            payload = _read_json(report_path)
+
+            assert payload["ok"] is False
+            assert payload["gate_mode"] == "release-grade"
+
+            status_source = payload["status_source"]
+            assert status_source["mode"] == "existing"
+            assert status_source["status_path"] == str(status_path)
+            assert status_source["status_exists_before_run"] is True
+            assert status_source["status_exists_after_generation"] is True
+            assert status_source["status_exists_after_run"] is True
+
+            assert payload["commands"] == []
+            assert payload["materialized_gate_sets"] == {}
+            assert payload["effective_required_gates"] == []
+
+            assert any(
+                "status artifact is not a JSON object" in error
+                for error in payload["errors"]
+            )
+
 def main() -> int:
     try:
         test_generate_core_honors_custom_status_path()
@@ -599,6 +652,7 @@ def main() -> int:
         test_release_grade_existing_missing_external_summary_fails_closed()
         test_release_grade_existing_stubbed_status_fails_closed()
         test_release_grade_existing_non_prod_run_mode_fails_closed()
+        test_release_grade_existing_malformed_status_fails_closed()
     except AssertionError as exc:
         print(f"ERROR: {exc}")
         return 1


### PR DESCRIPTION
## Summary

Adds release-grade operator handoff regression coverage for malformed and non-object existing status artifacts.

## Scope

Updates:

- `tests/test_operator_handoff_smoke.py`

## Purpose

This extends the PULSE-REF RA0 operator-handoff regression coverage.

Release-grade handoff must not materialize required or release_required gate sets when the supplied existing status artifact is malformed or not a JSON object.

This PR covers:

- malformed JSON status artifact;
- valid JSON that is not an object;
- fail-closed behavior before gate materialization;
- empty command list;
- empty materialized gate sets;
- empty effective required gate set.

## Authority boundary

This PR does not change release authority.

It only adds regression coverage proving that malformed existing status artifacts cannot enter the release-grade operator handoff gate-materialization path.

No release policy, gate semantics, status producer, workflow, release-decision engine, ledger, manifest, dashboard, schema, or audit-bundle behavior is changed.