### PR TITLE
docs(readme): close PULSE release-authority identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ UI and Pages surfaces must be pure readers/renderers of immutable run artefacts.
 
 ## Quickstart
 
-There are two practical entry points: local artifact inspection and the canonical Core release- authority lane.
+There are two practical entry points: local artifact inspection and the canonical Core release-authority lane.
 
 ### Fast local smoke — artifact inspection
 
@@ -264,7 +264,7 @@ It is useful when you want to:
 
 This is an inspection path, not the canonical Core CI release-authority lane.
 
-### Canonical Core release-governance lane
+### Canonical Core release-authority lane
 
 For the Core first-run path, start with:
 
@@ -410,7 +410,7 @@ Choose the integration shape that matches the release-authority boundary you wan
    - Applies the workflow-effective gate set described in `docs/GATE_SETS.md`.
    - Produces the release decision record, Quality Ledger, and CI artifacts for the repository release path. 
 
-Release gates are the deterministic enforcement mechanism inside the broader PULSE release-governance layer.
+Release gates are the deterministic enforcement mechanism inside the broader PULSE release-authority system.
 
 ---
 
@@ -431,7 +431,7 @@ PULSE evaluates release evidence under declared policy. In Core and release-grad
 - Q₃ **Fairness** (parity / equalized odds)
 - Q₄ **SLOs** (p95 latency & cost budgets)
 
-**Release-governance outputs**
+**Release-decision outputs**
 - **Quality Ledger** — human-readable release decision surface
 - **RDSI** — Release Decision Stability Index with deltas / confidence intervals where available
 - **CI artifacts** — `status.json`, report card, JUnit, SARIF, badges, and registered diagnostic artifacts


### PR DESCRIPTION
## Summary

This PR updates `README.md` only.

It closes the PULSE identity on the first screen:

PULSE is an artifact-first release-governance / release-authority system for AI applications.

PULSE structures recorded safety, quality, detector, stability, CI, and review evidence into deterministic, fail-closed release decisions under declared policy.

The README now opens with the existing PULSE release-authority mechanism rather than publication surfaces, badges, dashboards, operational notes, framework language, or generic governance framing.

## Mechanical change

This PR foregrounds:

- PULSE as an artifact-first release-governance / release-authority system;
- PULSEmech as the deterministic, fail-closed release-authority mechanism;
- the PULSEmech architecture map after the identity definition;
- the deterministic PULSEmech decision tuple;
- the normative decision path from recorded release evidence to CI allow/block release decision;
- the release boundary before deployment;
- the authority boundary between normative release inputs/enforcement and non-normative reader, trace, audit, dashboard, publication, diagnostic, and shadow surfaces.

The normative release-authority path remains:

recorded release evidence
→ status.json
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Wording normalization

This PR also aligns remaining README wording with the release-authority identity:

- workflow map language now uses release-authority framing;
- Quickstart and Core lane wording no longer drift back into generic governance framing;
- integration shapes are framed around the release-authority boundary;
- release outputs are described as release decision outputs;
- topology, EPF, Paradox, G-field, relational gain, and other diagnostic or shadow layers do not read as a second release-decision path.

## Authority boundary

This PR does not change PULSE release authority.

It clarifies the README language so that:

- `status.json`, declared gate policy, materialized required gate sets, and strict CI checking remain the normative release-authority path;
- Quality Ledger, release authority manifests, audit bundles, dashboards, badges, Pages, and publication surfaces remain non-normative reader / trace / audit / presentation surfaces;
- topology, EPF, Paradox, G-field, relational gain, and other diagnostic or shadow layers do not create a second release-decision path;
- diagnostic and shadow layers remain non-normative unless explicitly folded into recorded release evidence and enforced as required gates under declared policy.

## Scope

Changed:

- `README.md`

Not changed:

- code
- schemas
- workflows
- policies
- gate registry
- tests
- CI behavior
- release artifacts

## Validation

Documentation-only change.

Expected result:

- semantic PR title passes
- README has one primary PULSE release-authority identity
- first screen defines PULSE before badges, DOI records, dashboards, operational notes, or diagnostic overlays
- PULSEmech architecture map appears after the identity definition
- normative and non-normative surfaces remain separated
- no code or CI behavior changes