### PR TITLE
feat(pulse-ref): validate RA1 handoff reconstruction consistency

### DIFF
--- a/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
+++ b/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
@@ -128,6 +128,7 @@ def test_valid_ra1_minimal_package_verifies() -> None:
 
         assert "materialized_gate_sets_match_policy" in cross_check_names
         assert "status_satisfies_effective_required_gates" in cross_check_names
+        assert "handoff_matches_status_and_gate_sets" in cross_check_names
 
 def test_digest_mismatch_fails_with_schema_valid_report() -> None:
     with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
@@ -418,6 +419,107 @@ def test_materialized_gate_set_policy_mismatch_fails_with_schema_valid_report() 
         assert gate_set_checks[0]["ok"] is False
         assert "sets.required does not match" in gate_set_checks[0]["message"]
 
+def test_handoff_status_digest_mismatch_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.handoff_status_digest.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        handoff_path = package_copy / "handoff" / "operator_handoff_report.json"
+        handoff = _read_json(handoff_path)
+        handoff["status_source"]["status_sha256_before_run"] = "0" * 64
+        _write_json(handoff_path, handoff)
+
+        handoff_sha = _sha256_file(handoff_path)
+
+        digests_path = package_copy / "digests" / "package_digests.json"
+        digests = _read_json(digests_path)
+        digests["artifacts"]["handoff/operator_handoff_report.json"] = handoff_sha
+        _write_json(digests_path, digests)
+
+        digests_sha = _sha256_file(digests_path)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["operator_handoff_report"]["sha256"] = handoff_sha
+        manifest["package_digests"]["sha256"] = digests_sha
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        handoff_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "handoff_matches_status_and_gate_sets"
+        ]
+
+        assert len(handoff_checks) == 1
+        assert handoff_checks[0]["ok"] is False
+        assert "status_sha256_before_run mismatch" in handoff_checks[0]["message"]
+
+
+def test_handoff_effective_required_gates_mismatch_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.handoff_effective_gates.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        handoff_path = package_copy / "handoff" / "operator_handoff_report.json"
+        handoff = _read_json(handoff_path)
+        handoff["effective_required_gates"] = [
+            gate_id
+            for gate_id in handoff["effective_required_gates"]
+            if gate_id != "q4_slo_ok"
+        ]
+        _write_json(handoff_path, handoff)
+
+        handoff_sha = _sha256_file(handoff_path)
+
+        digests_path = package_copy / "digests" / "package_digests.json"
+        digests = _read_json(digests_path)
+        digests["artifacts"]["handoff/operator_handoff_report.json"] = handoff_sha
+        _write_json(digests_path, digests)
+
+        digests_sha = _sha256_file(digests_path)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["operator_handoff_report"]["sha256"] = handoff_sha
+        manifest["package_digests"]["sha256"] = digests_sha
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        handoff_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "handoff_matches_status_and_gate_sets"
+        ]
+
+        assert len(handoff_checks) == 1
+        assert handoff_checks[0]["ok"] is False
+        assert "effective_required_gates does not match" in handoff_checks[0]["message"]
+
 def main() -> int:
     tests = [
         test_valid_ra1_minimal_package_verifies,
@@ -427,6 +529,8 @@ def main() -> int:
         test_schema_invalid_package_artifact_fails_with_schema_valid_report,
         test_false_effective_required_gate_fails_with_schema_valid_report,
         test_materialized_gate_set_policy_mismatch_fails_with_schema_valid_report,
+        test_handoff_status_digest_mismatch_fails_with_schema_valid_report,
+        test_handoff_effective_required_gates_mismatch_fails_with_schema_valid_report,
     ]
 
     try:

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -605,6 +605,7 @@ def _check_status_satisfies_effective_required_gates(
         errors=errors,
     )
 
+
 def _check_handoff_matches_status_and_gate_sets(
     *,
     package_root: Path,
@@ -857,14 +858,14 @@ def verify_package(package_root: Path) -> dict[str, Any]:
                 errors=errors,
             )
         )
-       cross_artifact_checks.append(
+        cross_artifact_checks.append(
             _check_handoff_matches_status_and_gate_sets(
                 package_root=package_root,
                 manifest=manifest,
                 errors=errors,
             )
         )
-   
+
         authority_boundary = manifest.get("authority_boundary")
         creates_release_authority = (
             authority_boundary.get("creates_release_authority")
@@ -898,7 +899,7 @@ def verify_package(package_root: Path) -> dict[str, Any]:
                         source="package_digests",
                         errors=errors,
                     )
-                )     
+                )
 
         authority_boundary = digests.get("authority_boundary")
         creates_release_authority = (

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -605,6 +605,129 @@ def _check_status_satisfies_effective_required_gates(
         errors=errors,
     )
 
+def _check_handoff_matches_status_and_gate_sets(
+    *,
+    package_root: Path,
+    manifest: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any]:
+    handoff_path = _manifest_artifact_path(manifest, "operator_handoff_report")
+    status_path = _manifest_artifact_path(manifest, "status_artifact")
+    gate_sets_path = _manifest_artifact_path(manifest, "materialized_gate_sets")
+
+    if handoff_path is None or status_path is None or gate_sets_path is None:
+        return _cross_check_result(
+            name="handoff_matches_status_and_gate_sets",
+            ok=False,
+            path="handoff/operator_handoff_report.json",
+            message=(
+                "package manifest must reference operator_handoff_report, "
+                "status_artifact, and materialized_gate_sets"
+            ),
+            errors=errors,
+        )
+
+    handoff, handoff_error = _load_package_json_artifact(package_root, handoff_path)
+    if handoff_error is not None or handoff is None:
+        return _cross_check_result(
+            name="handoff_matches_status_and_gate_sets",
+            ok=False,
+            path=handoff_path,
+            message=handoff_error or f"could not load handoff artifact: {handoff_path}",
+            errors=errors,
+        )
+
+    gate_sets, gate_sets_error = _load_package_json_artifact(package_root, gate_sets_path)
+    if gate_sets_error is not None or gate_sets is None:
+        return _cross_check_result(
+            name="handoff_matches_status_and_gate_sets",
+            ok=False,
+            path=gate_sets_path,
+            message=gate_sets_error or f"could not load gate sets: {gate_sets_path}",
+            errors=errors,
+        )
+
+    status_file, status_path_error = _resolve_package_artifact(package_root, status_path)
+    if status_path_error is not None or status_file is None:
+        return _cross_check_result(
+            name="handoff_matches_status_and_gate_sets",
+            ok=False,
+            path=status_path,
+            message=status_path_error or f"could not resolve status path: {status_path}",
+            errors=errors,
+        )
+
+    status_sha = _sha256_file(status_file)
+    failures: list[str] = []
+
+    if handoff.get("ok") is not True:
+        failures.append(f"handoff ok must be true, found {handoff.get('ok')!r}")
+
+    if handoff.get("gate_mode") != "release-grade":
+        failures.append(
+            f"handoff gate_mode must be 'release-grade', found {handoff.get('gate_mode')!r}"
+        )
+
+    status_source = handoff.get("status_source")
+    if not isinstance(status_source, dict):
+        failures.append("handoff status_source must be an object")
+        status_source = {}
+
+    if status_source.get("mode") != "existing":
+        failures.append(
+            f"handoff status_source.mode must be 'existing', "
+            f"found {status_source.get('mode')!r}"
+        )
+
+    if status_source.get("status_path") != status_path:
+        failures.append(
+            f"handoff status_source.status_path mismatch: "
+            f"expected {status_path!r}, found {status_source.get('status_path')!r}"
+        )
+
+    for field in (
+        "status_sha256_before_run",
+        "status_sha256_after_generation",
+        "status_sha256_after_run",
+    ):
+        if status_source.get(field) != status_sha:
+            failures.append(
+                f"handoff status_source.{field} mismatch: "
+                f"expected {status_sha!r}, found {status_source.get(field)!r}"
+            )
+
+    sets = gate_sets.get("sets")
+    if not isinstance(sets, dict):
+        failures.append("materialized gate sets must contain object-valued sets")
+        sets = {}
+
+    if handoff.get("materialized_gate_sets") != sets:
+        failures.append("handoff materialized_gate_sets does not match package gate sets")
+
+    if handoff.get("effective_required_gates") != gate_sets.get("effective_required_gates"):
+        failures.append(
+            "handoff effective_required_gates does not match package gate sets"
+        )
+
+    boundary = handoff.get("authority_boundary")
+    creates_release_authority = (
+        boundary.get("creates_release_authority")
+        if isinstance(boundary, dict)
+        else None
+    )
+    if creates_release_authority is not False:
+        failures.append(
+            "handoff authority_boundary.creates_release_authority must be false"
+        )
+
+    return _cross_check_result(
+        name="handoff_matches_status_and_gate_sets",
+        ok=failures == [],
+        path=handoff_path,
+        message="; ".join(failures) if failures else None,
+        errors=errors,
+    )
+
 
 def verify_package(package_root: Path) -> dict[str, Any]:
     package_root = package_root.resolve()
@@ -734,7 +857,14 @@ def verify_package(package_root: Path) -> dict[str, Any]:
                 errors=errors,
             )
         )
-
+       cross_artifact_checks.append(
+            _check_handoff_matches_status_and_gate_sets(
+                package_root=package_root,
+                manifest=manifest,
+                errors=errors,
+            )
+        )
+   
         authority_boundary = manifest.get("authority_boundary")
         creates_release_authority = (
             authority_boundary.get("creates_release_authority")
@@ -768,7 +898,7 @@ def verify_package(package_root: Path) -> dict[str, Any]:
                         source="package_digests",
                         errors=errors,
                     )
-                )
+                )     
 
         authority_boundary = digests.get("authority_boundary")
         creates_release_authority = (


### PR DESCRIPTION
## Summary

Extends the RA1 package verifier with operator handoff reconstruction consistency checks.

## Scope

Updates:

- `tools/verify_pulse_ref_ra1_package.py`
- `tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py`

## Purpose

The RA1 verifier already validates package manifests, digest manifests, artifact SHA-256 bindings, artifact schemas, gate-set reconstruction, and status satisfaction of effective required gates.

This PR adds operator handoff consistency checks.

The verifier now checks that the packaged handoff report:

- has `ok=true`;
- uses `gate_mode=release-grade`;
- uses `status_source.mode=existing`;
- points to the packaged status artifact;
- records status SHA-256 values matching the packaged status bytes;
- carries materialized gate sets matching `gates/materialized_gate_sets.json`;
- carries effective required gates matching the package gate-set artifact;
- preserves `authority_boundary.creates_release_authority=false`.

The smoke coverage adds negative cases for:

- handoff status digest mismatch;
- handoff effective required gate mismatch.

Both failure cases still emit schema-valid verifier reports.

## Authority boundary

This PR does not create release authority.

The verifier is an external reconstruction check. It verifies that an archived RA1 package preserves the declared-policy release-authority trail, but it does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, fixture artifact content, or CI behavior is changed beyond verifier coverage.