### PR TITLE
test(operator): cover false required gate handoff

### DIFF
--- a/tests/test_operator_handoff_smoke.py
+++ b/tests/test_operator_handoff_smoke.py
@@ -778,6 +778,81 @@ def test_release_grade_existing_core_baseline_status_fails_closed() -> None:
             for error in payload["errors"]
         )
 
+def test_release_grade_existing_false_required_gate_fails_closed() -> None:
+    fixture_status = (
+        ROOT
+        / "tests"
+        / "fixtures"
+        / "release_reference_v1"
+        / "false_gate"
+        / "status.json"
+    )
+    expected_status_path = str(fixture_status.relative_to(ROOT))
+    expected_failing_gate = "pass_controls_refusal"
+
+    assert fixture_status.exists(), f"missing release-reference fixture: {fixture_status}"
+
+    with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
+        tmp_path = Path(tmp)
+        report_path = tmp_path / "operator_handoff_smoke.release_grade.false_gate.json"
+
+        result = _run(
+            "--gate-mode",
+            "release-grade",
+            "--status-source",
+            "existing",
+            "--status",
+            str(fixture_status),
+            "--out",
+            str(report_path),
+        )
+
+        _assert_returncode(result, 1)
+
+        assert report_path.exists()
+
+        payload = _read_json(report_path)
+
+        assert payload["ok"] is False
+        assert payload["gate_mode"] == "release-grade"
+
+        status_source = payload["status_source"]
+        assert status_source["mode"] == "existing"
+        assert status_source["status_path"] == expected_status_path
+        assert status_source["status_exists_before_run"] is True
+        assert status_source["status_exists_after_generation"] is True
+        assert status_source["status_exists_after_run"] is True
+
+        assert "required" in payload["materialized_gate_sets"]
+        assert "release_required" in payload["materialized_gate_sets"]
+        assert expected_failing_gate in payload["effective_required_gates"]
+
+        command_names = [command["name"] for command in payload["commands"]]
+
+        assert "materialize_required" in command_names
+        assert "materialize_release_required" in command_names
+        assert "check_gates_release-grade" in command_names
+
+        check_command = next(
+            command
+            for command in payload["commands"]
+            if command["name"] == "check_gates_release-grade"
+        )
+
+        assert check_command["ok"] is False
+        assert check_command["returncode"] != 0
+
+        combined_output = (
+            f"{check_command.get('stdout', '')}\n"
+            f"{check_command.get('stderr', '')}"
+        )
+        assert expected_failing_gate in combined_output
+
+        assert any(
+            "gate check failed in release-grade mode" in error
+            for error in payload["errors"]
+        )
+
 def main() -> int:
     try:
         test_generate_core_honors_custom_status_path()
@@ -792,6 +867,7 @@ def main() -> int:
         test_release_grade_existing_malformed_status_fails_closed()
         test_release_grade_existing_missing_stubbed_diagnostic_fails_closed()
         test_release_grade_existing_core_baseline_status_fails_closed()
+        test_release_grade_existing_false_required_gate_fails_closed()
     except AssertionError as exc:
         print(f"ERROR: {exc}")
         return 1


### PR DESCRIPTION
## Summary

Adds release-grade operator handoff regression coverage for an existing release-reference status artifact with a false policy-required gate.

## Scope

Updates:

- `tests/test_operator_handoff_smoke.py`

## Purpose

This extends the PULSE-REF RA0 operator-handoff regression coverage.

The existing operator handoff tests cover malformed, non-prod, stubbed, missing-evidence, and external-evidence failures.

This PR adds the valid-shaped but gate-failing case:

- `--gate-mode release-grade`
- `--status-source existing`
- existing `false_gate` release-reference fixture
- `metrics.run_mode=prod`
- `diagnostics.gates_stubbed=false`
- `pass_controls_refusal=false`
- required + release_required gate sets materialize
- `check_gates` fails closed in release-grade mode

This proves that operator handoff does not treat release-grade shape as sufficient when a declared required gate is false.

## Authority boundary

This PR does not change release authority.

It only adds regression coverage proving that release-grade operator handoff fails closed through declared-policy gate enforcement when an existing status artifact contains a false required gate.

No release policy, gate semantics, status producer, workflow, release-decision engine, ledger, manifest, dashboard, schema, or audit-bundle behavior is changed.