### PR TITLE
test(pulse-ref): add RA1 minimal package digest manifest

### DIFF
--- a/tests/fixtures/pulse_ref_ra1_package_minimal/digests/package_digests.json
+++ b/tests/fixtures/pulse_ref_ra1_package_minimal/digests/package_digests.json
@@ -1,0 +1,21 @@
+{
+  "schema": "pulse_ref_package_digests_v0",
+  "algorithm": "sha256",
+  "created_utc": "2026-05-09T00:00:00Z",
+  "package_id": "pulse-ref-ra1-minimal",
+  "artifacts": {
+    "README.md": "031bd247d8d2a9c5a11a49483d1d4f888ff6084f057c054e5f8faf9fe366643d",
+    "status/status.json": "f691f35160927cf029028159b78a59be1655a8dad6aeece743a027043a0feb8b",
+    "policy/pulse_gate_policy_v0.yml": "b5bb00d060382c88fa2f944dbd3df21591acf0d437cbc0fec8c4be58b430e2f4",
+    "policy/pulse_gate_registry_v0.yml": "d5fef7e1eb9623102a2f5931f31eac87ea7a2ab3bc58a485a07be374bd4ef12d",
+    "gates/materialized_gate_sets.json": "a8fe356f2a610d6cb2745fe7f7b5857c8c39969b55da3d9da4b6e2213c6eed9f",
+    "handoff/operator_handoff_report.json": "e5585d57b45756a15d693b65005f53068090519133b6d80fb007983f1e23a84b",
+    "release_authority/release_authority_manifest.json": "0b086ba9a75bff347f969883cda6c1a512f4a4827718536fb915ecf39e4bedf3",
+    "ci/ci_outcome.json": "c7e6421f0bf9ec6d7ba32db2416f06ea413adbef85420f8932782e628cf5da03",
+    "publication/publication_snapshot.json": "56468e6014a39b7435d07d975b0c293842febf2af23bcc8cdf0843160f2898c2"
+  },
+  "authority_boundary": {
+    "digest_role": "artifact_integrity_verification",
+    "creates_release_authority": false
+  }
+}


### PR DESCRIPTION
## Summary

Adds the package digest manifest for the PULSE-REF RA1 minimal release-reference package fixture.

## Scope

Adds:

- `tests/fixtures/pulse_ref_ra1_package_minimal/digests/package_digests.json`

## Purpose

RA1 is moving from standalone package artifacts toward an externally verifiable release-reference package.

This PR adds the package-side digest manifest:

`digests/package_digests.json`

The digest manifest records SHA-256 bindings for the current minimal package artifacts:

- `README.md`
- `status/status.json`
- `policy/pulse_gate_policy_v0.yml`
- `policy/pulse_gate_registry_v0.yml`
- `gates/materialized_gate_sets.json`
- `handoff/operator_handoff_report.json`
- `release_authority/release_authority_manifest.json`
- `ci/ci_outcome.json`
- `publication/publication_snapshot.json`

This PR only adds the digest artifact. Package-level validation of the digest values will be added in a follow-up PR.

## Authority boundary

This PR does not create release authority.

The digest manifest supports artifact integrity verification. It does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, schema, fixture validation test, or CI behavior is changed.