### PR TITLE
fix(pulse-ref): require non-empty RA1 materialized gate sets

### DIFF
--- a/schemas/pulse_ref_materialized_gate_sets_v0.schema.json
+++ b/schemas/pulse_ref_materialized_gate_sets_v0.schema.json
@@ -79,6 +79,7 @@
     },
     "gate_id_array": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "$ref": "#/$defs/gate_id"
       },


### PR DESCRIPTION
## Summary

Requires non-empty gate arrays in the PULSE-REF RA1 materialized gate sets schema.

## Scope

Updates:

- `schemas/pulse_ref_materialized_gate_sets_v0.schema.json`

## Purpose

The RA1 materialized gate sets artifact represents declared-policy gate-set materialization for release-reference packages.

An empty materialized gate set must not validate as a release-grade reconstruction artifact.

This PR adds `minItems: 1` to the shared `gate_id_array` definition, which applies to:

- `sets.required`
- `sets.release_required`
- `effective_required_gates`

This aligns the schema with fail-closed release-grade semantics: empty required gate materialization is invalid and must not mask gate-materialization regressions.

## Authority boundary

This PR does not create release authority.

The materialized gate sets artifact remains a reconstruction artifact for the declared-policy release path.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff, or CI behavior is changed.