### PR TITLE
docs(readme): restore pre-materialization mechanics anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The mechanism is PULSEmech: an artifact-first, policy-declared, gate-materialize
 
 ## PULSEmech architecture map
 
-[![PULSEmech architecture map: artifact-first governance, shadow diagnostics, normative release authority, traceability, and release output.](hero_pulsemech_architecture_map_v0_1.svg)](docs/PULSEMECH_ARCHITECTURE_MAP_v0_1.md)
+[![PULSEmech architecture map: artifact-first evidence flow, shadow diagnostics, normative release authority, traceability, and release output.](hero_pulsemech_architecture_map_v0_1.svg)](docs/PULSEMECH_ARCHITECTURE_MAP_v0_1.md)
 
 ## Mechanical identity
 


### PR DESCRIPTION
Restore the PULSE pre-materialization mechanics anchor in README.md.

This README-only change places the existing pre-materialization gate mechanics
anchor after the normative decision path and before the authority boundary.

The restored section clarifies that PULSE is pre-materialization gate mechanics
for release authority: required evidence must materialize before release-grade
validation, while unsupported authority must not materialize as a release
decision.

The normative release decision remains the PULSEmech path:

recorded release evidence
→ status.json
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

This preserves the existing release-authority boundary and links back to the
existing docs/PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md document.

README-only change.

No code, schema, workflow, policy, gate, CI, test, dashboard, ledger, manifest,
audit bundle, or release behavior is changed.