### PR TITLE
test(pulse-ref): add RA1 minimal package CI outcome artifact

### DIFF
--- a/tests/fixtures/pulse_ref_ra1_package_minimal/ci/ci_outcome.json
+++ b/tests/fixtures/pulse_ref_ra1_package_minimal/ci/ci_outcome.json
@@ -1,0 +1,20 @@
+{
+  "schema": "pulse_ref_ci_outcome_v0",
+  "provider": "github_actions",
+  "workflow": "PULSE CI",
+  "run_id": "22560000001",
+  "run_attempt": 1,
+  "run_url": "https://github.com/HKati/pulse-release-gates-0.1/actions/runs/22560000001",
+  "repository": "HKati/pulse-release-gates-0.1",
+  "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "gate_check_job": "Tools smoke tests",
+  "gate_check_conclusion": "success",
+  "created_utc": "2026-05-09T00:00:00Z",
+  "started_utc": "2026-05-09T00:00:00Z",
+  "completed_utc": "2026-05-09T00:00:03Z",
+  "authority_boundary": {
+    "normative_decision_path": "status.json -> declared gate policy -> materialized required gates -> strict gate checking -> CI outcome",
+    "ci_role": "records_declared_policy_enforcement",
+    "creates_release_authority": false
+  }
+}


### PR DESCRIPTION
## Summary

Adds the CI outcome artifact for the PULSE-REF RA1 minimal release-reference package fixture.

## Scope

Adds:

- `tests/fixtures/pulse_ref_ra1_package_minimal/ci/ci_outcome.json`

## Purpose

RA1 is moving from schema contracts toward a concrete externally verifiable release-reference package fixture.

This PR adds the package-side CI outcome artifact:

`ci/ci_outcome.json`

The CI outcome record captures:

- CI provider;
- workflow;
- run ID;
- run attempt;
- run URL;
- repository;
- commit SHA;
- gate-check job;
- gate-check conclusion;
- timestamps;
- authority-boundary metadata.

This extends the package-side release trail to:

`status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

## Authority boundary

This PR does not create release authority.

The CI outcome artifact preserves the CI-recorded result of declared-policy enforcement. It does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

This PR intentionally does not add `package_manifest.json` or `package_digests.json` yet. Those will be added after the remaining RA1 package artifacts are populated.

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, schema, or CI behavior is changed.