### PR TITLE
docs(readme): align Why PULSE section with PULSEmech mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,51 +84,17 @@ PULSE release authority is carried by the recorded artifact chain. Required gate
 
 Quality Ledger, release authority manifests, audit bundles, dashboards, and public Pages surfaces record, preserve, or display the decision trail. Authorization remains bound to the ordered PULSEmech tuple.
 
-## Why PULSE
+## Release-boundary mechanics
 
-Post-event control is not release control.
+PULSEmech places the release decision before deployment. Release effects are allowed to propagate only after the recorded artifact chain satisfies declared policy.
 
-Post-release control surfaces operate after release effects have already propagated: they detect, explain, patch, or audit.
-
-PULSE places the control point before release.
-
-Recorded evidence is checked against declared gate policy; required gates are materialized; missing required evidence, missing required gates, or non-true required gate values fail closed.
-
-The result is an evidence-bound release-authority path, not a post-event dashboard.
-
-Release evidence can include safety and consistency invariants, product quality gates, SLO budgets, external detector summaries, run metadata, logs, and release-stability signals. Policy defines which evidence and gates carry release authority. Evaluation is deterministic, explicit, and fail-closed.
-
-The output is a governed release surface:
-- machine-readable release status,
-- enforced gate outcomes,
-- a human-readable Quality Ledger,
-- CI-native reports and artifacts,
-- release-stability signals such as RDSI,
-- traceable release-state records.
+The release-boundary decision is evaluated as:
 
 ```text
 recorded release evidence
-+ declared gate policy
-+ deterministic evaluator
-→ auditable release decision record
+→ strict fail-closed CI checking
+→ CI allow/block release decision
 ```
-
-Release gates are the deterministic enforcement mechanism inside the broader PULSE release-governance layer.
-
-The normative release path is:
-
-```text
-recorded evidence
-→ status.json
-→ declared gate policy
-→ materialized required gate set
-→ strict gate checking
-→ CI decision
-```
-
-Release authority manifests, audit bundles, ledgers, dashboards, and public Pages surfaces preserve, publish, or display the decision trail.
-
-> **TL;DR**: Existing systems produce release evidence. PULSE binds that evidence to declared policy, evaluates it deterministically, enforces the release boundary in CI, and records the decision for audit.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ The release-boundary decision is evaluated as:
 
 ```text
 recorded release evidence
+→ status.json
+→ declared gate policy
+→ materialized required gate set
 → strict fail-closed CI checking
 → CI allow/block release decision
 ```


### PR DESCRIPTION
## Summary

Aligns the README post-intro section with the PULSEmech release-authority mechanics defined at the top of the document.

The previous `Why PULSE` section still contained older rhetorical, comparative, and duplicated wording. This PR replaces it with a mechanical release-boundary section that preserves the ordered PULSEmech decision structure.

## Scope

Updates only:

- `README.md`

## Purpose

The README now defines PULSE through PULSEmech release-authority mechanics:

`recorded release evidence → status.json → declared gate policy → materialized required gate set → strict fail-closed CI checking → CI allow/block release decision`

This PR makes the following section use the same mechanical frame instead of reverting to older comparison-style language.

## Mechanical change

Replaces the older `Why PULSE` wording with `Release-boundary mechanics`.

The new section states that:

- PULSEmech places the release decision before deployment;
- release effects are allowed to propagate only after the recorded artifact chain satisfies declared policy;
- required gates are explicit and materialized before checking;
- missing required evidence, missing required gates, invalid status artifacts, and non-true required gate values fail closed;
- release evidence may include safety and consistency invariants, product quality gates, SLO budgets, external detector summaries, run metadata, logs, review evidence, and release-stability signals;
- gate policy defines which recorded evidence carries release authority for a given lane.

## Artifact trail boundary

The release decision produces an artifact trail including:

- machine-readable release status;
- enforced gate outcomes;
- CI-native reports and artifacts;
- Quality Ledger display;
- release-stability signals such as RDSI;
- release authority manifests;
- audit bundles;
- traceable release-state records.

These surfaces record, preserve, or display the release decision trail. Authorization remains bound to the ordered PULSEmech tuple.

## Removed wording

Removes older rhetorical / comparative lines, including:

- `Post-event control is not release control.`
- `Post-release control surfaces operate after release effects have already propagated...`
- `The result is an evidence-bound release-authority path, not a post-event dashboard.`
- `recorded release evidence + declared gate policy + deterministic evaluator → auditable release decision record`
- `TL;DR: Existing systems produce release evidence...`

## Authority boundary

This is documentation-only.

It does not change:

- release semantics
- gate policy
- `status.json`
- required gate materialization
- `check_gates.py`
- CI behavior
- DOI metadata
- public crawler surfaces
- RA1
- EPF
- Paradox
- release authority manifests
- audit bundles

## Testing

- `git diff -- README.md`
- `git status --short`