### PR TITLE
fix(operator): reject stale policy path in release-grade handoff

### DIFF
--- a/tests/test_operator_handoff_smoke.py
+++ b/tests/test_operator_handoff_smoke.py
@@ -1180,6 +1180,81 @@ def test_release_grade_existing_matching_policy_hash_passes() -> None:
         assert "check_gates_release-grade" in command_names
         assert "check_shadow_layer_registry" in command_names
 
+def test_release_grade_existing_stale_policy_path_fails_closed() -> None:
+    source_status = (
+        ROOT
+        / "tests"
+        / "fixtures"
+        / "release_reference_v1"
+        / "refusal_delta_evidence_present"
+        / "status.json"
+    )
+
+    assert source_status.exists(), f"missing release-reference fixture: {source_status}"
+
+    with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
+        tmp_path = Path(tmp)
+        status_path = tmp_path / "operator_handoff_status.stale_policy_path.json"
+        report_path = (
+            tmp_path
+            / "operator_handoff_smoke.release_grade.stale_policy_path.json"
+        )
+
+        status_obj = _read_json(source_status)
+        metrics = status_obj.setdefault("metrics", {})
+        assert isinstance(metrics, dict), "source fixture must contain object-valued metrics"
+
+        metrics["gate_policy_path"] = "policy/other_gate_policy.yml"
+
+        status_path.write_text(
+            json.dumps(status_obj, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        result = _run(
+            "--gate-mode",
+            "release-grade",
+            "--status-source",
+            "existing",
+            "--status",
+            str(status_path),
+            "--out",
+            str(report_path),
+        )
+
+        _assert_returncode(result, 1)
+
+        assert report_path.exists()
+
+        payload = _read_json(report_path)
+
+        assert payload["ok"] is False
+        assert payload["gate_mode"] == "release-grade"
+
+        status_source = payload["status_source"]
+        assert status_source["mode"] == "existing"
+        assert status_source["status_path"] == str(status_path)
+        assert status_source["status_exists_before_run"] is True
+        assert status_source["status_exists_after_generation"] is True
+        assert status_source["status_exists_after_run"] is True
+
+        assert payload["commands"] == []
+        assert payload["materialized_gate_sets"] == {}
+        assert payload["effective_required_gates"] == []
+
+        assert any(
+            "metrics.gate_policy_path" in error
+            for error in payload["errors"]
+        )
+        assert any(
+            "current declared gate policy path" in error
+            for error in payload["errors"]
+        )
+        assert any(
+            "policy/other_gate_policy.yml" in error
+            for error in payload["errors"]
+        )
+
 def main() -> int:
     try:
         test_generate_core_honors_custom_status_path()
@@ -1199,6 +1274,7 @@ def main() -> int:
         test_release_grade_existing_scaffold_markers_fail_closed()
         test_release_grade_existing_stale_policy_hash_fails_closed()
         test_release_grade_existing_matching_policy_hash_passes()
+        test_release_grade_existing_stale_policy_path_fails_closed()
     except AssertionError as exc:
         print(f"ERROR: {exc}")
         return 1

--- a/tools/operator_handoff_smoke.py
+++ b/tools/operator_handoff_smoke.py
@@ -304,7 +304,7 @@ def main(argv: list[str] | None = None) -> int:
                         f"found {status_policy_sha!r}, expected {current_policy_sha!r}."
                     )
 
-                if isinstance(metrics, dict) and "gate_policy_path" in metrics:
+            if isinstance(metrics, dict) and "gate_policy_path" in metrics:
                 status_policy_path = metrics.get("gate_policy_path")
                 current_policy_path = _rel(GATE_POLICY)
 
@@ -314,7 +314,7 @@ def main(argv: list[str] | None = None) -> int:
                         "to match the current declared gate policy path; "
                         f"found {status_policy_path!r}, expected {current_policy_path!r}."
                     )
-           
+
             diagnostics = status_obj.get("diagnostics")
             gates_stubbed_value = (
                 diagnostics.get("gates_stubbed")

--- a/tools/operator_handoff_smoke.py
+++ b/tools/operator_handoff_smoke.py
@@ -304,6 +304,17 @@ def main(argv: list[str] | None = None) -> int:
                         f"found {status_policy_sha!r}, expected {current_policy_sha!r}."
                     )
 
+                if isinstance(metrics, dict) and "gate_policy_path" in metrics:
+                status_policy_path = metrics.get("gate_policy_path")
+                current_policy_path = _rel(GATE_POLICY)
+
+                if status_policy_path != current_policy_path:
+                    errors.append(
+                        "release-grade gate-mode requires metrics.gate_policy_path "
+                        "to match the current declared gate policy path; "
+                        f"found {status_policy_path!r}, expected {current_policy_path!r}."
+                    )
+           
             diagnostics = status_obj.get("diagnostics")
             gates_stubbed_value = (
                 diagnostics.get("gates_stubbed")


### PR DESCRIPTION
## Summary

Rejects stale gate policy paths in release-grade operator handoff.

## Scope

Updates:

- `tools/operator_handoff_smoke.py`
- `tests/test_operator_handoff_smoke.py`

## Purpose

This is a PULSE-REF RA0 operator-handoff hardening step.

If an existing release-grade status artifact declares `metrics.gate_policy_path`, that path must match the current declared gate policy path:

`pulse_gate_policy_v0.yml`

This PR adds a fail-closed precondition:

- `--gate-mode release-grade`
- `--status-source existing`
- `metrics.gate_policy_path` present
- path does not match current `pulse_gate_policy_v0.yml`
- fail closed before gate materialization

The regression mutates the positive release-reference fixture with a stale policy path and verifies that release-grade handoff rejects it before materializing gate sets.

## Authority boundary

This PR does not change release authority.

It hardens the operator handoff precondition for release-grade reconstruction. The normative release decision remains declared-policy gate enforcement over materialized evidence and CI outcome.

No release policy, gate semantics, status producer, workflow, release-decision engine, ledger, manifest, dashboard, schema, or audit-bundle behavior is changed.