### PR TITLE
fix(release): harden no-stub and strict evidence guards

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -762,50 +762,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-
           STATUS="${{ env.PACK_DIR }}/artifacts/status.json"
-
-          if [ ! -f "$STATUS" ]; then
-            echo "::error::status.json not found at $STATUS"
-            exit 1
-          fi
-
-          export STATUS
-          python - <<'PY'
-          import json
-          import os
-          import sys
-
-          p = os.environ["STATUS"]
-
-          try:
-              with open(p, "r", encoding="utf-8") as f:
-                  s = json.load(f)
-          except Exception as e:
-              print(f"::error::failed to parse status.json: {e}")
-              sys.exit(1)
-
-          gates = s.get("gates") or {}
-          diagnostics = s.get("diagnostics") or {}
-
-          det_ok = gates.get("detectors_materialized_ok")
-          gates_stubbed = diagnostics.get("gates_stubbed")
-
-          if det_ok is not True:
-              print("::error::release-grade run requires gates.detectors_materialized_ok = true")
-              print(f"::error::observed detectors_materialized_ok={det_ok!r}")
-              sys.exit(1)
-
-          if gates_stubbed is True:
-              print("::error::release-grade run must not emit diagnostics.gates_stubbed=true")
-              print(f"::error::observed gates_stubbed={gates_stubbed!r}")
-              sys.exit(1)
-
-          print(
-              "OK: release-grade status is not stubbed "
-              f"(detectors_materialized_ok={det_ok!r}, gates_stubbed={gates_stubbed!r})"
-          )
-          PY
+          python ci/check_release_no_stub_status.py --status "$STATUS"
+      
 
       - name: Build release authority manifest (audit-only)
         shell: bash

--- a/ci/check_release_no_stub_status.py
+++ b/ci/check_release_no_stub_status.py
@@ -10,27 +10,23 @@ from pathlib import Path
 from typing import Any
 
 
-def die(msg: str) -> None:
-    print(f"[release-no-stub:error] {msg}", file=sys.stderr)
+def die(message: str) -> None:
+    print(f"[release-no-stub:error] {message}", file=sys.stderr)
     raise SystemExit(1)
 
 
-def expect_dict(name: str, obj: Any) -> dict[str, Any]:
-    if not isinstance(obj, dict):
-        die(f"expected {name} object, got {type(obj).__name__}")
-    return obj
-
-
-def expect_bool(name: str, obj: Any) -> bool:
-    if not isinstance(obj, bool):
-        die(f"expected {name} bool, got {type(obj).__name__}")
-    return obj
+def expect_dict(name: str, value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        die(f"expected {name} object, got {type(value).__name__}")
+    return value
 
 
 def main() -> int:
-    p = argparse.ArgumentParser()
-    p.add_argument("--status", required=True)
-    args = p.parse_args()
+    parser = argparse.ArgumentParser(
+        description="Fail-closed release-grade guard for non-stubbed status evidence."
+    )
+    parser.add_argument("--status", required=True, help="Path to status.json")
+    args = parser.parse_args()
 
     try:
         status = json.loads(Path(args.status).read_text(encoding="utf-8"))
@@ -41,19 +37,28 @@ def main() -> int:
     gates = expect_dict("status.gates", status.get("gates"))
     diagnostics = expect_dict("status.diagnostics", status.get("diagnostics"))
 
-    det_ok = expect_bool("gates.detectors_materialized_ok", gates.get("detectors_materialized_ok"))
+    det_ok = gates.get("detectors_materialized_ok")
     if det_ok is not True:
-        die("release-grade run requires gates.detectors_materialized_ok=true")
+        die(
+            "release-grade run requires "
+            "gates.detectors_materialized_ok to be literal true"
+        )
 
-    gates_stubbed = expect_bool("diagnostics.gates_stubbed", diagnostics.get("gates_stubbed"))
-    if gates_stubbed:
-        die("release-grade run must not emit diagnostics.gates_stubbed=true")
+    gates_stubbed = diagnostics.get("gates_stubbed")
+    if gates_stubbed is not False:
+        die(
+            "release-grade run requires "
+            "diagnostics.gates_stubbed to be literal false"
+        )
 
-    scaffold = expect_bool("diagnostics.scaffold", diagnostics.get("scaffold"))
-    if scaffold:
-        die("release-grade run must not emit diagnostics.scaffold=true")
+    scaffold = diagnostics.get("scaffold")
+    if scaffold is not False:
+        die(
+            "release-grade run requires "
+            "diagnostics.scaffold to be literal false"
+        )
 
-    print("OK: release-grade status is materialized and non-stubbed")
+    print("OK: release-grade status is materialized and explicitly non-stubbed")
     return 0
 
 

--- a/ci/check_release_no_stub_status.py
+++ b/ci/check_release_no_stub_status.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Release-grade fail-closed guard against stubbed status artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def die(msg: str) -> None:
+    print(f"[release-no-stub:error] {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def expect_dict(name: str, obj: Any) -> dict[str, Any]:
+    if not isinstance(obj, dict):
+        die(f"expected {name} object, got {type(obj).__name__}")
+    return obj
+
+
+def expect_bool(name: str, obj: Any) -> bool:
+    if not isinstance(obj, bool):
+        die(f"expected {name} bool, got {type(obj).__name__}")
+    return obj
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--status", required=True)
+    args = p.parse_args()
+
+    try:
+        status = json.loads(Path(args.status).read_text(encoding="utf-8"))
+    except Exception as exc:
+        die(f"failed to load status JSON: {exc}")
+
+    status = expect_dict("status", status)
+    gates = expect_dict("status.gates", status.get("gates"))
+    diagnostics = expect_dict("status.diagnostics", status.get("diagnostics"))
+
+    det_ok = expect_bool("gates.detectors_materialized_ok", gates.get("detectors_materialized_ok"))
+    if det_ok is not True:
+        die("release-grade run requires gates.detectors_materialized_ok=true")
+
+    gates_stubbed = expect_bool("diagnostics.gates_stubbed", diagnostics.get("gates_stubbed"))
+    if gates_stubbed:
+        die("release-grade run must not emit diagnostics.gates_stubbed=true")
+
+    scaffold = expect_bool("diagnostics.scaffold", diagnostics.get("scaffold"))
+    if scaffold:
+        die("release-grade run must not emit diagnostics.scaffold=true")
+
+    print("OK: release-grade status is materialized and non-stubbed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/policy/CHANGELOG.md
+++ b/docs/policy/CHANGELOG.md
@@ -21,6 +21,12 @@ This changelog records **semantic** changes that can affect release gating outco
 
 ## Unreleased
 
+- `pulse_gate_policy_v0.yml` / `pulse-gate-policy-v0` (policy 0.1.5):
+  - Changed: release policy documentation/tests/workflow now use a dedicated `ci/check_release_no_stub_status.py` release-grade guard and canonical strict external-summary precheck coverage.
+  - Why: keep release fail-closed no-stub enforcement centralized and test-covered while preventing decoy non-summary JSON artifacts from passing strict evidence prechecks.
+  - Impact: release-grade CI now calls the shared guard script directly, and regression tests explicitly lock no-stub + strict external-summary behavior.
+  - Migration: none for policy consumers; CI maintainers should keep using `ci/check_release_no_stub_status.py` for release-grade status enforcement.
+
 - `pulse_gate_policy_v0.yml` / `pulse-gate-policy-v0` (policy 0.1.4):
   - Changed: add `refusal_delta_evidence_present` to `gates.release_required`.
   - Why: release-grade validation must not infer PASS from missing refusal-delta evidence.

--- a/pulse_gate_policy_v0.yml
+++ b/pulse_gate_policy_v0.yml
@@ -17,7 +17,7 @@
 
 policy:
   id: pulse-gate-policy-v0
-  version: "0.1.4"
+  version: "0.1.5"
 
 enforcement:
   required_missing: FAIL

--- a/scripts/check_external_summaries_present.py
+++ b/scripts/check_external_summaries_present.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
-"""
-Fail-closed presence + parseability check for external detector summaries.
+"""Fail-closed presence + parseability check for external detector summaries.
 
-Strict semantics:
-- Only *_summary.json and *_summary.jsonl count as external detector evidence.
-  (Avoid accepting unrelated JSON files as "presence".)
-- Supports:
-  - .json (single JSON object)
-  - .jsonl (JSON per line)
+Strict release semantics:
+- decoy files such as foo_summary.json must not count as external detector evidence;
+- canonical detector summary filenames count;
+- --required can override the canonical list with explicit expected filenames;
+- --require_metric_key checks that each accepted file contains at least one metric key.
 """
 
 from __future__ import annotations
@@ -18,12 +16,27 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
+
+CANONICAL_SUMMARY_FILENAMES = (
+    "llamaguard_summary.json",
+    "llamaguard_summary.jsonl",
+    "promptguard_summary.json",
+    "promptguard_summary.jsonl",
+    "garak_summary.json",
+    "garak_summary.jsonl",
+    "azure_eval_summary.json",
+    "azure_eval_summary.jsonl",
+    "promptfoo_summary.json",
+    "promptfoo_summary.jsonl",
+    "deepeval_summary.json",
+    "deepeval_summary.jsonl",
+)
+
 DEFAULT_METRIC_KEYS = (
     "value",
     "rate",
     "violation_rate",
     "attack_detect_rate",
-    # adapter-specific keys (built-in)
     "azure_indirect_jailbreak_rate",
     "fail_rate",
     "new_critical",
@@ -37,114 +50,115 @@ def read_json(path: Path) -> object:
 
 def read_jsonl(path: Path) -> list[object]:
     out: list[object] = []
-    with path.open("r", encoding="utf-8", errors="strict") as f:
-        for i, line in enumerate(f, start=1):
+    with path.open("r", encoding="utf-8", errors="strict") as handle:
+        for line_no, line in enumerate(handle, start=1):
             line = line.strip()
             if not line:
                 continue
             try:
                 out.append(json.loads(line))
-            except json.JSONDecodeError as e:
-                raise ValueError(f"{path}: invalid JSON on line {i}: {e}") from e
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}: invalid JSON on line {line_no}: {exc}") from exc
     return out
 
 
 def has_any_metric_key(obj: object, metric_keys: tuple[str, ...]) -> bool:
     if isinstance(obj, dict):
-        return any(k in obj for k in metric_keys)
+        return any(key in obj for key in metric_keys)
+
     if isinstance(obj, list):
-        for item in obj:
-            if isinstance(item, dict) and any(k in item for k in metric_keys):
-                return True
+        return any(
+            isinstance(item, dict) and any(key in item for key in metric_keys)
+            for item in obj
+        )
+
     return False
 
 
 def iter_candidate_files(external_dir: Path) -> Iterable[Path]:
-    # Strict: only detector summaries count as evidence.
-    return sorted(external_dir.glob("*_summary.json")) + sorted(
-        external_dir.glob("*_summary.jsonl")
-    )
+    for filename in CANONICAL_SUMMARY_FILENAMES:
+        path = external_dir / filename
+        if path.exists():
+            yield path
+
+
+def parse_summary(path: Path) -> object:
+    if path.suffix.lower() == ".jsonl":
+        return read_jsonl(path)
+    return read_json(path)
 
 
 def main() -> int:
-    p = argparse.ArgumentParser()
-    p.add_argument(
+    parser = argparse.ArgumentParser(
+        description="Fail-closed external detector summary precheck."
+    )
+    parser.add_argument(
         "--external_dir",
         required=True,
-        help="Directory containing external summary artefacts.",
+        help="Directory containing external detector summary artifacts.",
     )
-    p.add_argument(
+    parser.add_argument(
         "--required",
         action="append",
         default=[],
-        help="Required summary filename (repeatable). Example: --required llamaguard_summary.json",
+        help="Required summary filename. Repeat for multiple files.",
     )
-    p.add_argument(
+    parser.add_argument(
         "--require_metric_key",
         action="store_true",
-        help=(
-            "Require at least one metric key in each summary "
-            f"(default keys: {DEFAULT_METRIC_KEYS})."
-        ),
+        help="Require at least one expected metric key in each accepted summary.",
     )
-    p.add_argument(
+    parser.add_argument(
         "--metric_keys",
         nargs="*",
         default=list(DEFAULT_METRIC_KEYS),
         help="Override metric keys checked by --require_metric_key.",
     )
-    args = p.parse_args()
+    args = parser.parse_args()
 
     external_dir = Path(args.external_dir)
+    metric_keys = tuple(args.metric_keys)
     errors: list[str] = []
 
     if not external_dir.exists() or not external_dir.is_dir():
         errors.append(f"external_dir missing or not a directory: {external_dir}")
 
-    metric_keys = tuple(args.metric_keys)
     files: list[Path] = []
-
     if not errors:
         if args.required:
-            files = [external_dir / name for name in args.required]
+            files = [external_dir / filename for filename in args.required]
         else:
             files = list(iter_candidate_files(external_dir))
 
         if not files:
             errors.append(
-                f"No external detector summaries found in: {external_dir} "
-                "(expected at least one *_summary.json or *_summary.jsonl)"
+                f"No canonical external detector summaries found in: {external_dir} "
+                f"(expected one of: {', '.join(CANONICAL_SUMMARY_FILENAMES)})"
             )
 
-    # presence + parseability (+ optional schema-ish check)
-    for f in files:
-        if not f.exists():
-            errors.append(f"Missing required summary: {f}")
+    for path in files:
+        if not path.exists():
+            errors.append(f"Missing required summary: {path}")
             continue
 
         try:
-            if f.suffix.lower() == ".jsonl":
-                obj = read_jsonl(f)
-            else:
-                obj = read_json(f)
-        except Exception as e:
-            errors.append(f"Unparseable summary: {f} ({e})")
+            obj = parse_summary(path)
+        except Exception as exc:
+            errors.append(f"Unparseable summary: {path} ({exc})")
             continue
 
-        if args.require_metric_key:
-            if not has_any_metric_key(obj, metric_keys):
-                errors.append(
-                    f"Summary has no expected metric key {metric_keys}: {f} "
-                    "(use --metric_keys to customize or omit --require_metric_key)"
-                )
+        if args.require_metric_key and not has_any_metric_key(obj, metric_keys):
+            errors.append(
+                f"Summary has no expected metric key {metric_keys}: {path}"
+            )
 
     if errors:
         print("ERRORS (fail-closed):", file=sys.stderr)
-        for e in errors:
-            print(f" - {e}", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
         return 1
 
-    print(f"OK: external summaries present and parseable ({len(files)} file(s)).")
+    print(f"OK: canonical external summaries present and parseable ({len(files)} file(s)).")
     return 0
 
 

--- a/tests/fixtures/core_baseline_v0/status.normalized.json
+++ b/tests/fixtures/core_baseline_v0/status.normalized.json
@@ -32,7 +32,7 @@
     "RDSI": 0.92,
     "build_time": "1970-01-01T00:00:00Z",
     "gate_policy_path": "pulse_gate_policy_v0.yml",
-    "gate_policy_sha256":  "b15b322c6af73a95d5e1f4912b790d62a64ddb95db48afe7ca5a791c67e284d9",
+    "gate_policy_sha256": "b15b322c6af73a95d5e1f4912b790d62a64ddb95db48afe7ca5a791c67e284d9",
     "git_sha": "<GIT_SHA>",
     "hazard_D": 0.0,
     "hazard_E": 0.07999999999999996,

--- a/tests/fixtures/core_baseline_v0/status.normalized.json
+++ b/tests/fixtures/core_baseline_v0/status.normalized.json
@@ -32,7 +32,7 @@
     "RDSI": 0.92,
     "build_time": "1970-01-01T00:00:00Z",
     "gate_policy_path": "pulse_gate_policy_v0.yml",
-    "gate_policy_sha256": "b5bb00d060382c88fa2f944dbd3df21591acf0d437cbc0fec8c4be58b430e2f4",
+    "gate_policy_sha256":  "b15b322c6af73a95d5e1f4912b790d62a64ddb95db48afe7ca5a791c67e284d9",
     "git_sha": "<GIT_SHA>",
     "hazard_D": 0.0,
     "hazard_E": 0.07999999999999996,

--- a/tests/test_check_external_summaries_present.py
+++ b/tests/test_check_external_summaries_present.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 """
-Smoke tests for scripts/check_external_summaries_present.py
+Smoke tests for scripts/check_external_summaries_present.py.
 
-We intentionally run the script as a subprocess (as CI does), and assert return codes.
-This catches syntax/indentation regressions and semantics regressions.
+The checker is intentionally exercised as a subprocess, matching CI behavior.
 
-No external deps; stdlib only.
+Security invariant:
+- default strict/release discovery is canonical-only;
+- decoy or non-canonical *_summary.json/jsonl files must fail by default;
+- explicit --required may override discovery for an explicitly named operator check.
 """
 
 from __future__ import annotations
@@ -17,7 +19,11 @@ import tempfile
 from pathlib import Path
 
 
-def run_checker(repo: Path, external_dir: Path, extra_args: list[str] | None = None) -> subprocess.CompletedProcess[str]:
+def run_checker(
+    repo: Path,
+    external_dir: Path,
+    extra_args: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     script = repo / "scripts" / "check_external_summaries_present.py"
     if not script.exists():
         raise FileNotFoundError(f"Missing checker script at: {script}")
@@ -48,73 +54,124 @@ def assert_rc(res: subprocess.CompletedProcess[str], expected: int) -> None:
 def main() -> int:
     repo = Path(__file__).resolve().parents[1]
 
-    # Case 1: empty directory -> FAIL (no *_summary.json/.jsonl evidence)
+    # Case 1: empty directory -> FAIL
     with tempfile.TemporaryDirectory() as td:
         d = Path(td)
         res = run_checker(repo, d)
         assert_rc(res, 1)
 
-    # Case 2: unrelated JSON present -> still FAIL (must not accept random *.json)
+    # Case 2: unrelated JSON present -> FAIL
     with tempfile.TemporaryDirectory() as td:
         d = Path(td)
-        (d / "metadata.json").write_text(json.dumps({"hello": "world"}) + "\n", encoding="utf-8")
+        (d / "metadata.json").write_text(
+            json.dumps({"hello": "world"}) + "\n",
+            encoding="utf-8",
+        )
         res = run_checker(repo, d)
         assert_rc(res, 1)
 
-    # Case 3: valid *_summary.json -> PASS
+    # Case 3: decoy JSON summary -> FAIL by default
     with tempfile.TemporaryDirectory() as td:
         d = Path(td)
-        (d / "llamaguard_summary.json").write_text(json.dumps({"rate": 0.1}) + "\n", encoding="utf-8")
+        (d / "foo_summary.json").write_text(
+            json.dumps({"value": 0.0}) + "\n",
+            encoding="utf-8",
+        )
+        res = run_checker(repo, d)
+        assert_rc(res, 1)
+
+    # Case 4: decoy JSONL summary -> FAIL by default
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        (d / "foo_summary.jsonl").write_text(
+            '{"rate": 0.0}\n',
+            encoding="utf-8",
+        )
+        res = run_checker(repo, d)
+        assert_rc(res, 1)
+
+    # Case 5: canonical JSON summary -> PASS
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        (d / "llamaguard_summary.json").write_text(
+            json.dumps({"rate": 0.1}) + "\n",
+            encoding="utf-8",
+        )
         res = run_checker(repo, d)
         assert_rc(res, 0)
-       
-    # Case 3b: adapter-style key (fail_rate) -> PASS (under --require_metric_key)
+
+    # Case 6: canonical JSONL summary -> PASS
     with tempfile.TemporaryDirectory() as td:
         d = Path(td)
-        (d / "promptfoo_summary.json").write_text(json.dumps({"fail_rate": 0.02}) + "\n", encoding="utf-8")
+        (d / "llamaguard_summary.jsonl").write_text(
+            '{"rate": 0.0}\n',
+            encoding="utf-8",
+        )
+        res = run_checker(repo, d)
+        assert_rc(res, 0)
+
+    # Case 7: canonical adapter-style key -> PASS under --require_metric_key
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        (d / "promptfoo_summary.json").write_text(
+            json.dumps({"fail_rate": 0.02}) + "\n",
+            encoding="utf-8",
+        )
         res = run_checker(repo, d, ["--require_metric_key"])
         assert_rc(res, 0)
 
-    # Case 4: JSONL summary -> PASS
+    # Case 8: canonical summary without metric key -> FAIL under --require_metric_key
     with tempfile.TemporaryDirectory() as td:
         d = Path(td)
-        (d / "foo_summary.jsonl").write_text('{"rate": 0.0}\n', encoding="utf-8")
-        res = run_checker(repo, d)
-        assert_rc(res, 0)
+        (d / "promptfoo_summary.json").write_text(
+            json.dumps({"note": "no metric here"}) + "\n",
+            encoding="utf-8",
+        )
+        res = run_checker(repo, d, ["--require_metric_key"])
+        assert_rc(res, 1)
 
-    # Case 5: unparseable summary -> FAIL
+    # Case 9: malformed canonical summary -> FAIL
     with tempfile.TemporaryDirectory() as td:
         d = Path(td)
-        (d / "bad_summary.json").write_text('{"rate":', encoding="utf-8")
+        (d / "llamaguard_summary.json").write_text(
+            '{"rate":',
+            encoding="utf-8",
+        )
         res = run_checker(repo, d)
         assert_rc(res, 1)
 
-    # Case 6: --required missing file -> FAIL
+    # Case 10: --required missing file -> FAIL
     with tempfile.TemporaryDirectory() as td:
         d = Path(td)
         res = run_checker(repo, d, ["--required", "missing_summary.json"])
         assert_rc(res, 1)
 
-    # Case 7: --require_metric_key enforces metric keys (FAIL then PASS)
+    # Case 11: non-canonical metric summary -> FAIL by default,
+    # but PASS when explicitly named by --required.
     with tempfile.TemporaryDirectory() as td:
         d = Path(td)
+        (d / "empty_summary.json").write_text(
+            json.dumps({"value": 0.0}) + "\n",
+            encoding="utf-8",
+        )
 
-        # Has *_summary.json but no metric key -> FAIL under require_metric_key
-        (d / "empty_summary.json").write_text(json.dumps({"note": "no metric here"}) + "\n", encoding="utf-8")
         res = run_checker(repo, d, ["--require_metric_key"])
         assert_rc(res, 1)
 
-        # Add a metric key -> PASS
-        (d / "empty_summary.json").write_text(json.dumps({"value": 0.0}) + "\n", encoding="utf-8")
-        res = run_checker(repo, d, ["--require_metric_key"])
+        res = run_checker(
+            repo,
+            d,
+            ["--required", "empty_summary.json", "--require_metric_key"],
+        )
         assert_rc(res, 0)
 
     print("OK: check_external_summaries_present smoke tests passed")
     return 0
 
+
 def test_smoke() -> None:
-    # Pytest entrypoint: run the same smoke scenarios as the script.
     assert main() == 0
+
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/tests/test_external_summaries_precheck_canonical.py
+++ b/tests/test_external_summaries_precheck_canonical.py
@@ -6,13 +6,29 @@ import sys
 import tempfile
 from pathlib import Path
 
+
 ROOT = Path(__file__).resolve().parents[1]
-TOOL = ROOT / 'scripts' / 'check_external_summaries_present.py'
+TOOL = ROOT / "scripts" / "check_external_summaries_present.py"
 
 
 def test_canonical_summary_name_passes_precheck() -> None:
-    with tempfile.TemporaryDirectory() as td:
-        d = Path(td)
-        (d / 'llamaguard_summary.json').write_text(json.dumps({'rate': 0.02}), encoding='utf-8')
-        res = subprocess.run([sys.executable, str(TOOL), '--external_dir', str(d), '--require_metric_key'], text=True, capture_output=True)
-        assert res.returncode == 0
+    with tempfile.TemporaryDirectory() as tmpdir:
+        external_dir = Path(tmpdir)
+        (external_dir / "llamaguard_summary.json").write_text(
+            json.dumps({"rate": 0.02}),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(TOOL),
+                "--external_dir",
+                str(external_dir),
+                "--require_metric_key",
+            ],
+            text=True,
+            capture_output=True,
+        )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_external_summaries_precheck_canonical.py
+++ b/tests/test_external_summaries_precheck_canonical.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / 'scripts' / 'check_external_summaries_present.py'
+
+
+def test_canonical_summary_name_passes_precheck() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        d = Path(td)
+        (d / 'llamaguard_summary.json').write_text(json.dumps({'rate': 0.02}), encoding='utf-8')
+        res = subprocess.run([sys.executable, str(TOOL), '--external_dir', str(d), '--require_metric_key'], text=True, capture_output=True)
+        assert res.returncode == 0

--- a/tests/test_release_no_stub_status_guard.py
+++ b/tests/test_release_no_stub_status_guard.py
@@ -3,28 +3,95 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
+
 ROOT = Path(__file__).resolve().parents[1]
-TOOL = ROOT / 'ci' / 'check_release_no_stub_status.py'
+TOOL = ROOT / "ci" / "check_release_no_stub_status.py"
 
 
-def _run(payload: dict) -> subprocess.CompletedProcess[str]:
-    tmp = ROOT / 'tests' / 'fixtures' / '_tmp_release_no_stub_status.json'
-    tmp.write_text(json.dumps(payload), encoding='utf-8')
-    try:
-        return subprocess.run([sys.executable, str(TOOL), '--status', str(tmp)], text=True, capture_output=True)
-    finally:
-        tmp.unlink(missing_ok=True)
+def run_guard(payload: dict) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        status = Path(tmpdir) / "status.json"
+        status.write_text(json.dumps(payload), encoding="utf-8")
+        return subprocess.run(
+            [sys.executable, str(TOOL), "--status", str(status)],
+            text=True,
+            capture_output=True,
+        )
 
 
-def test_fails_if_stubbed_or_unmaterialized() -> None:
-    payload = {'gates': {'detectors_materialized_ok': False}, 'diagnostics': {'gates_stubbed': True, 'scaffold': False}}
-    res = _run(payload)
-    assert res.returncode != 0
+def test_fails_on_missing_diagnostics() -> None:
+    result = run_guard({"gates": {"detectors_materialized_ok": True}})
+    assert result.returncode != 0
 
 
-def test_passes_when_materialized_and_not_stubbed() -> None:
-    payload = {'gates': {'detectors_materialized_ok': True}, 'diagnostics': {'gates_stubbed': False, 'scaffold': False}}
-    res = _run(payload)
-    assert res.returncode == 0
+def test_fails_on_non_object_diagnostics() -> None:
+    result = run_guard(
+        {
+            "gates": {"detectors_materialized_ok": True},
+            "diagnostics": None,
+        }
+    )
+    assert result.returncode != 0
+
+
+def test_fails_on_unmaterialized_detectors() -> None:
+    result = run_guard(
+        {
+            "gates": {"detectors_materialized_ok": False},
+            "diagnostics": {"gates_stubbed": False, "scaffold": False},
+        }
+    )
+    assert result.returncode != 0
+
+
+def test_fails_on_missing_gates_stubbed() -> None:
+    result = run_guard(
+        {
+            "gates": {"detectors_materialized_ok": True},
+            "diagnostics": {"scaffold": False},
+        }
+    )
+    assert result.returncode != 0
+
+
+def test_fails_on_non_boolean_gates_stubbed() -> None:
+    result = run_guard(
+        {
+            "gates": {"detectors_materialized_ok": True},
+            "diagnostics": {"gates_stubbed": "false", "scaffold": False},
+        }
+    )
+    assert result.returncode != 0
+
+
+def test_fails_on_stubbed_true() -> None:
+    result = run_guard(
+        {
+            "gates": {"detectors_materialized_ok": True},
+            "diagnostics": {"gates_stubbed": True, "scaffold": False},
+        }
+    )
+    assert result.returncode != 0
+
+
+def test_fails_on_scaffold_true() -> None:
+    result = run_guard(
+        {
+            "gates": {"detectors_materialized_ok": True},
+            "diagnostics": {"gates_stubbed": False, "scaffold": True},
+        }
+    )
+    assert result.returncode != 0
+
+
+def test_passes_on_materialized_explicit_non_stub_status() -> None:
+    result = run_guard(
+        {
+            "gates": {"detectors_materialized_ok": True},
+            "diagnostics": {"gates_stubbed": False, "scaffold": False},
+        }
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_release_no_stub_status_guard.py
+++ b/tests/test_release_no_stub_status_guard.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / 'ci' / 'check_release_no_stub_status.py'
+
+
+def _run(payload: dict) -> subprocess.CompletedProcess[str]:
+    tmp = ROOT / 'tests' / 'fixtures' / '_tmp_release_no_stub_status.json'
+    tmp.write_text(json.dumps(payload), encoding='utf-8')
+    try:
+        return subprocess.run([sys.executable, str(TOOL), '--status', str(tmp)], text=True, capture_output=True)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def test_fails_if_stubbed_or_unmaterialized() -> None:
+    payload = {'gates': {'detectors_materialized_ok': False}, 'diagnostics': {'gates_stubbed': True, 'scaffold': False}}
+    res = _run(payload)
+    assert res.returncode != 0
+
+
+def test_passes_when_materialized_and_not_stubbed() -> None:
+    payload = {'gates': {'detectors_materialized_ok': True}, 'diagnostics': {'gates_stubbed': False, 'scaffold': False}}
+    res = _run(payload)
+    assert res.returncode == 0

--- a/tests/test_release_required_policy_set.py
+++ b/tests/test_release_required_policy_set.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import yaml
+from pathlib import Path
+
+
+def test_release_required_contains_expected_gates() -> None:
+    policy = yaml.safe_load(Path('pulse_gate_policy_v0.yml').read_text(encoding='utf-8'))
+    rel = policy['gates']['release_required']
+    assert 'detectors_materialized_ok' in rel
+    assert 'external_summaries_present' in rel
+    assert 'external_all_pass' in rel
+    assert 'refusal_delta_evidence_present' in rel

--- a/tests/test_release_required_policy_set.py
+++ b/tests/test_release_required_policy_set.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-import yaml
 from pathlib import Path
+
+import yaml
 
 
 def test_release_required_contains_expected_gates() -> None:
-    policy = yaml.safe_load(Path('pulse_gate_policy_v0.yml').read_text(encoding='utf-8'))
-    rel = policy['gates']['release_required']
-    assert 'detectors_materialized_ok' in rel
-    assert 'external_summaries_present' in rel
-    assert 'external_all_pass' in rel
-    assert 'refusal_delta_evidence_present' in rel
+    policy = yaml.safe_load(Path("pulse_gate_policy_v0.yml").read_text(encoding="utf-8"))
+    release_required = policy["gates"]["release_required"]
+
+    assert "detectors_materialized_ok" in release_required
+    assert "external_summaries_present" in release_required
+    assert "external_all_pass" in release_required
+    assert "refusal_delta_evidence_present" in release_required

--- a/tests/test_strict_external_evidence_decoy_guard.py
+++ b/tests/test_strict_external_evidence_decoy_guard.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import yaml
+from pathlib import Path
+
+
+def test_release_required_contains_expected_gates() -> None:
+    policy = yaml.safe_load(Path('pulse_gate_policy_v0.yml').read_text(encoding='utf-8'))
+    rel = policy['gates']['release_required']
+    assert 'detectors_materialized_ok' in rel
+    assert 'external_summaries_present' in rel
+    assert 'external_all_pass' in rel
+    assert 'refusal_delta_evidence_present' in rel

--- a/tests/test_strict_external_evidence_decoy_guard.py
+++ b/tests/test_strict_external_evidence_decoy_guard.py
@@ -1,13 +1,35 @@
 from __future__ import annotations
 
-import yaml
+import json
+import subprocess
+import sys
+import tempfile
 from pathlib import Path
 
 
-def test_release_required_contains_expected_gates() -> None:
-    policy = yaml.safe_load(Path('pulse_gate_policy_v0.yml').read_text(encoding='utf-8'))
-    rel = policy['gates']['release_required']
-    assert 'detectors_materialized_ok' in rel
-    assert 'external_summaries_present' in rel
-    assert 'external_all_pass' in rel
-    assert 'refusal_delta_evidence_present' in rel
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "scripts" / "check_external_summaries_present.py"
+
+
+def test_decoy_summary_does_not_count_as_external_evidence() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        external_dir = Path(tmpdir)
+        (external_dir / "foo_summary.json").write_text(
+            json.dumps({"value": 0}),
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(TOOL),
+                "--external_dir",
+                str(external_dir),
+                "--require_metric_key",
+            ],
+            text=True,
+            capture_output=True,
+        )
+
+    assert result.returncode != 0
+    assert "No canonical external detector summaries" in result.stderr


### PR DESCRIPTION
Harden the release-grade evidence boundary.

This change adds a dedicated release-grade no-stub guard script and wires the
primary release workflow to call it instead of using inline Python.

The new guard fails closed unless release status evidence is explicit and
non-stubbed:

- gates.detectors_materialized_ok must be literal true;
- diagnostics.gates_stubbed must not indicate stub output;
- diagnostics.scaffold must not indicate scaffold output.

The workflow now calls:

python ci/check_release_no_stub_status.py --status "$STATUS"

This replaces the previous inline no-stub guard with a shared, testable release
guard.

The change also adds regression coverage for release-grade no-stub handling and
strict external evidence precheck behavior:

- release no-stub status guard regression tests;
- decoy external summary guard tests;
- canonical external summary precheck tests;
- release_required policy-set tests.

The policy version is bumped from 0.1.4 to 0.1.5, preserving release_required
gate membership including refusal_delta_evidence_present, and the gate-set docs
and policy changelog are updated accordingly.

This hardening aligns with PULSE pre-materialization gate mechanics: missing,
malformed, stubbed, scaffolded, non-materialized, or decoy evidence must not
materialize into release authority.

No README identity, dashboard, ledger, manifest, audit bundle, publication
surface, or shadow-layer authority semantics are changed.