### PR TITLE
fix(epf): align FieldSpec source expectation

### DIFF
--- a/tests/test_epf_hazard_adapter_fieldspec_recommended_unit.py
+++ b/tests/test_epf_hazard_adapter_fieldspec_recommended_unit.py
@@ -133,7 +133,7 @@ def test_autowire_honors_recommended_features(monkeypatch, tmp_path: pathlib.Pat
 
     entry_a = _read_last_log_entry(run_a)
     assert entry_a["hazard"]["feature_mode_active"] is True
-    assert entry_a["hazard"]["feature_mode_source"] == "calibration_autowire"
+    assert entry_a["hazard"]["feature_mode_source"] == "recommended_features"
     assert entry_a["hazard"]["feature_keys"] == ["a.b"]
 
     # Case B: explicit empty recommended_features means deny-all -> no feature mode.
@@ -161,4 +161,4 @@ def test_autowire_honors_recommended_features(monkeypatch, tmp_path: pathlib.Pat
     entry_b = _read_last_log_entry(run_b)
     assert entry_b["hazard"]["feature_mode_active"] is False
     assert entry_b["hazard"]["feature_keys"] == []
-    assert entry_b["hazard"]["feature_mode_source"] == "none"
+    assert entry_b["hazard"]["feature_mode_source"] == "recommended_features"


### PR DESCRIPTION
## Summary

Aligns the FieldSpec/recommended-features EPF test with the restored feature-mode source attribution contract.

## Scope

Updates:

- `tests/test_epf_hazard_adapter_fieldspec_recommended_unit.py`

## Purpose

The previous EPF update restored precise feature-mode source attribution.

The adapter now records source names such as:

- `recommended_features`
- `artifact_allowlist`
- `runtime_allowlist`
- `runtime_and_artifact_allowlist`
- `snapshot_intersection`

instead of the older generic source string:

`calibration_autowire`

This PR updates the FieldSpec/recommended-features test to expect the new precise source contract.

For an explicit empty `recommended_features` list, the source remains:

`recommended_features`

while:

- `feature_mode_active=false`
- `feature_keys=[]`

This keeps provenance stable even when a recommendation artifact intentionally disables feature activation.

## Expected result

The EPF source-attribution subset should pass:

`python -m pytest -q tests/test_epf_hazard_adapter_feature_mode_source_unit.py tests/test_epf_hazard_calibrate_autowire_integration_unit.py tests/test_epf_hazard_adapter_fieldspec_recommended_unit.py --tb=short -rA`

The full pytest failure count should drop from 5 to 4, leaving the remaining Paradox-related failures.

## Authority boundary

This PR is a test contract alignment for the EPF shadow/research layer only.

It does not change:

- release policy;
- gate registry;
- required gate materialization;
- `check_gates.py` behavior;
- primary CI release-decision authority;
- RA1 package semantics;
- verifier behavior;
- DOI metadata;
- schema or fixture content;
- Paradox shadow-layer behavior.