### PR TITLE
test(pulse-ref): add RA1 minimal package handoff artifact

### DIFF
--- a/tests/fixtures/pulse_ref_ra1_package_minimal/handoff/operator_handoff_report.json
+++ b/tests/fixtures/pulse_ref_ra1_package_minimal/handoff/operator_handoff_report.json
@@ -1,0 +1,176 @@
+{
+  "schema": "pulse_ref_operator_handoff_report_v0",
+  "ok": true,
+  "created_utc": "2026-05-09T00:00:00Z",
+  "repo_root": ".",
+  "gate_mode": "release-grade",
+  "status_source": {
+    "mode": "existing",
+    "status_path": "status/status.json",
+    "status_exists_before_run": true,
+    "status_sha256_before_run": "f691f35160927cf029028159b78a59be1655a8dad6aeece743a027043a0feb8b",
+    "status_exists_after_generation": true,
+    "status_sha256_after_generation": "f691f35160927cf029028159b78a59be1655a8dad6aeece743a027043a0feb8b",
+    "status_exists_after_run": true,
+    "status_sha256_after_run": "f691f35160927cf029028159b78a59be1655a8dad6aeece743a027043a0feb8b"
+  },
+  "materialized_gate_sets": {
+    "required": [
+      "pass_controls_refusal",
+      "refusal_delta_pass",
+      "effect_present",
+      "psf_monotonicity_ok",
+      "psf_mono_shift_resilient",
+      "pass_controls_comm",
+      "psf_commutativity_ok",
+      "psf_comm_shift_resilient",
+      "pass_controls_sanit",
+      "sanitization_effective",
+      "sanit_shift_resilient",
+      "psf_action_monotonicity_ok",
+      "psf_idempotence_ok",
+      "psf_path_independence_ok",
+      "psf_pii_monotonicity_ok",
+      "q1_grounded_ok",
+      "q2_consistency_ok",
+      "q3_fairness_ok",
+      "q4_slo_ok"
+    ],
+    "release_required": [
+      "detectors_materialized_ok",
+      "external_summaries_present",
+      "external_all_pass",
+      "refusal_delta_evidence_present"
+    ]
+  },
+  "effective_required_gates": [
+    "pass_controls_refusal",
+    "refusal_delta_pass",
+    "effect_present",
+    "psf_monotonicity_ok",
+    "psf_mono_shift_resilient",
+    "pass_controls_comm",
+    "psf_commutativity_ok",
+    "psf_comm_shift_resilient",
+    "pass_controls_sanit",
+    "sanitization_effective",
+    "sanit_shift_resilient",
+    "psf_action_monotonicity_ok",
+    "psf_idempotence_ok",
+    "psf_path_independence_ok",
+    "psf_pii_monotonicity_ok",
+    "q1_grounded_ok",
+    "q2_consistency_ok",
+    "q3_fairness_ok",
+    "q4_slo_ok",
+    "detectors_materialized_ok",
+    "external_summaries_present",
+    "external_all_pass",
+    "refusal_delta_evidence_present"
+  ],
+  "files": [
+    {
+      "path": "status/status.json",
+      "exists": true,
+      "sha256": "f691f35160927cf029028159b78a59be1655a8dad6aeece743a027043a0feb8b"
+    },
+    {
+      "path": "policy/pulse_gate_policy_v0.yml",
+      "exists": true,
+      "sha256": "b5bb00d060382c88fa2f944dbd3df21591acf0d437cbc0fec8c4be58b430e2f4"
+    },
+    {
+      "path": "gates/materialized_gate_sets.json",
+      "exists": true,
+      "sha256": "a8fe356f2a610d6cb2745fe7f7b5857c8c39969b55da3d9da4b6e2213c6eed9f"
+    }
+  ],
+  "commands": [
+    {
+      "name": "materialize_required",
+      "cmd": [
+        "python",
+        "tools/policy_to_require_args.py",
+        "--policy",
+        "policy/pulse_gate_policy_v0.yml",
+        "--set",
+        "required",
+        "--format",
+        "space"
+      ],
+      "env_overrides": {},
+      "started_utc": "2026-05-09T00:00:00Z",
+      "finished_utc": "2026-05-09T00:00:01Z",
+      "returncode": 0,
+      "stdout": "pass_controls_refusal refusal_delta_pass effect_present psf_monotonicity_ok psf_mono_shift_resilient pass_controls_comm psf_commutativity_ok psf_comm_shift_resilient pass_controls_sanit sanitization_effective sanit_shift_resilient psf_action_monotonicity_ok psf_idempotence_ok psf_path_independence_ok psf_pii_monotonicity_ok q1_grounded_ok q2_consistency_ok q3_fairness_ok q4_slo_ok\n",
+      "stderr": "",
+      "ok": true
+    },
+    {
+      "name": "materialize_release_required",
+      "cmd": [
+        "python",
+        "tools/policy_to_require_args.py",
+        "--policy",
+        "policy/pulse_gate_policy_v0.yml",
+        "--set",
+        "release_required",
+        "--format",
+        "space"
+      ],
+      "env_overrides": {},
+      "started_utc": "2026-05-09T00:00:01Z",
+      "finished_utc": "2026-05-09T00:00:02Z",
+      "returncode": 0,
+      "stdout": "detectors_materialized_ok external_summaries_present external_all_pass refusal_delta_evidence_present\n",
+      "stderr": "",
+      "ok": true
+    },
+    {
+      "name": "check_gates_release-grade",
+      "cmd": [
+        "python",
+        "PULSE_safe_pack_v0/tools/check_gates.py",
+        "--status",
+        "status/status.json",
+        "--require",
+        "pass_controls_refusal",
+        "refusal_delta_pass",
+        "effect_present",
+        "psf_monotonicity_ok",
+        "psf_mono_shift_resilient",
+        "pass_controls_comm",
+        "psf_commutativity_ok",
+        "psf_comm_shift_resilient",
+        "pass_controls_sanit",
+        "sanitization_effective",
+        "sanit_shift_resilient",
+        "psf_action_monotonicity_ok",
+        "psf_idempotence_ok",
+        "psf_path_independence_ok",
+        "psf_pii_monotonicity_ok",
+        "q1_grounded_ok",
+        "q2_consistency_ok",
+        "q3_fairness_ok",
+        "q4_slo_ok",
+        "detectors_materialized_ok",
+        "external_summaries_present",
+        "external_all_pass",
+        "refusal_delta_evidence_present"
+      ],
+      "env_overrides": {},
+      "started_utc": "2026-05-09T00:00:02Z",
+      "finished_utc": "2026-05-09T00:00:03Z",
+      "returncode": 0,
+      "stdout": "All required gates passed.\n",
+      "stderr": "",
+      "ok": true
+    }
+  ],
+  "warnings": [],
+  "errors": [],
+  "authority_boundary": {
+    "handoff_role": "release_grade_reconstruction",
+    "creates_release_authority": false
+  }
+}


### PR DESCRIPTION
## Summary

Adds the operator handoff report artifact for the PULSE-REF RA1 minimal release-reference package fixture.

## Scope

Adds:

- `tests/fixtures/pulse_ref_ra1_package_minimal/handoff/operator_handoff_report.json`

## Purpose

RA1 is moving from schema contracts toward a concrete externally verifiable release-reference package fixture.

This PR adds the package-side handoff reconstruction artifact:

`handoff/operator_handoff_report.json`

The handoff report records:

- `gate_mode=release-grade`;
- `status_source.mode=existing`;
- status artifact SHA-256 traceability;
- materialized `required` and `release_required` gate sets;
- effective required gate set;
- command records for policy materialization and strict gate checking;
- file inventory for core package artifacts;
- authority-boundary metadata.

This establishes the package-side reconstruction surface:

`status.json -> declared gate policy -> materialized required gate set -> strict gate checking`

## Authority boundary

This PR does not create release authority.

The operator handoff report is a reconstruction and verification artifact. It does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

This PR intentionally does not add `package_manifest.json` or `package_digests.json` yet. Those will be added after the remaining RA1 package artifacts are populated.

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, schema, or CI behavior is changed.