### PR TITLE
docs: align DOI and citation surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Required gates are explicit, materialized, and checked before release effects ca
 | required gate value is not literal `true` | block |
 
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17214908.svg)](https://doi.org/10.5281/zenodo.17214908)
+[![DOI](https://doi.org/badge/DOI/10.5281/zenodo.17373002.svg)](https://doi.org/10.5281/zenodo.17373002)
 
 ---
 
@@ -123,9 +123,8 @@ Required gates are explicit, materialized, and checked before release effects ca
 
 ### Zenodo records
 
+- **Current release DOI / v1.0.2:** https://doi.org/10.5281/zenodo.17373002
 - **Concept DOI / all versions:** https://doi.org/10.5281/zenodo.17214908
-- **Current release DOI / v1.1.1:** https://doi.org/10.5281/zenodo.18203404
-- **Previous release DOI / v1.0.2:** https://doi.org/10.5281/zenodo.17373002
 - **Previous release DOI / v1.0.1:** https://doi.org/10.5281/zenodo.17214909
 - **Preprint DOI:** https://doi.org/10.5281/zenodo.17833583
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -129,8 +129,8 @@
 
       <!-- Élő badge‑ek a repóból -->
         <div class="badges" aria-label="Zenodo DOI">
-        <a href="https://zenodo.org/badge/latestdoi/1061766508">
-          <img src="https://zenodo.org/badge/1061766508.svg" alt="DOI">
+         <a href="https://doi.org/10.5281/zenodo.17373002">
+          <img src="https://doi.org/badge/DOI/10.5281/zenodo.17373002.svg" alt="DOI">
         </a>
       </div>
     </header>

--- a/tests/test_readme_doi_badge_contract.py
+++ b/tests/test_readme_doi_badge_contract.py
@@ -2,26 +2,70 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 README = ROOT / "README.md"
+DOCS_INDEX = ROOT / "docs" / "index.html"
+
+VERSIONED_RELEASE_DOI = "10.5281/zenodo.17373002"
+VERSIONED_RELEASE_URL = f"https://doi.org/{VERSIONED_RELEASE_DOI}"
+VERSIONED_RELEASE_BADGE = f"https://doi.org/badge/DOI/{VERSIONED_RELEASE_DOI}.svg"
+VERSIONED_RELEASE_MARKDOWN_BADGE = (
+    f"[![DOI]({VERSIONED_RELEASE_BADGE})]({VERSIONED_RELEASE_URL})"
+)
+CURRENT_RELEASE_RECORD = (
+    f"- **Current release DOI / v1.0.2:** {VERSIONED_RELEASE_URL}"
+)
+
+CONCEPT_DOI_URL = "https://doi.org/10.5281/zenodo.17214908"
+CONCEPT_RECORD = f"- **Concept DOI / all versions:** {CONCEPT_DOI_URL}"
+PREVIOUS_RELEASE_RECORD = (
+    "- **Previous release DOI / v1.0.1:** "
+    "https://doi.org/10.5281/zenodo.17214909"
+)
+PREPRINT_RECORD = "- **Preprint DOI:** https://doi.org/10.5281/zenodo.17833583"
+
+ACCIDENTAL_CURRENT_RELEASE_RECORD = (
+    "- **Current release DOI / v1.1.1:** "
+    "https://doi.org/10.5281/zenodo.18203404"
+)
+ACCIDENTAL_LATEST_DOI_ROUTE = "https://zenodo.org/badge/latestdoi/1061766508"
+ACCIDENTAL_REPOSITORY_BADGE = "https://zenodo.org/badge/1061766508.svg"
 
 
-def test_readme_top_doi_badge_uses_zenodo_repository_route() -> None:
-    text = README.read_text(encoding="utf-8")
-    assert (
-        "[![DOI](https://zenodo.org/badge/1061766508.svg)]"
-        "(https://zenodo.org/badge/latestdoi/1061766508)" in text
-    )
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
 
 
-def test_readme_zenodo_records_include_concept_doi_all_versions() -> None:
-    text = README.read_text(encoding="utf-8")
-    assert "- **Concept DOI / all versions:** https://doi.org/10.5281/zenodo.17214908" in text
+def test_readme_top_doi_badge_uses_versioned_release_doi() -> None:
+    text = _read(README)
+
+    assert VERSIONED_RELEASE_MARKDOWN_BADGE in text
 
 
-def test_readme_zenodo_records_identifies_current_release_v111() -> None:
-    text = README.read_text(encoding="utf-8")
-    assert "- **Current release DOI / v1.1.1:** https://doi.org/10.5281/zenodo.18203404" in text
+def test_readme_zenodo_records_match_april_known_good_release_identity() -> None:
+    text = _read(README)
+
+    assert CURRENT_RELEASE_RECORD in text
+    assert CONCEPT_RECORD in text
+    assert PREVIOUS_RELEASE_RECORD in text
+    assert PREPRINT_RECORD in text
 
 
-def test_readme_does_not_mark_v102_as_current_release() -> None:
-    text = README.read_text(encoding="utf-8")
-    assert "- **Current release DOI / v1.0.2:** https://doi.org/10.5281/zenodo.17373002" not in text
+def test_readme_does_not_use_accidental_current_release_or_latestdoi_route() -> None:
+    text = _read(README)
+
+    assert ACCIDENTAL_CURRENT_RELEASE_RECORD not in text
+    assert ACCIDENTAL_LATEST_DOI_ROUTE not in text
+    assert ACCIDENTAL_REPOSITORY_BADGE not in text
+
+
+def test_docs_index_doi_badge_uses_versioned_release_doi() -> None:
+    text = _read(DOCS_INDEX)
+
+    assert VERSIONED_RELEASE_URL in text
+    assert VERSIONED_RELEASE_BADGE in text
+
+
+def test_docs_index_does_not_use_accidental_latestdoi_route() -> None:
+    text = _read(DOCS_INDEX)
+
+    assert ACCIDENTAL_LATEST_DOI_ROUTE not in text
+    assert ACCIDENTAL_REPOSITORY_BADGE not in text


### PR DESCRIPTION
## Summary

This PR aligns the repository DOI and citation surfaces with the current PULSE artifact-bound release-authority identity.

It corrects the public citation path so the primary stable DOI is the Concept DOI / all versions:

`10.5281/zenodo.17214908`

and keeps the current versioned release DOI visible as the current release record:

`10.5281/zenodo.18203404`

## Mechanical change

This PR updates DOI / citation references so that:

- the Concept DOI / all versions is treated as the primary stable citation DOI;
- the current release DOI / v1.1.1 remains listed as the current versioned release;
- the old v1.0.2 DOI is no longer presented as the primary citation target;
- the Zenodo badge/repository identifier `1061766508` is not treated as a DOI;
- README / citation metadata surfaces use the current PULSE artifact-bound release-authority title.

## Scope

Changed:

- `README.md`
- `CITATION.cff`
- optional DOI/citation metadata files if present

Not changed:

- code
- workflows
- schemas
- policies
- gate registry
- tests
- CI behavior
- release artifacts
- release-authority semantics
- dashboard / ledger / manifest / audit-bundle authority status

## Authority boundary

This PR does not change PULSE release authority.

It only repairs public DOI and citation metadata.

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision