### PR TITLE
fix(pulse-ref): correct RA1 handoff artifact digest

### DIFF
--- a/tests/fixtures/pulse_ref_ra1_package_minimal/digests/package_digests.json
+++ b/tests/fixtures/pulse_ref_ra1_package_minimal/digests/package_digests.json
@@ -9,7 +9,7 @@
     "policy/pulse_gate_policy_v0.yml": "b5bb00d060382c88fa2f944dbd3df21591acf0d437cbc0fec8c4be58b430e2f4",
     "policy/pulse_gate_registry_v0.yml": "d5fef7e1eb9623102a2f5931f31eac87ea7a2ab3bc58a485a07be374bd4ef12d",
     "gates/materialized_gate_sets.json": "a8fe356f2a610d6cb2745fe7f7b5857c8c39969b55da3d9da4b6e2213c6eed9f",
-    "handoff/operator_handoff_report.json": "e5585d57b45756a15d693b65005f53068090519133b6d80fb007983f1e23a84b",
+    "handoff/operator_handoff_report.json": "e79974738ac7f8d2099b939870734d9f90eb7d1bcf046b6b12c25bf5de234917"
     "release_authority/release_authority_manifest.json": "0b086ba9a75bff347f969883cda6c1a512f4a4827718536fb915ecf39e4bedf3",
     "ci/ci_outcome.json": "c7e6421f0bf9ec6d7ba32db2416f06ea413adbef85420f8932782e628cf5da03",
     "publication/publication_snapshot.json": "56468e6014a39b7435d07d975b0c293842febf2af23bcc8cdf0843160f2898c2"


### PR DESCRIPTION
## Summary

Corrects the recorded SHA-256 digest for the RA1 minimal package operator handoff report artifact.

## Scope

Updates:

- `tests/fixtures/pulse_ref_ra1_package_minimal/digests/package_digests.json`

## Purpose

The RA1 minimal package digest manifest records byte-level artifact integrity bindings.

The recorded digest for:

`handoff/operator_handoff_report.json`

did not match the current artifact content.

This PR updates that digest to the current SHA-256 value:

`e79974738ac7f8d2099b939870734d9f90eb7d1bcf046b6b12c25bf5de234917`

This prevents future package-integrity validation from reporting a false mismatch for an otherwise valid fixture artifact.

## Authority boundary

This PR does not create release authority.

The digest manifest supports artifact integrity verification. It does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, schema, fixture artifact content outside the digest manifest, or CI behavior is changed.