### PR TITLE
fix(test): stabilize core baseline run identity

### DIFF
--- a/tests/tools/generate_core_baseline_v0.py
+++ b/tests/tools/generate_core_baseline_v0.py
@@ -160,6 +160,13 @@ def _generate_normalized_outputs() -> tuple[str, str, str]:
 
         env["PULSE_ARTIFACT_DIR"] = str(artifacts_dir)
 
+        # Seed deterministic CI provenance so the generated core baseline
+        # always includes the same provenance fields before normalization.
+        env["GITHUB_SHA"] = "0" * 40
+        env["GITHUB_RUN_ID"] = "0"
+        env["GITHUB_RUN_NUMBER"] = "0"
+        env["GITHUB_WORKFLOW"] = "core-baseline"
+        
         _run(
             [
                 sys.executable,


### PR DESCRIPTION
## Summary

Stabilizes core baseline run identity generation.

## Scope

Updates:

- `tests/tools/generate_core_baseline_v0.py`

## Purpose

The core baseline golden expects normalized provenance fields such as:

- `git_sha: "<GIT_SHA>"`
- `run_key: "<RUN_KEY>"`

`run_all.py` emits `metrics.run_key` only when CI run identity environment variables are present.

That means local full-pytest runs can generate a baseline without `run_key`, causing `tests/test_core_baseline_v0.py` to report baseline drift even though the golden fixture already expects the normalized field.

This PR seeds deterministic CI provenance inside the core baseline generator before running `run_all.py`:

- `GITHUB_SHA`
- `GITHUB_RUN_ID`
- `GITHUB_RUN_NUMBER`
- `GITHUB_WORKFLOW`

The generator then normalizes those values to the existing golden placeholders.

## Expected result

- `python -m pytest -q tests/test_core_baseline_v0.py --tb=short -rA` passes.
- The full pytest failure count should drop from 11 to 10.

## Authority boundary

This PR is a test-generator determinism fix only.

It does not change:

- release policy;
- gate semantics;
- runtime status producer behavior outside the baseline generator;
- required gate materialization;
- `check_gates.py` behavior;
- primary CI release-decision authority;
- RA1 package semantics;
- verifier behavior;
- DOI metadata;
- schema or fixture content;
- EPF or Paradox shadow-layer behavior.