### PR TITLE
fix(operator): require explicit non-stubbed release-grade status

### DIFF
--- a/tests/test_operator_handoff_smoke.py
+++ b/tests/test_operator_handoff_smoke.py
@@ -641,6 +641,79 @@ def test_release_grade_existing_malformed_status_fails_closed() -> None:
                 for error in payload["errors"]
             )
 
+def test_release_grade_existing_missing_stubbed_diagnostic_fails_closed() -> None:
+    source_status = (
+        ROOT
+        / "tests"
+        / "fixtures"
+        / "release_reference_v1"
+        / "refusal_delta_evidence_present"
+        / "status.json"
+    )
+
+    assert source_status.exists(), f"missing release-reference fixture: {source_status}"
+
+    with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
+        tmp_path = Path(tmp)
+        status_path = tmp_path / "operator_handoff_status.missing_gates_stubbed.json"
+        report_path = (
+            tmp_path
+            / "operator_handoff_smoke.release_grade.missing_gates_stubbed.json"
+        )
+
+        status_obj = _read_json(source_status)
+        diagnostics = status_obj.setdefault("diagnostics", {})
+        diagnostics.pop("gates_stubbed", None)
+
+        status_path.write_text(
+            json.dumps(status_obj, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        result = _run(
+            "--gate-mode",
+            "release-grade",
+            "--status-source",
+            "existing",
+            "--status",
+            str(status_path),
+            "--out",
+            str(report_path),
+        )
+
+        _assert_returncode(result, 1)
+
+        assert report_path.exists()
+
+        payload = _read_json(report_path)
+
+        assert payload["ok"] is False
+        assert payload["gate_mode"] == "release-grade"
+
+        status_source = payload["status_source"]
+        assert status_source["mode"] == "existing"
+        assert status_source["status_path"] == str(status_path)
+        assert status_source["status_exists_before_run"] is True
+        assert status_source["status_exists_after_generation"] is True
+        assert status_source["status_exists_after_run"] is True
+
+        assert payload["commands"] == []
+        assert payload["materialized_gate_sets"] == {}
+        assert payload["effective_required_gates"] == []
+
+        assert any(
+            "diagnostics.gates_stubbed=false" in error
+            for error in payload["errors"]
+        )
+        assert any(
+            "found None" in error
+            for error in payload["errors"]
+        )
+        assert any(
+            "stubbed status evidence" in error
+            for error in payload["errors"]
+        )
+
 def main() -> int:
     try:
         test_generate_core_honors_custom_status_path()
@@ -653,6 +726,7 @@ def main() -> int:
         test_release_grade_existing_stubbed_status_fails_closed()
         test_release_grade_existing_non_prod_run_mode_fails_closed()
         test_release_grade_existing_malformed_status_fails_closed()
+        test_release_grade_existing_missing_stubbed_diagnostic_fails_closed()
     except AssertionError as exc:
         print(f"ERROR: {exc}")
         return 1

--- a/tools/operator_handoff_smoke.py
+++ b/tools/operator_handoff_smoke.py
@@ -292,14 +292,16 @@ def main(argv: list[str] | None = None) -> int:
                 )
          
             diagnostics = status_obj.get("diagnostics")
-            gates_stubbed = (
-                isinstance(diagnostics, dict)
-                and diagnostics.get("gates_stubbed") is True
+             gates_stubbed_value = (
+                diagnostics.get("gates_stubbed")
+                if isinstance(diagnostics, dict)
+                else None
             )
 
-            if gates_stubbed:
+            if gates_stubbed_value is not False:
                 errors.append(
                     "release-grade gate-mode requires diagnostics.gates_stubbed=false; "
+                    f"found {gates_stubbed_value!r}. "
                     "stubbed status evidence must not be treated as release-grade evidence."
                 )
 

--- a/tools/operator_handoff_smoke.py
+++ b/tools/operator_handoff_smoke.py
@@ -264,7 +264,9 @@ def main(argv: list[str] | None = None) -> int:
         if commands[-1]["returncode"] != 0:
             errors.append("failed to generate local Core status artifact")
         elif not generated_status_path.exists():
-            errors.append(f"generated status artifact missing: {_rel(generated_status_path)}")
+            errors.append(
+                f"generated status artifact missing: {_rel(generated_status_path)}"
+            )
         elif generated_status_path.resolve() != status_path.resolve():
             shutil.copyfile(generated_status_path, status_path)
             warnings.append(
@@ -290,9 +292,9 @@ def main(argv: list[str] | None = None) -> int:
                     "release-grade gate-mode requires metrics.run_mode=prod; "
                     f"found {run_mode!r}."
                 )
-         
-             diagnostics = status_obj.get("diagnostics")
-             gates_stubbed_value = (
+
+            diagnostics = status_obj.get("diagnostics")
+            gates_stubbed_value = (
                 diagnostics.get("gates_stubbed")
                 if isinstance(diagnostics, dict)
                 else None
@@ -412,7 +414,10 @@ def main(argv: list[str] | None = None) -> int:
     }
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 
     print(json.dumps(report, indent=2, sort_keys=True))
 

--- a/tools/operator_handoff_smoke.py
+++ b/tools/operator_handoff_smoke.py
@@ -291,7 +291,7 @@ def main(argv: list[str] | None = None) -> int:
                     f"found {run_mode!r}."
                 )
          
-            diagnostics = status_obj.get("diagnostics")
+             diagnostics = status_obj.get("diagnostics")
              gates_stubbed_value = (
                 diagnostics.get("gates_stubbed")
                 if isinstance(diagnostics, dict)


### PR DESCRIPTION
## Summary

Requires `diagnostics.gates_stubbed=false` explicitly for release-grade operator handoff.

## Scope

Updates:

- `tools/operator_handoff_smoke.py`
- `tests/test_operator_handoff_smoke.py`

## Purpose

This is a PULSE-REF RA0 operator-handoff hardening step.

Release-grade operator handoff must not treat a status artifact as non-stubbed unless it explicitly declares:

`diagnostics.gates_stubbed=false`

This PR makes the precondition exact:

- `false` passes the precondition;
- `true` fails closed;
- missing value fails closed;
- null / non-boolean values fail closed.

The regression removes `diagnostics.gates_stubbed` from a positive release-reference fixture and verifies that release-grade handoff rejects it before gate materialization.

## Authority boundary

This PR does not change release authority.

It hardens the operator handoff precondition for release-grade reconstruction. The normative release decision remains declared-policy gate enforcement over materialized evidence and CI outcome.

No release policy, gate semantics, status producer, workflow, release-decision engine, ledger, manifest, dashboard, schema, or audit-bundle behavior is changed.