### PR TITLE
feat(pulse-ref): emit RA1 operating proof summary

### DIFF
--- a/docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md
+++ b/docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md
@@ -106,6 +106,25 @@ The RA1 operating proof can be exercised through one smoke entry point:
 python tests/test_pulse_ref_ra1_operating_proof_smoke.py
 ```
 
+The smoke also writes a machine-readable proof summary:
+
+```text
+tests/out/pulse_ref_ra1_operating_proof_summary.json
+```
+
+The summary records:
+
+```text
+command names;
+command arguments;
+return codes;
+pass/fail status;
+stdout/stderr;
+proof-summary authority boundary with creates_release_authority=false.
+```
+
+The summary is a test aggregation record only. It does not authorize release.
+
 Expected result:
 
 ```text

--- a/tests/test_pulse_ref_ra1_operating_proof_smoke.py
+++ b/tests/test_pulse_ref_ra1_operating_proof_smoke.py
@@ -1,64 +1,121 @@
 from __future__ import annotations
 
+import datetime as dt
+import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
+SUMMARY_PATH = ROOT / "tests" / "out" / "pulse_ref_ra1_operating_proof_summary.json"
 
 
 COMMANDS = [
-    [
-        sys.executable,
-        "-m",
-        "py_compile",
-        "tools/verify_pulse_ref_ra1_package.py",
-        "tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py",
-    ],
-    [
-        sys.executable,
-        "tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py",
-    ],
-    [
-        sys.executable,
-        "tests/test_pulse_ref_package_verifier_report_schema_v0.py",
-    ],
-    [
-        sys.executable,
-        "tests/test_pulse_ref_ra1_minimal_package_fixture.py",
-    ],
+    {
+        "name": "verifier_py_compile",
+        "argv": [
+            sys.executable,
+            "-m",
+            "py_compile",
+            "tools/verify_pulse_ref_ra1_package.py",
+            "tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py",
+        ],
+    },
+    {
+        "name": "ra1_package_verifier_smoke",
+        "argv": [
+            sys.executable,
+            "tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py",
+        ],
+    },
+    {
+        "name": "verifier_report_schema_smoke",
+        "argv": [
+            sys.executable,
+            "tests/test_pulse_ref_package_verifier_report_schema_v0.py",
+        ],
+    },
+    {
+        "name": "ra1_minimal_package_fixture_smoke",
+        "argv": [
+            sys.executable,
+            "tests/test_pulse_ref_ra1_minimal_package_fixture.py",
+        ],
+    },
 ]
 
 
-def _run_command(command: list[str]) -> None:
+def _utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _run_command(command: dict[str, Any]) -> dict[str, Any]:
+    argv = command["argv"]
+
     result = subprocess.run(
-        command,
+        argv,
         cwd=ROOT,
         capture_output=True,
         text=True,
         check=False,
     )
 
-    if result.returncode != 0:
-        rendered = " ".join(command)
-        raise AssertionError(
-            f"RA1 operating proof command failed: {rendered}\n"
-            f"returncode: {result.returncode}\n"
-            f"stdout:\n{result.stdout}\n"
-            f"stderr:\n{result.stderr}"
-        )
+    return {
+        "name": command["name"],
+        "command": argv,
+        "returncode": result.returncode,
+        "ok": result.returncode == 0,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def _write_summary(summary: dict[str, Any]) -> None:
+    SUMMARY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SUMMARY_PATH.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 
 
 def main() -> int:
-    try:
-        for command in COMMANDS:
-            _run_command(command)
-    except Exception as exc:
-        print(f"ERROR: {exc}")
+    command_results: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    for command in COMMANDS:
+        result = _run_command(command)
+        command_results.append(result)
+
+        if not result["ok"]:
+            rendered = " ".join(result["command"])
+            errors.append(
+                f"RA1 operating proof command failed: {rendered} "
+                f"(returncode={result['returncode']})"
+            )
+            break
+
+    summary: dict[str, Any] = {
+        "schema": "pulse_ref_ra1_operating_proof_summary_v0",
+        "ok": errors == [],
+        "created_utc": _utc_now(),
+        "commands": command_results,
+        "errors": errors,
+        "authority_boundary": {
+            "proof_summary_role": "test_aggregation_record",
+            "creates_release_authority": False,
+        },
+    }
+
+    _write_summary(summary)
+
+    if errors:
+        print(json.dumps(summary, indent=2, sort_keys=True))
         return 1
 
     print("OK: PULSE-REF RA1 operating proof smoke passed")
+    print(f"OK: wrote RA1 operating proof summary: {SUMMARY_PATH}")
     return 0
 
 


### PR DESCRIPTION
## Summary

Emits a machine-readable RA1 operating proof summary from the operating proof smoke test.

## Scope

Updates:

- `tests/test_pulse_ref_ra1_operating_proof_smoke.py`
- `docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md`

## Purpose

The RA1 operating proof is documented, audit-checked, and executable through one smoke entry point:

`python tests/test_pulse_ref_ra1_operating_proof_smoke.py`

This PR makes that smoke write a structured runtime proof summary:

`tests/out/pulse_ref_ra1_operating_proof_summary.json`

The summary records:

- command names;
- command arguments;
- return codes;
- pass/fail status;
- stdout/stderr;
- proof-summary authority boundary with `creates_release_authority=false`.

The operating proof note is updated to document the generated summary and its non-authorizing role.

## Authority boundary

This PR does not create release authority.

The RA1 operating proof summary is a test aggregation record only.

The verifier remains an external reconstruction check. It verifies that an archived RA1 package preserves the declared-policy release-authority trail, but it does not authorize release independently.

The normative release decision remains:

`recorded evidence -> status.json -> declared gate policy -> materialized required gate set -> strict gate checking -> CI outcome`

No release policy, gate semantics, status producer, workflow behavior, release-decision engine, ledger, manifest generator, dashboard, audit-bundle, operator-handoff implementation, schema, fixture artifact content, CI behavior, or verifier behavior is changed.