### PR TITLE
fix(pulse-ref): align RA1 verifier identity and smoke coverage

### DIFF
--- a/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
+++ b/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
@@ -136,7 +136,13 @@ def test_valid_ra1_minimal_package_verifies() -> None:
         assert "package_digests_cover_manifest_payload" in cross_check_names
         assert "package_inventory_matches_manifest" in cross_check_names
         assert "package_manifest_uses_canonical_layout" in cross_check_names
-      
+        assert "package_payload_files_are_regular_files" in cross_check_names
+        assert "package_manifest_uses_canonical_layout" in cross_check_names
+        assert "package_identity_matches_release_surfaces" in cross_check_names
+        assert "package_manifest_authority_boundary" in cross_check_names
+        assert "package_digests_authority_boundary" in cross_check_names
+        assert "package_id_consistency" in cross_check_names
+     
         cross_check_order = [
             check["name"]
             for check in report["cross_artifact_checks"]
@@ -1011,6 +1017,39 @@ def test_noncanonical_status_artifact_path_fails_with_schema_valid_report() -> N
         assert "status_artifact path mismatch" in layout_checks[0]["message"]
         assert "status/status.alt.json" in layout_checks[0]["message"]
 
+def test_package_manifest_git_sha_mismatch_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.package_manifest_git_sha.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["git_sha"] = "b" * 40
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        identity_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "package_identity_matches_release_surfaces"
+        ]
+
+        assert len(identity_checks) == 1
+        assert identity_checks[0]["ok"] is False
+        assert "package_manifest.git_sha mismatch" in identity_checks[0]["message"]
+    
 
 def main() -> int:
     tests = [
@@ -1032,6 +1071,7 @@ def main() -> int:
         test_untracked_package_file_fails_with_schema_valid_report,
         test_missing_package_file_fails_with_schema_valid_report,
         test_noncanonical_status_artifact_path_fails_with_schema_valid_report,
+        test_package_manifest_git_sha_mismatch_fails_with_schema_valid_report,
     ]
 
     try:

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -1357,6 +1357,143 @@ def _check_package_manifest_uses_canonical_layout(
         errors=errors,
     )
 
+def _is_git_sha(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    if len(value) != 40:
+        return False
+    return all(char in "0123456789abcdef" for char in value)
+
+
+def _check_package_identity_matches_release_surfaces(
+    *,
+    package_root: Path,
+    manifest: dict[str, Any],
+    digests: dict[str, Any] | None,
+    errors: list[str],
+) -> dict[str, Any]:
+    package_id = manifest.get("package_id")
+    run_key = manifest.get("run_key")
+    git_sha = manifest.get("git_sha")
+
+    failures: list[str] = []
+
+    if not isinstance(package_id, str) or not package_id:
+        failures.append("package_manifest.package_id must be a non-empty string")
+
+    if not isinstance(run_key, str) or not run_key:
+        failures.append("package_manifest.run_key must be a non-empty string")
+
+    if not _is_git_sha(git_sha):
+        failures.append("package_manifest.git_sha must be a 40-character lowercase git SHA")
+
+    if isinstance(digests, dict):
+        digest_package_id = digests.get("package_id")
+        if digest_package_id not in (None, package_id):
+            failures.append(
+                f"package_digests.package_id mismatch: "
+                f"expected {package_id!r}, found {digest_package_id!r}"
+            )
+    else:
+        failures.append("package_digests must be available for package identity check")
+
+    release_authority_path = _manifest_artifact_path(
+        manifest,
+        "release_authority_manifest",
+    )
+    ci_outcome_path = _manifest_artifact_path(manifest, "ci_outcome")
+    publication_path = _manifest_artifact_path(manifest, "publication_snapshot")
+
+    release_authority: dict[str, Any] | None = None
+    ci_outcome: dict[str, Any] | None = None
+    publication: dict[str, Any] | None = None
+
+    if release_authority_path is None:
+        failures.append("package manifest must reference release_authority_manifest")
+    else:
+        release_authority, release_authority_error = _load_package_json_artifact(
+            package_root,
+            release_authority_path,
+        )
+        if release_authority_error is not None or release_authority is None:
+            failures.append(
+                release_authority_error
+                or f"could not load release authority artifact: {release_authority_path}"
+            )
+
+    if ci_outcome_path is None:
+        failures.append("package manifest must reference ci_outcome")
+    else:
+        ci_outcome, ci_error = _load_package_json_artifact(
+            package_root,
+            ci_outcome_path,
+        )
+        if ci_error is not None or ci_outcome is None:
+            failures.append(
+                ci_error or f"could not load CI outcome artifact: {ci_outcome_path}"
+            )
+
+    if publication_path is None:
+        failures.append("package manifest must reference publication_snapshot")
+    else:
+        publication, publication_error = _load_package_json_artifact(
+            package_root,
+            publication_path,
+        )
+        if publication_error is not None or publication is None:
+            failures.append(
+                publication_error
+                or f"could not load publication snapshot artifact: {publication_path}"
+            )
+
+    if release_authority is not None:
+        run_identity = release_authority.get("run_identity")
+        if not isinstance(run_identity, dict):
+            failures.append("release_authority.run_identity must be an object")
+            run_identity = {}
+
+        if isinstance(git_sha, str) and run_identity.get("git_sha") != git_sha:
+            failures.append(
+                f"package_manifest.git_sha mismatch with "
+                f"release_authority.run_identity.git_sha: "
+                f"expected {git_sha!r}, found {run_identity.get('git_sha')!r}"
+            )
+
+    if ci_outcome is not None and isinstance(git_sha, str):
+        if ci_outcome.get("commit_sha") != git_sha:
+            failures.append(
+                f"package_manifest.git_sha mismatch with ci_outcome.commit_sha: "
+                f"expected {git_sha!r}, found {ci_outcome.get('commit_sha')!r}"
+            )
+
+    if publication is not None:
+        if isinstance(package_id, str) and publication.get("package_id") != package_id:
+            failures.append(
+                f"package_manifest.package_id mismatch with "
+                f"publication_snapshot.package_id: "
+                f"expected {package_id!r}, found {publication.get('package_id')!r}"
+            )
+
+        if isinstance(run_key, str) and publication.get("run_key") != run_key:
+            failures.append(
+                f"package_manifest.run_key mismatch with publication_snapshot.run_key: "
+                f"expected {run_key!r}, found {publication.get('run_key')!r}"
+            )
+
+        if isinstance(git_sha, str) and publication.get("git_sha") != git_sha:
+            failures.append(
+                f"package_manifest.git_sha mismatch with publication_snapshot.git_sha: "
+                f"expected {git_sha!r}, found {publication.get('git_sha')!r}"
+            )
+
+    return _cross_check_result(
+        name="package_identity_matches_release_surfaces",
+        ok=failures == [],
+        path="package_manifest.json",
+        message="; ".join(failures) if failures else None,
+        errors=errors,
+    )
+
 
 def verify_package(package_root: Path) -> dict[str, Any]:
     package_root = package_root.resolve()
@@ -1534,7 +1671,15 @@ def verify_package(package_root: Path) -> dict[str, Any]:
                 errors=errors,
             )
         )
-      
+        cross_artifact_checks.append(
+            _check_package_identity_matches_release_surfaces(
+                package_root=package_root,
+                manifest=manifest,
+                digests=digests,
+                errors=errors,
+            )
+        )
+
         authority_boundary = manifest.get("authority_boundary")
         creates_release_authority = (
             authority_boundary.get("creates_release_authority")


### PR DESCRIPTION
## Summary

Aligns RA1 package verifier identity checks and smoke coverage.

## Scope

Updates:

- `tools/verify_pulse_ref_ra1_package.py`
- `tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py`

## Purpose

The RA1 verifier currently emits more cross-artifact checks than the smoke test asserts, and the requested package identity cross-surface check was not yet implemented.

This PR fixes that drift.

The verifier now emits:

`package_identity_matches_release_surfaces`

The check validates package identity consistency across:

- `package_manifest.json`;
- `digests/package_digests.json`;
- `release_authority/release_authority_manifest.json`;
- `ci/ci_outcome.json`;
- `publication/publication_snapshot.json`.

It compares:

- `package_id`;
- `run_key`;
- `git_sha` / `commit_sha`.

The smoke test now asserts every emitted RA1 verifier cross-check name, including:

- regular-file payload validation;
- canonical layout validation;
- package identity validation;
- manifest authority boundary;
- digest manifest authority boundary;
- package ID consistency.

The smoke coverage also adds a negative case for package manifest `git_sha` drift while keeping the verifier report schema-valid.

## Authority boundary

This PR does not create release authority.

The verifier is an external reconstruction check. It verifies that an archived RA1 package preserves the declared-policy release-authority trail, but it does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, fixture artifact content, or CI behavior is changed beyond verifier coverage.