### PR TITLE
fix(pulse-ref): restore RA1 regular-file payload check

### DIFF
--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -1284,6 +1284,52 @@ def _check_package_inventory_matches_manifest(
         errors=errors,
     )
 
+def _check_package_payload_files_are_regular_files(
+    *,
+    package_root: Path,
+    manifest: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any]:
+    expected_paths: list[str] = [
+        "README.md",
+        "package_manifest.json",
+    ]
+
+    for field in ARTIFACT_REF_FIELDS:
+        rel_path = _manifest_artifact_path(manifest, field)
+
+        if rel_path is not None:
+            expected_paths.append(rel_path)
+
+    failures: list[str] = []
+
+    for rel_path in sorted(set(expected_paths)):
+        if not _is_safe_relative_path(rel_path):
+            failures.append(f"unsafe package payload path: {rel_path!r}")
+            continue
+
+        artifact_path = package_root / rel_path
+
+        if artifact_path.is_symlink():
+            failures.append(
+                f"package payload artifact must be a regular file, found symlink: {rel_path}"
+            )
+            continue
+
+        if not artifact_path.is_file():
+            failures.append(
+                f"package payload artifact missing or not a regular file: {rel_path}"
+            )
+
+    return _cross_check_result(
+        name="package_payload_files_are_regular_files",
+        ok=failures == [],
+        path="package_manifest.json",
+        message="; ".join(failures) if failures else None,
+        errors=errors,
+    )
+
+
 def _check_package_manifest_uses_canonical_layout(
     *,
     manifest: dict[str, Any],
@@ -1470,6 +1516,13 @@ def verify_package(package_root: Path) -> dict[str, Any]:
         )
         cross_artifact_checks.append(
             _check_package_inventory_matches_manifest(
+                package_root=package_root,
+                manifest=manifest,
+                errors=errors,
+            )
+        )
+        cross_artifact_checks.append(
+            _check_package_payload_files_are_regular_files(
                 package_root=package_root,
                 manifest=manifest,
                 errors=errors,


### PR DESCRIPTION
## Summary

Restores the RA1 package verifier regular-file payload check.

## Scope

Updates:

- `tools/verify_pulse_ref_ra1_package.py`
- `tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py`

## Purpose

The RA1 verifier already validates package manifests, digest manifests, artifact schemas, SHA-256 bindings, cross-artifact consistency, digest coverage, package inventory, and canonical layout.

This PR restores the regular-file payload invariant.

The verifier now checks that the declared RA1 package payload paths are regular files rather than symlinks:

- `README.md`
- `package_manifest.json`
- every artifact path referenced by `package_manifest.json`

This restores the package boundary rule:

`declared package artifact = actual regular file bytes at the declared package path`

not:

`declared package artifact = symlink target bytes`

The check rejects symlinked declared artifacts even when the symlink resolves inside the package root.

The smoke coverage includes a negative case for a declared artifact symlinked to another file inside the package while keeping the verifier report schema-valid.

## Authority boundary

This PR does not create release authority.

The verifier is an external reconstruction check. It verifies that an archived RA1 package preserves the declared-policy release-authority trail, but it does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, fixture artifact content, or CI behavior is changed beyond verifier coverage.