### PR TITLE
docs(public): restore Zenodo versioned DOI discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@
 
 # PULSE — Release Gates for Safe & Useful AI
 
-[![Concept DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17214908.svg)](https://doi.org/10.5281/zenodo.17214908)
+<p>
+  <a href="https://doi.org/10.5281/zenodo.17373002">
+    <img src="https://doi.org/badge/DOI/10.5281/zenodo.17373002.svg" alt="DOI">
+  </a>
+</p>
 
 #### Deterministic release-governance layer for LLM applications and AI-enabled systems
 


### PR DESCRIPTION
## Summary

Restores the Zenodo versioned DOI discovery surface for PULSE.

## Scope

Updates:

- `README.md`
- `CITATION.cff`
- `.zenodo.json`
- `docs/index.html`

## Purpose

The DOI is a core public artifact identity for PULSE.

The Zenodo repository DOI badge was present, but it had been moved inside the collapsed README details block and the expanded Zenodo record structure was no longer exposed clearly.

This PR restores:

- the Zenodo repository DOI badge as a visible top-level README anchor;
- the Zenodo concept DOI / all-versions record;
- the latest V1.1.1 release DOI;
- earlier versioned release DOI records;
- the preprint DOI;
- DOI-aware Pages JSON-LD metadata.

The top-level DOI badge uses Zenodo's repository badge endpoint:

`https://zenodo.org/badge/1061766508.svg`

linked through Zenodo's latest DOI endpoint:

`https://zenodo.org/badge/latestdoi/1061766508`

The versioned DOI records remain in the details / citation surfaces, not as extra visible badge decoration.

## Authority boundary

This PR is documentation/public metadata only.

It does not create release authority and does not change:

- release policy;
- gate semantics;
- status evidence;
- required gate materialization;
- `check_gates.py` behavior;
- primary CI release-decision authority;
- RA1 package semantics;
- verifier behavior;
- shadow-layer authority.