### PR TITLE
feat(pulse-ref): validate RA1 package file inventory

### DIFF
--- a/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
+++ b/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
@@ -134,7 +134,8 @@ def test_valid_ra1_minimal_package_verifies() -> None:
         assert "release_authority_manifest_matches_package_core" in cross_check_names
         assert "ci_outcome_and_publication_match_release_identity" in cross_check_names
         assert "package_digests_cover_manifest_payload" in cross_check_names
- 
+        assert "package_inventory_matches_manifest" in cross_check_names
+      
         cross_check_order = [
             check["name"]
             for check in report["cross_artifact_checks"]
@@ -851,6 +852,85 @@ def test_unexpected_package_digest_entry_fails_with_schema_valid_report() -> Non
         assert "extra/unused.json" in coverage_checks[0]["message"]
         assert "unexpected artifact entries" in coverage_checks[0]["message"]
 
+def test_untracked_package_file_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.untracked_file.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        extra_dir = package_copy / "extra"
+        extra_dir.mkdir()
+        extra_file = extra_dir / "untracked.json"
+        extra_file.write_text(
+            json.dumps(
+                {
+                    "untracked": True,
+                    "note": "This file is present in the package but not declared.",
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        inventory_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "package_inventory_matches_manifest"
+        ]
+
+        assert len(inventory_checks) == 1
+        assert inventory_checks[0]["ok"] is False
+        assert "extra/untracked.json" in inventory_checks[0]["message"]
+        assert "unexpected files" in inventory_checks[0]["message"]
+
+
+def test_missing_package_file_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.missing_file.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        readme_path = package_copy / "README.md"
+        readme_path.unlink()
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        inventory_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "package_inventory_matches_manifest"
+        ]
+
+        assert len(inventory_checks) == 1
+        assert inventory_checks[0]["ok"] is False
+        assert "README.md" in inventory_checks[0]["message"]
+        assert "missing expected files" in inventory_checks[0]["message"]
+
+
 def main() -> int:
     tests = [
         test_valid_ra1_minimal_package_verifies,
@@ -868,6 +948,8 @@ def main() -> int:
         test_publication_ci_url_mismatch_fails_with_schema_valid_report,
         test_missing_package_digest_entry_fails_with_schema_valid_report,
         test_unexpected_package_digest_entry_fails_with_schema_valid_report,
+        test_untracked_package_file_fails_with_schema_valid_report,
+        test_missing_package_file_fails_with_schema_valid_report,
     ]
 
     try:

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -1213,6 +1213,64 @@ def _check_package_digests_cover_manifest_payload(
         errors=errors,
     )
 
+def _package_file_inventory(package_root: Path) -> set[str]:
+    files: set[str] = set()
+
+    for path in package_root.rglob("*"):
+        if not (path.is_file() or path.is_symlink()):
+            continue
+
+        files.add(path.relative_to(package_root).as_posix())
+
+    return files
+
+
+def _check_package_inventory_matches_manifest(
+    *,
+    package_root: Path,
+    manifest: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any]:
+    expected: set[str] = {
+        "README.md",
+        "package_manifest.json",
+    }
+    failures: list[str] = []
+
+    for field in ARTIFACT_REF_FIELDS:
+        rel_path = _manifest_artifact_path(manifest, field)
+
+        if rel_path is None:
+            continue
+
+        if not _is_safe_relative_path(rel_path):
+            failures.append(
+                f"manifest field {field} has unsafe artifact path: {rel_path!r}"
+            )
+            continue
+
+        expected.add(rel_path)
+
+    actual = _package_file_inventory(package_root)
+
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+
+    if missing:
+        failures.append("package inventory missing expected files: " + ", ".join(missing))
+
+    if unexpected:
+        failures.append(
+            "package inventory contains unexpected files: " + ", ".join(unexpected)
+        )
+
+    return _cross_check_result(
+        name="package_inventory_matches_manifest",
+        ok=failures == [],
+        path="package_manifest.json",
+        message="; ".join(failures) if failures else None,
+        errors=errors,
+    )
 
 def verify_package(package_root: Path) -> dict[str, Any]:
     package_root = package_root.resolve()
@@ -1365,6 +1423,13 @@ def verify_package(package_root: Path) -> dict[str, Any]:
         )
         cross_artifact_checks.append(
             _check_package_digests_cover_manifest_payload(
+                package_root=package_root,
+                manifest=manifest,
+                errors=errors,
+            )
+        )
+        cross_artifact_checks.append(
+            _check_package_inventory_matches_manifest(
                 package_root=package_root,
                 manifest=manifest,
                 errors=errors,


### PR DESCRIPTION
## Summary

Extends the RA1 package verifier with package file inventory checks.

## Scope

Updates:

- `tools/verify_pulse_ref_ra1_package.py`
- `tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py`

## Purpose

The RA1 verifier already validates package manifests, digest manifests, artifact schemas, SHA-256 bindings, gate-set reconstruction, status satisfaction, operator handoff reconstruction, release authority manifest consistency, CI/publication consistency, and package digest coverage.

This PR adds file inventory validation.

The verifier now checks that the actual package files match the manifest-bound package inventory:

- `README.md`
- `package_manifest.json`
- all artifact paths referenced by `package_manifest.json`

The check rejects:

- unexpected files present in the package directory;
- missing files expected from the declared package payload.

The smoke coverage adds negative cases for:

- an untracked package file;
- a missing package file.

Both failure cases still emit schema-valid verifier reports.

## Authority boundary

This PR does not create release authority.

The verifier is an external reconstruction check. It verifies that an archived RA1 package preserves the declared-policy release-authority trail, but it does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, fixture artifact content, or CI behavior is changed beyond verifier coverage.