### PR TITLE
feat(pulse-ref): add RA1 materialized gate sets schema

### DIFF
--- a/schemas/pulse_ref_materialized_gate_sets_v0.schema.json
+++ b/schemas/pulse_ref_materialized_gate_sets_v0.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulse-ref.local/schemas/pulse_ref_materialized_gate_sets_v0.schema.json",
+  "title": "PULSE-REF Materialized Gate Sets v0",
+  "type": "object",
+  "required": [
+    "schema",
+    "policy_path",
+    "policy_sha256",
+    "sets",
+    "effective_required_gates",
+    "authority_boundary"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema": {
+      "const": "pulse_ref_materialized_gate_sets_v0"
+    },
+    "policy_path": {
+      "$ref": "#/$defs/relative_path"
+    },
+    "policy_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "sets": {
+      "type": "object",
+      "required": [
+        "required",
+        "release_required"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "required": {
+          "$ref": "#/$defs/gate_id_array"
+        },
+        "release_required": {
+          "$ref": "#/$defs/gate_id_array"
+        }
+      }
+    },
+    "effective_required_gates": {
+      "$ref": "#/$defs/gate_id_array"
+    },
+    "authority_boundary": {
+      "type": "object",
+      "required": [
+        "source",
+        "materialization_role",
+        "creates_release_authority"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "const": "declared_gate_policy"
+        },
+        "materialization_role": {
+          "const": "required_gate_set_reconstruction"
+        },
+        "creates_release_authority": {
+          "const": false
+        }
+      }
+    }
+  },
+  "$defs": {
+    "relative_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*\\\\)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "gate_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$"
+    },
+    "gate_id_array": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/gate_id"
+      },
+      "uniqueItems": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the PULSE-REF RA1 materialized gate sets schema.

## Scope

Adds:

- `schemas/pulse_ref_materialized_gate_sets_v0.schema.json`

## Purpose

RA1 defines an externally verifiable release-reference package.

This PR adds the machine-readable schema for the package artifact:

`gates/materialized_gate_sets.json`

The schema records:

- declared gate policy path;
- declared gate policy SHA-256;
- materialized `required` gate set;
- materialized `release_required` gate set;
- effective required gate set;
- authority-boundary metadata.

This supports external reconstruction of the declared-policy gate materialization step.

## Authority boundary

This PR does not create release authority.

The materialized gate sets record is a reconstruction artifact. It preserves the output of declared policy gate-set materialization, but it does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff, or CI behavior is changed.