### PR TITLE
fix(paradox): finish v0 fixture contract alignment

### DIFF
--- a/tests/test_paradox_diagram_renderer_v0_smoke.py
+++ b/tests/test_paradox_diagram_renderer_v0_smoke.py
@@ -46,4 +46,6 @@ def test_paradox_diagram_renderer_produces_svg(tmp_path: Path) -> None:
 
     assert out.exists(), "renderer did not produce SVG"
     txt = out.read_text(encoding="utf-8")
-    assert "<svg" in txt and "Paradox diagram (v0)" in txt
+    assert "<svg" in txt
+    assert "PULSE - Paradox diagram (v0)" in txt
+    assert "schema_version=v0" in txt


### PR DESCRIPTION
## Summary

Finishes the Paradox v0 fixture-contract alignment after the previous merged Paradox update.

## Scope

Updates:

- `scripts/inspect_paradox_core_v0.py`
- `tests/test_paradox_diagram_renderer_v0_smoke.py`
- `tests/fixtures/paradox_core_render_v0/golden_core_k2.svg`
- `tests/fixtures/paradox_diagram_v0/expected_paradox_diagram_v0.json`

## Purpose

The previous Paradox PR was merged after the CI-visible checks went green, but the later full pytest follow-up still identified the remaining Paradox fixture-contract drift.

This PR completes that alignment by:

- restoring explicit `CI-neutral` wording in the Paradox Core summary reviewer contract;
- aligning the diagram renderer smoke assertion with the current deterministic SVG title;
- checking rendered `schema_version=v0` metadata;
- regenerating the Paradox Core k=2 SVG golden fixture from the deterministic projection/render path;
- regenerating `expected_paradox_diagram_v0.json` from the deterministic diagram builder so the recorded core SHA and generated fixture match the canonical core fixture.

## Expected result

The Paradox subset should pass:

`python -m pytest -q tests/test_paradox_core_summary_v0.py tests/test_paradox_core_svg_golden_v0.py tests/test_paradox_diagram_renderer_v0_smoke.py tests/test_paradox_diagram_v0.py --tb=short -rA`

The full pytest suite should reach:

`0 failed`

## Authority boundary

This PR is a Paradox shadow/diagnostic fixture-contract alignment only.

It does not change:

- release policy;
- gate registry;
- required gate materialization;
- `check_gates.py` behavior;
- primary CI release-decision authority;
- RA1 package semantics;
- verifier behavior;
- DOI metadata;
- EPF behavior;
- runtime release behavior.