### PR TITLE
docs(readme): restore Zenodo repository badge source

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 # PULSE — Release Gates for Safe & Useful AI
 
-[![Concept DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17214908.svg)](https://doi.org/10.5281/zenodo.17214908)
+[![DOI](https://zenodo.org/badge/1061766508.svg)](https://zenodo.org/badge/latestdoi/1061766508)
 
 #### Deterministic release-governance layer for LLM applications and AI-enabled systems
 


### PR DESCRIPTION
## Summary

Restores the README top-level DOI badge to the Zenodo-managed GitHub repository badge.

## Scope

Updates:

- `README.md`

## Purpose

The README and Pages surfaces were using mixed Zenodo badge styles.

The README used a DOI-form Concept DOI badge endpoint:

`https://zenodo.org/badge/DOI/10.5281/zenodo.17214908.svg`

while the Pages source uses the Zenodo repository-ID badge:

`https://zenodo.org/badge/1061766508.svg`

linked through:

`https://zenodo.org/badge/latestdoi/1061766508`

This PR restores the README top-level DOI badge to the repository-ID Zenodo badge so the public repository surface uses the Zenodo-managed GitHub repository badge.

Concept DOI, release DOI, and preprint DOI remain represented through citation/metadata and Zenodo record surfaces rather than as top-level badge images.

## Authority boundary

This PR is documentation/public metadata only.

It does not create release authority and does not change:

- DOI identifiers;
- release policy;
- gate semantics;
- status evidence;
- required gate materialization;
- `check_gates.py` behavior;
- primary CI release-decision authority;
- RA1 package semantics;
- verifier behavior;
- schema behavior;
- fixture behavior;
- EPF behavior;
- Paradox behavior.