### PR TITLE
docs(status): add workshop status surface

### DIFF
--- a/docs/status/workshop_status.json
+++ b/docs/status/workshop_status.json
@@ -1,0 +1,16 @@
+{
+  "schema": "pulse_workshop_status_v0",
+  "status": "OPEN",
+  "label": "Visitor hours active",
+  "summary": "Public artifact surface is available.",
+  "updated_utc": "2026-05-09T00:00:00Z",
+  "signals": {
+    "release_authority_path": "ok",
+    "publication_surface": "ok",
+    "scheduled_link_check": "ok"
+  },
+  "authority_boundary": {
+    "status_surface_role": "public_visibility_and_maintenance",
+    "creates_release_authority": false
+  }
+}


### PR DESCRIPTION
## Summary

Adds a public workshop status surface for the README.

## Scope

Adds:

- `docs/status/workshop_status.json`
- `docs/badges/workshop_status.svg`
- `docs/WORKSHOP_STATUS_SURFACE_v0.md`

Updates:

- `README.md`

## Purpose

The repository needs a lightweight public status surface that distinguishes normal availability, publication-surface maintenance, and release-path blocking failures.

This adds three status states:

- `OPEN`: public artifact surface is available.
- `SERVICE`: publication/docs/lychee/Pages cleanup is needed; release authority path is unaffected.
- `BLOCKED`: primary release-authority path requires attention.

This prevents publication-surface issues, such as scheduled link-check failures, from being mistaken for release-authority failures.

## Authority boundary

This PR does not create release authority.

The workshop status surface is a public visibility and maintenance signal only.

It does not define or change:

- release semantics;
- gate policy;
- `status.json` semantics;
- required gate materialization;
- `check_gates.py` behavior;
- primary CI release-decision authority;
- release-reference package semantics;
- shadow-layer authority.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`