### PR TITLE
feat(pulse-ref): add RA1 package digests schema

### DIFF
--- a/schemas/pulse_ref_package_digests_v0.schema.json
+++ b/schemas/pulse_ref_package_digests_v0.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulse-ref.local/schemas/pulse_ref_package_digests_v0.schema.json",
+  "title": "PULSE-REF Package Digests v0",
+  "type": "object",
+  "required": [
+    "schema",
+    "algorithm",
+    "artifacts",
+    "authority_boundary"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema": {
+      "const": "pulse_ref_package_digests_v0"
+    },
+    "algorithm": {
+      "const": "sha256"
+    },
+    "created_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "package_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifacts": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "$ref": "#/$defs/relative_path"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/sha256"
+      }
+    },
+    "authority_boundary": {
+      "type": "object",
+      "required": [
+        "digest_role",
+        "creates_release_authority"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "digest_role": {
+          "const": "artifact_integrity_verification"
+        },
+        "creates_release_authority": {
+          "const": false
+        }
+      }
+    }
+  },
+  "$defs": {
+    "relative_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*\\\\)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the PULSE-REF RA1 package digests schema.

## Scope

Adds:

- `schemas/pulse_ref_package_digests_v0.schema.json`

## Purpose

RA1 defines an externally verifiable release-reference package.

This PR adds the machine-readable schema for the package artifact:

`digests/package_digests.json`

The schema records:

- fixed schema identity;
- fixed digest algorithm: `sha256`;
- optional package identity metadata;
- safe relative artifact path to SHA-256 digest bindings;
- authority-boundary metadata.

The `artifacts` field is an object map from package-relative artifact paths to SHA-256 digests. This supports deterministic external verification of package contents.

## Authority boundary

This PR does not create release authority.

The package digests artifact supports artifact integrity verification. It does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff, or CI behavior is changed.