### PR TITLE
docs(readme): close PULSE release-authority identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,16 +164,16 @@ Choose the path that matches the release-authority question you need to answer.
 Before opening `.github/workflows/`, keep this  authority split in mind.
 
 
-- **Primary release-governance workflow**
+- **Primary release- authority workflow**
   - `.github/workflows/pulse_ci.yml`
   - This is the primary CI workflow for enforcing the declared release gate policy.
 
 - **Repo / workflow guardrails**
   - Governance preflight and workflow validation checks
-  - These protect repository and workflow integrity around the release-governance lane.
+  - These protect repository and workflow integrity around the release- authority lane.
 
 - **Shadow / diagnostic workflows**
-   - Overlays, dry-runs, experiments, and diagnostic artifacts
+  - Overlays, dry-runs, experiments, and diagnostic artifacts
   - These provide review and governance evidence under their declared authority status.
 
 - **Publication / GitHub-native surfaces**
@@ -181,7 +181,7 @@ Before opening `.github/workflows/`, keep this  authority split in mind.
   - These publish or render release evidence and should remain separate opt-in workflows with explicit write permissions.
 
 Rule:
-release authority is carried by the primary release-governance workflow and its declared required gate set. Shadow, diagnostic, and publication workflows preserve their declared authority status unless explicitly promoted into the required gate set.
+release authority is carried by the primary release-authority workflow and its declared required gate set. Shadow, diagnostic, and publication workflows preserve their declared authority status unless explicitly promoted into the required gate set.
 
 See also:  [`docs/WORKFLOW_MAP.md`](docs/WORKFLOW_MAP.md)
 
@@ -247,7 +247,7 @@ UI and Pages surfaces must be pure readers/renderers of immutable run artefacts.
 
 ## Quickstart
 
-There are two practical entry points: local artifact inspection and the canonical Core release-governance lane.
+There are two practical entry points: local artifact inspection and the canonical Core release- authority lane.
 
 ### Fast local smoke — artifact inspection
 
@@ -262,7 +262,7 @@ It is useful when you want to:
 - sanity-check that the pack runs locally
 - look at the generated `status.json` / `report_card.html`
 
-This is an inspection path, not the canonical Core CI release-governance lane.
+This is an inspection path, not the canonical Core CI release-authority lane.
 
 ### Canonical Core release-governance lane
 
@@ -391,14 +391,14 @@ change any CI behaviour or gate logic.
 
 ### Integration shapes
 
-Choose the integration shape that matches the release-governance boundary you want to exercise.
+Choose the integration shape that matches the release-authority boundary you want to exercise.
 
 1. **Pack-only local smoke**
    - Runs the safe-pack locally for artifact inspection.
    - Useful for checking generated `status.json`, reports, and tool behavior.
    - This is an inspection path, not the canonical release-authority lane.
 
-2. **Core release-governance lane**
+2. **Core release-authority lane**
    - Follow `docs/QUICKSTART_CORE_v0.md`.
    - Runs the Core profile in CI.
    - Validates `status.json`.


### PR DESCRIPTION
## Summary

This PR updates `README.md` only.

It closes the PULSE identity on the first screen:

PULSE is an artifact-first release-governance / release-authority system for AI applications.

PULSE structures recorded safety, quality, detector, stability, CI, and review evidence into deterministic, fail-closed release decisions under declared policy.

The goal is to make the README open with the existing PULSE release-authority mechanism rather than publication surfaces, badges, dashboards, operational notes, framework language, or generic governance framing.

## Mechanical change

This PR foregrounds:

- PULSE as an artifact-first release-governance / release-authority system;
- PULSEmech as the deterministic, fail-closed release-authority mechanism;
- the PULSEmech architecture map after the identity definition;
- the deterministic PULSEmech decision tuple;
- the normative decision path from recorded release evidence to CI allow/block release decision;
- the authority boundary between normative release inputs/enforcement and non-normative reader, trace, audit, dashboard, publication, diagnostic, and shadow surfaces.

The normative release-authority path remains:

recorded release evidence
→ status.json
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Authority boundary

This PR does not change PULSE release authority.

It clarifies the README language so that:

- `status.json`, declared gate policy, materialized required gate sets, and strict CI checking remain the normative release-authority path;
- Quality Ledger, release authority manifests, audit bundles, dashboards, badges, Pages, and publication surfaces remain non-normative reader / trace / audit / presentation surfaces;
- topology, EPF, Paradox, G-field, relational gain, and other diagnostic or shadow layers do not create a second release-decision path;
- diagnostic and shadow layers remain non-normative unless explicitly folded into recorded release evidence and enforced as required gates under declared policy.

## Scope

Changed:

- `README.md`

Not changed:

- code
- schemas
- workflows
- policies
- gate registry
- tests
- CI behavior
- release artifacts

## Validation

Documentation-only change.

Expected result:

- semantic PR title passes
- README has one primary PULSE release-authority identity
- first screen defines PULSE before badges, DOI records, dashboards, or operational notes
- PULSEmech architecture map appears after the identity definition
- normative and non-normative surfaces remain separated
- no code or CI behavior changes