### PR TITLE
fix(pages): add canonical links to published ledger pages

### DIFF
--- a/.github/workflows/publish_report_pages.yml
+++ b/.github/workflows/publish_report_pages.yml
@@ -525,6 +525,42 @@ jobs:
           echo "Resolved Pages BASE_URL: $BASE_URL"
           export BASE_URL
 
+          # Ensure published HTML entrypoints expose canonical URLs for crawlers.
+          python3 - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+          from html import escape
+
+          base = os.environ["BASE_URL"].rstrip("/")
+
+          targets = {
+              Path("_site/index.html"): f"{base}/",
+              Path("_site/report_card.html"): f"{base}/report_card.html",
+          }
+
+          canonical_re = re.compile(
+              r'(?is)<link[^>]+rel=["\']canonical["\'][^>]*>'
+          )
+
+          for path, canonical in targets.items():
+              if not path.is_file():
+                  continue
+
+              html = path.read_text(encoding="utf-8")
+              link = f'<link rel="canonical" href="{escape(canonical, quote=True)}">'
+
+              if canonical_re.search(html):
+                  html = canonical_re.sub(link, html, count=1)
+              elif "<head>" in html:
+                  html = html.replace("<head>", f"<head>\n  {link}", 1)
+              else:
+                  raise SystemExit(f"missing <head> in {path}")
+
+              path.write_text(html, encoding="utf-8")
+              print(f"OK: canonical set for {path}: {canonical}")
+          PY
+         
           python3 - <<'PY'
           import os
           import xml.etree.ElementTree as ET


### PR DESCRIPTION
## Summary

Adds canonical links to the published Pages ledger entrypoints.

## Scope

Updates:

- `.github/workflows/publish_report_pages.yml`

## Purpose

The public surface audit confirmed that the deployed Pages URLs are reachable:

- homepage returns HTTP 200;
- `robots.txt` returns HTTP 200;
- `sitemap.xml` returns HTTP 200;
- `status.json` returns HTTP 200;
- `report_card.html` returns HTTP 200;
- Googlebot, Bingbot, and CommonCrawl user-agents receive HTTP 200;
- sitemap loc URLs return HTTP 200.

The remaining failure was:

`homepage missing canonical link`

The deployed homepage is currently the generated Quality Ledger / `report_card.html` surface promoted to `index.html`, not `docs/index.html`.

This PR injects canonical links into the published Pages output after the workflow resolves the actual Pages `BASE_URL`:

- `_site/index.html` -> `<base>/`
- `_site/report_card.html` -> `<base>/report_card.html`

This keeps canonical generation tied to the deployed Pages base and avoids hardcoding Pages-specific metadata in the generic Quality Ledger renderer.

## Expected result

After the next Pages publish, the manual public surface audit should pass:

`PASS: public surface audit clean`

## Authority boundary

This PR is Pages/public-surface metadata only.

It does not create release authority and does not change:

- release policy;
- gate semantics;
- status evidence;
- required gate materialization;
- `check_gates.py` behavior;
- primary CI release-decision authority;
- RA1 package semantics;
- verifier behavior;
- DOI metadata;
- schema behavior;
- fixture behavior;
- EPF behavior;
- Paradox behavior;
- release authority.