### PR TITLE
fix(ra1): fail closed on malformed gate ids

### DIFF
--- a/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
+++ b/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
@@ -1084,6 +1084,52 @@ def test_package_manifest_git_sha_mismatch_fails_with_schema_valid_report() -> N
         assert identity_checks[0]["ok"] is False
         assert "package_manifest.git_sha mismatch" in identity_checks[0]["message"]
     
+def test_malformed_effective_required_gate_id_fails_without_crash() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.malformed_gate_id.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        gate_sets_path = package_copy / "gates" / "materialized_gate_sets.json"
+        gate_sets = _read_json(gate_sets_path)
+        gate_sets["effective_required_gates"] = [
+            {"bad": "gate-id-object"}
+        ]
+        _write_json(gate_sets_path, gate_sets)
+
+        gate_sets_sha = _sha256_file(gate_sets_path)
+
+        digests_path = package_copy / "digests" / "package_digests.json"
+        digests = _read_json(digests_path)
+        digests["artifacts"]["gates/materialized_gate_sets.json"] = gate_sets_sha
+        _write_json(digests_path, digests)
+
+        digests_sha = _sha256_file(digests_path)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["materialized_gate_sets"]["sha256"] = gate_sets_sha
+        manifest["package_digests"]["sha256"] = digests_sha
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+        assert "Traceback" not in result.stderr
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+        assert any(
+            "effective_required_gates" in error
+            and "must be a string gate ID" in error
+            for error in report["errors"]
+        )
+
 
 def main() -> int:
     tests = [
@@ -1106,6 +1152,7 @@ def main() -> int:
         test_missing_package_file_fails_with_schema_valid_report,
         test_noncanonical_status_artifact_path_fails_with_schema_valid_report,
         test_package_manifest_git_sha_mismatch_fails_with_schema_valid_report,
+        test_malformed_effective_required_gate_id_fails_without_crash,
     ]
 
     try:

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -131,24 +131,28 @@ def _validate_gate_id_array(
 
     out: list[str] = []
     seen: set[str] = set()
+    local_failures: list[str] = []
 
     for index, item in enumerate(value):
         if not _is_gate_id(item):
-            failures.append(
+            local_failures.append(
                 f"{name}[{index}] must be a string gate ID, found "
                 f"{type(item).__name__}: {_safe_value(item)}"
             )
             continue
 
         if item in seen:
-            failures.append(f"{name}[{index}] duplicates gate ID {item!r}")
+            local_failures.append(f"{name}[{index}] duplicates gate ID {item!r}")
             continue
 
         seen.add(item)
         out.append(item)
 
-    return out if not failures else None
+    if local_failures:
+        failures.extend(local_failures)
+        return None
 
+    return out
 
 def _utc_now() -> str:
     return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
@@ -536,6 +540,7 @@ def _check_materialized_gate_sets_match_policy(
         )
 
     mismatches: list[str] = []
+
     required = _validate_gate_id_array(
         name="policy.gates.required",
         value=raw_required,
@@ -568,7 +573,7 @@ def _check_materialized_gate_sets_match_policy(
     if not isinstance(sets, dict):
         mismatches.append("materialized gate sets must contain object-valued sets")
     else:
-            materialized_required = _validate_gate_id_array(
+        materialized_required = _validate_gate_id_array(
             name="materialized_gate_sets.sets.required",
             value=sets.get("required"),
             failures=mismatches,
@@ -581,7 +586,9 @@ def _check_materialized_gate_sets_match_policy(
 
         if required is not None and materialized_required is not None:
             if materialized_required != required:
-                mismatches.append("sets.required does not match packaged policy gates.required")
+                mismatches.append(
+                    "sets.required does not match packaged policy gates.required"
+                )
 
         if release_required is not None and materialized_release_required is not None:
             if materialized_release_required != release_required:
@@ -673,13 +680,13 @@ def _check_status_satisfies_effective_required_gates(
         failures.append("status gates must be an object")
         gates = {}
 
-        effective_required_gate_ids = _validate_gate_id_array(
+    effective_required_gate_ids = _validate_gate_id_array(
         name="materialized_gate_sets.effective_required_gates",
         value=effective_required_gates,
         failures=failures,
     )
 
-        if effective_required_gate_ids is not None:
+    if effective_required_gate_ids is not None:
         missing = [
             gate_id
             for gate_id in effective_required_gate_ids
@@ -994,7 +1001,7 @@ def _check_release_authority_manifest_matches_package_core(
         authority = {}
 
     effective_required_gates = gate_sets.get("effective_required_gates")
-        effective_required_gate_ids = _validate_gate_id_array(
+    effective_required_gate_ids = _validate_gate_id_array(
         name="package gate_sets.effective_required_gates",
         value=effective_required_gates,
         failures=failures,
@@ -1011,7 +1018,7 @@ def _check_release_authority_manifest_matches_package_core(
     if authority.get("release_required_materialized") is not True:
         failures.append("authority.release_required_materialized must be true")
 
-        authority_effective_required_gates = _validate_gate_id_array(
+    authority_effective_required_gates = _validate_gate_id_array(
         name="release_authority.authority.effective_required_gates",
         value=authority.get("effective_required_gates"),
         failures=failures,

--- a/tools/verify_pulse_ref_ra1_package.py
+++ b/tools/verify_pulse_ref_ra1_package.py
@@ -5,6 +5,7 @@ import argparse
 import datetime as dt
 import hashlib
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -98,6 +99,55 @@ ARTIFACT_SCHEMA_TARGETS = [
         PUBLICATION_SNAPSHOT_SCHEMA,
     ),
 ]
+
+GATE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]*$")
+
+
+def _safe_value(value: Any) -> str:
+    try:
+        rendered = repr(value)
+    except Exception:
+        rendered = f"<unrepresentable {type(value).__name__}>"
+
+    if len(rendered) > 160:
+        return rendered[:157] + "..."
+
+    return rendered
+
+
+def _is_gate_id(value: Any) -> bool:
+    return isinstance(value, str) and bool(GATE_ID_RE.fullmatch(value))
+
+
+def _validate_gate_id_array(
+    *,
+    name: str,
+    value: Any,
+    failures: list[str],
+) -> list[str] | None:
+    if not isinstance(value, list):
+        failures.append(f"{name} must be an array of gate ID strings")
+        return None
+
+    out: list[str] = []
+    seen: set[str] = set()
+
+    for index, item in enumerate(value):
+        if not _is_gate_id(item):
+            failures.append(
+                f"{name}[{index}] must be a string gate ID, found "
+                f"{type(item).__name__}: {_safe_value(item)}"
+            )
+            continue
+
+        if item in seen:
+            failures.append(f"{name}[{index}] duplicates gate ID {item!r}")
+            continue
+
+        seen.add(item)
+        out.append(item)
+
+    return out if not failures else None
 
 
 def _utc_now() -> str:
@@ -473,8 +523,9 @@ def _check_materialized_gate_sets_match_policy(
         )
 
     try:
-        required = list(policy["gates"]["required"])
-        release_required = list(policy["gates"]["release_required"])
+        policy_gates = policy["gates"]
+        raw_required = policy_gates["required"]
+        raw_release_required = policy_gates["release_required"]
     except Exception as exc:
         return _cross_check_result(
             name="materialized_gate_sets_match_policy",
@@ -484,9 +535,21 @@ def _check_materialized_gate_sets_match_policy(
             errors=errors,
         )
 
-    effective = _unique_preserve_order(required + release_required)
-
     mismatches: list[str] = []
+    required = _validate_gate_id_array(
+        name="policy.gates.required",
+        value=raw_required,
+        failures=mismatches,
+    )
+    release_required = _validate_gate_id_array(
+        name="policy.gates.release_required",
+        value=raw_release_required,
+        failures=mismatches,
+    )
+
+    effective: list[str] | None = None
+    if required is not None and release_required is not None:
+        effective = _unique_preserve_order(required + release_required)
 
     if gate_sets.get("policy_path") != policy_path:
         mismatches.append(
@@ -505,17 +568,38 @@ def _check_materialized_gate_sets_match_policy(
     if not isinstance(sets, dict):
         mismatches.append("materialized gate sets must contain object-valued sets")
     else:
-        if sets.get("required") != required:
-            mismatches.append("sets.required does not match packaged policy gates.required")
-        if sets.get("release_required") != release_required:
-            mismatches.append(
-                "sets.release_required does not match packaged policy gates.release_required"
-            )
-
-    if gate_sets.get("effective_required_gates") != effective:
-        mismatches.append(
-            "effective_required_gates does not equal ordered required + release_required"
+            materialized_required = _validate_gate_id_array(
+            name="materialized_gate_sets.sets.required",
+            value=sets.get("required"),
+            failures=mismatches,
         )
+        materialized_release_required = _validate_gate_id_array(
+            name="materialized_gate_sets.sets.release_required",
+            value=sets.get("release_required"),
+            failures=mismatches,
+        )
+
+        if required is not None and materialized_required is not None:
+            if materialized_required != required:
+                mismatches.append("sets.required does not match packaged policy gates.required")
+
+        if release_required is not None and materialized_release_required is not None:
+            if materialized_release_required != release_required:
+                mismatches.append(
+                    "sets.release_required does not match packaged policy gates.release_required"
+                )
+
+    materialized_effective = _validate_gate_id_array(
+        name="materialized_gate_sets.effective_required_gates",
+        value=gate_sets.get("effective_required_gates"),
+        failures=mismatches,
+    )
+
+    if effective is not None and materialized_effective is not None:
+        if materialized_effective != effective:
+            mismatches.append(
+                "effective_required_gates does not equal ordered required + release_required"
+            )
 
     return _cross_check_result(
         name="materialized_gate_sets_match_policy",
@@ -589,25 +673,28 @@ def _check_status_satisfies_effective_required_gates(
         failures.append("status gates must be an object")
         gates = {}
 
-    if not isinstance(effective_required_gates, list):
-        failures.append("effective_required_gates must be an array")
-        effective_required_gates = []
+        effective_required_gate_ids = _validate_gate_id_array(
+        name="materialized_gate_sets.effective_required_gates",
+        value=effective_required_gates,
+        failures=failures,
+    )
 
-    missing = [
-        gate_id
-        for gate_id in effective_required_gates
-        if gate_id not in gates
-    ]
-    false_gates = [
-        gate_id
-        for gate_id in effective_required_gates
-        if gates.get(gate_id) is not True
-    ]
+        if effective_required_gate_ids is not None:
+        missing = [
+            gate_id
+            for gate_id in effective_required_gate_ids
+            if gate_id not in gates
+        ]
+        false_gates = [
+            gate_id
+            for gate_id in effective_required_gate_ids
+            if gates.get(gate_id) is not True
+        ]
 
-    if missing:
-        failures.append(f"missing effective required gates: {', '.join(missing)}")
-    if false_gates:
-        failures.append(f"false effective required gates: {', '.join(false_gates)}")
+        if missing:
+            failures.append(f"missing effective required gates: {', '.join(missing)}")
+        if false_gates:
+            failures.append(f"false effective required gates: {', '.join(false_gates)}")
 
     return _cross_check_result(
         name="status_satisfies_effective_required_gates",
@@ -907,9 +994,13 @@ def _check_release_authority_manifest_matches_package_core(
         authority = {}
 
     effective_required_gates = gate_sets.get("effective_required_gates")
-    if not isinstance(effective_required_gates, list):
-        failures.append("package gate_sets.effective_required_gates must be an array")
-        effective_required_gates = []
+        effective_required_gate_ids = _validate_gate_id_array(
+        name="package gate_sets.effective_required_gates",
+        value=effective_required_gates,
+        failures=failures,
+    )
+    if effective_required_gate_ids is None:
+        effective_required_gate_ids = []
 
     if authority.get("policy_set") != "required+release_required":
         failures.append(
@@ -920,10 +1011,17 @@ def _check_release_authority_manifest_matches_package_core(
     if authority.get("release_required_materialized") is not True:
         failures.append("authority.release_required_materialized must be true")
 
-    if authority.get("effective_required_gates") != effective_required_gates:
-        failures.append(
-            "authority.effective_required_gates does not match package gate sets"
-        )
+        authority_effective_required_gates = _validate_gate_id_array(
+        name="release_authority.authority.effective_required_gates",
+        value=authority.get("effective_required_gates"),
+        failures=failures,
+    )
+
+    if authority_effective_required_gates is not None:
+        if authority_effective_required_gates != effective_required_gate_ids:
+            failures.append(
+                "authority.effective_required_gates does not match package gate sets"
+            )
 
     evaluation = release_authority.get("evaluation")
     if not isinstance(evaluation, dict):
@@ -935,7 +1033,7 @@ def _check_release_authority_manifest_matches_package_core(
         failures.append("evaluation.required_gate_results must be an object")
         required_gate_results = {}
 
-    expected_results = {gate_id: True for gate_id in effective_required_gates}
+    expected_results = {gate_id: True for gate_id in effective_required_gate_ids}
 
     if required_gate_results != expected_results:
         failures.append(


### PR DESCRIPTION
## Summary

This PR hardens the RA1 package verifier against malformed gate IDs.

The verifier already performs schema validation, but cross-artifact checks still run after schema validation. A malformed gate ID such as an object or array can otherwise reach set, dict-key, membership, or join operations and crash the verifier instead of producing a structured fail-closed report.

## Mechanical change

This PR adds explicit gate ID array validation before verifier cross-check operations.

The verifier now rejects:

- non-string gate IDs;
- empty gate IDs;
- malformed gate IDs outside the declared gate ID pattern;
- duplicate gate IDs;
- object / array / null gate IDs.

Malformed gate IDs now produce structured verifier errors and a non-zero verifier exit instead of a traceback.

## Authority boundary

This PR does not create release authority.

It strengthens the RA1 external reconstruction verifier so malformed package input cannot terminate verification before a report is written.

The verifier remains an external reconstruction / audit check. It does not authorize, block, override, or create a second release-decision path.

## Scope

Changed:

- `tools/verify_pulse_ref_ra1_package.py`
- `tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py`

Not changed:

- README
- workflows
- gate policy
- gate registry
- status contract
- release authority manifest semantics
- audit bundle semantics
- dashboard / ledger / publication semantics
- shadow-layer authority semantics

## Validation

Expected regression coverage:

- valid RA1 package still verifies;
- malformed `effective_required_gates` gate ID fails closed;
- verifier writes a schema-valid report;
- verifier exits non-zero;
- verifier does not crash or emit a traceback.