### PR TITLE
feat(pulse-ref): add RA1 operator handoff report schema

### DIFF
--- a/schemas/pulse_ref_operator_handoff_report_v0.schema.json
+++ b/schemas/pulse_ref_operator_handoff_report_v0.schema.json
@@ -17,6 +17,38 @@
     "errors"
   ],
   "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "materialized_gate_sets": {
+            "type": "object",
+            "maxProperties": 0
+          }
+        },
+        "required": [
+          "materialized_gate_sets"
+        ]
+      },
+      "then": {
+        "properties": {
+          "ok": {
+            "const": false
+          },
+          "effective_required_gates": {
+            "$ref": "#/$defs/gate_id_array_empty"
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "effective_required_gates": {
+            "$ref": "#/$defs/gate_id_array_non_empty"
+          }
+        }
+      }
+    }
+  ],
   "properties": {
     "schema": {
       "const": "pulse_ref_operator_handoff_report_v0"
@@ -81,23 +113,10 @@
       }
     },
     "materialized_gate_sets": {
-      "type": "object",
-      "required": [
-        "required",
-        "release_required"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "required": {
-          "$ref": "#/$defs/gate_id_array"
-        },
-        "release_required": {
-          "$ref": "#/$defs/gate_id_array"
-        }
-      }
+      "$ref": "#/$defs/materialized_gate_sets"
     },
     "effective_required_gates": {
-      "$ref": "#/$defs/gate_id_array"
+      "$ref": "#/$defs/gate_id_array_any"
     },
     "files": {
       "type": "array",
@@ -164,13 +183,48 @@
       "minLength": 1,
       "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$"
     },
-    "gate_id_array": {
+    "gate_id_array_any": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/gate_id"
+      },
+      "uniqueItems": true
+    },
+    "gate_id_array_empty": {
+      "type": "array",
+      "maxItems": 0
+    },
+    "gate_id_array_non_empty": {
       "type": "array",
       "minItems": 1,
       "items": {
         "$ref": "#/$defs/gate_id"
       },
       "uniqueItems": true
+    },
+    "materialized_gate_sets": {
+      "oneOf": [
+        {
+          "type": "object",
+          "maxProperties": 0
+        },
+        {
+          "type": "object",
+          "required": [
+            "required",
+            "release_required"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "required": {
+              "$ref": "#/$defs/gate_id_array_non_empty"
+            },
+            "release_required": {
+              "$ref": "#/$defs/gate_id_array_non_empty"
+            }
+          }
+        }
+      ]
     },
     "file_inventory_entry": {
       "type": "object",

--- a/schemas/pulse_ref_operator_handoff_report_v0.schema.json
+++ b/schemas/pulse_ref_operator_handoff_report_v0.schema.json
@@ -1,0 +1,249 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulse-ref.local/schemas/pulse_ref_operator_handoff_report_v0.schema.json",
+  "title": "PULSE-REF Operator Handoff Report v0",
+  "type": "object",
+  "required": [
+    "ok",
+    "created_utc",
+    "repo_root",
+    "gate_mode",
+    "status_source",
+    "materialized_gate_sets",
+    "effective_required_gates",
+    "files",
+    "commands",
+    "warnings",
+    "errors"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema": {
+      "const": "pulse_ref_operator_handoff_report_v0"
+    },
+    "ok": {
+      "type": "boolean"
+    },
+    "created_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "repo_root": {
+      "$ref": "#/$defs/non_empty_string"
+    },
+    "gate_mode": {
+      "const": "release-grade"
+    },
+    "status_source": {
+      "type": "object",
+      "required": [
+        "mode",
+        "status_path",
+        "status_exists_before_run",
+        "status_sha256_before_run",
+        "status_exists_after_generation",
+        "status_sha256_after_generation",
+        "status_exists_after_run",
+        "status_sha256_after_run"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "const": "existing"
+        },
+        "status_path": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "status_exists_before_run": {
+          "type": "boolean"
+        },
+        "status_sha256_before_run": {
+          "$ref": "#/$defs/nullable_sha256"
+        },
+        "generated_artifact_dir": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "generated_status_path": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "status_exists_after_generation": {
+          "type": "boolean"
+        },
+        "status_sha256_after_generation": {
+          "$ref": "#/$defs/nullable_sha256"
+        },
+        "status_exists_after_run": {
+          "type": "boolean"
+        },
+        "status_sha256_after_run": {
+          "$ref": "#/$defs/nullable_sha256"
+        }
+      }
+    },
+    "materialized_gate_sets": {
+      "type": "object",
+      "required": [
+        "required",
+        "release_required"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "required": {
+          "$ref": "#/$defs/gate_id_array"
+        },
+        "release_required": {
+          "$ref": "#/$defs/gate_id_array"
+        }
+      }
+    },
+    "effective_required_gates": {
+      "$ref": "#/$defs/gate_id_array"
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/file_inventory_entry"
+      }
+    },
+    "commands": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/command_record"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "authority_boundary": {
+      "type": "object",
+      "required": [
+        "handoff_role",
+        "creates_release_authority"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "handoff_role": {
+          "const": "release_grade_reconstruction"
+        },
+        "creates_release_authority": {
+          "const": false
+        }
+      }
+    }
+  },
+  "$defs": {
+    "non_empty_string": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "nullable_sha256": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/sha256"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "gate_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]*$"
+    },
+    "gate_id_array": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/gate_id"
+      },
+      "uniqueItems": true
+    },
+    "file_inventory_entry": {
+      "type": "object",
+      "required": [
+        "path",
+        "exists",
+        "sha256"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "exists": {
+          "type": "boolean"
+        },
+        "sha256": {
+          "$ref": "#/$defs/nullable_sha256"
+        }
+      }
+    },
+    "command_record": {
+      "type": "object",
+      "required": [
+        "name",
+        "cmd",
+        "env_overrides",
+        "started_utc",
+        "finished_utc",
+        "returncode",
+        "stdout",
+        "stderr",
+        "ok"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "cmd": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "env_overrides": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "started_utc": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "finished_utc": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "returncode": {
+          "type": "integer"
+        },
+        "stdout": {
+          "type": "string"
+        },
+        "stderr": {
+          "type": "string"
+        },
+        "ok": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the PULSE-REF RA1 operator handoff report schema.

## Scope

Adds:

- `schemas/pulse_ref_operator_handoff_report_v0.schema.json`

## Purpose

RA1 defines an externally verifiable release-reference package.

This PR adds the machine-readable schema for the package artifact:

`handoff/operator_handoff_report.json`

The schema records:

- release-grade handoff mode;
- existing status source;
- status artifact digest traceability;
- materialized `required` and `release_required` gate sets;
- effective required gate set;
- command records;
- file inventory;
- warnings and errors;
- optional authority-boundary metadata.

This supports external reconstruction of the release-grade operator handoff path.

## Authority boundary

This PR does not create release authority.

The operator handoff report is a reconstruction and verification artifact. It does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff, or CI behavior is changed.