### PR TITLE
test(pulse-ref): add RA1 minimal package publication artifact

### DIFF
--- a/tests/fixtures/pulse_ref_ra1_package_minimal/publication/publication_snapshot.json
+++ b/tests/fixtures/pulse_ref_ra1_package_minimal/publication/publication_snapshot.json
@@ -1,0 +1,15 @@
+{
+  "schema": "pulse_ref_publication_snapshot_v0",
+  "snapshot_created_utc": "2026-05-09T00:00:00Z",
+  "package_id": "pulse-ref-ra1-minimal",
+  "run_key": "pulse-ref-ra1-minimal-fixture",
+  "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "quality_ledger_url": "https://hkati.github.io/pulse-release-gates-0.1/",
+  "status_json_url": "https://hkati.github.io/pulse-release-gates-0.1/status.json",
+  "release_authority_manifest_url": "https://hkati.github.io/pulse-release-gates-0.1/release_authority_manifest.json",
+  "audit_bundle_url": "https://hkati.github.io/pulse-release-gates-0.1/audit_bundle/",
+  "operator_handoff_report_url": "https://hkati.github.io/pulse-release-gates-0.1/operator_handoff_report.json",
+  "ci_outcome_url": "https://github.com/HKati/pulse-release-gates-0.1/actions/runs/22560000001",
+  "publication_surface": "github_pages_fixture",
+  "creates_release_authority": false
+}


### PR DESCRIPTION
## Summary

Adds the publication snapshot artifact for the PULSE-REF RA1 minimal release-reference package fixture.

## Scope

Adds:

- `tests/fixtures/pulse_ref_ra1_package_minimal/publication/publication_snapshot.json`

## Purpose

RA1 is moving from schema contracts toward a concrete externally verifiable release-reference package fixture.

This PR adds the package-side publication snapshot artifact:

`publication/publication_snapshot.json`

The publication snapshot records publication-surface references for:

- Quality Ledger;
- `status.json`;
- release authority manifest;
- audit bundle;
- operator handoff report;
- CI outcome.

The artifact explicitly declares:

`creates_release_authority=false`

This preserves the boundary that publication surfaces expose and preserve release state, but do not authorize release independently.

## Authority boundary

This PR does not create release authority.

The publication snapshot is an audit / publication / preservation artifact. It does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

This PR intentionally does not add `package_manifest.json` or `package_digests.json` yet. Those will be added after the remaining release-authority package artifact is populated.

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, schema, or CI behavior is changed.