### PR TITLE
feat(pulse-ref): enforce RA1 canonical package layout

### DIFF
--- a/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
+++ b/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
@@ -135,6 +135,7 @@ def test_valid_ra1_minimal_package_verifies() -> None:
         assert "ci_outcome_and_publication_match_release_identity" in cross_check_names
         assert "package_digests_cover_manifest_payload" in cross_check_names
         assert "package_inventory_matches_manifest" in cross_check_names
+        assert "package_manifest_uses_canonical_layout" in cross_check_names
       
         cross_check_order = [
             check["name"]
@@ -930,6 +931,86 @@ def test_missing_package_file_fails_with_schema_valid_report() -> None:
         assert "README.md" in inventory_checks[0]["message"]
         assert "missing expected files" in inventory_checks[0]["message"]
 
+def test_noncanonical_status_artifact_path_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.noncanonical_status_path.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        old_status_path = package_copy / "status" / "status.json"
+        new_status_path = package_copy / "status" / "status.alt.json"
+
+        new_status_path.write_text(
+            old_status_path.read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+        old_status_path.unlink()
+
+        status_sha = _sha256_file(new_status_path)
+
+        handoff_path = package_copy / "handoff" / "operator_handoff_report.json"
+        handoff = _read_json(handoff_path)
+        handoff["status_source"]["status_path"] = "status/status.alt.json"
+        handoff["status_source"]["status_sha256_before_run"] = status_sha
+        handoff["status_source"]["status_sha256_after_generation"] = status_sha
+        handoff["status_source"]["status_sha256_after_run"] = status_sha
+        _write_json(handoff_path, handoff)
+        handoff_sha = _sha256_file(handoff_path)
+
+        release_authority_path = (
+            package_copy
+            / "release_authority"
+            / "release_authority_manifest.json"
+        )
+        release_authority = _read_json(release_authority_path)
+        release_authority["inputs"]["status_json"]["path"] = "status/status.alt.json"
+        release_authority["inputs"]["status_json"]["sha256"] = status_sha
+        _write_json(release_authority_path, release_authority)
+        release_authority_sha = _sha256_file(release_authority_path)
+
+        digests_path = package_copy / "digests" / "package_digests.json"
+        digests = _read_json(digests_path)
+        digests["artifacts"].pop("status/status.json")
+        digests["artifacts"]["status/status.alt.json"] = status_sha
+        digests["artifacts"]["handoff/operator_handoff_report.json"] = handoff_sha
+        digests["artifacts"][
+            "release_authority/release_authority_manifest.json"
+        ] = release_authority_sha
+        _write_json(digests_path, digests)
+        digests_sha = _sha256_file(digests_path)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["status_artifact"]["path"] = "status/status.alt.json"
+        manifest["status_artifact"]["sha256"] = status_sha
+        manifest["operator_handoff_report"]["sha256"] = handoff_sha
+        manifest["release_authority_manifest"]["sha256"] = release_authority_sha
+        manifest["package_digests"]["sha256"] = digests_sha
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        layout_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "package_manifest_uses_canonical_layout"
+        ]
+
+        assert len(layout_checks) == 1
+        assert layout_checks[0]["ok"] is False
+        assert "status_artifact path mismatch" in layout_checks[0]["message"]
+        assert "status/status.alt.json" in layout_checks[0]["message"]
+
 
 def main() -> int:
     tests = [
@@ -950,6 +1031,7 @@ def main() -> int:
         test_unexpected_package_digest_entry_fails_with_schema_valid_report,
         test_untracked_package_file_fails_with_schema_valid_report,
         test_missing_package_file_fails_with_schema_valid_report,
+        test_noncanonical_status_artifact_path_fails_with_schema_valid_report,
     ]
 
     try:

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -59,6 +59,18 @@ ARTIFACT_REF_FIELDS = [
     "package_digests",
 ]
 
+CANONICAL_RA1_ARTIFACT_PATHS = {
+    "status_artifact": "status/status.json",
+    "gate_policy": "policy/pulse_gate_policy_v0.yml",
+    "gate_registry": "policy/pulse_gate_registry_v0.yml",
+    "materialized_gate_sets": "gates/materialized_gate_sets.json",
+    "operator_handoff_report": "handoff/operator_handoff_report.json",
+    "release_authority_manifest": "release_authority/release_authority_manifest.json",
+    "ci_outcome": "ci/ci_outcome.json",
+    "publication_snapshot": "publication/publication_snapshot.json",
+    "package_digests": "digests/package_digests.json",
+}
+
 ARTIFACT_SCHEMA_TARGETS = [
     (
         "materialized_gate_sets",
@@ -1272,6 +1284,34 @@ def _check_package_inventory_matches_manifest(
         errors=errors,
     )
 
+def _check_package_manifest_uses_canonical_layout(
+    *,
+    manifest: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any]:
+    failures: list[str] = []
+
+    for field, expected_path in CANONICAL_RA1_ARTIFACT_PATHS.items():
+        rel_path = _manifest_artifact_path(manifest, field)
+
+        if rel_path is None:
+            failures.append(f"package manifest missing {field}.path")
+            continue
+
+        if rel_path != expected_path:
+            failures.append(
+                f"{field} path mismatch: expected {expected_path!r}, found {rel_path!r}"
+            )
+
+    return _cross_check_result(
+        name="package_manifest_uses_canonical_layout",
+        ok=failures == [],
+        path="package_manifest.json",
+        message="; ".join(failures) if failures else None,
+        errors=errors,
+    )
+
+
 def verify_package(package_root: Path) -> dict[str, Any]:
     package_root = package_root.resolve()
 
@@ -1431,6 +1471,12 @@ def verify_package(package_root: Path) -> dict[str, Any]:
         cross_artifact_checks.append(
             _check_package_inventory_matches_manifest(
                 package_root=package_root,
+                manifest=manifest,
+                errors=errors,
+            )
+        )
+        cross_artifact_checks.append(
+            _check_package_manifest_uses_canonical_layout(
                 manifest=manifest,
                 errors=errors,
             )


### PR DESCRIPTION
## Summary

Extends the RA1 package verifier with canonical package layout validation.

## Scope

Updates:

- `tools/verify_pulse_ref_ra1_package.py`
- `tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py`

## Purpose

The RA1 verifier already validates package manifests, digest manifests, artifact schemas, SHA-256 bindings, cross-artifact consistency, digest coverage, package inventory, and regular-file payload boundaries.

This PR adds canonical layout validation.

The verifier now checks that `package_manifest.json` references the canonical RA1 artifact paths:

- `status/status.json`
- `policy/pulse_gate_policy_v0.yml`
- `policy/pulse_gate_registry_v0.yml`
- `gates/materialized_gate_sets.json`
- `handoff/operator_handoff_report.json`
- `release_authority/release_authority_manifest.json`
- `ci/ci_outcome.json`
- `publication/publication_snapshot.json`
- `digests/package_digests.json`

This prevents a package from passing verification while moving declared artifacts into non-standard paths, even if the digest manifest and cross-artifact references remain internally consistent.

The smoke coverage adds a negative case for a non-canonical status artifact path while keeping the verifier report schema-valid.

## Authority boundary

This PR does not create release authority.

The verifier is an external reconstruction check. It verifies that an archived RA1 package preserves the declared-policy release-authority trail, but it does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, fixture artifact content, or CI behavior is changed beyond verifier coverage.