### PR TITLE
fix: declare analysis dependencies

### DIFF
--- a/.github/workflows/pulse_pd_smoke.yml
+++ b/.github/workflows/pulse_pd_smoke.yml
@@ -43,12 +43,12 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install minimal deps
+      - name: Install analysis deps
         shell: bash
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install numpy matplotlib
+          python -m pip install -r requirements-analysis.txt
 
       - name: HEP adapters compile/import (deps-free)
         run: |

--- a/requirements-analysis.txt
+++ b/requirements-analysis.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+
+# Optional analysis / PULSE-PD runtime dependencies.
+# These are not part of the minimal core release-authority runtime.
+numpy>=1.26
+matplotlib>=3.8


### PR DESCRIPTION
## Summary

This PR declares optional analysis dependencies in a dedicated manifest.

The core PULSE runtime manifest remains minimal:

`requirements.txt`

The optional analysis / PULSE-PD runtime now has its own manifest:

`requirements-analysis.txt`

## Mechanical change

This PR adds:

`requirements-analysis.txt`

with:

- the core runtime requirements via `-r requirements.txt`;
- `numpy`;
- `matplotlib`.

It also updates the PULSE-PD smoke workflow to install from:

`requirements-analysis.txt`

instead of hard-coding `numpy matplotlib` inline.

## Why this matters

The PULSE-PD workflow already depends on analysis packages. Keeping those packages inline in the workflow creates dependency-manifest drift.

This PR makes the optional analysis dependency surface explicit without expanding the minimal core release-authority runtime.

## Authority boundary

This PR does not change PULSE release authority.

It only clarifies dependency manifests for the optional analysis / PULSE-PD surface.

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Scope

Changed:

- `requirements-analysis.txt`
- `.github/workflows/pulse_pd_smoke.yml`

Not changed:

- `requirements.txt`
- README
- schemas
- policies
- gate registry
- tests
- CI release-gating behavior
- release artifacts
- dashboard semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Expected result:

- PULSE-PD smoke workflow installs analysis dependencies from `requirements-analysis.txt`;
- core runtime dependencies remain unchanged;
- no release-authority semantics change.