### PR TITLE
feat(pulse-ref): add RA1 publication snapshot schema

### DIFF
--- a/schemas/pulse_ref_publication_snapshot_v0.schema.json
+++ b/schemas/pulse_ref_publication_snapshot_v0.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulse-ref.local/schemas/pulse_ref_publication_snapshot_v0.schema.json",
+  "title": "PULSE-REF Publication Snapshot v0",
+  "type": "object",
+  "required": [
+    "schema",
+    "snapshot_created_utc",
+    "quality_ledger_url",
+    "status_json_url",
+    "release_authority_manifest_url",
+    "audit_bundle_url",
+    "creates_release_authority"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema": {
+      "const": "pulse_ref_publication_snapshot_v0"
+    },
+    "snapshot_created_utc": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "package_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "run_key": {
+      "type": "string",
+      "minLength": 1
+    },
+    "git_sha": {
+      "$ref": "#/$defs/git_sha"
+    },
+    "quality_ledger_url": {
+      "$ref": "#/$defs/https_url"
+    },
+    "status_json_url": {
+      "$ref": "#/$defs/https_url"
+    },
+    "release_authority_manifest_url": {
+      "$ref": "#/$defs/https_url"
+    },
+    "audit_bundle_url": {
+      "$ref": "#/$defs/https_url"
+    },
+    "operator_handoff_report_url": {
+      "$ref": "#/$defs/https_url"
+    },
+    "ci_outcome_url": {
+      "$ref": "#/$defs/https_url"
+    },
+    "package_manifest_url": {
+      "$ref": "#/$defs/https_url"
+    },
+    "package_digests_url": {
+      "$ref": "#/$defs/https_url"
+    },
+    "publication_surface": {
+      "type": "string",
+      "minLength": 1
+    },
+    "creates_release_authority": {
+      "const": false
+    }
+  },
+  "$defs": {
+    "https_url": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^https://"
+    },
+    "git_sha": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the PULSE-REF RA1 publication snapshot schema.

## Scope

Adds:

- `schemas/pulse_ref_publication_snapshot_v0.schema.json`

## Purpose

RA1 defines an externally verifiable release-reference package.

This PR adds the machine-readable schema for the package artifact:

`publication/publication_snapshot.json`

The schema records publication-surface URLs for:

- Quality Ledger;
- `status.json`;
- release authority manifest;
- audit bundle;
- optional operator handoff report;
- optional CI outcome;
- optional package manifest;
- optional package digests.

This supports external verification that publication surfaces refer to the same release-reference run artifacts.

## Authority boundary

This PR does not create release authority.

The publication snapshot exposes and preserves release state. It does not authorize release independently.

The schema requires:

`creates_release_authority=false`

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff, or CI behavior is changed.