### PR TITLE
feat(pulse-ref): add RA1 operating proof smoke

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -47,6 +47,7 @@ tests/test_pulse_ref_publication_snapshot_schema_v0.py
 tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
 tests/test_pulse_ref_package_verifier_report_schema_v0.py
 tests/test_pulse_ref_ra1_minimal_package_fixture.py
+tests/test_pulse_ref_ra1_operating_proof_smoke.py
 tests/test_agent_orchestration_evidence_schema_v0.py
 tests/test_check_agent_orchestration_evidence_v0.py
 

--- a/tests/test_pulse_ref_ra1_operating_proof_smoke.py
+++ b/tests/test_pulse_ref_ra1_operating_proof_smoke.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+COMMANDS = [
+    [
+        sys.executable,
+        "-m",
+        "py_compile",
+        "tools/verify_pulse_ref_ra1_package.py",
+        "tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py",
+    ],
+    [
+        sys.executable,
+        "tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py",
+    ],
+    [
+        sys.executable,
+        "tests/test_pulse_ref_package_verifier_report_schema_v0.py",
+    ],
+    [
+        sys.executable,
+        "tests/test_pulse_ref_ra1_minimal_package_fixture.py",
+    ],
+]
+
+
+def _run_command(command: list[str]) -> None:
+    result = subprocess.run(
+        command,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if result.returncode != 0:
+        rendered = " ".join(command)
+        raise AssertionError(
+            f"RA1 operating proof command failed: {rendered}\n"
+            f"returncode: {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+
+
+def main() -> int:
+    try:
+        for command in COMMANDS:
+            _run_command(command)
+    except Exception as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    print("OK: PULSE-REF RA1 operating proof smoke passed")
+    return 0
+
+
+def test_smoke() -> None:
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a single RA1 operating proof smoke entry point.

## Scope

Adds:

- `tests/test_pulse_ref_ra1_operating_proof_smoke.py`

Updates:

- `ci/tools-tests.list`

## Purpose

The RA1 operating proof is now documented and the RA1 verifier consistency/coverage audit has passed.

This PR makes the operating proof executable through one smoke test:

`python tests/test_pulse_ref_ra1_operating_proof_smoke.py`

The smoke runs:

- verifier `py_compile`;
- RA1 package verifier smoke;
- verifier report schema smoke;
- RA1 minimal package fixture smoke.

This gives reviewers one small command that exercises the core RA1 operating proof path.

## Authority boundary

This PR does not create release authority.

The RA1 operating proof smoke is a test aggregation entry point only.

The verifier remains an external reconstruction check. It verifies that an archived RA1 package preserves the declared-policy release-authority trail, but it does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, schema, fixture artifact content, or verifier behavior is changed.