### PR TITLE
test(ra1): cover non-normative authority boundaries

### DIFF
--- a/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
+++ b/tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py
@@ -1375,6 +1375,131 @@ def test_publication_run_key_mismatch_fails_with_schema_valid_report() -> None:
             for error in report["errors"]
         )
 
+def test_package_manifest_authority_boundary_true_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.package_manifest_authority.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["authority_boundary"]["creates_release_authority"] = True
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+        assert "Traceback" not in result.stderr
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        boundary_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "package_manifest_authority_boundary"
+        ]
+
+        assert len(boundary_checks) == 1
+        assert boundary_checks[0]["ok"] is False
+        assert "package_manifest.json must not create release authority" in boundary_checks[0]["message"]
+
+
+def test_package_digests_authority_boundary_true_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.package_digests_authority.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        digests_path = package_copy / "digests" / "package_digests.json"
+        digests = _read_json(digests_path)
+        digests["authority_boundary"]["creates_release_authority"] = True
+        _write_json(digests_path, digests)
+
+        digests_sha = _sha256_file(digests_path)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["package_digests"]["sha256"] = digests_sha
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+        assert "Traceback" not in result.stderr
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        boundary_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "package_digests_authority_boundary"
+        ]
+
+        assert len(boundary_checks) == 1
+        assert boundary_checks[0]["ok"] is False
+        assert "digests/package_digests.json must not create release authority" in boundary_checks[0]["message"]
+
+
+def test_ci_outcome_authority_boundary_true_fails_with_schema_valid_report() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-ra1-verifier-") as tmp:
+        tmp_path = Path(tmp)
+        package_copy = tmp_path / "package"
+        out_path = tmp_path / "verifier_report.ci_outcome_authority.json"
+
+        shutil.copytree(PACKAGE, package_copy)
+
+        ci_path = package_copy / "ci" / "ci_outcome.json"
+        ci_outcome = _read_json(ci_path)
+        ci_outcome["authority_boundary"]["creates_release_authority"] = True
+        _write_json(ci_path, ci_outcome)
+
+        ci_sha = _sha256_file(ci_path)
+
+        digests_path = package_copy / "digests" / "package_digests.json"
+        digests = _read_json(digests_path)
+        digests["artifacts"]["ci/ci_outcome.json"] = ci_sha
+        _write_json(digests_path, digests)
+
+        digests_sha = _sha256_file(digests_path)
+
+        manifest_path = package_copy / "package_manifest.json"
+        manifest = _read_json(manifest_path)
+        manifest["ci_outcome"]["sha256"] = ci_sha
+        manifest["package_digests"]["sha256"] = digests_sha
+        _write_json(manifest_path, manifest)
+
+        result = _run(package_copy, out_path)
+
+        assert result.returncode == 1
+        assert out_path.exists()
+        assert "Traceback" not in result.stderr
+
+        report = _read_json(out_path)
+        _validate_report(report)
+
+        assert report["ok"] is False
+
+        ci_checks = [
+            check
+            for check in report["cross_artifact_checks"]
+            if check["name"] == "ci_outcome_and_publication_match_release_identity"
+        ]
+
+        assert len(ci_checks) == 1
+        assert ci_checks[0]["ok"] is False
+        assert "ci_outcome authority_boundary.creates_release_authority must be false" in ci_checks[0]["message"]
 
 def main() -> int:
     tests = [
@@ -1403,6 +1528,9 @@ def main() -> int:
         test_publication_git_sha_mismatch_fails_with_schema_valid_report,
         test_publication_package_id_mismatch_fails_with_schema_valid_report,
         test_publication_run_key_mismatch_fails_with_schema_valid_report,
+        test_package_manifest_authority_boundary_true_fails_with_schema_valid_report,
+        test_package_digests_authority_boundary_true_fails_with_schema_valid_report,
+        test_ci_outcome_authority_boundary_true_fails_with_schema_valid_report,
     ]
 
     try:


### PR DESCRIPTION
## Summary

This PR adds RA1 package verifier regression coverage for non-normative authority boundaries.

It covers three authority-boundary mismatch classes:

- `package_manifest.authority_boundary.creates_release_authority=true`;
- `package_digests.authority_boundary.creates_release_authority=true`;
- `ci_outcome.authority_boundary.creates_release_authority=true`.

## Mechanical purpose

The tests prove that RA1 reconstruction artifacts fail closed when non-normative audit / trace surfaces claim to create release authority.

Expected behavior:

- verifier exits non-zero;
- verifier writes a schema-valid report;
- verifier does not crash or emit a traceback;
- authority-boundary mismatch is recorded as an error.

## Authority boundary

This PR does not create release authority.

It only adds regression coverage for the RA1 external reconstruction verifier.

The verifier remains an audit / reconstruction check. It does not authorize, block, override, or create a second release-decision path.

## Scope

Changed:

- `tests/test_pulse_ref_ra1_package_verifier_tool_smoke.py`

Not changed:

- verifier logic
- README
- workflows
- gate policy
- gate registry
- schemas
- status contract
- dashboard semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Expected regression coverage:

- package manifest authority-boundary claim fails closed;
- package digests authority-boundary claim fails closed;
- CI outcome authority-boundary claim fails closed;
- verifier writes a schema-valid report;
- verifier exits non-zero;
- verifier does not crash or emit a traceback.