### PR TITLE
fix(paradox): realign v0 fixtures and contracts

### DIFF
--- a/scripts/inspect_paradox_core_v0.py
+++ b/scripts/inspect_paradox_core_v0.py
@@ -158,7 +158,7 @@ def render_summary(core: Dict[str, Any], max_atoms: int, max_edges: int, max_sum
     lines.append("# Paradox Core Summary v0")
     lines.append("")
     lines.append("> Diagnostic projection. Edges are association/co-occurrence only (non-causal).")
-    lines.append("> This summary must not redefine or flip CI release semantics.")
+    lines.append("> This summary is CI-neutral and must not redefine or flip CI release semantics.")
     lines.append("")
 
     lines.append("## Identity")

--- a/tests/fixtures/paradox_diagram_v0/expected_paradox_diagram_v0.json
+++ b/tests/fixtures/paradox_diagram_v0/expected_paradox_diagram_v0.json
@@ -43,7 +43,7 @@
   "inputs": {
     "paradox_core_v0": {
       "path_hint": "tests/fixtures/paradox_diagram_v0/core_k2.json",
-      "sha256": "447b407b0171e227fa454bbd446360c473a01134a880478875b3edd4cce5dd1a"
+      "sha256": "5299d6f2cdada95a5f44eda66571bfa8ef3f3c8fbd8c7864f8108a3fe2dc8467"
     }
   },
   "nodes": [

--- a/tests/test_paradox_diagram_renderer_v0_smoke.py
+++ b/tests/test_paradox_diagram_renderer_v0_smoke.py
@@ -21,14 +21,18 @@ def test_paradox_diagram_renderer_produces_svg(tmp_path: Path) -> None:
     inp.write_text(
         json.dumps(
             {
-                "version": "v0",
+                "schema_version": "v0",
                 "timestamp_utc": "2026-02-06T00:00:00+00:00",
-                "decision": "NORMAL",
+                "shadow": True,
+                "decision_key": "NORMAL",
                 "decision_raw": "NORMAL",
-                "settle_time_p95_ms": 10.0,
-                "settle_time_budget_ms": 50.0,
-                "downstream_error_rate": 0.02,
-                "paradox_density": 0.1,
+                "source": "test_paradox_diagram_renderer_v0_smoke",
+                "notes": "renderer smoke fixture",
+                "metrics": {
+                    "settle_time_p95_ms": 10.0,
+                    "settle_time_budget_ms": 50.0,
+                    "downstream_error_rate": 0.02,
+                    "paradox_density": 0.1
             },
             indent=2,
         )
@@ -41,4 +45,4 @@ def test_paradox_diagram_renderer_produces_svg(tmp_path: Path) -> None:
 
     assert out.exists(), "renderer did not produce SVG"
     txt = out.read_text(encoding="utf-8")
-    assert "<svg" in txt and "Paradox Diagram v0" in txt
+    assert "<svg" in txt and "Paradox diagram (v0)" in txt

--- a/tests/test_paradox_diagram_renderer_v0_smoke.py
+++ b/tests/test_paradox_diagram_renderer_v0_smoke.py
@@ -33,6 +33,7 @@ def test_paradox_diagram_renderer_produces_svg(tmp_path: Path) -> None:
                     "settle_time_budget_ms": 50.0,
                     "downstream_error_rate": 0.02,
                     "paradox_density": 0.1
+               },
             },
             indent=2,
         )


### PR DESCRIPTION
## Summary

Realigns the Paradox v0 summary, renderer smoke input, and golden fixtures with the current contract.

## Scope

Updates:

- `scripts/inspect_paradox_core_v0.py`
- `tests/test_paradox_diagram_renderer_v0_smoke.py`
- `tests/fixtures/paradox_core_render_v0/golden_core_k2.svg`
- `tests/fixtures/paradox_diagram_v0/expected_paradox_diagram_v0.json`

## Purpose

After the core and EPF repairs, the full pytest suite is down to four remaining Paradox-related failures.

This PR addresses that single remaining cluster.

Changes:

- restores explicit `CI-neutral` wording in the Paradox Core summary reviewer contract;
- updates the diagram renderer smoke input to the current `paradox_diagram_input_v0` contract shape;
- regenerates the Paradox Core k=2 SVG golden fixture from the deterministic projection/render path;
- regenerates the expected Paradox diagram fixture from the deterministic diagram builder so the recorded core SHA matches the canonical core fixture.

## Expected result

The Paradox subset should pass:

`python -m pytest -q tests/test_paradox_core_summary_v0.py tests/test_paradox_core_svg_golden_v0.py tests/test_paradox_diagram_renderer_v0_smoke.py tests/test_paradox_diagram_v0.py --tb=short -rA`

The full pytest suite should reach:

`0 failed`

## Authority boundary

This PR is a Paradox shadow/diagnostic fixture-contract alignment only.

It does not change:

- release policy;
- gate registry;
- required gate materialization;
- `check_gates.py` behavior;
- primary CI release-decision authority;
- RA1 package semantics;
- verifier behavior;
- DOI metadata;
- EPF behavior;
- runtime release behavior.