### PR TITLE
docs(pulse-ref): update RA1 minimal package fixture status

### DIFF
--- a/tests/fixtures/pulse_ref_ra1_package_minimal/README.md
+++ b/tests/fixtures/pulse_ref_ra1_package_minimal/README.md
@@ -1,6 +1,6 @@
 # PULSE-REF RA1 Minimal Release-Reference Package Fixture
 
-Status: fixture skeleton  
+Status: partially populated RA1 fixture  
 Scope: PULSE-REF RA1 externally verifiable release-reference package  
 Authority: non-normative test fixture / package-layout anchor
 
@@ -25,7 +25,7 @@ It does not create release authority.
 
 ## Intended package layout
 
-The minimal RA1 package fixture is expected to use this layout:
+The minimal RA1 package fixture uses this target layout:
 
 ```text
 pulse_ref_ra1_package_minimal/
@@ -52,12 +52,11 @@ pulse_ref_ra1_package_minimal/
   external_evidence/
 ```
 
-## Expected future artifacts
+## Current populated artifacts
 
-Future PRs should populate this fixture with schema-valid artifacts:
+The fixture currently includes these package artifacts:
 
 ```text
-package_manifest.json
 status/status.json
 policy/pulse_gate_policy_v0.yml
 policy/pulse_gate_registry_v0.yml
@@ -66,25 +65,83 @@ handoff/operator_handoff_report.json
 release_authority/release_authority_manifest.json
 ci/ci_outcome.json
 publication/publication_snapshot.json
+```
+
+These artifacts establish the current RA1 minimal package chain:
+
+```text
+status.json
+-> declared gate policy
+-> materialized required gate set
+-> operator handoff reconstruction
+-> release authority manifest
+-> CI outcome
+-> publication snapshot
+```
+
+## Pending package artifacts
+
+The fixture intentionally does not yet include:
+
+```text
+package_manifest.json
 digests/package_digests.json
 ```
 
-Optional or later-stage areas include:
+These should be added only after the currently populated artifacts are stable enough to be bound by digest.
+
+The package manifest and digest manifest will bind the package into a stronger externally verifiable artifact set.
+
+## Optional or later-stage areas
+
+The following directories are reserved for later-stage package expansion:
 
 ```text
 audit/
 external_evidence/
 ```
 
-## Verification intent
+These areas may later hold audit bundle contents and external evidence artifacts.
 
-A future package-level smoke test should verify that:
+They are not required for the current minimal fixture state.
+
+## Current validation coverage
+
+The current minimal package fixture is validated by:
 
 ```text
-all required package artifacts exist
-all JSON artifacts validate against their RA1 schemas
+tests/test_pulse_ref_ra1_minimal_package_fixture.py
+```
+
+That smoke test verifies the current package state:
+
+```text
+expected package artifacts exist
+RA1 JSON artifacts validate against their schemas
+release authority manifest passes the existing checker
+materialized gate sets match the packaged policy
+status artifact satisfies all effective required gates
+handoff report matches status and materialized gate-set artifacts
+release authority manifest matches the package core
+CI outcome and publication snapshot preserve the non-authority boundary
+```
+
+This test is registered in:
+
+```text
+ci/tools-tests.list
+```
+
+so the fixture validation runs in the tools smoke suite.
+
+## Verification intent
+
+Future package-level validation should extend the current fixture checks to include:
+
+```text
 package_digests.json matches artifact byte contents
 package_manifest.json references existing artifacts
+package_manifest.json references the package digest manifest
 status digest matches operator handoff status_source digest
 policy digest matches materialized gate-set metadata
 CI outcome is bound to the same run identity
@@ -109,10 +166,37 @@ status.json
 -> CI outcome
 ```
 
+The following fixture surfaces are non-normative:
+
+```text
+operator handoff report
+release authority manifest
+publication snapshot
+package manifest
+package digest manifest
+README
+audit bundle
+external evidence directory
+```
+
+They may preserve, explain, reconstruct, or verify release state.
+
+They do not authorize release independently.
+
 ## Current state
 
-This PR only establishes the fixture skeleton.
+The RA1 minimal package fixture is partially populated and actively smoke-tested.
 
-It intentionally does not add package artifact JSON files yet.
+The next implementation step should add digest binding:
 
-The next implementation step should populate the minimal package artifacts and then add package-level validation smoke coverage.
+```text
+digests/package_digests.json
+```
+
+After that, the package manifest can be added:
+
+```text
+package_manifest.json
+```
+
+The package manifest should reference the populated artifacts and the digest manifest without creating release authority.


### PR DESCRIPTION
## Summary

Updates the PULSE-REF RA1 minimal package fixture README to reflect the current populated fixture state.

## Scope

Updates:

- `tests/fixtures/pulse_ref_ra1_package_minimal/README.md`

## Purpose

The RA1 minimal package fixture is no longer just a skeleton.

It now contains:

- `status/status.json`
- `policy/pulse_gate_policy_v0.yml`
- `policy/pulse_gate_registry_v0.yml`
- `gates/materialized_gate_sets.json`
- `handoff/operator_handoff_report.json`
- `release_authority/release_authority_manifest.json`
- `ci/ci_outcome.json`
- `publication/publication_snapshot.json`

The README now records the current populated artifacts, the current validation coverage, the pending digest and package manifest artifacts, and the authority boundary.

## Authority boundary

This PR is documentation-only.

It does not create release authority.

The RA1 minimal package fixture remains a non-normative external reconstruction artifact set.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, schema, fixture artifact content, or CI behavior is changed.