### PR TITLE
feat(pulse-ref): validate RA1 CI and publication consistency

### DIFF
--- a/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
+++ b/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
@@ -130,6 +130,7 @@ def test_valid_ra1_minimal_package_verifies() -> None:
         assert "status_satisfies_effective_required_gates" in cross_check_names
         assert "handoff_matches_status_and_gate_sets" in cross_check_names
         assert "release_authority_manifest_matches_package_core" in cross_check_names
+        assert "ci_outcome_and_publication_match_release_identity" in cross_check_names
 
 def test_digest_mismatch_fails_with_schema_valid_report() -> None:
     with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
@@ -637,6 +638,104 @@ def test_release_authority_effective_gates_mismatch_fails_with_schema_valid_repo
             in release_authority_checks[0]["message"]
         )
 
+def test_ci_outcome_commit_mismatch_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.ci_commit_mismatch.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        ci_path = package_copy / "ci" / "ci_outcome.json"
+        ci_outcome = _read_json(ci_path)
+        ci_outcome["commit_sha"] = "b" * 40
+        _write_json(ci_path, ci_outcome)
+
+        ci_sha = _sha256_file(ci_path)
+
+        digests_path = package_copy / "digests" / "package_digests.json"
+        digests = _read_json(digests_path)
+        digests["artifacts"]["ci/ci_outcome.json"] = ci_sha
+        _write_json(digests_path, digests)
+
+        digests_sha = _sha256_file(digests_path)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["ci_outcome"]["sha256"] = ci_sha
+        manifest["package_digests"]["sha256"] = digests_sha
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        ci_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "ci_outcome_and_publication_match_release_identity"
+        ]
+
+        assert len(ci_checks) == 1
+        assert ci_checks[0]["ok"] is False
+        assert "ci_outcome.commit_sha mismatch" in ci_checks[0]["message"]
+
+
+def test_publication_ci_url_mismatch_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.publication_ci_url.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        publication_path = package_copy / "publication" / "publication_snapshot.json"
+        publication = _read_json(publication_path)
+        publication["ci_outcome_url"] = (
+            "https://github.com/HKati/pulse-release-gates-0.1/actions/runs/999999999"
+        )
+        _write_json(publication_path, publication)
+
+        publication_sha = _sha256_file(publication_path)
+
+        digests_path = package_copy / "digests" / "package_digests.json"
+        digests = _read_json(digests_path)
+        digests["artifacts"]["publication/publication_snapshot.json"] = publication_sha
+        _write_json(digests_path, digests)
+
+        digests_sha = _sha256_file(digests_path)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["publication_snapshot"]["sha256"] = publication_sha
+        manifest["package_digests"]["sha256"] = digests_sha
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        ci_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "ci_outcome_and_publication_match_release_identity"
+        ]
+
+        assert len(ci_checks) == 1
+        assert ci_checks[0]["ok"] is False
+        assert "publication_snapshot.ci_outcome_url mismatch" in ci_checks[0]["message"]
 
 def main() -> int:
     tests = [
@@ -651,6 +750,8 @@ def main() -> int:
         test_handoff_effective_required_gates_mismatch_fails_with_schema_valid_report,
         test_release_authority_status_digest_mismatch_fails_with_schema_valid_report,
         test_release_authority_effective_gates_mismatch_fails_with_schema_valid_report,
+        test_ci_outcome_commit_mismatch_fails_with_schema_valid_report,
+        test_publication_ci_url_mismatch_fails_with_schema_valid_report,
     ]
 
     try:

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -971,6 +971,173 @@ def _check_release_authority_manifest_matches_package_core(
         errors=errors,
     )
 
+def _check_ci_outcome_and_publication_match_release_identity(
+    *,
+    package_root: Path,
+    manifest: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any]:
+    ci_outcome_path = _manifest_artifact_path(manifest, "ci_outcome")
+    publication_path = _manifest_artifact_path(manifest, "publication_snapshot")
+    release_authority_path = _manifest_artifact_path(
+        manifest,
+        "release_authority_manifest",
+    )
+
+    if (
+        ci_outcome_path is None
+        or publication_path is None
+        or release_authority_path is None
+    ):
+        return _cross_check_result(
+            name="ci_outcome_and_publication_match_release_identity",
+            ok=False,
+            path="ci/ci_outcome.json",
+            message=(
+                "package manifest must reference ci_outcome, "
+                "publication_snapshot, and release_authority_manifest"
+            ),
+            errors=errors,
+        )
+
+    ci_outcome, ci_error = _load_package_json_artifact(package_root, ci_outcome_path)
+    if ci_error is not None or ci_outcome is None:
+        return _cross_check_result(
+            name="ci_outcome_and_publication_match_release_identity",
+            ok=False,
+            path=ci_outcome_path,
+            message=ci_error or f"could not load CI outcome artifact: {ci_outcome_path}",
+            errors=errors,
+        )
+
+    publication, publication_error = _load_package_json_artifact(
+        package_root,
+        publication_path,
+    )
+    if publication_error is not None or publication is None:
+        return _cross_check_result(
+            name="ci_outcome_and_publication_match_release_identity",
+            ok=False,
+            path=publication_path,
+            message=(
+                publication_error
+                or f"could not load publication snapshot artifact: {publication_path}"
+            ),
+            errors=errors,
+        )
+
+    release_authority, release_authority_error = _load_package_json_artifact(
+        package_root,
+        release_authority_path,
+    )
+    if release_authority_error is not None or release_authority is None:
+        return _cross_check_result(
+            name="ci_outcome_and_publication_match_release_identity",
+            ok=False,
+            path=release_authority_path,
+            message=(
+                release_authority_error
+                or f"could not load release authority artifact: {release_authority_path}"
+            ),
+            errors=errors,
+        )
+
+    failures: list[str] = []
+
+    if ci_outcome.get("provider") != "github_actions":
+        failures.append(
+            f"ci_outcome.provider must be 'github_actions', "
+            f"found {ci_outcome.get('provider')!r}"
+        )
+
+    if ci_outcome.get("gate_check_conclusion") != "success":
+        failures.append(
+            f"ci_outcome.gate_check_conclusion must be 'success', "
+            f"found {ci_outcome.get('gate_check_conclusion')!r}"
+        )
+
+    run_attempt = ci_outcome.get("run_attempt")
+    if not isinstance(run_attempt, int) or run_attempt < 1:
+        failures.append(
+            f"ci_outcome.run_attempt must be an integer >= 1, found {run_attempt!r}"
+        )
+
+    ci_boundary = ci_outcome.get("authority_boundary")
+    ci_creates_release_authority = (
+        ci_boundary.get("creates_release_authority")
+        if isinstance(ci_boundary, dict)
+        else None
+    )
+    if ci_creates_release_authority is not False:
+        failures.append(
+            "ci_outcome authority_boundary.creates_release_authority must be false"
+        )
+
+    run_identity = release_authority.get("run_identity")
+    if not isinstance(run_identity, dict):
+        failures.append("release authority run_identity must be an object")
+        run_identity = {}
+
+    if str(ci_outcome.get("run_id")) != str(run_identity.get("run_id")):
+        failures.append(
+            f"ci_outcome.run_id mismatch: expected {run_identity.get('run_id')!r}, "
+            f"found {ci_outcome.get('run_id')!r}"
+        )
+
+    if str(ci_outcome.get("run_attempt")) != str(run_identity.get("attempt")):
+        failures.append(
+            f"ci_outcome.run_attempt mismatch: expected {run_identity.get('attempt')!r}, "
+            f"found {ci_outcome.get('run_attempt')!r}"
+        )
+
+    if ci_outcome.get("commit_sha") != run_identity.get("git_sha"):
+        failures.append(
+            f"ci_outcome.commit_sha mismatch: expected {run_identity.get('git_sha')!r}, "
+            f"found {ci_outcome.get('commit_sha')!r}"
+        )
+
+    if publication.get("creates_release_authority") is not False:
+        failures.append("publication_snapshot.creates_release_authority must be false")
+
+    if publication.get("git_sha") != ci_outcome.get("commit_sha"):
+        failures.append(
+            f"publication_snapshot.git_sha mismatch: "
+            f"expected {ci_outcome.get('commit_sha')!r}, "
+            f"found {publication.get('git_sha')!r}"
+        )
+
+    if publication.get("ci_outcome_url") != ci_outcome.get("run_url"):
+        failures.append(
+            f"publication_snapshot.ci_outcome_url mismatch: "
+            f"expected {ci_outcome.get('run_url')!r}, "
+            f"found {publication.get('ci_outcome_url')!r}"
+        )
+
+    manifest_package_id = manifest.get("package_id")
+    if (
+        isinstance(manifest_package_id, str)
+        and publication.get("package_id") != manifest_package_id
+    ):
+        failures.append(
+            f"publication_snapshot.package_id mismatch: "
+            f"expected {manifest_package_id!r}, found {publication.get('package_id')!r}"
+        )
+        
+    manifest_run_key = manifest.get("run_key")
+    if isinstance(manifest_run_key, str) and publication.get("run_key") != manifest_run_key:
+        failures.append(
+            f"publication_snapshot.run_key mismatch: "
+            f"expected {manifest_run_key!r}, found {publication.get('run_key')!r}"
+        )
+
+    return _cross_check_result(
+        name="ci_outcome_and_publication_match_release_identity",
+        ok=failures == [],
+        path=ci_outcome_path,
+        message="; ".join(failures) if failures else None,
+        errors=errors,
+    )
+
 def verify_package(package_root: Path) -> dict[str, Any]:
     package_root = package_root.resolve()
 
@@ -1113,7 +1280,14 @@ def verify_package(package_root: Path) -> dict[str, Any]:
                 errors=errors,
             )
         )
-   
+          cross_artifact_checks.append(
+            _check_ci_outcome_and_publication_match_release_identity(
+                package_root=package_root,
+                manifest=manifest,
+                errors=errors,
+            )
+        )
+      
         authority_boundary = manifest.get("authority_boundary")
         creates_release_authority = (
             authority_boundary.get("creates_release_authority")

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -1280,7 +1280,7 @@ def verify_package(package_root: Path) -> dict[str, Any]:
                 errors=errors,
             )
         )
-          cross_artifact_checks.append(
+        cross_artifact_checks.append(
             _check_ci_outcome_and_publication_match_release_identity(
                 package_root=package_root,
                 manifest=manifest,


### PR DESCRIPTION
## Summary

Extends the RA1 package verifier with CI outcome and publication snapshot consistency checks.

## Scope

Updates:

- `tools/verify_pulse_ref_ra1_package.py`
- `tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py`

## Purpose

The RA1 verifier already validates package manifests, digest manifests, artifact schemas, gate-set reconstruction, status satisfaction, operator handoff reconstruction, and release authority manifest consistency.

This PR adds CI/publication consistency checks.

The verifier now checks that:

- `ci/ci_outcome.json` records `provider=github_actions`;
- `ci/ci_outcome.json` records `gate_check_conclusion=success`;
- `ci/ci_outcome.json` has a valid `run_attempt`;
- CI outcome does not create release authority;
- CI run ID matches the release authority manifest run ID;
- CI run attempt matches the release authority manifest attempt;
- CI commit SHA matches the release authority manifest git SHA;
- `publication/publication_snapshot.json` has `creates_release_authority=false`;
- publication git SHA matches the CI outcome commit SHA;
- publication CI outcome URL matches the CI outcome run URL;
- publication package ID and run key match the package manifest.

The smoke coverage adds negative cases for:

- CI commit SHA mismatch;
- publication CI outcome URL mismatch.

Both failure cases still emit schema-valid verifier reports.

## Authority boundary

This PR does not create release authority.

The verifier is an external reconstruction check. It verifies that an archived RA1 package preserves the declared-policy release-authority trail, but it does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, fixture artifact content, or CI behavior is changed beyond verifier coverage.