### PR TITLE
test(ra1): cover package digest integrity

### DIFF
--- a/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
+++ b/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
@@ -1131,6 +1131,113 @@ def test_malformed_effective_required_gate_id_fails_without_crash() -> None:
         )
 
 
+def test_unsafe_manifest_artifact_path_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.unsafe_manifest_path.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["status_artifact"]["path"] = "../outside/status.json"
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+        assert "Traceback" not in result.stderr
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+        assert any(
+            "unsafe artifact path" in error
+            or "schema validation failed" in error
+            or "does not match" in error
+            for error in report["errors"]
+        )
+
+def test_package_digests_self_digest_mismatch_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.package_digests_self_mismatch.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        digests_path = package_copy / "digests" / "package_digests.json"
+        digests = _read_json(digests_path)
+
+        # Mutate the digest manifest itself without updating the package_manifest
+        # reference to digests/package_digests.json. This must be detected as a
+        # package-manifest digest mismatch.
+        digests["package_id"] = "tampered-package-id"
+        _write_json(digests_path, digests)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+        assert "Traceback" not in result.stderr
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        digest_checks = [
+            check
+            for check in report["artifact_digests_checked"]
+            if (
+                check["artifact_path"] == "digests/package_digests.json"
+                and check.get("source") == "package_manifest"
+            )
+        ]
+
+        assert len(digest_checks) == 1
+        assert digest_checks[0]["ok"] is False
+        assert digest_checks[0]["actual_sha256"] is not None
+        assert any(
+            "digests/package_digests.json digest mismatch" in error
+            for error in report["errors"]
+        )
+
+
+def test_unsafe_manifest_artifact_path_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.unsafe_manifest_path.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["status_artifact"]["path"] = "../outside/status.json"
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+        assert "Traceback" not in result.stderr
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+        assert any(
+            "unsafe artifact path" in error
+            or "schema validation failed" in error
+            or "does not match" in error
+            for error in report["errors"]
+        )
+
+
 def main() -> int:
     tests = [
         test_valid_ra1_minimal_package_verifies,
@@ -1153,6 +1260,8 @@ def main() -> int:
         test_noncanonical_status_artifact_path_fails_with_schema_valid_report,
         test_package_manifest_git_sha_mismatch_fails_with_schema_valid_report,
         test_malformed_effective_required_gate_id_fails_without_crash,
+        test_package_digests_self_digest_mismatch_fails_with_schema_valid_report,
+        test_unsafe_manifest_artifact_path_fails_with_schema_valid_report,
     ]
 
     try:


### PR DESCRIPTION
## Summary

This PR adds RA1 package verifier regression coverage for package digest integrity.

It covers two artifact-integrity classes:

- `package_digests.json` changes without the package manifest digest reference being updated;
- `package_manifest.json` contains an unsafe artifact path escaping the package root.

## Mechanical purpose

The tests prove that the RA1 verifier fails closed when package artifact integrity is broken.

Expected behavior:

- verifier exits non-zero;
- verifier writes a schema-valid report;
- verifier does not crash or emit a traceback;
- package digest mismatch / unsafe path is recorded as an error.

## Authority boundary

This PR does not create release authority.

It only adds regression coverage for the RA1 external reconstruction verifier.

The verifier remains an audit / reconstruction check. It does not authorize, block, override, or create a second release-decision path.

## Scope

Changed:

- `tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py`

Not changed:

- verifier logic
- README
- workflows
- gate policy
- gate registry
- schemas
- status contract
- dashboard semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surfaces
- shadow-layer authority semantics

## Validation

Expected regression coverage:

- package digest manifest self-mismatch fails closed;
- unsafe manifest artifact path fails closed;
- verifier writes a schema-valid report;
- verifier exits non-zero;
- verifier does not crash or emit a traceback.