### PR TITLE
feat(pulse-ref): validate RA1 package digest coverage

### DIFF
--- a/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
+++ b/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
@@ -133,7 +133,8 @@ def test_valid_ra1_minimal_package_verifies() -> None:
         assert "handoff_matches_status_and_gate_sets" in cross_check_names
         assert "release_authority_manifest_matches_package_core" in cross_check_names
         assert "ci_outcome_and_publication_match_release_identity" in cross_check_names
-
+        assert "package_digests_cover_manifest_payload" in cross_check_names
+ 
         cross_check_order = [
             check["name"]
             for check in report["cross_artifact_checks"]
@@ -750,6 +751,106 @@ def test_publication_ci_url_mismatch_fails_with_schema_valid_report() -> None:
         assert ci_checks[0]["ok"] is False
         assert "publication_snapshot.ci_outcome_url mismatch" in ci_checks[0]["message"]
 
+
+def test_missing_package_digest_entry_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.missing_digest_entry.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        digests_path = package_copy / "digests" / "package_digests.json"
+        digests = _read_json(digests_path)
+        digests["artifacts"].pop("ci/ci_outcome.json")
+        _write_json(digests_path, digests)
+
+        digests_sha = _sha256_file(digests_path)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["package_digests"]["sha256"] = digests_sha
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        coverage_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "package_digests_cover_manifest_payload"
+        ]
+
+        assert len(coverage_checks) == 1
+        assert coverage_checks[0]["ok"] is False
+        assert "ci/ci_outcome.json" in coverage_checks[0]["message"]
+        assert "missing expected payload artifacts" in coverage_checks[0]["message"]
+
+
+def test_unexpected_package_digest_entry_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.unexpected_digest_entry.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        extra_dir = package_copy / "extra"
+        extra_dir.mkdir()
+        extra_artifact = extra_dir / "unused.json"
+        extra_artifact.write_text(
+            json.dumps(
+                {
+                    "unused": True,
+                    "note": "This artifact is not referenced by the package manifest.",
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        digests_path = package_copy / "digests" / "package_digests.json"
+        digests = _read_json(digests_path)
+        digests["artifacts"]["extra/unused.json"] = _sha256_file(extra_artifact)
+        _write_json(digests_path, digests)
+
+        digests_sha = _sha256_file(digests_path)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["package_digests"]["sha256"] = digests_sha
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        coverage_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "package_digests_cover_manifest_payload"
+        ]
+
+        assert len(coverage_checks) == 1
+        assert coverage_checks[0]["ok"] is False
+        assert "extra/unused.json" in coverage_checks[0]["message"]
+        assert "unexpected artifact entries" in coverage_checks[0]["message"]
+
 def main() -> int:
     tests = [
         test_valid_ra1_minimal_package_verifies,
@@ -765,6 +866,8 @@ def main() -> int:
         test_release_authority_effective_gates_mismatch_fails_with_schema_valid_report,
         test_ci_outcome_commit_mismatch_fails_with_schema_valid_report,
         test_publication_ci_url_mismatch_fails_with_schema_valid_report,
+        test_missing_package_digest_entry_fails_with_schema_valid_report,
+        test_unexpected_package_digest_entry_fails_with_schema_valid_report,
     ]
 
     try:

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -1356,14 +1356,14 @@ def verify_package(package_root: Path) -> dict[str, Any]:
                 errors=errors,
             )
         )
-          cross_artifact_checks.append(
+        cross_artifact_checks.append(
             _check_ci_outcome_and_publication_match_release_identity(
                 package_root=package_root,
                 manifest=manifest,
                 errors=errors,
             )
         )
-          cross_artifact_checks.append(
+        cross_artifact_checks.append(
             _check_package_digests_cover_manifest_payload(
                 package_root=package_root,
                 manifest=manifest,

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -1356,8 +1356,15 @@ def verify_package(package_root: Path) -> dict[str, Any]:
                 errors=errors,
             )
         )
-        cross_artifact_checks.append(
+          cross_artifact_checks.append(
             _check_ci_outcome_and_publication_match_release_identity(
+                package_root=package_root,
+                manifest=manifest,
+                errors=errors,
+            )
+        )
+          cross_artifact_checks.append(
+            _check_package_digests_cover_manifest_payload(
                 package_root=package_root,
                 manifest=manifest,
                 errors=errors,

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -1138,6 +1138,82 @@ def _check_ci_outcome_and_publication_match_release_identity(
         errors=errors,
     )
 
+
+def _check_package_digests_cover_manifest_payload(
+    *,
+    package_root: Path,
+    manifest: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any]:
+    digests_path = _manifest_artifact_path(manifest, "package_digests")
+
+    if digests_path is None:
+        return _cross_check_result(
+            name="package_digests_cover_manifest_payload",
+            ok=False,
+            path="digests/package_digests.json",
+            message="package manifest must reference package_digests",
+            errors=errors,
+        )
+
+    digests, digests_error = _load_package_json_artifact(package_root, digests_path)
+    if digests_error is not None or digests is None:
+        return _cross_check_result(
+            name="package_digests_cover_manifest_payload",
+            ok=False,
+            path=digests_path,
+            message=digests_error or f"could not load digest manifest: {digests_path}",
+            errors=errors,
+        )
+
+    artifacts = digests.get("artifacts")
+    if not isinstance(artifacts, dict):
+        return _cross_check_result(
+            name="package_digests_cover_manifest_payload",
+            ok=False,
+            path=digests_path,
+            message="package_digests artifacts must be an object",
+            errors=errors,
+        )
+
+    expected_paths: list[str] = ["README.md"]
+
+    for field in ARTIFACT_REF_FIELDS:
+        if field == "package_digests":
+            continue
+
+        rel_path = _manifest_artifact_path(manifest, field)
+        if rel_path is not None:
+            expected_paths.append(rel_path)
+
+    expected = set(expected_paths)
+    actual = set(artifacts.keys())
+
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+
+    failures: list[str] = []
+
+    if missing:
+        failures.append(
+            "package_digests missing expected payload artifacts: " + ", ".join(missing)
+        )
+
+    if unexpected:
+        failures.append(
+            "package_digests contains unexpected artifact entries: "
+            + ", ".join(unexpected)
+        )
+
+    return _cross_check_result(
+        name="package_digests_cover_manifest_payload",
+        ok=failures == [],
+        path=digests_path,
+        message="; ".join(failures) if failures else None,
+        errors=errors,
+    )
+
+
 def verify_package(package_root: Path) -> dict[str, Any]:
     package_root = package_root.resolve()
 


### PR DESCRIPTION
## Summary

Extends the RA1 package verifier with package digest coverage checks.

## Scope

Updates:

- `tools/verify_pulse_ref_ra1_package.py`
- `tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py`

## Purpose

The RA1 verifier already validates package manifests, digest manifests, artifact schemas, SHA-256 bindings, gate-set reconstruction, status satisfaction, operator handoff reconstruction, release authority manifest consistency, and CI/publication consistency.

This PR adds digest coverage validation.

The verifier now checks that `digests/package_digests.json` covers the expected manifest-bound package payload artifacts:

- `README.md`
- status artifact
- packaged gate policy
- gate registry
- materialized gate sets
- operator handoff report
- release authority manifest
- CI outcome
- publication snapshot

The digest manifest intentionally does not hash itself and does not hash `package_manifest.json`, because the package manifest references the digest manifest by SHA-256.

The new check rejects:

- missing expected payload digest entries;
- unexpected digest entries outside the manifest-bound payload set.

The smoke coverage adds negative cases for both failures while keeping verifier reports schema-valid.

## Authority boundary

This PR does not create release authority.

The verifier is an external reconstruction check. It verifies that an archived RA1 package preserves the declared-policy release-authority trail, but it does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, fixture artifact content, or CI behavior is changed beyond verifier coverage.