### PR TITLE
docs(metadata): define PULSE DOI registry

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,8 +1,8 @@
 {
   "title": "PULSE: Deterministic Release Gates for Safe & Useful AI",
-  "publication_date": "2025-10-18",
-  "version": "v1.0.2",
-  "description": "PULSE provides deterministic, fail-closed release gates across Safety (I2–I7), Utility (Q1–Q4) and SLO dimensions. It produces audit artefacts including a human-readable Quality Ledger and SVG badges that summarise pass/fail states. This software package allows developers to enforce safety invariants, utility budgets and service level objectives prior to shipment.",
+    "publication_date": "2026-05-15",
+  "version": "v1.1.1",
+  "description": "PULSE provides deterministic, fail-closed release gates across Safety (I2\u2013I7), Utility (Q1\u2013Q4) and SLO dimensions. It produces audit artefacts including a human-readable Quality Ledger and SVG badges that summarise pass/fail states. This software package allows developers to enforce safety invariants, utility budgets and service level objectives prior to shipment.",
   "upload_type": "software",
   "language": "eng",
   "license": "Apache-2.0",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,8 +26,8 @@ keywords:
   - "CI"
 
 # The specific release you want others to cite
-doi: "10.5281/zenodo.17373002"
-version: "v1.0.2"
+doi: "10.5281/zenodo.18203404"
+version: "v1.1.1"
 date-released: "2025-10-18"
 
 # The all-versions (concept) DOI so the badge can stay stable across releases
@@ -45,9 +45,9 @@ preferred-citation:
       orcid: "https://orcid.org/0009-0001-9745-3764"
       affiliation: "EPLabsAI"
     - name: "EPLabsAI"
-  version: "v1.0.2"
-  doi: "10.5281/zenodo.17373002"
-  url: "https://doi.org/10.5281/zenodo.17373002"
+  version: "v1.1.1"
+  doi: "10.5281/zenodo.18203404"
+  url: "https://doi.org/10.5281/zenodo.18203404"
 
 references:
   - type: dataset

--- a/ORCID_add_work.json
+++ b/ORCID_add_work.json
@@ -1,7 +1,7 @@
 {
   "title": "PULSE: Deterministic Release Gates for Safe & Useful AI (Software)",
   "type": "software",
-  "doi": "10.5281/zenodo.17214909",
+  "doi": "10.5281/zenodo.17214908",
   "year": 2025,
   "authors": [
     {
@@ -14,4 +14,5 @@
     }
   ],
   "description": "Software package implementing deterministic release gates across safety, utility and SLO dimensions."
+
 }


### PR DESCRIPTION
## Summary

Defines the PULSE DOI / versioning contract as a machine-checkable publication and identity layer.

This PR adds a normative DOI registry, documents the DOI role contract, and adds an offline regression test so DOI roles do not drift across README, citation metadata, Zenodo metadata, ORCID helper metadata, and JSON-LD public identity surfaces.

## Scope

Adds:

- `metadata/pulse_doi_registry_v0.json`
- `docs/PULSE_DOI_VERSIONING_CONTRACT_v0.md`
- `tests/test_pulse_doi_registry_v0.py`

Updates DOI / citation / public identity metadata only:

- `README.md`
- `README_HOW_TO_CITE.md`
- `CITATION.cff`
- `.zenodo.json`
- `ORCID_add_work.json`
- `docs/index.html`

## DOI role contract

This PR separates the DOI roles explicitly:

- Concept DOI / all versions: `10.5281/zenodo.17214908`
- Current release DOI / v1.1.1: `10.5281/zenodo.18203404`
- Previous release DOI / v1.0.2: `10.5281/zenodo.17373002`
- Previous release DOI / v1.0.1: `10.5281/zenodo.17214909`
- Preprint DOI: `10.5281/zenodo.17833583`

## Purpose

The DOI is an identity contract, not a badge decoration or release-authority mechanism.

This PR makes the roles stable:

- Concept DOI identifies the PULSE software family / all versions.
- Version DOI identifies one concrete archived software release.
- Preprint DOI identifies the publication / documented-by surface.
- README top DOI badge uses the Concept DOI.
- Preferred software citation uses the current release DOI.
- Preprint citation uses the preprint DOI.
- `.zenodo.json` uses the current release version and links:
  - Concept DOI as `isVersionOf`
  - Preprint DOI as `isDocumentedBy`
- ORCID software work uses the stable Concept DOI.
- `docs/index.html` JSON-LD identifier uses the Concept DOI.
- `docs/index.html` JSON-LD citation uses the current release DOI.

## Regression guard

Adds `tests/test_pulse_doi_registry_v0.py`, an offline test that verifies:

- the DOI registry exists and is valid JSON;
- the registry contains the expected concept, current release, previous release, and preprint DOI roles;
- README top DOI badge uses the Concept DOI;
- README does not use the moving `latestdoi` badge endpoint;
- README identifies `v1.1.1 / 10.5281/zenodo.18203404` as the current release;
- README does not identify `v1.0.2 / 10.5281/zenodo.17373002` as the current release;
- `CITATION.cff` uses `v1.1.1 / 10.5281/zenodo.18203404` as the preferred software citation;
- `CITATION.cff` keeps the Concept DOI as the all-versions identifier;
- `.zenodo.json` version is `v1.1.1`;
- `.zenodo.json` has the Concept DOI as `isVersionOf`;
- `.zenodo.json` has the Preprint DOI as `isDocumentedBy`;
- `README_HOW_TO_CITE.md` uses `10.5281/zenodo.17833583` for the preprint;
- `README_HOW_TO_CITE.md` does not call `10.5281/zenodo.17214909` the preprint DOI;
- `ORCID_add_work.json` uses the Concept DOI for the software work;
- `docs/index.html` JSON-LD identifier uses the Concept DOI;
- `docs/index.html` JSON-LD citation uses the current release DOI.

## Authority boundary

This PR is publication / identity metadata only.

It does not change:

- release authority
- release semantics
- gate policy
- `status.json`
- required gate materialization
- `check_gates.py`
- primary CI release behavior
- RA1 verifier behavior
- EPF behavior
- Paradox behavior
- public crawler surfaces
- release authority manifests
- audit bundles
- external Zenodo records or DOI identifiers

DOI metadata does not authorize, block, override, or create a second release-decision path.

## Testing

- `pytest -q tests/test_pulse_doi_registry_v0.py`
- `pytest -q tests/test_readme_doi_badge_contract.py tests/test_pulse_doi_registry_v0.py`
- `git diff -- README.md README_HOW_TO_CITE.md CITATION.cff .zenodo.json ORCID_add_work.json docs/index.html metadata/pulse_doi_registry_v0.json docs/PULSE_DOI_VERSIONING_CONTRACT_v0.md tests/test_pulse_doi_registry_v0.py`
- `git status --short`

## Expected result

The DOI roles become mechanically stable:

`Concept DOI = software family / all versions`  
`Version DOI = current archived software release`  
`Preprint DOI = publication / documented-by surface`

The repository no longer mixes DOI roles across README, citation metadata, Zenodo metadata, ORCID helper metadata, and JSON-LD.