### PR TITLE
docs: add technical maintenance notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@
 
 [![DOI](https://zenodo.org/badge/1061766508.svg)](https://zenodo.org/badge/latestdoi/1061766508)
 
+
+> 🚧 **Closed for technical maintenance**
+>
+> The machine we would use for this work is currently under repair. 
+>
+> PULSE remains active.
+
+
 #### Deterministic release-governance layer for LLM applications and AI-enabled systems
 
 PULSE operates through **PULSEmech release-authority mechanics**.


### PR DESCRIPTION
## Summary

Adds a short technical maintenance notice to indicate that current front-door / README wording work is temporarily paused while the tooling environment is unstable.

## Scope

Documentation-only notice.

No PULSE release-authority mechanics are changed.

## Authority boundary

This change does not modify:

- release semantics
- PULSEMech identity
- status.json
- gate policy
- CI behavior
- DOI / Zenodo metadata
- crawler surfaces
- release authority manifests
- audit bundles

PULSE remains active.

## Testing

Documentation-only change.

Checked with:

```bash
git diff -- README.md
git status --short