### PR TITLE
feat(pulse-ref): validate RA1 package artifact schemas

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -47,7 +47,6 @@ tests/test_pulse_ref_publication_snapshot_schema_v0.py
 tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
 tests/test_pulse_ref_package_verifier_report_schema_v0.py
 tests/test_pulse_ref_ra1_minimal_package_fixture.py
-tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
 tests/test_agent_orchestration_evidence_schema_v0.py
 tests/test_check_agent_orchestration_evidence_v0.py
 

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -47,6 +47,7 @@ tests/test_pulse_ref_publication_snapshot_schema_v0.py
 tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
 tests/test_pulse_ref_package_verifier_report_schema_v0.py
 tests/test_pulse_ref_ra1_minimal_package_fixture.py
+tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
 tests/test_agent_orchestration_evidence_schema_v0.py
 tests/test_check_agent_orchestration_evidence_v0.py
 

--- a/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
+++ b/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
@@ -108,6 +108,18 @@ def test_valid_ra1_minimal_package_verifies() -> None:
         assert "package_manifest" in digest_sources
         assert "package_digests" in digest_sources
 
+        schema_paths = {
+            check["artifact_path"]
+            for check in report["schemas_validated"]
+        }
+
+        assert "package_manifest.json" in schema_paths
+        assert "digests/package_digests.json" in schema_paths
+        assert "gates/materialized_gate_sets.json" in schema_paths
+        assert "handoff/operator_handoff_report.json" in schema_paths
+        assert "release_authority/release_authority_manifest.json" in schema_paths
+        assert "ci/ci_outcome.json" in schema_paths
+        assert "publication/publication_snapshot.json" in schema_paths
 
 def test_digest_mismatch_fails_with_schema_valid_report() -> None:
     with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
@@ -242,12 +254,64 @@ def test_malformed_digest_string_fails_with_schema_valid_report() -> None:
         assert status_checks[0]["ok"] is False
         assert status_checks[0]["expected_sha256"] == "0" * 64
 
+def test_schema_invalid_package_artifact_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.schema_fail.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        publication_path = package_copy / "publication" / "publication_snapshot.json"
+        publication = _read_json(publication_path)
+        publication["creates_release_authority"] = True
+        _write_json(publication_path, publication)
+
+        publication_sha = _sha256_file(publication_path)
+
+        digests_path = package_copy / "digests" / "package_digests.json"
+        digests = _read_json(digests_path)
+        digests["artifacts"]["publication/publication_snapshot.json"] = publication_sha
+        _write_json(digests_path, digests)
+
+        digests_sha = _sha256_file(digests_path)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["publication_snapshot"]["sha256"] = publication_sha
+        manifest["package_digests"]["sha256"] = digests_sha
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        publication_schema_checks = [
+            check
+            for check in report["schemas_validated"]
+            if check["artifact_path"] == "publication/publication_snapshot.json"
+        ]
+
+        assert len(publication_schema_checks) == 1
+        assert publication_schema_checks[0]["ok"] is False
+        assert any(
+            "publication/publication_snapshot.json schema validation failed" in error
+            for error in report["errors"]
+        )
+
 def main() -> int:
     tests = [
         test_valid_ra1_minimal_package_verifies,
         test_digest_mismatch_fails_with_schema_valid_report,
         test_symlinked_artifact_outside_package_root_fails_with_schema_valid_report,
         test_malformed_digest_string_fails_with_schema_valid_report,
+        test_schema_invalid_package_artifact_fails_with_schema_valid_report,
     ]
 
     try:

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -20,11 +20,31 @@ PACKAGE_MANIFEST_SCHEMA = (
 PACKAGE_DIGESTS_SCHEMA = (
     REPO_ROOT / "schemas" / "pulse_ref_package_digests_v0.schema.json"
 )
-
+MATERIALIZED_GATE_SETS_SCHEMA = (
+    REPO_ROOT / "schemas" / "pulse_ref_materialized_gate_sets_v0.schema.json"
+)
+OPERATOR_HANDOFF_REPORT_SCHEMA = (
+    REPO_ROOT / "schemas" / "pulse_ref_operator_handoff_report_v0.schema.json"
+)
+RELEASE_AUTHORITY_SCHEMA = REPO_ROOT / "schemas" / "release_authority_v0.schema.json"
+CI_OUTCOME_SCHEMA = REPO_ROOT / "schemas" / "pulse_ref_ci_outcome_v0.schema.json"
+PUBLICATION_SNAPSHOT_SCHEMA = (
+    REPO_ROOT / "schemas" / "pulse_ref_publication_snapshot_v0.schema.json"
+)
 
 PACKAGE_MANIFEST_SCHEMA_PATH = "schemas/pulse_ref_release_reference_package_v0.schema.json"
 PACKAGE_DIGESTS_SCHEMA_PATH = "schemas/pulse_ref_package_digests_v0.schema.json"
-
+MATERIALIZED_GATE_SETS_SCHEMA_PATH = (
+    "schemas/pulse_ref_materialized_gate_sets_v0.schema.json"
+)
+OPERATOR_HANDOFF_REPORT_SCHEMA_PATH = (
+    "schemas/pulse_ref_operator_handoff_report_v0.schema.json"
+)
+RELEASE_AUTHORITY_SCHEMA_PATH = "schemas/release_authority_v0.schema.json"
+CI_OUTCOME_SCHEMA_PATH = "schemas/pulse_ref_ci_outcome_v0.schema.json"
+PUBLICATION_SNAPSHOT_SCHEMA_PATH = (
+    "schemas/pulse_ref_publication_snapshot_v0.schema.json"
+)
 
 ARTIFACT_REF_FIELDS = [
     "status_artifact",
@@ -38,6 +58,33 @@ ARTIFACT_REF_FIELDS = [
     "package_digests",
 ]
 
+ARTIFACT_SCHEMA_TARGETS = [
+    (
+        "materialized_gate_sets",
+        MATERIALIZED_GATE_SETS_SCHEMA_PATH,
+        MATERIALIZED_GATE_SETS_SCHEMA,
+    ),
+    (
+        "operator_handoff_report",
+        OPERATOR_HANDOFF_REPORT_SCHEMA_PATH,
+        OPERATOR_HANDOFF_REPORT_SCHEMA,
+    ),
+    (
+        "release_authority_manifest",
+        RELEASE_AUTHORITY_SCHEMA_PATH,
+        RELEASE_AUTHORITY_SCHEMA,
+    ),
+    (
+        "ci_outcome",
+        CI_OUTCOME_SCHEMA_PATH,
+        CI_OUTCOME_SCHEMA,
+    ),
+    (
+        "publication_snapshot",
+        PUBLICATION_SNAPSHOT_SCHEMA_PATH,
+        PUBLICATION_SNAPSHOT_SCHEMA,
+    ),
+]
 
 def _utc_now() -> str:
     return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
@@ -72,6 +119,9 @@ def _is_safe_relative_path(value: Any) -> bool:
         return False
 
     return True
+
+def _report_safe_path(value: Any) -> str:
+    return value if _is_safe_relative_path(value) else "_invalid_artifact_path"
 
 def _is_sha256(value: Any) -> bool:
     if not isinstance(value, str):
@@ -184,6 +234,18 @@ def _schema_check(
         "ok": True,
     }
 
+def _load_package_json_artifact(
+    package_root: Path,
+    rel_path: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    artifact_file, path_error = _resolve_package_artifact(package_root, rel_path)
+
+    if path_error is not None:
+        return None, path_error
+    if artifact_file is None:
+        return None, f"artifact path could not be resolved: {rel_path}"
+
+    return _read_json(artifact_file)
 
 def _digest_check(
     *,
@@ -207,7 +269,7 @@ def _digest_check(
     )
 
     result: dict[str, Any] = {
-        "artifact_path": artifact_path if isinstance(artifact_path, str) else "<invalid>",
+        "artifact_path": _report_safe_path(artifact_path),
         "expected_sha256": report_expected_sha256,
         "actual_sha256": actual_sha256,
         "ok": ok,
@@ -272,6 +334,54 @@ def _check_package_id_consistency(
         result["message"] = message
 
     return result
+
+        for field, schema_path, schema_file in ARTIFACT_SCHEMA_TARGETS:
+            artifact_ref = manifest.get(field)
+
+            if not isinstance(artifact_ref, dict):
+                continue
+
+            rel_path = artifact_ref.get("path")
+
+            if not isinstance(rel_path, str):
+                message = f"{field} must contain string path"
+                errors.append(message)
+                schemas_validated.append(
+                    {
+                        "artifact_path": "_invalid_artifact_path",
+                        "schema_path": schema_path,
+                        "ok": False,
+                        "message": message,
+                    }
+                )
+                continue
+
+            artifact_obj, artifact_error = _load_package_json_artifact(
+                package_root,
+                rel_path,
+            )
+
+            if artifact_error is not None:
+                schemas_validated.append(
+                    {
+                        "artifact_path": _report_safe_path(rel_path),
+                        "schema_path": schema_path,
+                        "ok": False,
+                        "message": artifact_error,
+                    }
+                )
+                errors.append(f"{rel_path} could not be loaded: {artifact_error}")
+                continue
+
+            schemas_validated.append(
+                _schema_check(
+                    artifact_path=_report_safe_path(rel_path),
+                    schema_path=schema_path,
+                    instance=artifact_obj,
+                    schema_file=schema_file,
+                    errors=errors,
+                )
+            )
 
 def _check_authority_boundary(
     *,

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -86,6 +86,7 @@ ARTIFACT_SCHEMA_TARGETS = [
     ),
 ]
 
+
 def _utc_now() -> str:
     return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
 
@@ -120,8 +121,10 @@ def _is_safe_relative_path(value: Any) -> bool:
 
     return True
 
+
 def _report_safe_path(value: Any) -> str:
     return value if _is_safe_relative_path(value) else "_invalid_artifact_path"
+
 
 def _is_sha256(value: Any) -> bool:
     if not isinstance(value, str):
@@ -165,9 +168,6 @@ def _resolve_package_artifact(
         )
 
     return resolved_candidate, None
-
-def _package_path(package_root: Path, rel_path: str) -> Path:
-    return package_root / rel_path
 
 
 def _read_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
@@ -234,6 +234,7 @@ def _schema_check(
         "ok": True,
     }
 
+
 def _load_package_json_artifact(
     package_root: Path,
     rel_path: str,
@@ -246,6 +247,7 @@ def _load_package_json_artifact(
         return None, f"artifact path could not be resolved: {rel_path}"
 
     return _read_json(artifact_file)
+
 
 def _digest_check(
     *,
@@ -335,53 +337,6 @@ def _check_package_id_consistency(
 
     return result
 
-        for field, schema_path, schema_file in ARTIFACT_SCHEMA_TARGETS:
-            artifact_ref = manifest.get(field)
-
-            if not isinstance(artifact_ref, dict):
-                continue
-
-            rel_path = artifact_ref.get("path")
-
-            if not isinstance(rel_path, str):
-                message = f"{field} must contain string path"
-                errors.append(message)
-                schemas_validated.append(
-                    {
-                        "artifact_path": "_invalid_artifact_path",
-                        "schema_path": schema_path,
-                        "ok": False,
-                        "message": message,
-                    }
-                )
-                continue
-
-            artifact_obj, artifact_error = _load_package_json_artifact(
-                package_root,
-                rel_path,
-            )
-
-            if artifact_error is not None:
-                schemas_validated.append(
-                    {
-                        "artifact_path": _report_safe_path(rel_path),
-                        "schema_path": schema_path,
-                        "ok": False,
-                        "message": artifact_error,
-                    }
-                )
-                errors.append(f"{rel_path} could not be loaded: {artifact_error}")
-                continue
-
-            schemas_validated.append(
-                _schema_check(
-                    artifact_path=_report_safe_path(rel_path),
-                    schema_path=schema_path,
-                    instance=artifact_obj,
-                    schema_file=schema_file,
-                    errors=errors,
-                )
-            )
 
 def _check_authority_boundary(
     *,
@@ -472,6 +427,54 @@ def verify_package(package_root: Path) -> dict[str, Any]:
                 )
             )
 
+        for field, schema_path, schema_file in ARTIFACT_SCHEMA_TARGETS:
+            artifact_ref = manifest.get(field)
+
+            if not isinstance(artifact_ref, dict):
+                continue
+
+            rel_path = artifact_ref.get("path")
+
+            if not isinstance(rel_path, str):
+                message = f"{field} must contain string path"
+                errors.append(message)
+                schemas_validated.append(
+                    {
+                        "artifact_path": "_invalid_artifact_path",
+                        "schema_path": schema_path,
+                        "ok": False,
+                        "message": message,
+                    }
+                )
+                continue
+
+            artifact_obj, artifact_error = _load_package_json_artifact(
+                package_root,
+                rel_path,
+            )
+
+            if artifact_error is not None:
+                schemas_validated.append(
+                    {
+                        "artifact_path": _report_safe_path(rel_path),
+                        "schema_path": schema_path,
+                        "ok": False,
+                        "message": artifact_error,
+                    }
+                )
+                errors.append(f"{rel_path} could not be loaded: {artifact_error}")
+                continue
+
+            schemas_validated.append(
+                _schema_check(
+                    artifact_path=_report_safe_path(rel_path),
+                    schema_path=schema_path,
+                    instance=artifact_obj,
+                    schema_file=schema_file,
+                    errors=errors,
+                )
+            )
+
         authority_boundary = manifest.get("authority_boundary")
         creates_release_authority = (
             authority_boundary.get("creates_release_authority")
@@ -492,7 +495,9 @@ def verify_package(package_root: Path) -> dict[str, Any]:
         if isinstance(artifacts, dict):
             for rel_path, expected_sha256 in artifacts.items():
                 if not isinstance(rel_path, str) or not isinstance(expected_sha256, str):
-                    errors.append("digest manifest artifacts must map string path to string sha256")
+                    errors.append(
+                        "digest manifest artifacts must map string path to string sha256"
+                    )
                     continue
 
                 artifact_digests_checked.append(


### PR DESCRIPTION
## Summary

Extends the RA1 package verifier to validate package JSON artifacts against their schemas.

## Scope

Updates:

- `tools/verify_pulse_ref_ra1_package.py`
- `tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py`

## Purpose

The verifier already validates:

- `package_manifest.json`
- `digests/package_digests.json`

This PR extends schema validation to package artifacts referenced by the package manifest:

- `gates/materialized_gate_sets.json`
- `handoff/operator_handoff_report.json`
- `release_authority/release_authority_manifest.json`
- `ci/ci_outcome.json`
- `publication/publication_snapshot.json`

The smoke coverage verifies that a schema-invalid package artifact fails verification while the emitted verifier report remains schema-valid.

## Authority boundary

This PR does not create release authority.

The verifier is an external reconstruction check. It verifies that an archived RA1 package preserves the declared-policy release-authority trail, but it does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, fixture artifact content, or CI behavior is changed beyond verifier coverage.