### PR TITLE
test(operator): cover matching policy path handoff

### DIFF
--- a/tests/test_operator_handoff_smoke.py
+++ b/tests/test_operator_handoff_smoke.py
@@ -1255,6 +1255,77 @@ def test_release_grade_existing_stale_policy_path_fails_closed() -> None:
             for error in payload["errors"]
         )
 
+def test_release_grade_existing_matching_policy_path_passes() -> None:
+    source_status = (
+        ROOT
+        / "tests"
+        / "fixtures"
+        / "release_reference_v1"
+        / "refusal_delta_evidence_present"
+        / "status.json"
+    )
+
+    assert source_status.exists(), f"missing release-reference fixture: {source_status}"
+
+    with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
+        tmp_path = Path(tmp)
+        status_path = tmp_path / "operator_handoff_status.matching_policy_path.json"
+        report_path = (
+            tmp_path
+            / "operator_handoff_smoke.release_grade.matching_policy_path.json"
+        )
+
+        status_obj = _read_json(source_status)
+        metrics = status_obj.setdefault("metrics", {})
+        assert isinstance(metrics, dict), "source fixture must contain object-valued metrics"
+
+        metrics["gate_policy_path"] = "pulse_gate_policy_v0.yml"
+
+        status_path.write_text(
+            json.dumps(status_obj, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        result = _run(
+            "--gate-mode",
+            "release-grade",
+            "--status-source",
+            "existing",
+            "--status",
+            str(status_path),
+            "--out",
+            str(report_path),
+        )
+
+        _assert_returncode(result, 0)
+
+        assert report_path.exists()
+
+        payload = _read_json(report_path)
+
+        assert payload["ok"] is True
+        assert payload["gate_mode"] == "release-grade"
+        assert payload["errors"] == []
+
+        status_source = payload["status_source"]
+        assert status_source["mode"] == "existing"
+        assert status_source["status_path"] == str(status_path)
+        assert status_source["status_exists_before_run"] is True
+        assert status_source["status_exists_after_generation"] is True
+        assert status_source["status_exists_after_run"] is True
+
+        assert "required" in payload["materialized_gate_sets"]
+        assert "release_required" in payload["materialized_gate_sets"]
+
+        assert "refusal_delta_evidence_present" in payload["effective_required_gates"]
+
+        command_names = [command["name"] for command in payload["commands"]]
+
+        assert "materialize_required" in command_names
+        assert "materialize_release_required" in command_names
+        assert "check_gates_release-grade" in command_names
+        assert "check_shadow_layer_registry" in command_names
+
 def main() -> int:
     try:
         test_generate_core_honors_custom_status_path()
@@ -1275,6 +1346,7 @@ def main() -> int:
         test_release_grade_existing_stale_policy_hash_fails_closed()
         test_release_grade_existing_matching_policy_hash_passes()
         test_release_grade_existing_stale_policy_path_fails_closed()
+        test_release_grade_existing_matching_policy_path_passes()
     except AssertionError as exc:
         print(f"ERROR: {exc}")
         return 1


### PR DESCRIPTION
## Summary

Adds positive release-grade operator handoff coverage for an existing status artifact with a matching gate policy path.

## Scope

Updates:

- `tests/test_operator_handoff_smoke.py`

## Purpose

This extends the PULSE-REF RA0 operator-handoff regression coverage.

The existing stale-policy-path test proves that release-grade handoff fails closed when `metrics.gate_policy_path` is present but does not match the current declared gate policy path.

This PR adds the positive pair:

- `--gate-mode release-grade`
- `--status-source existing`
- positive release-reference status fixture mutated in a temp directory
- `metrics.gate_policy_path` set to `pulse_gate_policy_v0.yml`
- required + release_required gate sets materialize
- `check_gates` passes
- shadow registry check runs

This proves that matching declared-policy path metadata is accepted.

## Authority boundary

This PR does not change release authority.

It only adds regression coverage proving that release-grade operator handoff accepts an existing status artifact when declared policy path metadata matches the current gate policy and all release-grade gates pass.

No release policy, gate semantics, status producer, workflow, release-decision engine, ledger, manifest, dashboard, schema, or audit-bundle behavior is changed.