### PR TITLE
docs(readme): lock DOI badge role contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@
 
 ### Zenodo records
 
-- **Release DOI / v1.0.2:** https://doi.org/10.5281/zenodo.17373002
+- **Concept DOI / all versions:** https://doi.org/10.5281/zenodo.17214908
+- **Current release DOI / v1.1.1:** https://doi.org/10.5281/zenodo.18203404
+- **Previous release DOI / v1.0.2:** https://doi.org/10.5281/zenodo.17373002
+- **Previous release DOI / v1.0.1:** https://doi.org/10.5281/zenodo.17214909
 - **Preprint DOI:** https://doi.org/10.5281/zenodo.17833583
 
 ### Live release surfaces
@@ -28,7 +31,7 @@
 
 # PULSE — Release Gates for Safe & Useful AI
 
-[![DOI](https://zenodo.org/badge/1061766508.svg)](https://zenodo.org/badge/latestdoi/1061766508)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17214908.svg)](https://doi.org/10.5281/zenodo.17214908)
 
 #### Deterministic release-governance layer for LLM applications and AI-enabled systems
 

--- a/tests/test_readme_doi_badge_contract.py
+++ b/tests/test_readme_doi_badge_contract.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+
+
+def test_readme_top_doi_badge_uses_concept_doi() -> None:
+    text = README.read_text(encoding="utf-8")
+    assert (
+        "[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17214908.svg)]"
+        "(https://doi.org/10.5281/zenodo.17214908)" in text
+    )
+
+
+def test_readme_top_doi_badge_not_latestdoi() -> None:
+    text = README.read_text(encoding="utf-8")
+    assert "https://zenodo.org/badge/latestdoi/1061766508" not in text
+
+
+def test_readme_zenodo_records_identifies_current_release_v111() -> None:
+    text = README.read_text(encoding="utf-8")
+    assert "- **Current release DOI / v1.1.1:** https://doi.org/10.5281/zenodo.18203404" in text
+
+
+def test_readme_does_not_mark_v102_as_current_release() -> None:
+    text = README.read_text(encoding="utf-8")
+    assert "- **Current release DOI / v1.0.2:** https://doi.org/10.5281/zenodo.17373002" not in text


### PR DESCRIPTION
## Summary

Normalizes the README DOI badge and Zenodo records block to use explicit DOI roles.

The top README DOI badge now points to the stable Concept DOI / all-versions record:

`10.5281/zenodo.17214908`

instead of the moving Zenodo `latestdoi` repository badge.

The README Zenodo records block now identifies:

- Concept DOI / all versions: `10.5281/zenodo.17214908`
- Current release DOI / v1.1.1: `10.5281/zenodo.18203404`
- Previous release DOI / v1.0.2: `10.5281/zenodo.17373002`
- Previous release DOI / v1.0.1: `10.5281/zenodo.17214909`
- Preprint DOI: `10.5281/zenodo.17833583`

## Scope

Updates:

- `README.md`

Adds:

- `tests/test_readme_doi_badge_contract.py`

## Purpose

The README top DOI badge should be a stable public identity anchor for the PULSE software family, not a moving latest-release pointer.

This PR separates DOI roles on the README surface:

- Concept DOI = software family / all versions
- Current release DOI = current archived software release
- Previous release DOI = older archived release
- Preprint DOI = publication / documented-by surface

## Regression guard

Adds a small offline test that verifies:

- the README top DOI badge uses the Concept DOI;
- the README top DOI badge does not use the moving `latestdoi` endpoint;
- the README identifies `v1.1.1 / 10.5281/zenodo.18203404` as the current release;
- the README does not identify `v1.0.2 / 10.5281/zenodo.17373002` as the current release.

## Authority boundary

This PR is README/public identity metadata only.

It does not change:

- release authority
- release semantics
- gate policy
- `status.json`
- required gate materialization
- `check_gates.py`
- primary CI release behavior
- DOI identifiers
- Zenodo records
- `CITATION.cff`
- `.zenodo.json`
- `README_HOW_TO_CITE.md`
- `ORCID_add_work.json`
- `docs/index.html`
- RA1 verifier behavior
- EPF behavior
- Paradox behavior
- release authority manifests
- audit bundles

The full DOI registry / versioning contract remains a separate follow-up PR.

## Testing

- `pytest -q tests/test_readme_doi_badge_contract.py`