### PR TITLE
docs(readme): point DOI badge to concept DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Required gates are explicit, materialized, and checked before release effects ca
 | required gate value is not literal `true` | block |
 
 
-[![DOI](https://zenodo.org/badge/1061766508.svg)](https://zenodo.org/badge/latestdoi/1061766508)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17214908.svg)](https://doi.org/10.5281/zenodo.17214908)
 
 ---
 


### PR DESCRIPTION
## Summary

This PR updates the README DOI surface.

The README now points the DOI badge and the top public release surface to the Concept DOI / all versions:

`10.5281/zenodo.17214908`

## Mechanical change

The previous badge used the Zenodo repository badge identifier:

`1061766508`

That value is not a DOI.

This PR replaces the badge with a DOI-based Zenodo badge:

`https://zenodo.org/badge/DOI/10.5281/zenodo.17214908.svg`

and links it to:

`https://doi.org/10.5281/zenodo.17214908`

The Public release surfaces section now includes:

`Concept DOI / all versions: https://doi.org/10.5281/zenodo.17214908`

## Scope

Changed:

- `README.md`

Not changed:

- code
- workflows
- schemas
- policies
- gate registry
- tests
- CI behavior
- release artifacts
- `CITATION.cff`
- `.zenodo.json`
- dashboard semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Authority boundary

This PR does not change PULSE release authority.

It only corrects the public DOI surface so the all-versions Concept DOI is exposed directly.

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Validation

Expected result:

- README badge points to the Concept DOI;
- README public release surfaces includes the Concept DOI / all versions;
- the `1061766508` badge/latestdoi identifier no longer appears in README;
- detailed Zenodo records remain available in the existing details box;
- no code or CI behavior changes.