### PR TITLE
docs(readme): restore top-level Zenodo repository badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
 **PULSE-REF RA1 operating proof:** [docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md](docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md)  
 **RA1 operating proof smoke:** `python tests/test_pulse_ref_ra1_operating_proof_smoke.py`
 
+[![DOI](https://zenodo.org/badge/1061766508.svg)](https://zenodo.org/badge/latestdoi/1061766508)
+
+<details>
+  <summary><strong>Project badges and live release surfaces</strong></summary>
 
 
 PULSE is a deterministic, fail-closed release-governance layer for LLM applications and AI-enabled systems. It is built above existing application, model, evaluation, and deployment pipelines. At the release boundary, PULSE evaluates recorded release evidence against declared gate policy and emits an auditable release decision record.


### PR DESCRIPTION
## Summary

Restores the Zenodo repository DOI badge as a top-level README badge.

## Scope

Updates:

- `README.md`

## Purpose

The Zenodo DOI badge is the repository-level Zenodo badge, not a manual DOI list.

The correct badge was present but hidden inside the collapsed `Project badges and live release surfaces` details block.

This PR moves it back to the visible top-level README area:

`https://zenodo.org/badge/1061766508.svg`

linked through:

`https://zenodo.org/badge/latestdoi/1061766508`

No manual concept/release/preprint DOI list is introduced in the README badge area.

## Authority boundary

This PR is documentation/public metadata only.

It does not create release authority and does not change:

- DOI identifiers;
- citation metadata;
- release policy;
- gate semantics;
- status evidence;
- required gate materialization;
- `check_gates.py` behavior;
- primary CI release-decision authority;
- RA1 package semantics;
- verifier behavior;
- shadow-layer authority.