### PR TITLE
fix(release): fail closed without folded external detector evidence

### DIFF
--- a/PULSE_safe_pack_v0/tools/augment_status.py
+++ b/PULSE_safe_pack_v0/tools/augment_status.py
@@ -238,6 +238,42 @@ def fold_q1_reference_shadow(status: Dict[str, Any], summary_path: Optional[str]
     meta = ensure_meta(status)
     meta["q1_reference_shadow"] = shadow
 
+CANONICAL_EXTERNAL_SUMMARY_FILENAMES = (
+    "llamaguard_summary.json",
+    "llamaguard_summary.jsonl",
+    "promptguard_summary.json",
+    "promptguard_summary.jsonl",
+    "garak_summary.json",
+    "garak_summary.jsonl",
+    "azure_eval_summary.json",
+    "azure_eval_summary.jsonl",
+    "promptfoo_summary.json",
+    "promptfoo_summary.jsonl",
+    "deepeval_summary.json",
+    "deepeval_summary.jsonl",
+)
+
+
+def list_external_summary_files(ext_dir: str) -> list[str]:
+    if not os.path.isdir(ext_dir):
+        return []
+
+    files = sorted(glob.glob(os.path.join(ext_dir, "*_summary.json")))
+    files += sorted(glob.glob(os.path.join(ext_dir, "*_summary.jsonl")))
+    return sorted(files)
+
+
+def list_canonical_external_summary_files(ext_dir: str) -> list[str]:
+    if not os.path.isdir(ext_dir):
+        return []
+
+    out: list[str] = []
+    for filename in CANONICAL_EXTERNAL_SUMMARY_FILENAMES:
+        path = os.path.join(ext_dir, filename)
+        if os.path.exists(path):
+            out.append(path)
+    return sorted(out)
+
 
 # ---------------------------------------------------------------------------
 # Main
@@ -350,16 +386,29 @@ def main() -> int:
     # Ensure we start from a clean list.
     external["metrics"] = []
 
-    summary_files: list[str] = []
-    if os.path.isdir(ext_dir):
-        summary_files = sorted(glob.glob(os.path.join(ext_dir, "*_summary.json")))
-        summary_files += sorted(glob.glob(os.path.join(ext_dir, "*_summary.jsonl")))
+    summary_files = list_external_summary_files(ext_dir)
+    canonical_summary_files = list_canonical_external_summary_files(ext_dir)
 
-    summaries_present = bool(summary_files)
+    summary_file_set = set(summary_files)
+    canonical_summary_file_set = set(canonical_summary_files)
+    unrecognized_summary_files = sorted(summary_file_set - canonical_summary_file_set)
+
+    # Only canonical detector summaries count as release-relevant external
+    # summary presence. Generic *_summary.json/jsonl files remain diagnostic
+    # observations and must not satisfy release-required evidence gates.
+    summaries_present = bool(canonical_summary_files)
+
     external["summaries_present"] = summaries_present
     external["summary_count"] = len(summary_files)
 
-    # Diagnostic gate (normative only if policy promotes it).
+    external["canonical_summary_count"] = len(canonical_summary_files)
+    external["unrecognized_summary_count"] = len(unrecognized_summary_files)
+    external["unrecognized_summaries"] = [
+        os.path.basename(path) for path in unrecognized_summary_files
+    ]
+
+    # Diagnostic gate unless policy promotes it; when promoted, it is backed by
+    # canonical detector summary presence, not arbitrary decoy filenames.
     gates["external_summaries_present"] = summaries_present
     status["external_summaries_present"] = summaries_present
 
@@ -561,10 +610,12 @@ def main() -> int:
 
     if not oks:
         # Default/onboarding: no folded external evidence does not fail the run.
-        # Strict/release-grade: fail closed only when summaries are explicitly required
-        # and none are present on disk. Filename/metric-key strictness belongs to the
-        # dedicated precheck path.
-        if args.require_external_summaries and not summaries_present:
+        # Strict/release-grade: at least one recognized detector summary must be
+        # successfully folded before external_all_pass can become true.
+        #
+        # Decoy-only, unrecognized-only, malformed-only, or no-folded-result
+        # evidence states must not materialize into release authority.
+        if args.require_external_summaries:
             ext_all = False
         else:
             ext_all = True

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -15,6 +15,7 @@ tests/test_status_to_summary_gate_flags.py
 tests/test_tools_governance_smoke.py
 tests/test_check_external_summaries_present.py
 tests/test_augment_status_smoke.py
+tests/test_augment_status_strict_external_evidence.py
 tests/test_run_all_mode_contract.py
 tests/test_validate_status_schema_tool.py
 tests/test_validate_space_relation_map_tool.py

--- a/docs/policy/CHANGELOG.md
+++ b/docs/policy/CHANGELOG.md
@@ -21,6 +21,10 @@ This changelog records **semantic** changes that can affect release gating outco
 
 ## Unreleased
 
+- Hardened strict external evidence fold-in so release-grade paths fail closed
+  when no recognized detector summary is successfully folded. Decoy-only or
+  unrecognized-only external summaries no longer allow `external_all_pass=true`
+  in strict mode.
 - `pulse_gate_policy_v0.yml` / `pulse-gate-policy-v0` (policy 0.1.5):
   - Changed: release policy documentation/tests/workflow now use a dedicated `ci/check_release_no_stub_status.py` release-grade guard and canonical strict external-summary precheck coverage.
   - Why: keep release fail-closed no-stub enforcement centralized and test-covered while preventing decoy non-summary JSON artifacts from passing strict evidence prechecks.

--- a/tests/test_augment_status_strict_external_evidence.py
+++ b/tests/test_augment_status_strict_external_evidence.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "PULSE_safe_pack_v0" / "tools" / "augment_status.py"
+
+
+def write_status(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "version": "1.0",
+                "created_utc": "1970-01-01T00:00:00Z",
+                "gates": {},
+                "metrics": {},
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def run_augment(
+    status_path: Path,
+    thresholds_path: Path,
+    external_dir: Path,
+    *,
+    strict: bool,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        sys.executable,
+        str(TOOL),
+        "--status",
+        str(status_path),
+        "--thresholds",
+        str(thresholds_path),
+        "--external_dir",
+        str(external_dir),
+    ]
+
+    if strict:
+        cmd.append("--require_external_summaries")
+
+    return subprocess.run(
+        cmd,
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+    )
+
+
+def read_status(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_strict_decoy_only_external_summary_fails_closed() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        status_path = tmp / "status.json"
+        thresholds_path = tmp / "external_thresholds.yaml"
+        external_dir = tmp / "external"
+        external_dir.mkdir()
+
+        write_status(status_path)
+        thresholds_path.write_text("llamaguard_violation_rate_max: 0.10\n", encoding="utf-8")
+
+        (external_dir / "foo_summary.json").write_text(
+            json.dumps({"value": 0.0}) + "\n",
+            encoding="utf-8",
+        )
+
+        result = run_augment(
+            status_path,
+            thresholds_path,
+            external_dir,
+            strict=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+
+        status = read_status(status_path)
+        assert status["gates"]["external_summaries_present"] is False
+        assert status["gates"]["external_all_pass"] is False
+        assert status["external"]["summaries_present"] is False
+        assert status["external"]["summary_count"] == 1
+        assert status["external"]["canonical_summary_count"] == 0
+        assert status["external"]["unrecognized_summary_count"] == 1
+        assert status["external"]["metrics"] == []
+
+
+def test_strict_no_external_summary_fails_closed() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        status_path = tmp / "status.json"
+        thresholds_path = tmp / "external_thresholds.yaml"
+        external_dir = tmp / "external"
+        external_dir.mkdir()
+
+        write_status(status_path)
+        thresholds_path.write_text("llamaguard_violation_rate_max: 0.10\n", encoding="utf-8")
+
+        result = run_augment(
+            status_path,
+            thresholds_path,
+            external_dir,
+            strict=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+
+        status = read_status(status_path)
+        assert status["gates"]["external_summaries_present"] is False
+        assert status["gates"]["external_all_pass"] is False
+        assert status["external"]["summaries_present"] is False
+        assert status["external"]["canonical_summary_count"] == 0
+        assert status["external"]["metrics"] == []
+
+
+def test_strict_canonical_external_summary_passes_when_folded() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        status_path = tmp / "status.json"
+        thresholds_path = tmp / "external_thresholds.yaml"
+        external_dir = tmp / "external"
+        external_dir.mkdir()
+
+        write_status(status_path)
+        thresholds_path.write_text("llamaguard_violation_rate_max: 0.10\n", encoding="utf-8")
+
+        (external_dir / "llamaguard_summary.json").write_text(
+            json.dumps({"rate": 0.02}) + "\n",
+            encoding="utf-8",
+        )
+
+        result = run_augment(
+            status_path,
+            thresholds_path,
+            external_dir,
+            strict=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+
+        status = read_status(status_path)
+        assert status["gates"]["external_summaries_present"] is True
+        assert status["gates"]["external_all_pass"] is True
+        assert status["external"]["summaries_present"] is True
+        assert status["external"]["canonical_summary_count"] == 1
+        assert len(status["external"]["metrics"]) == 1
+        assert status["external"]["metrics"][0]["pass"] is True
+
+
+def test_strict_canonical_external_summary_fails_when_metric_fails() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        status_path = tmp / "status.json"
+        thresholds_path = tmp / "external_thresholds.yaml"
+        external_dir = tmp / "external"
+        external_dir.mkdir()
+
+        write_status(status_path)
+        thresholds_path.write_text("llamaguard_violation_rate_max: 0.10\n", encoding="utf-8")
+
+        (external_dir / "llamaguard_summary.json").write_text(
+            json.dumps({"rate": 0.50}) + "\n",
+            encoding="utf-8",
+        )
+
+        result = run_augment(
+            status_path,
+            thresholds_path,
+            external_dir,
+            strict=True,
+        )
+
+        assert result.returncode == 0, result.stderr
+
+        status = read_status(status_path)
+        assert status["gates"]["external_summaries_present"] is True
+        assert status["gates"]["external_all_pass"] is False
+        assert status["external"]["summaries_present"] is True
+        assert status["external"]["canonical_summary_count"] == 1
+        assert len(status["external"]["metrics"]) == 1
+        assert status["external"]["metrics"][0]["pass"] is False


### PR DESCRIPTION
## Summary

This PR hardens strict external evidence fold-in.

The previous release workflow precheck was hardened to reject decoy summaries, but `augment_status.py` still allowed a component-level strict-mode gap: if summary files existed but no recognized detector summary was successfully folded, `external_all_pass` could still become `true`.

This PR closes that root condition.

## Mechanical change

Strict/release-grade external evidence now requires at least one recognized detector summary to be successfully folded before `external_all_pass` can become `true`.

Decoy-only, unrecognized-only, malformed-only, or no-folded-result external evidence states fail closed.

The change also distinguishes:

- generic `*_summary.json/jsonl` files as diagnostic observations;
- canonical detector summaries as release-relevant external evidence presence.

## Authority boundary

This PR does not create a second release-decision path.

It strengthens the existing PULSE release-authority path:

recorded release evidence
→ status.json
→ declared gate policy
→ materialized required gate set
→ strict fail-closed gate checking
→ CI allow/block decision

The hardening preserves the PULSE pre-materialization rule:

unsupported evidence state → no release authority

## Scope

Changed:

- `PULSE_safe_pack_v0/tools/augment_status.py`
- strict external evidence regression tests
- policy changelog entry

Not changed:

- README
- workflow semantics
- gate policy
- gate registry
- no-stub guard
- dashboard semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surfaces
- shadow-layer authority semantics

## Validation

Expected regression coverage:

- strict decoy-only external summary evidence fails closed;
- strict no-summary external evidence fails closed;
- strict canonical passing detector summary passes;
- strict canonical failing detector summary fails;
- decoy or unrecognized summaries do not materialize release authority.