### PR TITLE
fix(pulse-ref): emit RA1 CI publication consistency check

### DIFF
--- a/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
+++ b/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
@@ -24,6 +24,7 @@ def _read_json(path: Path) -> dict[str, Any]:
 def _write_json(path: Path, obj: dict[str, Any]) -> None:
     path.write_text(json.dumps(obj, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
+
 def _sha256_file(path: Path) -> str:
     import hashlib
 
@@ -34,6 +35,7 @@ def _sha256_file(path: Path) -> str:
             h.update(chunk)
 
     return h.hexdigest()
+
 
 def _run(package_root: Path, out_path: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
@@ -131,6 +133,17 @@ def test_valid_ra1_minimal_package_verifies() -> None:
         assert "handoff_matches_status_and_gate_sets" in cross_check_names
         assert "release_authority_manifest_matches_package_core" in cross_check_names
         assert "ci_outcome_and_publication_match_release_identity" in cross_check_names
+
+        cross_check_order = [
+            check["name"]
+            for check in report["cross_artifact_checks"]
+        ]
+        assert cross_check_order.index(
+            "release_authority_manifest_matches_package_core"
+        ) < cross_check_order.index(
+            "ci_outcome_and_publication_match_release_identity"
+        )
+
 
 def test_digest_mismatch_fails_with_schema_valid_report() -> None:
     with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:


### PR DESCRIPTION
## Summary

Aligns the RA1 package verifier implementation with the CI/publication consistency smoke expectations.

## Scope

Updates:

- `tools/verify_pulse_ref_ra1_package.py`
- `tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py`

## Purpose

The smoke test expects the verifier to emit:

`ci_outcome_and_publication_match_release_identity`

This PR adds that verifier cross-artifact check and fixes the call-site indentation so the verifier compiles and runs.

The check validates that:

- CI provider is `github_actions`;
- gate-check conclusion is `success`;
- CI run attempt is valid;
- CI outcome does not create release authority;
- CI run identity matches the release authority manifest;
- CI commit SHA matches the release authority manifest git SHA;
- publication snapshot does not create release authority;
- publication git SHA matches the CI outcome commit SHA;
- publication CI URL matches the CI outcome run URL;
- publication package ID and run key match the package manifest.

## Authority boundary

This PR does not create release authority.

The verifier is an external reconstruction check. It verifies that an archived RA1 package preserves the declared-policy release-authority trail, but it does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, fixture artifact content, or CI behavior is changed beyond verifier coverage.