### PR TITLE
docs(readme): remove duplicate Zenodo surface list

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,6 @@ PULSE acts at the release boundary, before deployment.
 
 - Quality Ledger: https://hkati.github.io/pulse-release-gates-0.1/
 - Live Status JSON: https://hkati.github.io/pulse-release-gates-0.1/status.json
-- Concept DOI / all versions: https://doi.org/10.5281/zenodo.17214908
-- Current release DOI / v1.1.1: https://doi.org/10.5281/zenodo.18203404
-- Preprint DOI: https://doi.org/10.5281/zenodo.17833583
 
 ## Current verification checkpoint
 


### PR DESCRIPTION
## Summary

This PR removes the duplicate Zenodo / DOI listing from the README `Public release surfaces` section.

The top README surface list now keeps only:

- Quality Ledger
- Live Status JSON

The DOI and citation material remains in the dedicated DOI / citation section.

## Mechanical purpose

The README first-screen sequence is intended to foreground PULSE release-authority mechanics:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

The repeated Zenodo / DOI list is not needed in that mechanical sequence and is already represented in the dedicated citation / DOI area.

## Authority boundary

This PR does not change PULSE release authority.

It only removes duplicate README surface text.

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Scope

Changed:

- `README.md`

Not changed:

- code
- workflows
- schemas
- policies
- gate registry
- tests
- CI behavior
- release artifacts
- dashboard semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Expected result:

- README top `Public release surfaces` section lists only Quality Ledger and Live Status JSON;
- duplicate Zenodo / DOI entries are removed from the top mechanical section;
- dedicated DOI / citation material remains available elsewhere;
- no code or CI behavior changes.