### PR TITLE
fix(pulse): scope refusal-delta fallback to status pack

### DIFF
--- a/PULSE_safe_pack_v0/tools/augment_status.py
+++ b/PULSE_safe_pack_v0/tools/augment_status.py
@@ -293,12 +293,14 @@ def main() -> int:
     # -----------------------------------------------------------------------
     # 1) Refusal-delta summary -> metrics + gates + top-level mirror
     # -----------------------------------------------------------------------
-    # Pack dir: stable (script location), not derived from status path.
-    pack_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # .../PULSE_safe_pack_v0
-
     # Artifacts dir: derive from the baseline status.json location.
     artifacts_dir = os.path.dirname(status_path)
-
+  
+    # Pack dir: derive from the status artifact location, not from the script
+    # or thresholds file. This keeps refusal-delta fallback checks scoped to
+    # the pack whose status is being augmented.
+    pack_dir = os.path.dirname(artifacts_dir)
+  
     rd_path = os.path.join(artifacts_dir, "refusal_delta_summary.json")
 
     rd = jload(rd_path)

--- a/docs/refusal_delta_gate.md
+++ b/docs/refusal_delta_gate.md
@@ -45,8 +45,21 @@ From that input it resolves:
 PULSE_safe_pack_v0/artifacts/refusal_delta_summary.json
 ```
 
-The pack root used for fallback checks is resolved from the script location,
-not from the `--status` path.
+The pack root used for fallback checks is resolved from the `--status` path.
+
+For a status artifact at:
+
+```text
+<pack>/artifacts/status.json
+```
+
+the fallback refusal-pairs path is:
+
+```text
+<pack>/examples/refusal_pairs.jsonl
+```
+
+This keeps fallback behavior scoped to the pack being augmented, not to the script location or thresholds file location.
 
 ---
 

--- a/tests/test_augment_status_refusal_delta.py
+++ b/tests/test_augment_status_refusal_delta.py
@@ -116,6 +116,37 @@ def test_refusal_delta_fail_closed_if_pairs_exist_and_no_summary(tmp_path: Path)
     assert data["refusal_delta_pass"] is False
 
 
+def test_refusal_delta_fallback_ignores_thresholds_location_pairs(tmp_path: Path):
+    """
+    Refusal-delta fallback must resolve refusal_pairs.jsonl from the pack that
+    owns the status artifact, not from the thresholds file location.
+    """
+    pack_dir = tmp_path / "pack"
+    artifacts_dir = pack_dir / "artifacts"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    status_path = artifacts_dir / "status.json"
+    write_json(status_path, {})
+
+    thresholds_root = tmp_path / "thresholds_root"
+    thresholds_path = thresholds_root / "thresholds.json"
+    write_json(thresholds_path, {})
+
+    external_dir = tmp_path / "external"
+    external_dir.mkdir(parents=True, exist_ok=True)
+
+    thresholds_pairs = thresholds_root / "examples" / "refusal_pairs.jsonl"
+    thresholds_pairs.parent.mkdir(parents=True, exist_ok=True)
+    thresholds_pairs.write_text("dummy\n", encoding="utf-8")
+
+    run_augment_status(status_path, thresholds_path, external_dir)
+
+    data = json.loads(status_path.read_text(encoding="utf-8"))
+
+    assert data["gates"]["refusal_delta_pass"] is True
+    assert data["refusal_delta_pass"] is True
+
+
 def test_refusal_delta_pass_if_no_pairs_and_no_summary(tmp_path: Path):
     """
     If there is no summary and no real refusal_pairs.jsonl,


### PR DESCRIPTION
## Summary

Scopes refusal-delta fallback checks to the pack containing the status artifact.

## Scope

Updates:

- `PULSE_safe_pack_v0/tools/augment_status.py`
- `tests/test_augment_status_refusal_delta.py`
- `docs/refusal_delta_gate.md`

## Purpose

The refusal-delta fallback should be pack-local.

When `refusal_delta_summary.json` is missing, the fallback checks whether real refusal pairs exist. That check must use:

`<pack>/examples/refusal_pairs.jsonl`

where `<pack>` is derived from the `--status` artifact path:

`<pack>/artifacts/status.json`

The previous implementation resolved the pack root from the script location. That allowed isolated or temporary pack runs to observe the repository's own `PULSE_safe_pack_v0/examples/refusal_pairs.jsonl`, causing `refusal_delta_pass` to fail closed even when the active pack had no refusal pairs.

This PR restores the intended behavior:

- no summary + real pairs in active pack -> fail closed;
- no summary + no pairs in active pack -> pass by default/onboarding behavior;
- summary present -> gate mirrors the summary `pass` value.

The new regression test also ensures that refusal pairs near the thresholds file are ignored unless they belong to the active status pack.

The refusal-delta documentation is updated to match the status-pack-scoped fallback behavior.

## Authority boundary

This PR does not create release authority.

It preserves the existing declared-policy gate model and only fixes how `augment_status.py` scopes refusal-delta fallback evidence.

It does not change:

- release policy;
- gate registry;
- required gate materialization;
- `check_gates.py` behavior;
- primary CI release-decision authority;
- RA1 package semantics;
- verifier behavior;
- DOI metadata;
- schema or fixture content;
- EPF or Paradox shadow-layer behavior.