### PR TITLE
fix(epf): restore feature-mode source attribution

### DIFF
--- a/PULSE_safe_pack_v0/epf/epf_hazard_adapter.py
+++ b/PULSE_safe_pack_v0/epf/epf_hazard_adapter.py
@@ -612,7 +612,21 @@ def _maybe_enable_feature_mode_from_calibration(
         preserve_empty=True,
     )
 
-    effective_allow = _combine_allowlists(runtime_allow, artifact_allow, recommended_allow)
+    if runtime_allow is not None and artifact_allow is not None:
+        feature_mode_source = "runtime_and_artifact_allowlist"
+        effective_allow = _combine_allowlists(runtime_allow, artifact_allow)
+    elif runtime_allow is not None:
+        feature_mode_source = "runtime_allowlist"
+        effective_allow = runtime_allow
+    elif artifact_allow is not None:
+        feature_mode_source = "artifact_allowlist"
+        effective_allow = artifact_allow
+    elif recommended_allow is not None:
+        feature_mode_source = "recommended_features"
+        effective_allow = recommended_allow
+    else:
+        feature_mode_source = "snapshot_intersection"
+        effective_allow = None
 
     keys = _select_feature_keys_for_autowire(
         list(scalers.keys()),
@@ -620,12 +634,17 @@ def _maybe_enable_feature_mode_from_calibration(
         reference_snapshot=reference_snapshot,
         allowlist=effective_allow,
     )
+   
+    cfg.feature_mode_source = feature_mode_source 
+   
     if not keys:
-        return False, None, None
+        cfg.feature_mode_active = False
+        return False, [], feature_mode_source
 
     cfg.feature_scalers = {k: scalers[k] for k in keys}
     cfg.feature_specs = [FeatureSpec(key=k) for k in keys]
-    return True, keys, "calibration_autowire"
+    cfg.feature_mode_active = True
+    return True, keys, feature_mode_source
 
 
 def probe_hazard_and_append_log(

--- a/PULSE_safe_pack_v0/tools/epf_hazard_calibrate.py
+++ b/PULSE_safe_pack_v0/tools/epf_hazard_calibrate.py
@@ -355,7 +355,7 @@ def recommend_features(
 
     cand_sorted = sorted(cand, key=rank_key)
     selected = cand_sorted[:max_features_i]
-    recommended = [k for (k, _cov, _spread, _present) in selected]
+    recommended = sorted(k for (k, _cov, _spread, _present) in selected)
 
     meta = {
         "max_features": max_features_i,


### PR DESCRIPTION
## Summary

Restores deterministic EPF feature-mode source attribution.

## Scope

Updates:

- `PULSE_safe_pack_v0/epf/epf_hazard_adapter.py`
- `PULSE_safe_pack_v0/tools/epf_hazard_calibrate.py`

## Purpose

The EPF hazard adapter tests expect feature-mode activation to preserve the source of the selected feature set.

The adapter now records:

- `recommended_features`
- `artifact_allowlist`
- `runtime_allowlist`
- `runtime_and_artifact_allowlist`
- `snapshot_intersection`

on the `HazardConfig` object as `feature_mode_source`.

It also records `feature_mode_active`.

The selection rules are:

- runtime + artifact allowlists are intersected when both are present;
- runtime allowlist alone takes precedence;
- artifact allowlist alone takes precedence;
- recommended features are used only when no explicit runtime/artifact allowlist is present;
- snapshot intersection is used when no allowlist/recommendation is present.

The calibrator now emits selected `recommended_features` in canonical key order after selection, preserving deterministic downstream autowire behavior.

## Expected result

- EPF feature-mode source tests pass.
- EPF calibrate/autowire integration test passes.
- Full pytest failure count should drop from 10 to 4.

## Authority boundary

This PR is an EPF shadow/research determinism fix only.

It does not change:

- release policy;
- gate registry;
- required gate materialization;
- `check_gates.py` behavior;
- primary CI release-decision authority;
- RA1 package semantics;
- verifier behavior;
- DOI metadata;
- schema or fixture content;
- Paradox shadow-layer behavior.