### PR TITLE
test(pulse-ref): add RA1 minimal package release authority artifact

### DIFF
--- a/tests/fixtures/pulse_ref_ra1_package_minimal/release_authority/release_authority_manifest.json
+++ b/tests/fixtures/pulse_ref_ra1_package_minimal/release_authority/release_authority_manifest.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "release_authority_v0",
+  "created_utc": "2026-05-09T00:00:00Z",
+  "run_identity": {
+    "run_mode": "prod",
+    "workflow_name": "PULSE CI",
+    "event_name": "release_reference_fixture",
+    "ref": "refs/heads/main",
+    "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "run_id": "22560000001",
+    "attempt": 1,
+    "actor": "HKati"
+  },
+  "inputs": {
+    "status_json": {
+      "path": "status/status.json",
+      "sha256": "f691f35160927cf029028159b78a59be1655a8dad6aeece743a027043a0feb8b"
+    },
+    "gate_policy": {
+      "path": "policy/pulse_gate_policy_v0.yml",
+      "sha256": "b5bb00d060382c88fa2f944dbd3df21591acf0d437cbc0fec8c4be58b430e2f4",
+      "policy_id": "pulse-gate-policy-v0",
+      "version": "0.1.4"
+    },
+    "gate_registry": {
+      "path": "policy/pulse_gate_registry_v0.yml",
+      "sha256": "d5fef7e1eb9623102a2f5931f31eac87ea7a2ab3bc58a485a07be374bd4ef12d",
+      "version": "gate_registry_v0"
+    }
+  },
+  "authority": {
+    "policy_set": "required+release_required",
+    "effective_required_gates": [
+      "pass_controls_refusal",
+      "refusal_delta_pass",
+      "effect_present",
+      "psf_monotonicity_ok",
+      "psf_mono_shift_resilient",
+      "pass_controls_comm",
+      "psf_commutativity_ok",
+      "psf_comm_shift_resilient",
+      "pass_controls_sanit",
+      "sanitization_effective",
+      "sanit_shift_resilient",
+      "psf_action_monotonicity_ok",
+      "psf_idempotence_ok",
+      "psf_path_independence_ok",
+      "psf_pii_monotonicity_ok",
+      "q1_grounded_ok",
+      "q2_consistency_ok",
+      "q3_fairness_ok",
+      "q4_slo_ok",
+      "detectors_materialized_ok",
+      "external_summaries_present",
+      "external_all_pass",
+      "refusal_delta_evidence_present"
+    ],
+    "release_required_materialized": true,
+    "advisory_gates": [
+      "external_summaries_present",
+      "external_all_pass"
+    ]
+  },
+  "evaluation": {
+    "evaluator": "PULSE_safe_pack_v0/tools/check_gates.py",
+    "required_gate_results": {
+      "pass_controls_refusal": true,
+      "refusal_delta_pass": true,
+      "effect_present": true,
+      "psf_monotonicity_ok": true,
+      "psf_mono_shift_resilient": true,
+      "pass_controls_comm": true,
+      "psf_commutativity_ok": true,
+      "psf_comm_shift_resilient": true,
+      "pass_controls_sanit": true,
+      "sanitization_effective": true,
+      "sanit_shift_resilient": true,
+      "psf_action_monotonicity_ok": true,
+      "psf_idempotence_ok": true,
+      "psf_path_independence_ok": true,
+      "psf_pii_monotonicity_ok": true,
+      "q1_grounded_ok": true,
+      "q2_consistency_ok": true,
+      "q3_fairness_ok": true,
+      "q4_slo_ok": true,
+      "detectors_materialized_ok": true,
+      "external_summaries_present": true,
+      "external_all_pass": true,
+      "refusal_delta_evidence_present": true
+    },
+    "failed_required_gates": [],
+    "missing_required_gates": []
+  },
+  "decision": {
+    "state": "PASS",
+    "fail_closed": true
+  },
+  "diagnostics": {
+    "shadow_surfaces_non_normative": true
+  }
+}


### PR DESCRIPTION
## Summary

Adds the release authority manifest artifact for the PULSE-REF RA1 minimal release-reference package fixture.

## Scope

Adds:

- `tests/fixtures/pulse_ref_ra1_package_minimal/release_authority/release_authority_manifest.json`

## Purpose

RA1 is moving from schema contracts toward a concrete externally verifiable release-reference package fixture.

This PR adds the package-side release authority preservation artifact:

`release_authority/release_authority_manifest.json`

The manifest records:

- prod run identity;
- status / policy / registry inputs;
- effective required gate set;
- release_required materialization;
- required gate evaluation results;
- PASS decision;
- fail-closed semantics;
- non-normative diagnostics boundary.

This extends the package-side release trail to:

`status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

## Authority boundary

This PR does not create release authority.

The release authority manifest preserves the release-authority decision trail. It does not authorize release independently and does not create a second decision engine.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

This PR intentionally does not add `package_manifest.json` or `package_digests.json` yet. Those will be added after the package artifacts are ready to be bound by digest.

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, schema, or CI behavior is changed.