### PR TITLE
test(pulse-ref): add RA1 minimal package manifest

### DIFF
--- a/tests/fixtures/pulse_ref_ra1_package_minimal/package_manifest.json
+++ b/tests/fixtures/pulse_ref_ra1_package_minimal/package_manifest.json
@@ -1,0 +1,48 @@
+{
+  "schema": "pulse_ref_release_reference_package_v0",
+  "package_id": "pulse-ref-ra1-minimal",
+  "created_utc": "2026-05-09T00:00:00Z",
+  "run_key": "pulse-ref-ra1-minimal-fixture",
+  "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "status_artifact": {
+    "path": "status/status.json",
+    "sha256": "f691f35160927cf029028159b78a59be1655a8dad6aeece743a027043a0feb8b"
+  },
+  "gate_policy": {
+    "path": "policy/pulse_gate_policy_v0.yml",
+    "sha256": "b5bb00d060382c88fa2f944dbd3df21591acf0d437cbc0fec8c4be58b430e2f4"
+  },
+  "gate_registry": {
+    "path": "policy/pulse_gate_registry_v0.yml",
+    "sha256": "d5fef7e1eb9623102a2f5931f31eac87ea7a2ab3bc58a485a07be374bd4ef12d"
+  },
+  "materialized_gate_sets": {
+    "path": "gates/materialized_gate_sets.json",
+    "sha256": "a8fe356f2a610d6cb2745fe7f7b5857c8c39969b55da3d9da4b6e2213c6eed9f"
+  },
+  "operator_handoff_report": {
+    "path": "handoff/operator_handoff_report.json",
+    "sha256": "e79974738ac7f8d2099b939870734d9f90eb7d1bcf046b6b12c25bf5de234917"
+  },
+  "release_authority_manifest": {
+    "path": "release_authority/release_authority_manifest.json",
+    "sha256": "0b086ba9a75bff347f969883cda6c1a512f4a4827718536fb915ecf39e4bedf3"
+  },
+  "ci_outcome": {
+    "path": "ci/ci_outcome.json",
+    "sha256": "c7e6421f0bf9ec6d7ba32db2416f06ea413adbef85420f8932782e628cf5da03"
+  },
+  "publication_snapshot": {
+    "path": "publication/publication_snapshot.json",
+    "sha256": "56468e6014a39b7435d07d975b0c293842febf2af23bcc8cdf0843160f2898c2"
+  },
+  "package_digests": {
+    "path": "digests/package_digests.json",
+    "sha256": "4bf66efc9d72366932f3edf9704a6d8d0662ef1b1fec04dc0cbe92e1ace1237a"
+  },
+  "authority_boundary": {
+    "normative_decision_path": "status.json -> declared gate policy -> materialized required gates -> strict gate checking -> CI outcome",
+    "package_role": "audit_preservation_reconstruction",
+    "creates_release_authority": false
+  }
+}

--- a/tests/test_pulse_ref_ra1_minimal_package_fixture.py
+++ b/tests/test_pulse_ref_ra1_minimal_package_fixture.py
@@ -432,7 +432,7 @@ def main() -> int:
         test_release_authority_manifest_matches_package_core,
         test_ci_outcome_and_publication_snapshot_preserve_boundary,
         test_package_digests_match_current_fixture_artifacts,
-        test_package_manifest_matches_current_fixture_artifact
+        test_package_manifest_matches_current_fixture_artifacts,
     ]
     
     

--- a/tests/test_pulse_ref_ra1_minimal_package_fixture.py
+++ b/tests/test_pulse_ref_ra1_minimal_package_fixture.py
@@ -76,6 +76,7 @@ def _unique_preserve_order(items: list[str]) -> list[str]:
 def test_expected_ra1_minimal_package_artifacts_exist() -> None:
     expected = [
         "README.md",
+        "package_manifest.json",
         "status/status.json",
         "policy/pulse_gate_policy_v0.yml",
         "policy/pulse_gate_registry_v0.yml",
@@ -98,6 +99,10 @@ def test_expected_ra1_minimal_package_artifacts_exist() -> None:
 
 def test_ra1_minimal_package_json_artifacts_validate_schemas() -> None:
     targets = [
+        (
+            "package_manifest.json",
+            "schemas/pulse_ref_release_reference_package_v0.schema.json",
+        ),
         (
             "gates/materialized_gate_sets.json",
             "schemas/pulse_ref_materialized_gate_sets_v0.schema.json",
@@ -352,6 +357,70 @@ def test_package_digests_match_current_fixture_artifacts() -> None:
 
     assert mismatches == []
 
+def test_package_manifest_matches_current_fixture_artifacts() -> None:
+    manifest = _read_json("package_manifest.json")
+
+    assert manifest["schema"] == "pulse_ref_release_reference_package_v0"
+    assert manifest["package_id"] == "pulse-ref-ra1-minimal"
+    assert manifest["run_key"] == "pulse-ref-ra1-minimal-fixture"
+    assert manifest["git_sha"] == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    expected_refs = {
+        "status_artifact": "status/status.json",
+        "gate_policy": "policy/pulse_gate_policy_v0.yml",
+        "gate_registry": "policy/pulse_gate_registry_v0.yml",
+        "materialized_gate_sets": "gates/materialized_gate_sets.json",
+        "operator_handoff_report": "handoff/operator_handoff_report.json",
+        "release_authority_manifest": "release_authority/release_authority_manifest.json",
+        "ci_outcome": "ci/ci_outcome.json",
+        "publication_snapshot": "publication/publication_snapshot.json",
+        "package_digests": "digests/package_digests.json",
+    }
+
+    mismatches = []
+
+    for field, rel_path in expected_refs.items():
+        artifact_ref = manifest[field]
+
+        if artifact_ref["path"] != rel_path:
+            mismatches.append(
+                {
+                    "field": field,
+                    "expected_path": rel_path,
+                    "actual_path": artifact_ref["path"],
+                }
+            )
+            continue
+
+        actual_sha = _sha256_file(_artifact(rel_path))
+        expected_sha = artifact_ref["sha256"]
+
+        if actual_sha != expected_sha:
+            mismatches.append(
+                {
+                    "field": field,
+                    "path": rel_path,
+                    "expected_sha": expected_sha,
+                    "actual_sha": actual_sha,
+                }
+            )
+
+    assert mismatches == []
+
+    boundary = manifest["authority_boundary"]
+    assert boundary["package_role"] == "audit_preservation_reconstruction"
+    assert boundary["creates_release_authority"] is False
+
+    ci_outcome = _read_json("ci/ci_outcome.json")
+    publication = _read_json("publication/publication_snapshot.json")
+    release_authority = _read_json("release_authority/release_authority_manifest.json")
+
+    assert manifest["git_sha"] == ci_outcome["commit_sha"]
+    assert manifest["git_sha"] == publication["git_sha"]
+    assert manifest["git_sha"] == release_authority["run_identity"]["git_sha"]
+
+    assert manifest["run_key"] == publication["run_key"]
+
 def main() -> int:
     tests = [
         test_expected_ra1_minimal_package_artifacts_exist,
@@ -363,6 +432,7 @@ def main() -> int:
         test_release_authority_manifest_matches_package_core,
         test_ci_outcome_and_publication_snapshot_preserve_boundary,
         test_package_digests_match_current_fixture_artifacts,
+        test_package_manifest_matches_current_fixture_artifact
     ]
     
     


### PR DESCRIPTION
## Summary

Adds the package manifest for the PULSE-REF RA1 minimal release-reference package fixture.

## Scope

Adds:

- `tests/fixtures/pulse_ref_ra1_package_minimal/package_manifest.json`

Updates:

- `tests/test_pulse_ref_ra1_minimal_package_fixture.py`

## Purpose

RA1 is moving from standalone package artifacts toward an externally verifiable release-reference package.

This PR adds the package-side manifest:

`package_manifest.json`

The package manifest binds the current minimal package artifacts:

- status artifact;
- packaged gate policy;
- gate registry;
- materialized gate sets;
- operator handoff report;
- release authority manifest;
- CI outcome;
- publication snapshot;
- package digest manifest.

The existing RA1 minimal package smoke test is extended to:

- require the package manifest;
- validate it against `schemas/pulse_ref_release_reference_package_v0.schema.json`;
- verify that each artifact reference path and SHA-256 value matches the current fixture byte contents;
- verify authority-boundary metadata remains non-authoritative;
- verify the package identity is consistent with the CI outcome, publication snapshot, and release authority manifest.

## Authority boundary

This PR does not create release authority.

The package manifest binds artifacts for external verification. It does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, schema, fixture artifact content outside the package manifest, or CI behavior is changed beyond adding fixture validation coverage.