### PR TITLE
docs(pulse-ref): update RA1 minimal package manifest-bound status

### DIFF
--- a/tests/fixtures/pulse_ref_ra1_package_minimal/README.md
+++ b/tests/fixtures/pulse_ref_ra1_package_minimal/README.md
@@ -1,12 +1,12 @@
 # PULSE-REF RA1 Minimal Release-Reference Package Fixture
 
-Status: partially populated RA1 fixture  
+Status: manifest-bound RA1 minimal fixture  
 Scope: PULSE-REF RA1 externally verifiable release-reference package  
 Authority: non-normative test fixture / package-layout anchor
 
 ## Purpose
 
-This fixture directory is the target location for the first minimal PULSE-REF RA1 release-reference package.
+This fixture directory contains the current minimal PULSE-REF RA1 release-reference package.
 
 RA1 packages bind the artifacts needed for external reconstruction of the PULSE release-authority path:
 
@@ -23,9 +23,9 @@ The package preserves and verifies the release decision trail.
 
 It does not create release authority.
 
-## Intended package layout
+## Package layout
 
-The minimal RA1 package fixture uses this target layout:
+The minimal RA1 package fixture uses this layout:
 
 ```text
 pulse_ref_ra1_package_minimal/
@@ -57,6 +57,7 @@ pulse_ref_ra1_package_minimal/
 The fixture currently includes these package artifacts:
 
 ```text
+package_manifest.json
 status/status.json
 policy/pulse_gate_policy_v0.yml
 policy/pulse_gate_registry_v0.yml
@@ -65,6 +66,7 @@ handoff/operator_handoff_report.json
 release_authority/release_authority_manifest.json
 ci/ci_outcome.json
 publication/publication_snapshot.json
+digests/package_digests.json
 ```
 
 These artifacts establish the current RA1 minimal package chain:
@@ -77,20 +79,51 @@ status.json
 -> release authority manifest
 -> CI outcome
 -> publication snapshot
+-> package digest manifest
+-> package manifest
 ```
 
-## Pending package artifacts
+## Digest binding
 
-The fixture intentionally does not yet include:
+The fixture includes:
 
 ```text
-package_manifest.json
 digests/package_digests.json
 ```
 
-These should be added only after the currently populated artifacts are stable enough to be bound by digest.
+The digest manifest records SHA-256 bindings for the current fixture payload artifacts.
 
-The package manifest and digest manifest will bind the package into a stronger externally verifiable artifact set.
+It intentionally does not hash itself.
+
+It also intentionally does not hash `package_manifest.json` in this fixture version, because the package manifest references the digest manifest. Avoiding a circular digest relationship keeps this minimal hand-authored fixture stable and externally checkable.
+
+The package manifest records the SHA-256 of the digest manifest instead.
+
+## Package manifest binding
+
+The fixture includes:
+
+```text
+package_manifest.json
+```
+
+The package manifest binds the current RA1 package artifacts:
+
+```text
+status artifact
+packaged gate policy
+gate registry
+materialized gate sets
+operator handoff report
+release authority manifest
+CI outcome
+publication snapshot
+package digest manifest
+```
+
+The package manifest is an audit / preservation / reconstruction artifact.
+
+It does not authorize release independently.
 
 ## Optional or later-stage areas
 
@@ -124,6 +157,8 @@ status artifact satisfies all effective required gates
 handoff report matches status and materialized gate-set artifacts
 release authority manifest matches the package core
 CI outcome and publication snapshot preserve the non-authority boundary
+package_digests.json matches current fixture artifact byte contents
+package_manifest.json references existing artifacts with matching SHA-256 values
 ```
 
 This test is registered in:
@@ -136,16 +171,14 @@ so the fixture validation runs in the tools smoke suite.
 
 ## Verification intent
 
-Future package-level validation should extend the current fixture checks to include:
+Future package-level validation may extend the current fixture checks to include:
 
 ```text
-package_digests.json matches artifact byte contents
-package_manifest.json references existing artifacts
-package_manifest.json references the package digest manifest
-status digest matches operator handoff status_source digest
-policy digest matches materialized gate-set metadata
-CI outcome is bound to the same run identity
-publication snapshot does not create release authority
+audit bundle contents
+external evidence artifacts
+external verifier instructions
+package generator output parity
+publication snapshot links to package manifest and package digests
 ```
 
 ## Authority boundary
@@ -185,18 +218,6 @@ They do not authorize release independently.
 
 ## Current state
 
-The RA1 minimal package fixture is partially populated and actively smoke-tested.
+The RA1 minimal package fixture is populated through package manifest and digest manifest binding and is actively smoke-tested.
 
-The next implementation step should add digest binding:
-
-```text
-digests/package_digests.json
-```
-
-After that, the package manifest can be added:
-
-```text
-package_manifest.json
-```
-
-The package manifest should reference the populated artifacts and the digest manifest without creating release authority.
+The next implementation step should move from fixture validation toward a package generator or verifier workflow that can produce and check the same artifact structure automatically.

--- a/tests/fixtures/pulse_ref_ra1_package_minimal/digests/package_digests.json
+++ b/tests/fixtures/pulse_ref_ra1_package_minimal/digests/package_digests.json
@@ -4,7 +4,7 @@
   "created_utc": "2026-05-09T00:00:00Z",
   "package_id": "pulse-ref-ra1-minimal",
   "artifacts": {
-    "README.md": "031bd247d8d2a9c5a11a49483d1d4f888ff6084f057c054e5f8faf9fe366643d",
+    "README.md": "e0ad9c8fb414ff25641fc699834185f5d1d71a69c51008f2fc82d265e5346224",
     "status/status.json": "f691f35160927cf029028159b78a59be1655a8dad6aeece743a027043a0feb8b",
     "policy/pulse_gate_policy_v0.yml": "b5bb00d060382c88fa2f944dbd3df21591acf0d437cbc0fec8c4be58b430e2f4",
     "policy/pulse_gate_registry_v0.yml": "d5fef7e1eb9623102a2f5931f31eac87ea7a2ab3bc58a485a07be374bd4ef12d",

--- a/tests/fixtures/pulse_ref_ra1_package_minimal/package_manifest.json
+++ b/tests/fixtures/pulse_ref_ra1_package_minimal/package_manifest.json
@@ -38,7 +38,7 @@
   },
   "package_digests": {
     "path": "digests/package_digests.json",
-    "sha256": "4bf66efc9d72366932f3edf9704a6d8d0662ef1b1fec04dc0cbe92e1ace1237a"
+    "sha256": "5acfc389d8c60826f6ed682d9c578e62734c176c9b721c9d2e8c972ba7ffb747"
   },
   "authority_boundary": {
     "normative_decision_path": "status.json -> declared gate policy -> materialized required gates -> strict gate checking -> CI outcome",


### PR DESCRIPTION
## Summary

Updates the PULSE-REF RA1 minimal package fixture README to reflect the current manifest-bound state.

## Scope

Updates:

- `tests/fixtures/pulse_ref_ra1_package_minimal/README.md`
- `tests/fixtures/pulse_ref_ra1_package_minimal/digests/package_digests.json`
- `tests/fixtures/pulse_ref_ra1_package_minimal/package_manifest.json`

## Purpose

The RA1 minimal package fixture now includes both:

- `package_manifest.json`
- `digests/package_digests.json`

The README is updated to document the current package state, including:

- populated package artifacts;
- digest binding;
- package manifest binding;
- current validation coverage;
- authority boundary;
- next implementation direction.

Because README content changes affect the digest manifest, this PR refreshes the README SHA-256 recorded in `package_digests.json`.

Because `package_manifest.json` references the digest manifest SHA-256, this PR also refreshes the `package_digests` reference in the package manifest.

## Authority boundary

This PR does not create release authority.

The README, package digest manifest, and package manifest are audit / preservation / reconstruction artifacts. They do not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, schema, or CI behavior is changed.