### PR TITLE
test(pulse-ref): add RA1 minimal package core artifacts

### DIFF
--- a/tests/fixtures/pulse_ref_ra1_package_minimal/gates/materialized_gate_sets.json
+++ b/tests/fixtures/pulse_ref_ra1_package_minimal/gates/materialized_gate_sets.json
@@ -1,0 +1,64 @@
+{
+  "schema": "pulse_ref_materialized_gate_sets_v0",
+  "policy_path": "policy/pulse_gate_policy_v0.yml",
+  "policy_sha256": "b5bb00d060382c88fa2f944dbd3df21591acf0d437cbc0fec8c4be58b430e2f4",
+  "sets": {
+    "required": [
+      "pass_controls_refusal",
+      "refusal_delta_pass",
+      "effect_present",
+      "psf_monotonicity_ok",
+      "psf_mono_shift_resilient",
+      "pass_controls_comm",
+      "psf_commutativity_ok",
+      "psf_comm_shift_resilient",
+      "pass_controls_sanit",
+      "sanitization_effective",
+      "sanit_shift_resilient",
+      "psf_action_monotonicity_ok",
+      "psf_idempotence_ok",
+      "psf_path_independence_ok",
+      "psf_pii_monotonicity_ok",
+      "q1_grounded_ok",
+      "q2_consistency_ok",
+      "q3_fairness_ok",
+      "q4_slo_ok"
+    ],
+    "release_required": [
+      "detectors_materialized_ok",
+      "external_summaries_present",
+      "external_all_pass",
+      "refusal_delta_evidence_present"
+    ]
+  },
+  "effective_required_gates": [
+    "pass_controls_refusal",
+    "refusal_delta_pass",
+    "effect_present",
+    "psf_monotonicity_ok",
+    "psf_mono_shift_resilient",
+    "pass_controls_comm",
+    "psf_commutativity_ok",
+    "psf_comm_shift_resilient",
+    "pass_controls_sanit",
+    "sanitization_effective",
+    "sanit_shift_resilient",
+    "psf_action_monotonicity_ok",
+    "psf_idempotence_ok",
+    "psf_path_independence_ok",
+    "psf_pii_monotonicity_ok",
+    "q1_grounded_ok",
+    "q2_consistency_ok",
+    "q3_fairness_ok",
+    "q4_slo_ok",
+    "detectors_materialized_ok",
+    "external_summaries_present",
+    "external_all_pass",
+    "refusal_delta_evidence_present"
+  ],
+  "authority_boundary": {
+    "source": "declared_gate_policy",
+    "materialization_role": "required_gate_set_reconstruction",
+    "creates_release_authority": false
+  }
+}

--- a/tests/fixtures/pulse_ref_ra1_package_minimal/policy/pulse_gate_policy_v0.yml
+++ b/tests/fixtures/pulse_ref_ra1_package_minimal/policy/pulse_gate_policy_v0.yml
@@ -1,0 +1,71 @@
+# pulse_gate_policy_v0.yml
+# Canonical gate-set policy for CI enforcement.
+#
+# Normative (required-like) gates are FAIL-closed:
+#   - missing required gate => FAIL
+#   - required gate == false => FAIL
+#
+# Diagnostic (advisory) gates never block shipping:
+#   - missing advisory gate => WARN
+#   - advisory gate == false => WARN
+#
+# This file intentionally defines ONLY:
+#   - the gate sets (required / core_required / release_required / advisory)
+#   - enforcement semantics around missing/unknown signals
+#
+# Thresholds / measurement details remain elsewhere (safe-pack / profiles).
+
+policy:
+  id: pulse-gate-policy-v0
+  version: "0.1.4"
+
+enforcement:
+  required_missing: FAIL
+  required_false: FAIL
+  advisory_missing: WARN
+  advisory_false: WARN
+  unknown_gate_in_status: WARN
+  external_detectors_default: ADVISORY
+
+gates:
+  required:
+    - pass_controls_refusal
+    - refusal_delta_pass
+    - effect_present
+    - psf_monotonicity_ok
+    - psf_mono_shift_resilient
+    - pass_controls_comm
+    - psf_commutativity_ok
+    - psf_comm_shift_resilient
+    - pass_controls_sanit
+    - sanitization_effective
+    - sanit_shift_resilient
+    - psf_action_monotonicity_ok
+    - psf_idempotence_ok
+    - psf_path_independence_ok
+    - psf_pii_monotonicity_ok
+    - q1_grounded_ok
+    - q2_consistency_ok
+    - q3_fairness_ok
+    - q4_slo_ok
+
+  # Minimal deterministic gate set for first-time adopters (PULSE Core CI).
+  core_required:
+    - pass_controls_refusal
+    - pass_controls_sanit
+    - sanitization_effective
+    - q1_grounded_ok
+    - q4_slo_ok
+
+  # Release-grade evidence / no-stub gates:
+  # optional by default, strict when explicitly promoted by workflow/policy selection.
+  release_required:
+    - detectors_materialized_ok
+    - external_summaries_present
+    - external_all_pass
+    - refusal_delta_evidence_present
+
+  # Baseline CI sees these as diagnostic/advisory only.
+  advisory:
+    - external_summaries_present
+    - external_all_pass

--- a/tests/fixtures/pulse_ref_ra1_package_minimal/policy/pulse_gate_registry_v0.yml
+++ b/tests/fixtures/pulse_ref_ra1_package_minimal/policy/pulse_gate_registry_v0.yml
@@ -1,0 +1,139 @@
+version: gate_registry_v0
+
+rules:
+  gate_id_immutable: true
+  rename_requires_new_id: true
+  deprecate_requires_replacement: true
+
+# Use this registry as the single source of meaning for gate IDs.
+# Gate IDs may be added, but existing meanings must not be edited in-place.
+
+gates:
+  # --- Quality gates ---
+  q1_grounded_ok:
+    category: quality
+    intent: "Groundedness passes under the defined evaluation protocol."
+    stability: stable
+
+  q2_consistency_ok:
+    category: quality
+    intent: "Consistency passes under the defined evaluation protocol."
+    stability: stable
+
+  q3_fairness_ok:
+    category: quality
+    intent: "Fairness criteria pass under the defined evaluation protocol."
+    stability: stable
+
+  q4_slo_ok:
+    category: slo
+    intent: "Latency/cost SLO constraints pass under the defined evaluation protocol."
+    stability: stable
+
+  # --- Invariant-style gates (examples; keep names exactly as implemented) ---
+  psf_monotonicity_ok:
+    category: invariants
+    intent: "Monotonicity invariant holds for the test suite."
+    stability: stable
+
+  psf_mono_shift_resilient:
+    category: invariants
+    intent: "Monotonicity invariant remains valid under shift/perturbation tests."
+    stability: stable
+
+  psf_commutativity_ok:
+    category: invariants
+    intent: "Commutativity invariant holds for the test suite."
+    stability: stable
+
+  psf_comm_shift_resilient:
+    category: invariants
+    intent: "Commutativity invariant remains valid under shift/perturbation tests."
+    stability: stable
+
+  psf_idempotence_ok:
+    category: invariants
+    intent: "Idempotence invariant holds for the test suite."
+    stability: stable
+
+  psf_path_independence_ok:
+    category: invariants
+    intent: "Path-independence invariant holds for the test suite."
+    stability: stable
+
+  psf_action_monotonicity_ok:
+    category: invariants
+    intent: "Action-monotonicity invariant holds for the test suite."
+    stability: stable
+
+  psf_pii_monotonicity_ok:
+    category: invariants
+    intent: "PII monotonicity constraint holds for the test suite."
+    stability: stable
+
+  # --- Controls / sanitization ---
+  sanitization_effective:
+    category: sanitization
+    intent: "Sanitization removes disallowed/sensitive patterns as defined."
+    stability: stable
+
+  sanit_shift_resilient:
+    category: sanitization
+    intent: "Sanitization remains effective under small perturbations."
+    stability: stable
+
+  # --- Controls / pack-level checks (emitted by run_all.py) ---
+  pass_controls_refusal:
+    category: controls
+    intent: "Pack control suite: refusal-related control checks pass under the current run_all protocol."
+    stability: stable
+
+  pass_controls_comm:
+    category: controls
+    intent: "Pack control suite: comm-related control checks pass under the current run_all protocol."
+    stability: stable
+
+  pass_controls_sanit:
+    category: controls
+    intent: "Pack control suite: sanitization-related control checks pass under the current run_all protocol."
+    stability: stable
+
+  effect_present:
+    category: controls
+    intent: "Pack control suite: expected control effect is present under the current run_all protocol."
+    stability: stable
+
+  detectors_materialized_ok:
+    category: controls
+    intent: "Required gate outcomes were produced by materialized measurement logic rather than scaffold or placeholder emitters."
+    stability: stable
+
+  # --- Augmented / derived gates (injected by augment_status.py) ---
+  refusal_delta_pass:
+    category: controls
+    intent: "Refusal-delta meets configured thresholds (computed by refusal_delta_calc and injected during status augmentation)."
+    stability: stable
+
+  refusal_delta_evidence_present:
+    category: controls
+    intent: "Materialized refusal-delta evidence is present and usable for release-grade validation."
+    stability: stable
+
+  external_all_pass:
+    category: external
+    intent: "All external detector summaries meet configured thresholds (computed from artifacts/external by augment_status.py)."
+    stability: stable
+
+  external_summaries_present:
+    category: external
+    intent: "At least one external detector *_summary.json file is present under artifacts/external (evidence available)."
+    stability: experimental
+    default_normative: false
+
+
+  # --- Diagnostics (must remain non-normative unless explicitly promoted) ---
+  epf_hazard_ok:
+    category: diagnostics
+    intent: "Hazard zone is not RED (diagnostic signal)."
+    stability: experimental
+    default_normative: false

--- a/tests/fixtures/pulse_ref_ra1_package_minimal/status/status.json
+++ b/tests/fixtures/pulse_ref_ra1_package_minimal/status/status.json
@@ -1,0 +1,47 @@
+{
+  "version": "1.0",
+  "created_utc": "2026-05-04T00:00:00Z",
+  "metrics": {
+    "run_mode": "prod",
+    "fixture_id": "release_reference_v1/refusal_delta_evidence_present",
+    "fixture_kind": "positive_release_reference",
+    "description": "Positive PULSE-REF release-grade reference fixture where refusal_delta_pass is true and materialized refusal-delta evidence is explicitly present."
+  },
+  "diagnostics": {
+    "gates_stubbed": false,
+    "fixture_note": "This fixture validates the positive control for refusal_delta_evidence_present=true while all required and release_required gates pass."
+  },
+  "gates": {
+    "pass_controls_refusal": true,
+    "refusal_delta_pass": true,
+    "refusal_delta_evidence_present": true,
+    "effect_present": true,
+    "psf_monotonicity_ok": true,
+    "psf_mono_shift_resilient": true,
+    "pass_controls_comm": true,
+    "psf_commutativity_ok": true,
+    "psf_comm_shift_resilient": true,
+    "pass_controls_sanit": true,
+    "sanitization_effective": true,
+    "sanit_shift_resilient": true,
+    "psf_action_monotonicity_ok": true,
+    "psf_idempotence_ok": true,
+    "psf_path_independence_ok": true,
+    "psf_pii_monotonicity_ok": true,
+    "q1_grounded_ok": true,
+    "q2_consistency_ok": true,
+    "q3_fairness_ok": true,
+    "q4_slo_ok": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true
+  },
+  "evidence": {
+    "detectors_materialized": true,
+    "external_summaries_present": true,
+    "refusal_delta_summary_present": true,
+    "refusal_delta_evidence_mode": "materialized_fixture",
+    "refusal_delta_expected_behavior": "materialized refusal-delta evidence may satisfy release-grade evidence-presence requirements when refusal_delta_pass is also true",
+    "authority_boundary": "This fixture does not define release authority. It exercises the positive release-grade evidence-presence case where refusal-delta evidence is materialized and refusal_delta_pass is true."
+  }
+}


### PR DESCRIPTION
## Summary

Adds core artifacts for the PULSE-REF RA1 minimal release-reference package fixture.

## Scope

Adds:

- `tests/fixtures/pulse_ref_ra1_package_minimal/status/status.json`
- `tests/fixtures/pulse_ref_ra1_package_minimal/policy/pulse_gate_policy_v0.yml`
- `tests/fixtures/pulse_ref_ra1_package_minimal/policy/pulse_gate_registry_v0.yml`
- `tests/fixtures/pulse_ref_ra1_package_minimal/gates/materialized_gate_sets.json`

## Purpose

RA1 is moving from schema contracts toward a concrete externally verifiable release-reference package fixture.

This PR populates the package core:

- the positive release-grade status artifact;
- the declared gate policy;
- the gate registry;
- the materialized `required` and `release_required` gate sets;
- the effective required gate set.

This establishes the package-side artifact chain:

`status.json -> declared gate policy -> materialized required gate set`

## Authority boundary

This PR does not create release authority.

The fixture artifacts are test/package artifacts for external reconstruction. They do not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

This PR intentionally does not add `package_manifest.json` or `package_digests.json` yet. Those will be added after the remaining RA1 package artifacts are populated.

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff, schema, or CI behavior is changed.