### PR TITLE
docs(public): restore compact DOI artifact badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,17 @@
 **PULSE-REF RA1 operating proof:** [docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md](docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md)  
 **RA1 operating proof smoke:** `python tests/test_pulse_ref_ra1_operating_proof_smoke.py`
 
-[![PULSE release DOI: 10.5281/zenodo.17373002](https://zenodo.org/badge/DOI/10.5281/zenodo.17373002.svg)](https://doi.org/10.5281/zenodo.17373002)
-
-**Release DOI:** https://doi.org/10.5281/zenodo.17373002  
-**Concept DOI:** https://doi.org/10.5281/zenodo.17214908  
-**Preprint DOI:** https://doi.org/10.5281/zenodo.17833583
+<p>
+  <a href="https://doi.org/10.5281/zenodo.17373002" title="PULSE release DOI">
+    <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.17373002.svg" alt="PULSE release DOI: 10.5281/zenodo.17373002">
+  </a>
+  <a href="https://doi.org/10.5281/zenodo.17214908" title="PULSE concept DOI">
+    <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.17214908.svg" alt="PULSE concept DOI: 10.5281/zenodo.17214908">
+  </a>
+  <a href="https://doi.org/10.5281/zenodo.17833583" title="PULSE preprint DOI">
+    <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.17833583.svg" alt="PULSE preprint DOI: 10.5281/zenodo.17833583">
+  </a>
+</p>
 
 PULSE is a deterministic, fail-closed release-governance layer for LLM applications and AI-enabled systems. It is built above existing application, model, evaluation, and deployment pipelines. At the release boundary, PULSE evaluates recorded release evidence against declared gate policy and emits an auditable release decision record.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -81,7 +81,16 @@
     "programmingLanguage": "Python",
     "license": "https://www.apache.org/licenses/LICENSE-2.0",
     "author": { "@type": "Organization", "name": "EPLabsAI" },
-    "description": "Pre-release, deterministic, fail-closed release gates across Safety, Utility and SLO with audit artifacts (status.json, Quality Ledger, badges)."
+        "description": "PULSE is an evidence-bound release-authority layer for AI-assisted production work, with deterministic fail-closed release gates, status evidence, Quality Ledger, CI enforcement, and audit-ready release decision records.",
+    "identifier": "https://doi.org/10.5281/zenodo.17373002",
+    "citation": "https://doi.org/10.5281/zenodo.17373002",
+    "sameAs": [
+      "https://doi.org/10.5281/zenodo.17373002",
+      "https://doi.org/10.5281/zenodo.17214908",
+      "https://doi.org/10.5281/zenodo.17833583",
+      "https://github.com/HKati/pulse-release-gates-0.1",
+      "https://hkati.github.io/pulse-release-gates-0.1/"
+    ]
   }
   </script>
 </head>
@@ -123,6 +132,17 @@
         <img src="../badges/pulse_status.svg" alt="PULSE status badge">
         <img src="../badges/rdsi.svg" alt="RDSI badge">
         <img src="../badges/q_ledger_check.svg" alt="Q‑Ledger badge">
+      </div>
+      <div class="badges" aria-label="PULSE DOI artifact identifiers">
+        <a href="https://doi.org/10.5281/zenodo.17373002" title="PULSE release DOI">
+          <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.17373002.svg" alt="PULSE release DOI: 10.5281/zenodo.17373002">
+        </a>
+        <a href="https://doi.org/10.5281/zenodo.17214908" title="PULSE concept DOI">
+          <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.17214908.svg" alt="PULSE concept DOI: 10.5281/zenodo.17214908">
+        </a>
+        <a href="https://doi.org/10.5281/zenodo.17833583" title="PULSE preprint DOI">
+          <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.17833583.svg" alt="PULSE preprint DOI: 10.5281/zenodo.17833583">
+        </a>
       </div>
     </header>
 


### PR DESCRIPTION
## Summary

Restores compact DOI artifact badges across the public PULSE surfaces.

## Scope

Updates:

- `README.md`
- `docs/index.html`

## Purpose

The DOI is a core public artifact identity for PULSE, not a decorative element and not a large marketing block.

This PR restores DOI visibility in a compact form:

- release DOI badge;
- concept DOI badge;
- preprint DOI badge.

The badge anchors include descriptive `title` and `alt` text so crawlers, bots, and assistive readers can identify the DOI roles without requiring large visible URL text.

The Pages landing page also receives the compact DOI badge row, and its JSON-LD metadata keeps DOI identity available through:

- `identifier`;
- `citation`;
- `sameAs`.

## Authority boundary

This PR is documentation/public metadata only.

It does not create release authority and does not change:

- release policy;
- gate semantics;
- status evidence;
- required gate materialization;
- `check_gates.py` behavior;
- primary CI release-decision authority;
- RA1 package semantics;
- verifier behavior;
- shadow-layer authority.