### PR TITLE
fix(pulse-ref): align RA1 CI outcome schema  contract

### DIFF
--- a/schemas/pulse_ref_ci_outcome_v0.schema.json
+++ b/schemas/pulse_ref_ci_outcome_v0.schema.json
@@ -8,6 +8,7 @@
     "provider",
     "workflow",
     "run_id",
+    "run_attempt",
     "run_url",
     "commit_sha",
     "gate_check_job",
@@ -31,6 +32,10 @@
       "minLength": 1,
       "pattern": "^[0-9]+$"
     },
+    "run_attempt": {
+      "type": "integer",
+      "minimum": 1
+    },
     "run_url": {
       "type": "string",
       "minLength": 1,
@@ -43,10 +48,6 @@
     },
     "commit_sha": {
       "$ref": "#/$defs/git_sha"
-    },
-    "run_attempt": {
-      "type": "integer",
-      "minimum": 1
     },
     "gate_check_job": {
       "$ref": "#/$defs/non_empty_string"
@@ -100,13 +101,15 @@
     "github_conclusion": {
       "type": "string",
       "enum": [
-        "success",
+        "action_required",
+        "cancelled",
         "failure",
         "neutral",
-        "cancelled",
         "skipped",
-        "timed_out",
-        "action_required"
+        "stale",
+        "startup_failure",
+        "success",
+        "timed_out"
       ]
     }
   }


### PR DESCRIPTION
## Summary

Adds executable smoke coverage for the PULSE-REF RA1 CI outcome schema and aligns the schema with the intended RA1 CI outcome contract.

## Scope

Updates:

- `schemas/pulse_ref_ci_outcome_v0.schema.json`
- `tests/test_pulse_ref_ci_outcome_schema_v0.py`
- `ci/tools-tests.list`

## Purpose

The RA1 CI outcome artifact records the CI-recorded end of the declared-policy release path.

This PR adds smoke coverage for the CI outcome schema and ensures the schema matches the tested contract.

The schema now requires:

- `run_attempt`, so rerun outcomes can be disambiguated during external reconstruction.

The schema also accepts terminal GitHub conclusion values including:

- `stale`
- `startup_failure`

The smoke test covers:

- valid CI outcome artifact;
- required `run_attempt`;
- positive `run_attempt` values;
- fixed provider;
- fixed schema identity;
- GitHub Actions run URL shape;
- repository shape;
- commit SHA shape;
- accepted terminal GitHub conclusion values;
- rejection of unknown conclusion values;
- required `created_utc`;
- additional-property rejection;
- authority-boundary invariants.

The test is registered in `ci/tools-tests.list` so it runs in the tools smoke suite.

## Authority boundary

This PR does not create release authority.

The CI outcome artifact preserves the CI-recorded result of declared-policy enforcement. It does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff, or CI behavior is changed beyond schema contract alignment and smoke coverage.