### PR TITLE
docs(readme): restore pre-materialization mechanics anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ CI enforces the materialized required gate set through strict, true-only, fail-c
 
 The CI result is the release decision.
 
+## Pre-materialization mechanics
+
+PULSE is pre-materialization gate mechanics for release authority: required evidence must materialize before release-grade validation, while unsupported authority must not materialize as a release decision.
+
+This is a non-normative explanatory anchor for the release-authority boundary. The normative release decision remains the PULSEmech path above:
+
+recorded release evidence
+→ `status.json`
+→ declared gate policy
+→ materialized required gate set
+→ strict fail-closed CI checking
+→ CI allow/block release decision
+
+See [`docs/PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md`](docs/PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md).
+
 ## Authority boundary
 
 | Surface | Mechanical role | Authority status |


### PR DESCRIPTION
## Summary

This PR updates `README.md` only.

It restores the existing PULSE pre-materialization mechanics anchor to the README first-screen mechanical sequence.

The new README placement is:

Normative decision path
→ Pre-materialization mechanics
→ Authority boundary

## Mechanical change

This PR adds a short `Pre-materialization mechanics` section after the normative decision path and before the authority boundary.

The section states:

PULSE is pre-materialization gate mechanics for release authority: required evidence must materialize before release-grade validation, while unsupported authority must not materialize as a release decision.

It also links to the existing document:

`docs/PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md`

## Why this belongs here

The pre-materialization mechanics anchor is not a new concept and not a new decision path.

It explains the mechanical boundary already used by PULSE:

- evidence must become explicit, recorded, inspectable, and usable before release-grade validation;
- unsupported authority must not materialize as a release decision;
- missing, malformed, unsigned, unverified, stale, stubbed, or non-materialized required evidence must fail closed.

## Authority boundary

This PR does not change PULSE release authority.

The normative release decision remains:

recorded release evidence
→ status.json
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

The explanatory document, README section, ledgers, manifests, dashboards, summaries, audit bundles, fixtures, and publication surfaces remain non-normative unless explicitly routed through the declared policy-controlled path.

## Scope

Changed:

- `README.md`

Not changed:

- code
- schemas
- workflows
- policies
- gate registry
- tests
- CI behavior
- dashboard semantics
- Quality Ledger semantics
- release authority manifest semantics
- audit bundle semantics
- release artifacts

## Validation

Documentation-only change.

Expected result:

- semantic PR title passes
- README keeps the release-authority identity first
- pre-materialization mechanics appears after the normative decision path
- authority boundary remains explicit
- no code or CI behavior changes