### PR TITLE
fix(docs): repair lychee link check targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 <p>
   <a href="https://doi.org/10.5281/zenodo.17373002">
-    <img src="https://doi.org/badge/DOI/10.5281/zenodo.17373002.svg" alt="DOI">
+    <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.17373002.svg" alt="DOI">
   </a>
 </p>
 

--- a/docs/latest/index.html
+++ b/docs/latest/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="robots" content="index,follow" />
+    <title>PULSE Latest Artefacts</title>
+  </head>
+  <body>
+    <h1>PULSE Latest Artefacts</h1>
+
+    <p>
+      This placeholder keeps the repository-local documentation link target
+      available for link checking. Runtime publication workflows may replace or
+      extend this surface with generated latest-run artefacts.
+    </p>
+  </body>
+</html>

--- a/docs/report_card.html
+++ b/docs/report_card.html
@@ -12,12 +12,11 @@
     <p><strong>Last updated (UTC):</strong> <span>LASTMOD_UTC</span></p>
 
     <p><strong>Latest artefacts (crawler entry):</strong><br />
-      <a href="./latest/">https://hkati.github.io/pulse-release-gates-0.1/latest/</a>
+      <a href="./latest/index.html">Latest artefacts index</a>
     </p>
 
     <p><strong>Run archive:</strong><br />
-      <a href="./runs/">https://hkati.github.io/pulse-release-gates-0.1/runs/</a>
+      <a href="./runs/index.html">Run archive index</a>
     </p>
   </body>
 </html>
-

--- a/docs/runs/index.html
+++ b/docs/runs/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="robots" content="index,follow" />
+    <title>PULSE Run Archive</title>
+  </head>
+  <body>
+    <h1>PULSE Run Archive</h1>
+
+    <p>
+      This placeholder keeps the repository-local documentation link target
+      available for link checking. Runtime publication workflows may replace or
+      extend this surface with generated run archive artefacts.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Repairs documentation links reported by the scheduled lychee run.

## Scope

Updates:

- `README.md`
- `docs/report_card.html`

Adds:

- `docs/latest/index.html`
- `docs/runs/index.html`

## Purpose

The scheduled lychee run reported three link errors:

- `docs/report_card.html` linked to `./latest/`, but `docs/latest` did not exist in the repository checkout.
- `docs/report_card.html` linked to `./runs/`, but `docs/runs` did not exist in the repository checkout.
- `README.md` used a DOI badge image URL under `doi.org/badge/...svg`, which returned 404.

This PR:

- switches the DOI badge image to the Zenodo badge endpoint while keeping the DOI target link unchanged;
- updates the report card to point at repository-local `latest/index.html` and `runs/index.html` targets;
- adds placeholder index pages for those two link-check targets.

## Authority boundary

This PR is documentation/link hygiene only.

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, schema, fixture artifact content, or CI behavior is changed.