### PR TITLE
feat(pulse-ref): validate RA1 release authority manifest consistency

### DIFF
--- a/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
+++ b/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
@@ -129,6 +129,7 @@ def test_valid_ra1_minimal_package_verifies() -> None:
         assert "materialized_gate_sets_match_policy" in cross_check_names
         assert "status_satisfies_effective_required_gates" in cross_check_names
         assert "handoff_matches_status_and_gate_sets" in cross_check_names
+        assert "release_authority_manifest_matches_package_core" in cross_check_names
 
 def test_digest_mismatch_fails_with_schema_valid_report() -> None:
     with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
@@ -520,6 +521,123 @@ def test_handoff_effective_required_gates_mismatch_fails_with_schema_valid_repor
         assert handoff_checks[0]["ok"] is False
         assert "effective_required_gates does not match" in handoff_checks[0]["message"]
 
+def test_release_authority_status_digest_mismatch_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.release_authority_status_digest.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        release_authority_path = (
+            package_copy
+            / "release_authority"
+            / "release_authority_manifest.json"
+        )
+        release_authority = _read_json(release_authority_path)
+        release_authority["inputs"]["status_json"]["sha256"] = "0" * 64
+        _write_json(release_authority_path, release_authority)
+
+        release_authority_sha = _sha256_file(release_authority_path)
+
+        digests_path = package_copy / "digests" / "package_digests.json"
+        digests = _read_json(digests_path)
+        digests["artifacts"][
+            "release_authority/release_authority_manifest.json"
+        ] = release_authority_sha
+        _write_json(digests_path, digests)
+
+        digests_sha = _sha256_file(digests_path)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["release_authority_manifest"]["sha256"] = release_authority_sha
+        manifest["package_digests"]["sha256"] = digests_sha
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        release_authority_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "release_authority_manifest_matches_package_core"
+        ]
+
+        assert len(release_authority_checks) == 1
+        assert release_authority_checks[0]["ok"] is False
+        assert "inputs.status_json.sha256 mismatch" in release_authority_checks[0]["message"]
+
+
+def test_release_authority_effective_gates_mismatch_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.release_authority_effective_gates.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        release_authority_path = (
+            package_copy
+            / "release_authority"
+            / "release_authority_manifest.json"
+        )
+        release_authority = _read_json(release_authority_path)
+        release_authority["authority"]["effective_required_gates"] = [
+            gate_id
+            for gate_id in release_authority["authority"]["effective_required_gates"]
+            if gate_id != "q4_slo_ok"
+        ]
+        _write_json(release_authority_path, release_authority)
+
+        release_authority_sha = _sha256_file(release_authority_path)
+
+        digests_path = package_copy / "digests" / "package_digests.json"
+        digests = _read_json(digests_path)
+        digests["artifacts"][
+            "release_authority/release_authority_manifest.json"
+        ] = release_authority_sha
+        _write_json(digests_path, digests)
+
+        digests_sha = _sha256_file(digests_path)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["release_authority_manifest"]["sha256"] = release_authority_sha
+        manifest["package_digests"]["sha256"] = digests_sha
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        release_authority_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "release_authority_manifest_matches_package_core"
+        ]
+
+        assert len(release_authority_checks) == 1
+        assert release_authority_checks[0]["ok"] is False
+        assert (
+            "authority.effective_required_gates does not match package gate sets"
+            in release_authority_checks[0]["message"]
+        )
+
+
 def main() -> int:
     tests = [
         test_valid_ra1_minimal_package_verifies,
@@ -531,6 +649,8 @@ def main() -> int:
         test_materialized_gate_set_policy_mismatch_fails_with_schema_valid_report,
         test_handoff_status_digest_mismatch_fails_with_schema_valid_report,
         test_handoff_effective_required_gates_mismatch_fails_with_schema_valid_report,
+        test_release_authority_status_digest_mismatch_fails_with_schema_valid_report,
+        test_release_authority_effective_gates_mismatch_fails_with_schema_valid_report,
     ]
 
     try:

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -729,6 +729,247 @@ def _check_handoff_matches_status_and_gate_sets(
         errors=errors,
     )
 
+def _check_release_authority_manifest_matches_package_core(
+    *,
+    package_root: Path,
+    manifest: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any]:
+    release_authority_path = _manifest_artifact_path(
+        manifest,
+        "release_authority_manifest",
+    )
+    status_path = _manifest_artifact_path(manifest, "status_artifact")
+    policy_path = _manifest_artifact_path(manifest, "gate_policy")
+    registry_path = _manifest_artifact_path(manifest, "gate_registry")
+    gate_sets_path = _manifest_artifact_path(manifest, "materialized_gate_sets")
+
+    if (
+        release_authority_path is None
+        or status_path is None
+        or policy_path is None
+        or registry_path is None
+        or gate_sets_path is None
+    ):
+        return _cross_check_result(
+            name="release_authority_manifest_matches_package_core",
+            ok=False,
+            path="release_authority/release_authority_manifest.json",
+            message=(
+                "package manifest must reference release_authority_manifest, "
+                "status_artifact, gate_policy, gate_registry, and materialized_gate_sets"
+            ),
+            errors=errors,
+        )
+
+    release_authority, release_authority_error = _load_package_json_artifact(
+        package_root,
+        release_authority_path,
+    )
+    if release_authority_error is not None or release_authority is None:
+        return _cross_check_result(
+            name="release_authority_manifest_matches_package_core",
+            ok=False,
+            path=release_authority_path,
+            message=(
+                release_authority_error
+                or f"could not load release authority artifact: {release_authority_path}"
+            ),
+            errors=errors,
+        )
+
+    gate_sets, gate_sets_error = _load_package_json_artifact(package_root, gate_sets_path)
+    if gate_sets_error is not None or gate_sets is None:
+        return _cross_check_result(
+            name="release_authority_manifest_matches_package_core",
+            ok=False,
+            path=gate_sets_path,
+            message=gate_sets_error or f"could not load gate sets: {gate_sets_path}",
+            errors=errors,
+        )
+
+    status_file, status_error = _resolve_package_artifact(package_root, status_path)
+    policy_file, policy_error = _resolve_package_artifact(package_root, policy_path)
+    registry_file, registry_error = _resolve_package_artifact(package_root, registry_path)
+
+    if status_error is not None or status_file is None:
+        return _cross_check_result(
+            name="release_authority_manifest_matches_package_core",
+            ok=False,
+            path=status_path,
+            message=status_error or f"could not resolve status path: {status_path}",
+            errors=errors,
+        )
+
+    if policy_error is not None or policy_file is None:
+        return _cross_check_result(
+            name="release_authority_manifest_matches_package_core",
+            ok=False,
+            path=policy_path,
+            message=policy_error or f"could not resolve policy path: {policy_path}",
+            errors=errors,
+        )
+
+    if registry_error is not None or registry_file is None:
+        return _cross_check_result(
+            name="release_authority_manifest_matches_package_core",
+            ok=False,
+            path=registry_path,
+            message=registry_error or f"could not resolve registry path: {registry_path}",
+            errors=errors,
+        )
+
+    status_sha = _sha256_file(status_file)
+    policy_sha = _sha256_file(policy_file)
+    registry_sha = _sha256_file(registry_file)
+
+    failures: list[str] = []
+
+    run_identity = release_authority.get("run_identity")
+    if not isinstance(run_identity, dict):
+        failures.append("release authority run_identity must be an object")
+        run_identity = {}
+
+    if run_identity.get("run_mode") != "prod":
+        failures.append(
+            f"release authority run_identity.run_mode must be 'prod', "
+            f"found {run_identity.get('run_mode')!r}"
+        )
+
+    inputs = release_authority.get("inputs")
+    if not isinstance(inputs, dict):
+        failures.append("release authority inputs must be an object")
+        inputs = {}
+
+    status_input = inputs.get("status_json")
+    if not isinstance(status_input, dict):
+        failures.append("release authority inputs.status_json must be an object")
+        status_input = {}
+
+    if status_input.get("path") != status_path:
+        failures.append(
+            f"inputs.status_json.path mismatch: expected {status_path!r}, "
+            f"found {status_input.get('path')!r}"
+        )
+    if status_input.get("sha256") != status_sha:
+        failures.append(
+            f"inputs.status_json.sha256 mismatch: expected {status_sha!r}, "
+            f"found {status_input.get('sha256')!r}"
+        )
+
+    policy_input = inputs.get("gate_policy")
+    if not isinstance(policy_input, dict):
+        failures.append("release authority inputs.gate_policy must be an object")
+        policy_input = {}
+
+    if policy_input.get("path") != policy_path:
+        failures.append(
+            f"inputs.gate_policy.path mismatch: expected {policy_path!r}, "
+            f"found {policy_input.get('path')!r}"
+        )
+    if policy_input.get("sha256") != policy_sha:
+        failures.append(
+            f"inputs.gate_policy.sha256 mismatch: expected {policy_sha!r}, "
+            f"found {policy_input.get('sha256')!r}"
+        )
+
+    registry_input = inputs.get("gate_registry")
+    if not isinstance(registry_input, dict):
+        failures.append("release authority inputs.gate_registry must be an object")
+        registry_input = {}
+
+    if registry_input.get("path") != registry_path:
+        failures.append(
+            f"inputs.gate_registry.path mismatch: expected {registry_path!r}, "
+            f"found {registry_input.get('path')!r}"
+        )
+    if registry_input.get("sha256") != registry_sha:
+        failures.append(
+            f"inputs.gate_registry.sha256 mismatch: expected {registry_sha!r}, "
+            f"found {registry_input.get('sha256')!r}"
+        )
+
+    authority = release_authority.get("authority")
+    if not isinstance(authority, dict):
+        failures.append("release authority authority must be an object")
+        authority = {}
+
+    effective_required_gates = gate_sets.get("effective_required_gates")
+    if not isinstance(effective_required_gates, list):
+        failures.append("package gate_sets.effective_required_gates must be an array")
+        effective_required_gates = []
+
+    if authority.get("policy_set") != "required+release_required":
+        failures.append(
+            f"authority.policy_set must be 'required+release_required', "
+            f"found {authority.get('policy_set')!r}"
+        )
+
+    if authority.get("release_required_materialized") is not True:
+        failures.append("authority.release_required_materialized must be true")
+
+    if authority.get("effective_required_gates") != effective_required_gates:
+        failures.append(
+            "authority.effective_required_gates does not match package gate sets"
+        )
+
+    evaluation = release_authority.get("evaluation")
+    if not isinstance(evaluation, dict):
+        failures.append("release authority evaluation must be an object")
+        evaluation = {}
+
+    required_gate_results = evaluation.get("required_gate_results")
+    if not isinstance(required_gate_results, dict):
+        failures.append("evaluation.required_gate_results must be an object")
+        required_gate_results = {}
+
+    expected_results = {gate_id: True for gate_id in effective_required_gates}
+
+    if required_gate_results != expected_results:
+        failures.append(
+            "evaluation.required_gate_results does not match effective required gates"
+        )
+
+    if evaluation.get("failed_required_gates") != []:
+        failures.append(
+            f"evaluation.failed_required_gates must be [], "
+            f"found {evaluation.get('failed_required_gates')!r}"
+        )
+
+    if evaluation.get("missing_required_gates") != []:
+        failures.append(
+            f"evaluation.missing_required_gates must be [], "
+            f"found {evaluation.get('missing_required_gates')!r}"
+        )
+
+    decision = release_authority.get("decision")
+    if not isinstance(decision, dict):
+        failures.append("release authority decision must be an object")
+        decision = {}
+
+    if decision.get("state") != "PASS":
+        failures.append(
+            f"decision.state must be 'PASS', found {decision.get('state')!r}"
+        )
+
+    if decision.get("fail_closed") is not True:
+        failures.append("decision.fail_closed must be true")
+
+    diagnostics = release_authority.get("diagnostics")
+    if not isinstance(diagnostics, dict):
+        failures.append("release authority diagnostics must be an object")
+        diagnostics = {}
+
+    if diagnostics.get("shadow_surfaces_non_normative") is not True:
+        failures.append("diagnostics.shadow_surfaces_non_normative must be true")
+
+    return _cross_check_result(
+        name="release_authority_manifest_matches_package_core",
+        ok=failures == [],
+        path=release_authority_path,
+        message="; ".join(failures) if failures else None,
+        errors=errors,
+    )
 
 def verify_package(package_root: Path) -> dict[str, Any]:
     package_root = package_root.resolve()
@@ -865,7 +1106,14 @@ def verify_package(package_root: Path) -> dict[str, Any]:
                 errors=errors,
             )
         )
-
+        cross_artifact_checks.append(
+            _check_release_authority_manifest_matches_package_core(
+                package_root=package_root,
+                manifest=manifest,
+                errors=errors,
+            )
+        )
+   
         authority_boundary = manifest.get("authority_boundary")
         creates_release_authority = (
             authority_boundary.get("creates_release_authority")


### PR DESCRIPTION
## Summary

Extends the RA1 package verifier with release authority manifest consistency checks.

## Scope

Updates:

- `tools/verify_pulse_ref_ra1_package.py`
- `tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py`

## Purpose

The RA1 package verifier already validates:

- package manifest integrity;
- package digest manifest integrity;
- artifact SHA-256 bindings;
- package artifact schemas;
- materialized gate-set reconstruction against packaged policy;
- status satisfaction of effective required gates;
- operator handoff reconstruction consistency.

This PR adds release authority manifest consistency checks.

The verifier now checks that the packaged release authority manifest records:

- `run_identity.run_mode=prod`;
- status input path and SHA-256 matching the packaged status artifact;
- gate policy input path and SHA-256 matching the packaged policy artifact;
- gate registry input path and SHA-256 matching the packaged registry artifact;
- `authority.policy_set=required+release_required`;
- `authority.release_required_materialized=true`;
- effective required gates matching the package gate-set artifact;
- required gate evaluation results matching all effective required gates;
- empty failed required gates;
- empty missing required gates;
- `decision.state=PASS`;
- `decision.fail_closed=true`;
- `diagnostics.shadow_surfaces_non_normative=true`.

The smoke coverage adds negative cases for:

- release authority status digest mismatch;
- release authority effective required gate mismatch.

Both failure cases still emit schema-valid verifier reports.

## Authority boundary

This PR does not create release authority.

The verifier is an external reconstruction check. It verifies that an archived RA1 package preserves the declared-policy release-authority trail, but it does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, fixture artifact content, or CI behavior is changed beyond verifier coverage.