### PR TITLE
feat(operator): record status digest in handoff report

### DIFF
--- a/tests/test_operator_handoff_smoke.py
+++ b/tests/test_operator_handoff_smoke.py
@@ -731,15 +731,16 @@ def test_release_grade_existing_missing_stubbed_diagnostic_fails_closed() -> Non
 
 
 def test_release_grade_existing_core_baseline_status_fails_closed() -> None:
-    source_status = (
+    fixture_status = (
         ROOT
         / "tests"
         / "fixtures"
-        / "core_baseline_v1"
-        / "status.json"
+        / "core_baseline_v0"
+        / "status.normalized.json"
     )
+    expected_status_path = str(fixture_status.relative_to(ROOT))
 
-    assert source_status.exists(), f"missing core-baseline fixture: {source_status}"
+    assert fixture_status.exists(), f"missing core baseline fixture: {fixture_status}"
 
     with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
         tmp_path = Path(tmp)
@@ -751,7 +752,7 @@ def test_release_grade_existing_core_baseline_status_fails_closed() -> None:
             "--status-source",
             "existing",
             "--status",
-            str(source_status),
+            str(fixture_status),
             "--out",
             str(report_path),
         )
@@ -767,7 +768,7 @@ def test_release_grade_existing_core_baseline_status_fails_closed() -> None:
 
         status_source = payload["status_source"]
         assert status_source["mode"] == "existing"
-        assert status_source["status_path"] == str(source_status.relative_to(ROOT))
+        assert status_source["status_path"] == expected_status_path
         assert status_source["status_exists_before_run"] is True
         assert status_source["status_exists_after_generation"] is True
         assert status_source["status_exists_after_run"] is True
@@ -777,6 +778,7 @@ def test_release_grade_existing_core_baseline_status_fails_closed() -> None:
         assert payload["effective_required_gates"] == []
 
         assert any("metrics.run_mode=prod" in error for error in payload["errors"])
+        assert any("found 'core'" in error for error in payload["errors"])
         assert any("diagnostics.gates_stubbed=false" in error for error in payload["errors"])
         assert any("found True" in error for error in payload["errors"])
 

--- a/tests/test_operator_handoff_smoke.py
+++ b/tests/test_operator_handoff_smoke.py
@@ -8,7 +8,6 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "tools" / "operator_handoff_smoke.py"
 
@@ -27,6 +26,7 @@ def _run(*args: str) -> subprocess.CompletedProcess[str]:
 def _read_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
+
 def _sha256_file(path: Path) -> str:
     h = hashlib.sha256()
 
@@ -35,6 +35,7 @@ def _sha256_file(path: Path) -> str:
             h.update(chunk)
 
     return h.hexdigest()
+
 
 def _assert_returncode(
     result: subprocess.CompletedProcess[str],
@@ -79,8 +80,15 @@ def test_generate_core_honors_custom_status_path() -> None:
             status_path.parent / "status.json"
         )
         assert status_source["status_exists_before_run"] is False
+        assert status_source["status_sha256_before_run"] is None
         assert status_source["status_exists_after_generation"] is True
+        assert isinstance(status_source["status_sha256_after_generation"], str)
+        assert len(status_source["status_sha256_after_generation"]) == 64
         assert status_source["status_exists_after_run"] is True
+        assert (
+            status_source["status_sha256_after_run"]
+            == status_source["status_sha256_after_generation"]
+        )
 
         command_names = [command["name"] for command in payload["commands"]]
 
@@ -168,17 +176,17 @@ def test_existing_missing_status_fails_closed() -> None:
         assert status_source["mode"] == "existing"
         assert status_source["status_path"] == str(status_path)
         assert status_source["status_exists_before_run"] is False
+        assert status_source["status_sha256_before_run"] is None
         assert status_source["status_exists_after_generation"] is False
+        assert status_source["status_sha256_after_generation"] is None
         assert status_source["status_exists_after_run"] is False
+        assert status_source["status_sha256_after_run"] is None
 
         assert payload["commands"] == []
         assert payload["materialized_gate_sets"] == {}
         assert payload["effective_required_gates"] == []
 
-        assert any(
-            "status artifact missing" in error
-            for error in payload["errors"]
-        )
+        assert any("status artifact missing" in error for error in payload["errors"])
         assert any(
             "status-source=existing was selected" in warning
             for warning in payload["warnings"]
@@ -196,7 +204,9 @@ def test_release_grade_accepts_existing_release_reference_status() -> None:
     )
     expected_status_path = str(fixture_status.relative_to(ROOT))
 
-    assert fixture_status.exists(), f"missing release-reference fixture: {fixture_status}"
+    assert (
+        fixture_status.exists()
+    ), f"missing release-reference fixture: {fixture_status}"
 
     with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
         tmp_path = Path(tmp)
@@ -226,8 +236,18 @@ def test_release_grade_accepts_existing_release_reference_status() -> None:
         assert status_source["mode"] == "existing"
         assert status_source["status_path"] == expected_status_path
         assert status_source["status_exists_before_run"] is True
+        assert isinstance(status_source["status_sha256_before_run"], str)
+        assert len(status_source["status_sha256_before_run"]) == 64
         assert status_source["status_exists_after_generation"] is True
+        assert (
+            status_source["status_sha256_after_generation"]
+            == status_source["status_sha256_before_run"]
+        )
         assert status_source["status_exists_after_run"] is True
+        assert (
+            status_source["status_sha256_after_run"]
+            == status_source["status_sha256_before_run"]
+        )
 
         assert "required" in payload["materialized_gate_sets"]
         assert "release_required" in payload["materialized_gate_sets"]
@@ -241,6 +261,7 @@ def test_release_grade_accepts_existing_release_reference_status() -> None:
         assert "check_gates_release-grade" in command_names
         assert "check_shadow_layer_registry" in command_names
 
+
 def test_release_grade_existing_missing_refusal_delta_fails_closed() -> None:
     fixture_status = (
         ROOT
@@ -252,11 +273,15 @@ def test_release_grade_existing_missing_refusal_delta_fails_closed() -> None:
     )
     expected_status_path = str(fixture_status.relative_to(ROOT))
 
-    assert fixture_status.exists(), f"missing release-reference fixture: {fixture_status}"
+    assert (
+        fixture_status.exists()
+    ), f"missing release-reference fixture: {fixture_status}"
 
     with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
         tmp_path = Path(tmp)
-        report_path = tmp_path / "operator_handoff_smoke.release_grade.missing_refusal_delta.json"
+        report_path = (
+            tmp_path / "operator_handoff_smoke.release_grade.missing_refusal_delta.json"
+        )
 
         result = _run(
             "--gate-mode",
@@ -304,13 +329,16 @@ def test_release_grade_existing_missing_refusal_delta_fails_closed() -> None:
         assert check_command["ok"] is False
         assert check_command["returncode"] != 0
 
-        combined_output = f"{check_command.get('stdout', '')}\n{check_command.get('stderr', '')}"
+        combined_output = (
+            f"{check_command.get('stdout', '')}\n{check_command.get('stderr', '')}"
+        )
         assert "refusal_delta_evidence_present" in combined_output
 
         assert any(
             "gate check failed in release-grade mode" in error
             for error in payload["errors"]
         )
+
 
 def test_release_grade_existing_external_evidence_failures_fail_closed() -> None:
     cases = [
@@ -329,13 +357,14 @@ def test_release_grade_existing_external_evidence_failures_fail_closed() -> None
         )
         expected_status_path = str(fixture_status.relative_to(ROOT))
 
-        assert fixture_status.exists(), f"missing release-reference fixture: {fixture_status}"
+        assert (
+            fixture_status.exists()
+        ), f"missing release-reference fixture: {fixture_status}"
 
         with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
             tmp_path = Path(tmp)
             report_path = (
-                tmp_path
-                / f"operator_handoff_smoke.release_grade.{fixture_id}.json"
+                tmp_path / f"operator_handoff_smoke.release_grade.{fixture_id}.json"
             )
 
             result = _run(
@@ -395,6 +424,7 @@ def test_release_grade_existing_external_evidence_failures_fail_closed() -> None
                 for error in payload["errors"]
             )
 
+
 def test_release_grade_existing_missing_external_summary_fails_closed() -> None:
     fixture_status = (
         ROOT
@@ -407,14 +437,13 @@ def test_release_grade_existing_missing_external_summary_fails_closed() -> None:
     expected_status_path = str(fixture_status.relative_to(ROOT))
     expected_failing_gate = "external_summaries_present"
 
-    assert fixture_status.exists(), f"missing release-reference fixture: {fixture_status}"
+    assert (
+        fixture_status.exists()
+    ), f"missing release-reference fixture: {fixture_status}"
 
     with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
         tmp_path = Path(tmp)
-        report_path = (
-            tmp_path
-            / "operator_handoff_smoke.release_grade.missing_external.json"
-        )
+        report_path = tmp_path / "operator_handoff_smoke.release_grade.missing_external.json"
 
         result = _run(
             "--gate-mode",
@@ -485,7 +514,9 @@ def test_release_grade_existing_stubbed_status_fails_closed() -> None:
     )
     expected_status_path = str(fixture_status.relative_to(ROOT))
 
-    assert fixture_status.exists(), f"missing release-reference fixture: {fixture_status}"
+    assert (
+        fixture_status.exists()
+    ), f"missing release-reference fixture: {fixture_status}"
 
     with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
         tmp_path = Path(tmp)
@@ -522,14 +553,9 @@ def test_release_grade_existing_stubbed_status_fails_closed() -> None:
         assert payload["materialized_gate_sets"] == {}
         assert payload["effective_required_gates"] == []
 
-        assert any(
-            "diagnostics.gates_stubbed=false" in error
-            for error in payload["errors"]
-        )
-        assert any(
-            "stubbed status evidence" in error
-            for error in payload["errors"]
-        )
+        assert any("diagnostics.gates_stubbed=false" in error for error in payload["errors"])
+        assert any("stubbed status evidence" in error for error in payload["errors"])
+
 
 def test_release_grade_existing_non_prod_run_mode_fails_closed() -> None:
     source_status = (
@@ -541,7 +567,9 @@ def test_release_grade_existing_non_prod_run_mode_fails_closed() -> None:
         / "status.json"
     )
 
-    assert source_status.exists(), f"missing release-reference fixture: {source_status}"
+    assert (
+        source_status.exists()
+    ), f"missing release-reference fixture: {source_status}"
 
     with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
         tmp_path = Path(tmp)
@@ -588,67 +616,51 @@ def test_release_grade_existing_non_prod_run_mode_fails_closed() -> None:
         assert payload["materialized_gate_sets"] == {}
         assert payload["effective_required_gates"] == []
 
-        assert any(
-            "metrics.run_mode=prod" in error
-            for error in payload["errors"]
-        )
-        assert any(
-            "found 'core'" in error
-            for error in payload["errors"]
-        )
+        assert any("metrics.run_mode=prod" in error for error in payload["errors"])
+        assert any("found 'core'" in error for error in payload["errors"])
+
 
 def test_release_grade_existing_malformed_status_fails_closed() -> None:
-    cases = [
-        ("malformed_json", "{not json\n"),
-        ("json_array", "[]\n"),
-    ]
+    with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
+        tmp_path = Path(tmp)
+        status_path = tmp_path / "operator_handoff_status.malformed.json"
+        report_path = tmp_path / "operator_handoff_smoke.release_grade.malformed.json"
 
-    for case_id, status_text in cases:
-        with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
-            tmp_path = Path(tmp)
-            status_path = tmp_path / f"operator_handoff_status.{case_id}.json"
-            report_path = (
-                tmp_path
-                / f"operator_handoff_smoke.release_grade.{case_id}.json"
-            )
+        status_path.write_text('["not", "an", "object"]\n', encoding="utf-8")
 
-            status_path.write_text(status_text, encoding="utf-8")
+        result = _run(
+            "--gate-mode",
+            "release-grade",
+            "--status-source",
+            "existing",
+            "--status",
+            str(status_path),
+            "--out",
+            str(report_path),
+        )
 
-            result = _run(
-                "--gate-mode",
-                "release-grade",
-                "--status-source",
-                "existing",
-                "--status",
-                str(status_path),
-                "--out",
-                str(report_path),
-            )
+        _assert_returncode(result, 1)
 
-            _assert_returncode(result, 1)
+        assert report_path.exists()
 
-            assert report_path.exists()
+        payload = _read_json(report_path)
 
-            payload = _read_json(report_path)
+        assert payload["ok"] is False
+        assert payload["gate_mode"] == "release-grade"
 
-            assert payload["ok"] is False
-            assert payload["gate_mode"] == "release-grade"
+        status_source = payload["status_source"]
+        assert status_source["mode"] == "existing"
+        assert status_source["status_path"] == str(status_path)
+        assert status_source["status_exists_before_run"] is True
+        assert status_source["status_exists_after_generation"] is True
+        assert status_source["status_exists_after_run"] is True
 
-            status_source = payload["status_source"]
-            assert status_source["mode"] == "existing"
-            assert status_source["status_path"] == str(status_path)
-            assert status_source["status_exists_before_run"] is True
-            assert status_source["status_exists_after_generation"] is True
-            assert status_source["status_exists_after_run"] is True
+        assert payload["commands"] == []
+        assert payload["materialized_gate_sets"] == {}
+        assert payload["effective_required_gates"] == []
 
-            assert payload["commands"] == []
-            assert payload["materialized_gate_sets"] == {}
-            assert payload["effective_required_gates"] == []
+        assert any("status artifact is not a JSON object" in error for error in payload["errors"])
 
-            assert any(
-                "status artifact is not a JSON object" in error
-                for error in payload["errors"]
-            )
 
 def test_release_grade_existing_missing_stubbed_diagnostic_fails_closed() -> None:
     source_status = (
@@ -660,18 +672,20 @@ def test_release_grade_existing_missing_stubbed_diagnostic_fails_closed() -> Non
         / "status.json"
     )
 
-    assert source_status.exists(), f"missing release-reference fixture: {source_status}"
+    assert (
+        source_status.exists()
+    ), f"missing release-reference fixture: {source_status}"
 
     with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
         tmp_path = Path(tmp)
-        status_path = tmp_path / "operator_handoff_status.missing_gates_stubbed.json"
+        status_path = tmp_path / "operator_handoff_status.missing_stubbed_diag.json"
         report_path = (
-            tmp_path
-            / "operator_handoff_smoke.release_grade.missing_gates_stubbed.json"
+            tmp_path / "operator_handoff_smoke.release_grade.missing_stubbed_diag.json"
         )
 
         status_obj = _read_json(source_status)
-        diagnostics = status_obj.setdefault("diagnostics", {})
+        diagnostics = status_obj.get("diagnostics")
+        assert isinstance(diagnostics, dict), "source fixture must contain diagnostics object"
         diagnostics.pop("gates_stubbed", None)
 
         status_path.write_text(
@@ -711,29 +725,21 @@ def test_release_grade_existing_missing_stubbed_diagnostic_fails_closed() -> Non
         assert payload["effective_required_gates"] == []
 
         assert any(
-            "diagnostics.gates_stubbed=false" in error
-            for error in payload["errors"]
+            "diagnostics.gates_stubbed=false" in error for error in payload["errors"]
         )
-        assert any(
-            "found None" in error
-            for error in payload["errors"]
-        )
-        assert any(
-            "stubbed status evidence" in error
-            for error in payload["errors"]
-        )
+        assert any("found None" in error for error in payload["errors"])
+
 
 def test_release_grade_existing_core_baseline_status_fails_closed() -> None:
-    fixture_status = (
+    source_status = (
         ROOT
         / "tests"
         / "fixtures"
-        / "core_baseline_v0"
-        / "status.normalized.json"
+        / "core_baseline_v1"
+        / "status.json"
     )
-    expected_status_path = str(fixture_status.relative_to(ROOT))
 
-    assert fixture_status.exists(), f"missing core baseline fixture: {fixture_status}"
+    assert source_status.exists(), f"missing core-baseline fixture: {source_status}"
 
     with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
         tmp_path = Path(tmp)
@@ -745,7 +751,7 @@ def test_release_grade_existing_core_baseline_status_fails_closed() -> None:
             "--status-source",
             "existing",
             "--status",
-            str(fixture_status),
+            str(source_status),
             "--out",
             str(report_path),
         )
@@ -761,7 +767,7 @@ def test_release_grade_existing_core_baseline_status_fails_closed() -> None:
 
         status_source = payload["status_source"]
         assert status_source["mode"] == "existing"
-        assert status_source["status_path"] == expected_status_path
+        assert status_source["status_path"] == str(source_status.relative_to(ROOT))
         assert status_source["status_exists_before_run"] is True
         assert status_source["status_exists_after_generation"] is True
         assert status_source["status_exists_after_run"] is True
@@ -770,22 +776,10 @@ def test_release_grade_existing_core_baseline_status_fails_closed() -> None:
         assert payload["materialized_gate_sets"] == {}
         assert payload["effective_required_gates"] == []
 
-        assert any(
-            "metrics.run_mode=prod" in error
-            for error in payload["errors"]
-        )
-        assert any(
-            "found 'core'" in error
-            for error in payload["errors"]
-        )
-        assert any(
-            "diagnostics.gates_stubbed=false" in error
-            for error in payload["errors"]
-        )
-        assert any(
-            "found True" in error
-            for error in payload["errors"]
-        )
+        assert any("metrics.run_mode=prod" in error for error in payload["errors"])
+        assert any("diagnostics.gates_stubbed=false" in error for error in payload["errors"])
+        assert any("found True" in error for error in payload["errors"])
+
 
 def test_release_grade_existing_false_required_gate_fails_closed() -> None:
     fixture_status = (
@@ -799,7 +793,9 @@ def test_release_grade_existing_false_required_gate_fails_closed() -> None:
     expected_status_path = str(fixture_status.relative_to(ROOT))
     expected_failing_gate = "pass_controls_refusal"
 
-    assert fixture_status.exists(), f"missing release-reference fixture: {fixture_status}"
+    assert (
+        fixture_status.exists()
+    ), f"missing release-reference fixture: {fixture_status}"
 
     with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
         tmp_path = Path(tmp)
@@ -862,6 +858,7 @@ def test_release_grade_existing_false_required_gate_fails_closed() -> None:
             for error in payload["errors"]
         )
 
+
 def test_release_grade_existing_missing_required_gate_fails_closed() -> None:
     source_status = (
         ROOT
@@ -873,14 +870,15 @@ def test_release_grade_existing_missing_required_gate_fails_closed() -> None:
     )
     expected_missing_gate = "refusal_delta_evidence_present"
 
-    assert source_status.exists(), f"missing release-reference fixture: {source_status}"
+    assert (
+        source_status.exists()
+    ), f"missing release-reference fixture: {source_status}"
 
     with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
         tmp_path = Path(tmp)
         status_path = tmp_path / "operator_handoff_status.missing_required_gate.json"
         report_path = (
-            tmp_path
-            / "operator_handoff_smoke.release_grade.missing_required_gate.json"
+            tmp_path / "operator_handoff_smoke.release_grade.missing_required_gate.json"
         )
 
         status_obj = _read_json(source_status)
@@ -952,6 +950,7 @@ def test_release_grade_existing_missing_required_gate_fails_closed() -> None:
             for error in payload["errors"]
         )
 
+
 def test_release_grade_existing_scaffold_markers_fail_closed() -> None:
     source_status = (
         ROOT
@@ -962,7 +961,9 @@ def test_release_grade_existing_scaffold_markers_fail_closed() -> None:
         / "status.json"
     )
 
-    assert source_status.exists(), f"missing release-reference fixture: {source_status}"
+    assert (
+        source_status.exists()
+    ), f"missing release-reference fixture: {source_status}"
 
     cases = [
         (
@@ -988,8 +989,7 @@ def test_release_grade_existing_scaffold_markers_fail_closed() -> None:
             tmp_path = Path(tmp)
             status_path = tmp_path / f"operator_handoff_status.{case_id}.json"
             report_path = (
-                tmp_path
-                / f"operator_handoff_smoke.release_grade.{case_id}.json"
+                tmp_path / f"operator_handoff_smoke.release_grade.{case_id}.json"
             )
 
             status_obj = _read_json(source_status)
@@ -1033,10 +1033,8 @@ def test_release_grade_existing_scaffold_markers_fail_closed() -> None:
             assert payload["effective_required_gates"] == []
 
             for fragment in expected_error_fragments:
-                assert any(
-                    fragment in error
-                    for error in payload["errors"]
-                )
+                assert any(fragment in error for error in payload["errors"])
+
 
 def test_release_grade_existing_stale_policy_hash_fails_closed() -> None:
     source_status = (
@@ -1048,14 +1046,15 @@ def test_release_grade_existing_stale_policy_hash_fails_closed() -> None:
         / "status.json"
     )
 
-    assert source_status.exists(), f"missing release-reference fixture: {source_status}"
+    assert (
+        source_status.exists()
+    ), f"missing release-reference fixture: {source_status}"
 
     with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
         tmp_path = Path(tmp)
         status_path = tmp_path / "operator_handoff_status.stale_policy_hash.json"
         report_path = (
-            tmp_path
-            / "operator_handoff_smoke.release_grade.stale_policy_hash.json"
+            tmp_path / "operator_handoff_smoke.release_grade.stale_policy_hash.json"
         )
 
         status_obj = _read_json(source_status)
@@ -1098,14 +1097,11 @@ def test_release_grade_existing_stale_policy_hash_fails_closed() -> None:
         assert payload["materialized_gate_sets"] == {}
         assert payload["effective_required_gates"] == []
 
+        assert any("metrics.gate_policy_sha256" in error for error in payload["errors"])
         assert any(
-            "metrics.gate_policy_sha256" in error
-            for error in payload["errors"]
+            "current declared gate policy" in error for error in payload["errors"]
         )
-        assert any(
-            "current declared gate policy" in error
-            for error in payload["errors"]
-        )
+
 
 def test_release_grade_existing_matching_policy_hash_passes() -> None:
     source_status = (
@@ -1118,20 +1114,23 @@ def test_release_grade_existing_matching_policy_hash_passes() -> None:
     )
     policy_path = ROOT / "pulse_gate_policy_v0.yml"
 
-    assert source_status.exists(), f"missing release-reference fixture: {source_status}"
+    assert (
+        source_status.exists()
+    ), f"missing release-reference fixture: {source_status}"
     assert policy_path.exists(), f"missing gate policy: {policy_path}"
 
     with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
         tmp_path = Path(tmp)
         status_path = tmp_path / "operator_handoff_status.matching_policy_hash.json"
         report_path = (
-            tmp_path
-            / "operator_handoff_smoke.release_grade.matching_policy_hash.json"
+            tmp_path / "operator_handoff_smoke.release_grade.matching_policy_hash.json"
         )
 
         status_obj = _read_json(source_status)
         metrics = status_obj.setdefault("metrics", {})
-        assert isinstance(metrics, dict), "source fixture must contain object-valued metrics"
+        assert isinstance(
+            metrics, dict
+        ), "source fixture must contain object-valued metrics"
 
         metrics["gate_policy_sha256"] = _sha256_file(policy_path)
 
@@ -1180,6 +1179,7 @@ def test_release_grade_existing_matching_policy_hash_passes() -> None:
         assert "check_gates_release-grade" in command_names
         assert "check_shadow_layer_registry" in command_names
 
+
 def test_release_grade_existing_stale_policy_path_fails_closed() -> None:
     source_status = (
         ROOT
@@ -1190,19 +1190,22 @@ def test_release_grade_existing_stale_policy_path_fails_closed() -> None:
         / "status.json"
     )
 
-    assert source_status.exists(), f"missing release-reference fixture: {source_status}"
+    assert (
+        source_status.exists()
+    ), f"missing release-reference fixture: {source_status}"
 
     with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
         tmp_path = Path(tmp)
         status_path = tmp_path / "operator_handoff_status.stale_policy_path.json"
         report_path = (
-            tmp_path
-            / "operator_handoff_smoke.release_grade.stale_policy_path.json"
+            tmp_path / "operator_handoff_smoke.release_grade.stale_policy_path.json"
         )
 
         status_obj = _read_json(source_status)
         metrics = status_obj.setdefault("metrics", {})
-        assert isinstance(metrics, dict), "source fixture must contain object-valued metrics"
+        assert isinstance(
+            metrics, dict
+        ), "source fixture must contain object-valued metrics"
 
         metrics["gate_policy_path"] = "policy/other_gate_policy.yml"
 
@@ -1242,18 +1245,14 @@ def test_release_grade_existing_stale_policy_path_fails_closed() -> None:
         assert payload["materialized_gate_sets"] == {}
         assert payload["effective_required_gates"] == []
 
+        assert any("metrics.gate_policy_path" in error for error in payload["errors"])
         assert any(
-            "metrics.gate_policy_path" in error
-            for error in payload["errors"]
+            "current declared gate policy path" in error for error in payload["errors"]
         )
         assert any(
-            "current declared gate policy path" in error
-            for error in payload["errors"]
+            "policy/other_gate_policy.yml" in error for error in payload["errors"]
         )
-        assert any(
-            "policy/other_gate_policy.yml" in error
-            for error in payload["errors"]
-        )
+
 
 def test_release_grade_existing_matching_policy_path_passes() -> None:
     source_status = (
@@ -1265,19 +1264,22 @@ def test_release_grade_existing_matching_policy_path_passes() -> None:
         / "status.json"
     )
 
-    assert source_status.exists(), f"missing release-reference fixture: {source_status}"
+    assert (
+        source_status.exists()
+    ), f"missing release-reference fixture: {source_status}"
 
     with tempfile.TemporaryDirectory(prefix="pulse-operator-handoff-") as tmp:
         tmp_path = Path(tmp)
         status_path = tmp_path / "operator_handoff_status.matching_policy_path.json"
         report_path = (
-            tmp_path
-            / "operator_handoff_smoke.release_grade.matching_policy_path.json"
+            tmp_path / "operator_handoff_smoke.release_grade.matching_policy_path.json"
         )
 
         status_obj = _read_json(source_status)
         metrics = status_obj.setdefault("metrics", {})
-        assert isinstance(metrics, dict), "source fixture must contain object-valued metrics"
+        assert isinstance(
+            metrics, dict
+        ), "source fixture must contain object-valued metrics"
 
         metrics["gate_policy_path"] = "pulse_gate_policy_v0.yml"
 
@@ -1325,6 +1327,7 @@ def test_release_grade_existing_matching_policy_path_passes() -> None:
         assert "materialize_release_required" in command_names
         assert "check_gates_release-grade" in command_names
         assert "check_shadow_layer_registry" in command_names
+
 
 def main() -> int:
     try:

--- a/tools/operator_handoff_smoke.py
+++ b/tools/operator_handoff_smoke.py
@@ -318,68 +318,80 @@ def main(argv: list[str] | None = None) -> int:
                     )
 
             diagnostics = status_obj.get("diagnostics")
-            if not isinstance(diagnostics, dict):
-                diagnostics = {}
+            gates_stubbed_value = (
+                diagnostics.get("gates_stubbed")
+                if isinstance(diagnostics, dict)
+                else None
+            )
 
-            gates_stubbed = diagnostics.get("gates_stubbed")
-            if gates_stubbed is not False:
+            if gates_stubbed_value is not False:
                 errors.append(
                     "release-grade gate-mode requires diagnostics.gates_stubbed=false; "
-                    f"found {gates_stubbed!r}."
+                    f"found {gates_stubbed_value!r}. "
+                    "stubbed status evidence must not be treated as release-grade evidence."
                 )
-                errors.append("release-grade gate-mode rejects stubbed status evidence.")
 
-            scaffold = diagnostics.get("scaffold")
-            if scaffold is True:
+            scaffold_value = (
+                diagnostics.get("scaffold")
+                if isinstance(diagnostics, dict)
+                else None
+            )
+
+            if scaffold_value is True:
                 errors.append(
                     "release-grade gate-mode requires diagnostics.scaffold!=true; "
-                    f"found {scaffold!r}."
+                    "scaffold status evidence must not be treated as release-grade evidence."
                 )
-                errors.append("release-grade gate-mode rejects scaffold status evidence.")
 
-            if "stub_profile" in diagnostics:
+            stub_profile_present = (
+                isinstance(diagnostics, dict)
+                and "stub_profile" in diagnostics
+            )
+            stub_profile_value = (
+                diagnostics.get("stub_profile")
+                if isinstance(diagnostics, dict)
+                else None
+            )
+
+            if stub_profile_present:
                 errors.append(
                     "release-grade gate-mode requires diagnostics.stub_profile to be absent; "
-                    f"found {diagnostics.get('stub_profile')!r}."
-                )
-                errors.append(
-                    "release-grade gate-mode rejects stub-profiled status evidence."
+                    f"found {stub_profile_value!r}. "
+                    "stub-profiled status evidence must not be treated as release-grade evidence."
                 )
 
     materialized_gate_sets: dict[str, list[str]] = {}
-    effective_required_gates: list[str] = []
 
     if not errors:
         if args.gate_mode == "core":
-            core_gates, materialize_result = _materialize_gate_set("core_required")
-            commands.append(materialize_result)
+            core_required, cmd = _materialize_gate_set("core_required")
+            commands.append(cmd)
 
-            if materialize_result["returncode"] != 0:
-                errors.append("failed to materialize core_required gate set")
-            else:
-                materialized_gate_sets["core_required"] = core_gates
-                effective_required_gates = core_gates
+            materialized_gate_sets["core_required"] = core_required
+            required_gates = core_required
+
+            if not required_gates:
+                errors.append("core_required materialized to an empty gate set")
+
         else:
-            required_gates, required_result = _materialize_gate_set("required")
-            release_gates, release_result = _materialize_gate_set("release_required")
-            commands.extend([required_result, release_result])
+            required, cmd_required = _materialize_gate_set("required")
+            release_required, cmd_release = _materialize_gate_set("release_required")
 
-            if required_result["returncode"] != 0:
-                errors.append("failed to materialize required gate set")
-            if release_result["returncode"] != 0:
-                errors.append("failed to materialize release_required gate set")
+            commands.append(cmd_required)
+            commands.append(cmd_release)
 
-            if not errors:
-                materialized_gate_sets["required"] = required_gates
-                materialized_gate_sets["release_required"] = release_gates
-                effective_required_gates = _unique_preserve_order(
-                    [*required_gates, *release_gates]
-                )
+            materialized_gate_sets["required"] = required
+            materialized_gate_sets["release_required"] = release_required
 
-    if not errors and args.status_source == "existing":
-        warnings.append(
-            "status-source=existing was selected; generation step was skipped by design."
-        )
+            required_gates = _unique_preserve_order(required + release_required)
+
+            if not required:
+                errors.append("required materialized to an empty gate set")
+            if not release_required:
+                errors.append("release_required materialized to an empty gate set")
+
+    else:
+        required_gates = []
 
     if not errors:
         commands.append(
@@ -389,8 +401,8 @@ def main(argv: list[str] | None = None) -> int:
                     str(CHECK_GATES),
                     "--status",
                     str(status_path),
-                    "--required",
-                    *effective_required_gates,
+                    "--require",
+                    *required_gates,
                 ],
                 name=f"check_gates_{args.gate_mode}",
             )
@@ -405,41 +417,65 @@ def main(argv: list[str] | None = None) -> int:
                 [
                     sys.executable,
                     str(SHADOW_REGISTRY_CHECKER),
-                    "--registry",
+                    "--input",
                     str(SHADOW_REGISTRY),
-                    "--gate-registry",
-                    str(GATE_REGISTRY),
-                    "--policy",
-                    str(GATE_POLICY),
                 ],
                 name="check_shadow_layer_registry",
             )
         )
 
         if commands[-1]["returncode"] != 0:
-            errors.append("shadow layer registry check failed")
+            errors.append("shadow layer registry validation failed")
+
+    if not errors and args.include_tests:
+        test_targets = [
+            "tests/test_check_shadow_layer_registry.py",
+            "tests/test_check_epf_shadow_run_manifest_contract.py",
+            "tests/test_check_epf_paradox_summary_contract.py",
+        ]
+
+        commands.append(
+            _run_command(
+                [sys.executable, "-m", "pytest", "-q", *test_targets],
+                name="pytest_handoff_regressions",
+            )
+        )
+
+        if commands[-1]["returncode"] != 0:
+            errors.append("handoff regression pytest targets failed")
+
+    if args.status_source == "existing" and not status_source["status_exists_before_run"]:
+        warnings.append(
+            "status-source=existing was selected, but the status artifact did not "
+            "exist before this smoke run."
+        )
 
     status_source["status_exists_after_run"] = status_path.exists()
     status_source["status_sha256_after_run"] = _sha256(status_path)
 
-    payload: dict[str, Any] = {
-        "ok": not errors,
-        "generated_utc": _utc_now(),
+    report = {
+        "ok": len(errors) == 0,
+        "created_utc": _utc_now(),
+        "repo_root": str(REPO_ROOT),
         "gate_mode": args.gate_mode,
         "status_source": status_source,
         "materialized_gate_sets": materialized_gate_sets,
-        "effective_required_gates": effective_required_gates,
-        "required_files": _file_inventory(required_files),
-        "status_file_inventory": _file_inventory([status_path]),
+        "effective_required_gates": required_gates,
+        "files": _file_inventory(required_files + [status_path]),
         "commands": commands,
         "warnings": warnings,
         "errors": errors,
     }
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    out_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 
-    return 0 if not errors else 1
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+    return 0 if report["ok"] else 1
 
 
 if __name__ == "__main__":

--- a/tools/operator_handoff_smoke.py
+++ b/tools/operator_handoff_smoke.py
@@ -233,6 +233,7 @@ def main(argv: list[str] | None = None) -> int:
         "mode": args.status_source,
         "status_path": _rel(status_path),
         "status_exists_before_run": status_path.exists(),
+        "status_sha256_before_run": _sha256(status_path),
     }
 
     if not errors and args.status_source == "generate-core":
@@ -275,6 +276,7 @@ def main(argv: list[str] | None = None) -> int:
             )
 
     status_source["status_exists_after_generation"] = status_path.exists()
+    status_source["status_sha256_after_generation"] = _sha256(status_path)
 
     if not status_path.exists():
         errors.append(f"status artifact missing: {_rel(status_path)}")
@@ -316,80 +318,68 @@ def main(argv: list[str] | None = None) -> int:
                     )
 
             diagnostics = status_obj.get("diagnostics")
-            gates_stubbed_value = (
-                diagnostics.get("gates_stubbed")
-                if isinstance(diagnostics, dict)
-                else None
-            )
+            if not isinstance(diagnostics, dict):
+                diagnostics = {}
 
-            if gates_stubbed_value is not False:
+            gates_stubbed = diagnostics.get("gates_stubbed")
+            if gates_stubbed is not False:
                 errors.append(
                     "release-grade gate-mode requires diagnostics.gates_stubbed=false; "
-                    f"found {gates_stubbed_value!r}. "
-                    "stubbed status evidence must not be treated as release-grade evidence."
+                    f"found {gates_stubbed!r}."
                 )
+                errors.append("release-grade gate-mode rejects stubbed status evidence.")
 
-            scaffold_value = (
-                diagnostics.get("scaffold")
-                if isinstance(diagnostics, dict)
-                else None
-            )
-
-            if scaffold_value is True:
+            scaffold = diagnostics.get("scaffold")
+            if scaffold is True:
                 errors.append(
                     "release-grade gate-mode requires diagnostics.scaffold!=true; "
-                    "scaffold status evidence must not be treated as release-grade evidence."
+                    f"found {scaffold!r}."
                 )
+                errors.append("release-grade gate-mode rejects scaffold status evidence.")
 
-            stub_profile_present = (
-                isinstance(diagnostics, dict)
-                and "stub_profile" in diagnostics
-            )
-            stub_profile_value = (
-                diagnostics.get("stub_profile")
-                if isinstance(diagnostics, dict)
-                else None
-            )
-
-            if stub_profile_present:
+            if "stub_profile" in diagnostics:
                 errors.append(
                     "release-grade gate-mode requires diagnostics.stub_profile to be absent; "
-                    f"found {stub_profile_value!r}. "
-                    "stub-profiled status evidence must not be treated as release-grade evidence."
+                    f"found {diagnostics.get('stub_profile')!r}."
+                )
+                errors.append(
+                    "release-grade gate-mode rejects stub-profiled status evidence."
                 )
 
     materialized_gate_sets: dict[str, list[str]] = {}
+    effective_required_gates: list[str] = []
 
     if not errors:
         if args.gate_mode == "core":
-            core_required, cmd = _materialize_gate_set("core_required")
-            commands.append(cmd)
+            core_gates, materialize_result = _materialize_gate_set("core_required")
+            commands.append(materialize_result)
 
-            materialized_gate_sets["core_required"] = core_required
-            required_gates = core_required
-
-            if not required_gates:
-                errors.append("core_required materialized to an empty gate set")
-
+            if materialize_result["returncode"] != 0:
+                errors.append("failed to materialize core_required gate set")
+            else:
+                materialized_gate_sets["core_required"] = core_gates
+                effective_required_gates = core_gates
         else:
-            required, cmd_required = _materialize_gate_set("required")
-            release_required, cmd_release = _materialize_gate_set("release_required")
+            required_gates, required_result = _materialize_gate_set("required")
+            release_gates, release_result = _materialize_gate_set("release_required")
+            commands.extend([required_result, release_result])
 
-            commands.append(cmd_required)
-            commands.append(cmd_release)
+            if required_result["returncode"] != 0:
+                errors.append("failed to materialize required gate set")
+            if release_result["returncode"] != 0:
+                errors.append("failed to materialize release_required gate set")
 
-            materialized_gate_sets["required"] = required
-            materialized_gate_sets["release_required"] = release_required
+            if not errors:
+                materialized_gate_sets["required"] = required_gates
+                materialized_gate_sets["release_required"] = release_gates
+                effective_required_gates = _unique_preserve_order(
+                    [*required_gates, *release_gates]
+                )
 
-            required_gates = _unique_preserve_order(required + release_required)
-
-            if not required:
-                errors.append("required materialized to an empty gate set")
-            if not release_required:
-                errors.append("release_required materialized to an empty gate set")
-
-    else:
-        required_gates = []
+    if not errors and args.status_source == "existing":
+        warnings.append(
+            "status-source=existing was selected; generation step was skipped by design."
+        )
 
     if not errors:
         commands.append(
@@ -399,8 +389,8 @@ def main(argv: list[str] | None = None) -> int:
                     str(CHECK_GATES),
                     "--status",
                     str(status_path),
-                    "--require",
-                    *required_gates,
+                    "--required",
+                    *effective_required_gates,
                 ],
                 name=f"check_gates_{args.gate_mode}",
             )
@@ -415,64 +405,41 @@ def main(argv: list[str] | None = None) -> int:
                 [
                     sys.executable,
                     str(SHADOW_REGISTRY_CHECKER),
-                    "--input",
+                    "--registry",
                     str(SHADOW_REGISTRY),
+                    "--gate-registry",
+                    str(GATE_REGISTRY),
+                    "--policy",
+                    str(GATE_POLICY),
                 ],
                 name="check_shadow_layer_registry",
             )
         )
 
         if commands[-1]["returncode"] != 0:
-            errors.append("shadow layer registry validation failed")
-
-    if not errors and args.include_tests:
-        test_targets = [
-            "tests/test_check_shadow_layer_registry.py",
-            "tests/test_check_epf_shadow_run_manifest_contract.py",
-            "tests/test_check_epf_paradox_summary_contract.py",
-        ]
-
-        commands.append(
-            _run_command(
-                [sys.executable, "-m", "pytest", "-q", *test_targets],
-                name="pytest_handoff_regressions",
-            )
-        )
-
-        if commands[-1]["returncode"] != 0:
-            errors.append("handoff regression pytest targets failed")
-
-    if args.status_source == "existing" and not status_source["status_exists_before_run"]:
-        warnings.append(
-            "status-source=existing was selected, but the status artifact did not "
-            "exist before this smoke run."
-        )
+            errors.append("shadow layer registry check failed")
 
     status_source["status_exists_after_run"] = status_path.exists()
+    status_source["status_sha256_after_run"] = _sha256(status_path)
 
-    report = {
-        "ok": len(errors) == 0,
-        "created_utc": _utc_now(),
-        "repo_root": str(REPO_ROOT),
+    payload: dict[str, Any] = {
+        "ok": not errors,
+        "generated_utc": _utc_now(),
         "gate_mode": args.gate_mode,
         "status_source": status_source,
         "materialized_gate_sets": materialized_gate_sets,
-        "effective_required_gates": required_gates,
-        "files": _file_inventory(required_files + [status_path]),
+        "effective_required_gates": effective_required_gates,
+        "required_files": _file_inventory(required_files),
+        "status_file_inventory": _file_inventory([status_path]),
         "commands": commands,
         "warnings": warnings,
         "errors": errors,
     }
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_text(
-        json.dumps(report, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    out_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
-    print(json.dumps(report, indent=2, sort_keys=True))
-
-    return 0 if report["ok"] else 1
+    return 0 if not errors else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Records status artifact SHA-256 values in the operator handoff report.

## Scope

Updates:

- `tools/operator_handoff_smoke.py`
- `tests/test_operator_handoff_smoke.py`

## Purpose

This strengthens the PULSE-REF RA0 operator handoff audit surface.

The `status_source` block now records:

- `status_sha256_before_run`
- `status_sha256_after_generation`
- `status_sha256_after_run`

This binds the handoff report to the exact status artifact content used during reconstruction.

The regression coverage verifies:

- generated Core status starts with no digest and gains one after generation;
- missing existing status has no digest;
- positive release-grade existing status keeps the same digest before generation, after generation, and after run.

## Authority boundary

This PR does not change release authority.

It improves operator handoff report traceability only.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow, release-decision engine, ledger, manifest, dashboard, schema, or audit-bundle behavior is changed.