### PR TITLE
fix(pulse-ref): align RA1 verifier identity and smoke coverage

### DIFF
--- a/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
+++ b/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
@@ -191,6 +191,40 @@ def test_digest_mismatch_fails_with_schema_valid_report() -> None:
         assert failing_checks[0]["ok"] is False
         assert failing_checks[0]["actual_sha256"] is not None
 
+
+def test_package_manifest_git_sha_mismatch_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.git_sha_mismatch.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["git_sha"] = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        identity_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "package_identity_matches_release_surfaces"
+        ]
+
+        assert len(identity_checks) == 1
+        assert identity_checks[0]["ok"] is False
+
+
 def test_symlinked_artifact_outside_package_root_fails_with_schema_valid_report() -> None:
     with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
         tmp_path = Path(tmp)

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -1389,7 +1389,9 @@ def _check_package_identity_matches_release_surfaces(
 
     if isinstance(digests, dict):
         digest_package_id = digests.get("package_id")
-        if digest_package_id not in (None, package_id):
+        if not isinstance(digest_package_id, str) or not digest_package_id:
+            failures.append("package_digests.package_id must be a non-empty string")
+        elif digest_package_id != package_id:
             failures.append(
                 f"package_digests.package_id mismatch: "
                 f"expected {package_id!r}, found {digest_package_id!r}"


### PR DESCRIPTION
## Summary

Closes the RA1 verifier consistency/coverage drift found by audit.

## Scope

Updates:

- `tools/verify_pulse_ref_ra1_package.py`
- `tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py`

## Purpose

The RA1 verifier emits multiple cross-artifact checks, but the smoke test did not yet assert every emitted check name, and the requested package identity cross-surface check was not yet implemented.

This PR adds:

`package_identity_matches_release_surfaces`

The check validates package identity consistency across:

- `package_manifest.json`;
- `digests/package_digests.json`;
- `release_authority/release_authority_manifest.json`;
- `ci/ci_outcome.json`;
- `publication/publication_snapshot.json`.

It compares:

- `package_id`;
- `run_key`;
- `git_sha` / `commit_sha`.

The smoke test now asserts every emitted RA1 verifier cross-check name, including:

- regular-file payload validation;
- canonical layout validation;
- package identity validation;
- manifest authority boundary;
- digest manifest authority boundary;
- package ID consistency.

The smoke coverage also adds a negative case for package manifest `git_sha` drift while keeping the verifier report schema-valid.

## Authority boundary

This PR does not create release authority.

The verifier is an external reconstruction check. It verifies that an archived RA1 package preserves the declared-policy release-authority trail, but it does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, fixture artifact content, or CI behavior is changed beyond verifier coverage.