### PR TITLE
docs(readme): restore Zenodo repository DOI badge route

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 # PULSE — Release Gates for Safe & Useful AI
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17214908.svg)](https://doi.org/10.5281/zenodo.17214908)
+[![DOI](https://zenodo.org/badge/1061766508.svg)](https://zenodo.org/badge/latestdoi/1061766508)
 
 #### Deterministic release-governance layer for LLM applications and AI-enabled systems
 

--- a/tests/test_readme_doi_badge_contract.py
+++ b/tests/test_readme_doi_badge_contract.py
@@ -4,17 +4,17 @@ ROOT = Path(__file__).resolve().parents[1]
 README = ROOT / "README.md"
 
 
-def test_readme_top_doi_badge_uses_concept_doi() -> None:
+def test_readme_top_doi_badge_uses_zenodo_repository_route() -> None:
     text = README.read_text(encoding="utf-8")
     assert (
-        "[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17214908.svg)]"
-        "(https://doi.org/10.5281/zenodo.17214908)" in text
+        "[![DOI](https://zenodo.org/badge/1061766508.svg)]"
+        "(https://zenodo.org/badge/latestdoi/1061766508)" in text
     )
 
 
-def test_readme_top_doi_badge_not_latestdoi() -> None:
+def test_readme_zenodo_records_include_concept_doi_all_versions() -> None:
     text = README.read_text(encoding="utf-8")
-    assert "https://zenodo.org/badge/latestdoi/1061766508" not in text
+    assert "- **Concept DOI / all versions:** https://doi.org/10.5281/zenodo.17214908" in text
 
 
 def test_readme_zenodo_records_identifies_current_release_v111() -> None:


### PR DESCRIPTION
## Summary

Restores the README top DOI badge to the Zenodo-managed repository/latest DOI badge route.

This is a minimal bot/discovery-route repair. The README keeps explicit DOI roles in the Zenodo records block, while the top badge returns to the Zenodo repository badge endpoint.

## Scope

Updates only:

- `README.md`
- `tests/test_readme_doi_badge_contract.py`

## Purpose

The top DOI badge is treated as a Zenodo-managed public discovery route.

This PR restores:

`[![DOI](https://zenodo.org/badge/1061766508.svg)](https://zenodo.org/badge/latestdoi/1061766508)`

The DOI role table remains explicit in the README Zenodo records block.

## Authority boundary

This PR does not change release authority, release semantics, gate policy, `status.json`, required gate materialization, `check_gates.py`, CI release behavior, RA1, EPF, Paradox, public crawler workflows, citation metadata files, `.zenodo.json`, ORCID helper metadata, JSON-LD metadata, manifests, or audit bundles.

## Testing

- `pytest -q tests/test_readme_doi_badge_contract.py`
- `git diff -- README.md tests/test_readme_doi_badge_contract.py`
- `git status --short`