### PR TITLE
docs(pulse-ref): document RA1 operating proof smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@
 
 **See the latest Quality Ledger (live):** https://hkati.github.io/pulse-release-gates-0.1/
 
-**PULSE-REF RA1 operating proof:** [docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md](docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md)
+**PULSE-REF RA1 operating proof:** [docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md](docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md)  
+**RA1 operating proof smoke:** `python tests/test_pulse_ref_ra1_operating_proof_smoke.py`
 
 <p>
   <a href="https://doi.org/10.5281/zenodo.17373002">

--- a/docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md
+++ b/docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md
@@ -100,6 +100,27 @@ The verifier enforces the canonical artifact paths declared in `package_manifest
 
 ## Positive proof
 
+The RA1 operating proof can be exercised through one smoke entry point:
+
+```bash
+python tests/test_pulse_ref_ra1_operating_proof_smoke.py
+```
+
+Expected result:
+
+```text
+OK: PULSE-REF RA1 operating proof smoke passed
+```
+
+This command aggregates:
+
+```text
+verifier compile check;
+RA1 package verifier smoke;
+verifier report schema smoke;
+RA1 minimal package fixture smoke.
+```
+
 The canonical RA1 minimal fixture is expected to verify successfully:
 
 ```bash


### PR DESCRIPTION
## Summary

Documents the single RA1 operating proof smoke entry point.

## Scope

Updates:

- `docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md`
- `README.md`

## Purpose

The RA1 operating proof is now available through a single smoke command:

`python tests/test_pulse_ref_ra1_operating_proof_smoke.py`

This PR records that command in the operating proof note and README.

The note clarifies that the smoke aggregates:

- verifier compile check;
- RA1 package verifier smoke;
- verifier report schema smoke;
- RA1 minimal package fixture smoke.

## Authority boundary

This PR is documentation-only.

It does not create release authority.

The RA1 operating proof smoke is a test aggregation entry point only.

The verifier remains an external reconstruction check. It verifies that an archived RA1 package preserves the declared-policy release-authority trail, but it does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, schema, fixture artifact content, CI behavior, or verifier behavior is changed.