### PR TITLE
docs(public): restore Zenodo repository DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,7 @@
 <details>
   <summary><strong>Project badges and live release surfaces</strong></summary>
 
-<p align="center">
-  <img src="pulse_grail.svg" width="90" alt="Pulse Holy Grail">
-</p>
-
-<p align="center">
-  <img src="https://img.shields.io/badge/PULSE-HOLY%20GRAIL-%237DF9FF?style=for-the-badge&logo=codesandbox&logoColor=white" alt="Pulse Holy Grail badge">
-  <a href="https://hkati.github.io/pulse-release-gates-0.1/"><img src="badges/pulse_status.svg" alt="PULSE status"></a>
-  <a href="https://hkati.github.io/pulse-release-gates-0.1/status.json"><img src="badges/rdsi.svg" alt="RDSI"></a>
-  <a href="https://hkati.github.io/pulse-release-gates-0.1/#quality-ledger"><img src="badges/q_ledger.svg" alt="Q-Ledger"></a>
-</p>
+[![DOI](https://zenodo.org/badge/1061766508.svg)](https://zenodo.org/badge/latestdoi/1061766508)
 
 - **Quality Ledger:** https://hkati.github.io/pulse-release-gates-0.1/
 - **Status JSON:** https://hkati.github.io/pulse-release-gates-0.1/status.json
@@ -28,17 +19,7 @@
 **PULSE-REF RA1 operating proof:** [docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md](docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md)  
 **RA1 operating proof smoke:** `python tests/test_pulse_ref_ra1_operating_proof_smoke.py`
 
-<p>
-  <a href="https://doi.org/10.5281/zenodo.17373002" title="PULSE release DOI">
-    <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.17373002.svg" alt="PULSE release DOI: 10.5281/zenodo.17373002">
-  </a>
-  <a href="https://doi.org/10.5281/zenodo.17214908" title="PULSE concept DOI">
-    <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.17214908.svg" alt="PULSE concept DOI: 10.5281/zenodo.17214908">
-  </a>
-  <a href="https://doi.org/10.5281/zenodo.17833583" title="PULSE preprint DOI">
-    <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.17833583.svg" alt="PULSE preprint DOI: 10.5281/zenodo.17833583">
-  </a>
-</p>
+
 
 PULSE is a deterministic, fail-closed release-governance layer for LLM applications and AI-enabled systems. It is built above existing application, model, evaluation, and deployment pipelines. At the release boundary, PULSE evaluates recorded release evidence against declared gate policy and emits an auditable release decision record.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -128,20 +128,9 @@
       </div>
 
       <!-- Élő badge‑ek a repóból -->
-      <div class="badges">
-        <img src="../badges/pulse_status.svg" alt="PULSE status badge">
-        <img src="../badges/rdsi.svg" alt="RDSI badge">
-        <img src="../badges/q_ledger_check.svg" alt="Q‑Ledger badge">
-      </div>
-      <div class="badges" aria-label="PULSE DOI artifact identifiers">
-        <a href="https://doi.org/10.5281/zenodo.17373002" title="PULSE release DOI">
-          <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.17373002.svg" alt="PULSE release DOI: 10.5281/zenodo.17373002">
-        </a>
-        <a href="https://doi.org/10.5281/zenodo.17214908" title="PULSE concept DOI">
-          <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.17214908.svg" alt="PULSE concept DOI: 10.5281/zenodo.17214908">
-        </a>
-        <a href="https://doi.org/10.5281/zenodo.17833583" title="PULSE preprint DOI">
-          <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.17833583.svg" alt="PULSE preprint DOI: 10.5281/zenodo.17833583">
+        <div class="badges" aria-label="Zenodo DOI">
+        <a href="https://zenodo.org/badge/latestdoi/1061766508">
+          <img src="https://zenodo.org/badge/1061766508.svg" alt="DOI">
         </a>
       </div>
     </header>


### PR DESCRIPTION
## Summary

Restores the official Zenodo repository DOI badge for PULSE.

## Scope

Updates:

- `README.md`
- `docs/index.html` if the manual DOI badge/list surface was added there

## Purpose

The DOI is a core public artifact identity for PULSE.

This PR restores the Zenodo-managed GitHub repository DOI badge:

`https://zenodo.org/badge/1061766508.svg`

and links it through Zenodo's own latest DOI endpoint:

`https://zenodo.org/badge/latestdoi/1061766508`

This is the correct public DOI badge surface for the versioned repository.

It removes manually rendered concept/release/preprint DOI badge or URL lists from the README badge area.

Release DOI, concept DOI, and preprint DOI remain represented through Zenodo/CITATION metadata rather than visible README decoration.

## Authority boundary

This PR is documentation/public metadata only.

It does not create release authority and does not change:

- release policy;
- gate semantics;
- status evidence;
- required gate materialization;
- `check_gates.py` behavior;
- primary CI release-decision authority;
- RA1 package semantics;
- verifier behavior;
- shadow-layer authority.