### PR TITLE
docs(readme): foreground artifact-bound release authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# PULSE — Release Authority for Safe & Useful AI
+# PULSE — Artifact-Bound Release Authority for AI Release Decisions
 
-### PULSE is an artifact-first release-governance / release-authority system for AI applications.
+
+PULSE introduces artifact-bound release authority: AI release decisions are made from recorded evidence, declared policy, materialized required gates, and fail-closed CI enforcement.
+
+PULSEmech converts recorded release evidence into deterministic, fail-closed CI allow/block release decisions before deployment under declared policy.
 
 PULSE structures recorded safety, quality, detector, stability, CI, and review evidence into deterministic, fail-closed release decisions under declared policy.
 
-The mechanism is PULSEmech: an artifact-first, policy-declared, gate-materialized, CI-enforced release-authority mechanism for AI applications and AI-enabled systems.
 
 ## PULSEmech architecture map
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PULSE — Artifact-Bound Release Authority for AI Release Decisions
 
 
-PULSE introduces artifact-bound release authority: AI release decisions are made from recorded evidence, declared policy, materialized required gates, and fail-closed CI enforcement.
+PULSE introduces artifact-bound release authority: AI release decisions are made from recorded evidence, declared policy, materialized required gate set, and fail-closed CI enforcement.
 
 PULSEmech converts recorded release evidence into deterministic, fail-closed CI allow/block release decisions before deployment under declared policy.
 


### PR DESCRIPTION
## Summary

This PR updates the README opening.

The README now foregrounds PULSE as:

`Artifact-Bound Release Authority for AI Release Decisions`

The first screen states that AI release decisions are made from:

- recorded evidence;
- declared policy;
- materialized required gates;
- fail-closed CI enforcement.

It also states that PULSEmech converts recorded release evidence into deterministic, fail-closed CI allow/block release decisions before deployment under declared policy.

## Mechanical purpose

This change strengthens the README first-screen identity.

The opening now presents PULSE as an artifact-bound release-authority mechanism rather than a framework, dashboard, eval pipeline, or generic governance surface.

The PULSEmech architecture map and normative release-authority path remain directly below the opening.

## Authority boundary

This PR does not change PULSE release authority.

It only clarifies the README first-screen language.

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Scope

Changed:

- `README.md`

Not changed:

- code
- workflows
- schemas
- policies
- gate registry
- tests
- CI behavior
- release artifacts
- dashboard semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Expected result:

- README opens with artifact-bound release authority;
- first-screen language emphasizes recorded evidence, declared policy, materialized required gates, and fail-closed CI enforcement;
- PULSEmech remains the named mechanism;
- no code or CI behavior changes.