### PR TITLE
feat: add recognition surface drift builder

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -21,6 +21,7 @@ tests/test_validate_status_schema_tool.py
 tests/test_validate_space_relation_map_tool.py
 tests/test_render_space_relation_map_summary_tool.py
 tests/test_build_space_relation_map_summary_tool.py
+tests/test_build_recognition_surface_drift_v0.py
 tests/test_no_legacy_status_schema_refs_smoke.py
 tests/test_pack_tools_compile.py
 tests/test_paradox_diagram_example_v0_smoke.py

--- a/docs/PULSE_RECOGNITION_SURFACE_POISONING_v0.md
+++ b/docs/PULSE_RECOGNITION_SURFACE_POISONING_v0.md
@@ -115,16 +115,20 @@ same internal artifact basis
 
 ## Diagnostic output
 
-PULSE defines and validates this condition as:
+PULSE defines, builds on demand, and validates this condition as:
 
 `recognition_surface_drift_v0`
 
 The diagnostic contract is implemented by:
 
 - `schemas/recognition_surface_drift_v0.schema.json`
+- `scripts/build_recognition_surface_drift_v0.py`
 - `scripts/check_recognition_surface_drift_v0_contract.py`
 - `tests/fixtures/recognition_surface_drift_v0/`
 - `tests/test_recognition_surface_drift_v0_contract.py`
+- `tests/test_build_recognition_surface_drift_v0.py`
+
+The builder can produce a `recognition_surface_drift_v0` diagnostic artifact from a structured input bundle containing normative artifact basis, recognition surfaces, and analysis-run summaries.
 
 The diagnostic result is non-normative by default.
 

--- a/scripts/build_recognition_surface_drift_v0.py
+++ b/scripts/build_recognition_surface_drift_v0.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Build recognition_surface_drift_v0 diagnostic artifacts.
+
+This builder does not run an AI model.
+
+It materializes a diagnostic artifact from structured analysis-run summaries:
+- normative artifact basis;
+- recognition surfaces;
+- mechanism-first and recognition-surface analysis runs.
+
+The produced artifact is non-normative.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "recognition_surface_drift_v0"
+AUTHORITY_STATUS = "diagnostic_non_normative"
+INVARIANT = (
+    "non_normative_recognition_surfaces_must_not_override_"
+    "normative_artifact_inspection"
+)
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    obj = json.loads(path.read_text(encoding="utf-8"))
+
+    if not isinstance(obj, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+
+    return obj
+
+
+def _write_json(path: Path, obj: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(obj, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _claims(run: dict[str, Any]) -> list[str]:
+    value = run.get("claims", [])
+
+    if not isinstance(value, list):
+        return []
+
+    return [str(item) for item in value]
+
+
+def _normative_path(run: dict[str, Any]) -> str | None:
+    value = run.get("normative_path")
+
+    if isinstance(value, str) and value:
+        return value
+
+    value = run.get("normative_path_claim")
+
+    if isinstance(value, str) and value:
+        return value
+
+    return None
+
+
+def _find_mechanism_first_run(
+    analysis_runs: list[dict[str, Any]],
+) -> dict[str, Any]:
+    for run in analysis_runs:
+        if run.get("condition") == "mechanism_first":
+            return run
+
+    raise ValueError("analysis_runs must include a mechanism_first baseline run")
+
+
+def _compute_drift(
+    analysis_runs: list[dict[str, Any]],
+) -> tuple[dict[str, Any], str]:
+    baseline = _find_mechanism_first_run(analysis_runs)
+    variants = [run for run in analysis_runs if run is not baseline]
+
+    if not variants:
+        raise ValueError("analysis_runs must include at least one non-baseline run")
+
+    baseline_classification = baseline.get("system_classification")
+    baseline_authority_basis = baseline.get("authority_basis")
+    baseline_claims = _claims(baseline)
+    baseline_normative_path = _normative_path(baseline)
+
+    identity_classification_changed = any(
+        run.get("system_classification") != baseline_classification
+        for run in variants
+    )
+
+    authority_boundary_changed = any(
+        run.get("authority_basis") != baseline_authority_basis
+        for run in variants
+    )
+
+    if baseline_normative_path is not None:
+        normative_path_changed = any(
+            _normative_path(run) != baseline_normative_path
+            for run in variants
+        )
+    else:
+        normative_path_changed = any(
+            run.get("authority_basis") in ("recognition_surface", "mixed")
+            for run in variants
+        )
+
+    mechanical_claims_changed = any(
+        _claims(run) != baseline_claims
+        for run in variants
+    )
+
+    changed_dimensions = [
+        identity_classification_changed,
+        authority_boundary_changed,
+        normative_path_changed,
+        mechanical_claims_changed,
+    ]
+
+    drift_score = sum(1 for item in changed_dimensions if item) / len(changed_dimensions)
+
+    if drift_score == 0:
+        result = "stable"
+    elif drift_score >= 0.5:
+        result = "contaminated"
+    else:
+        result = "unstable"
+
+    drift = {
+        "identity_classification_changed": identity_classification_changed,
+        "authority_boundary_changed": authority_boundary_changed,
+        "normative_path_changed": normative_path_changed,
+        "mechanical_claims_changed": mechanical_claims_changed,
+        "drift_score": drift_score,
+    }
+
+    return drift, result
+
+
+def _require_list(name: str, value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be an array")
+
+    if not value:
+        raise ValueError(f"{name} must not be empty")
+
+    out: list[dict[str, Any]] = []
+
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise ValueError(f"{name}[{index}] must be an object")
+        out.append(item)
+
+    return out
+
+
+def build(input_obj: dict[str, Any]) -> dict[str, Any]:
+    normative_artifact_basis = _require_list(
+        "normative_artifact_basis",
+        input_obj.get("normative_artifact_basis"),
+    )
+    recognition_surfaces = _require_list(
+        "recognition_surfaces",
+        input_obj.get("recognition_surfaces"),
+    )
+    analysis_runs = _require_list(
+        "analysis_runs",
+        input_obj.get("analysis_runs"),
+    )
+
+    drift, result = _compute_drift(analysis_runs)
+
+    out: dict[str, Any] = {
+        "schema": SCHEMA,
+        "authority_status": AUTHORITY_STATUS,
+        "invariant": INVARIANT,
+        "normative_artifact_basis": normative_artifact_basis,
+        "recognition_surfaces": recognition_surfaces,
+        "analysis_runs": analysis_runs,
+        "drift": drift,
+        "result": result,
+    }
+
+    notes = input_obj.get("notes")
+    if isinstance(notes, str) and notes:
+        out["notes"] = notes
+
+    return out
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build a recognition_surface_drift_v0 diagnostic artifact."
+    )
+    parser.add_argument("--input", required=True, help="Input bundle JSON.")
+    parser.add_argument("--out", required=True, help="Output diagnostic JSON.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        input_obj = _load_json_object(Path(args.input))
+        output_obj = build(input_obj)
+        _write_json(Path(args.out), output_obj)
+    except Exception as exc:
+        print(f"::error::failed to build recognition_surface_drift_v0: {exc}")
+        return 1
+
+    print(f"OK: wrote recognition_surface_drift_v0 artifact: {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/recognition_surface_drift_v0/builder_contaminated_input.json
+++ b/tests/fixtures/recognition_surface_drift_v0/builder_contaminated_input.json
@@ -1,0 +1,54 @@
+{
+  "normative_artifact_basis": [
+    {
+      "authority_status": "normative_input",
+      "path": "status.json",
+      "role": "machine-readable release state"
+    },
+    {
+      "authority_status": "normative_input",
+      "path": "pulse_gate_policy_v0.yml",
+      "role": "declared gate policy"
+    },
+    {
+      "authority_status": "normative_enforcement",
+      "path": "PULSE_safe_pack_v0/tools/check_gates.py",
+      "role": "strict gate enforcement"
+    }
+  ],
+  "recognition_surfaces": [
+    {
+      "authority_status": "non_normative_recognition_surface",
+      "path_or_label": "external title variant",
+      "surface_id": "presentation-title",
+      "surface_type": "title"
+    }
+  ],
+  "analysis_runs": [
+    {
+      "authority_basis": "normative_artifact_inspection",
+      "claims": [
+        "release decision is produced by status evidence, declared policy, materialized required gates, and strict CI checking"
+      ],
+      "condition": "mechanism_first",
+      "normative_artifacts_available": true,
+      "normative_path": "status.json -> declared policy -> materialized required gate set -> strict CI checking",
+      "recognition_surface_available": false,
+      "run_id": "mechanism-first",
+      "system_classification": "artifact-bound release authority"
+    },
+    {
+      "authority_basis": "recognition_surface",
+      "claims": [
+        "presentation layer changed the classification despite unchanged normative artifacts"
+      ],
+      "condition": "recognition_surface_variant",
+      "normative_artifacts_available": true,
+      "normative_path": "dashboard presentation -> reviewer impression",
+      "recognition_surface_available": true,
+      "run_id": "recognition-captured",
+      "system_classification": "dashboard framework"
+    }
+  ],
+  "notes": "Recognition surface changed the analytic classification despite unchanged normative artifact basis."
+}

--- a/tests/fixtures/recognition_surface_drift_v0/builder_stable_input.json
+++ b/tests/fixtures/recognition_surface_drift_v0/builder_stable_input.json
@@ -1,0 +1,54 @@
+{
+  "normative_artifact_basis": [
+    {
+      "authority_status": "normative_input",
+      "path": "status.json",
+      "role": "machine-readable release state"
+    },
+    {
+      "authority_status": "normative_input",
+      "path": "pulse_gate_policy_v0.yml",
+      "role": "declared gate policy"
+    },
+    {
+      "authority_status": "normative_enforcement",
+      "path": "PULSE_safe_pack_v0/tools/check_gates.py",
+      "role": "strict gate enforcement"
+    }
+  ],
+  "recognition_surfaces": [
+    {
+      "authority_status": "non_normative_recognition_surface",
+      "path_or_label": "README title",
+      "surface_id": "readme-title",
+      "surface_type": "title"
+    }
+  ],
+  "analysis_runs": [
+    {
+      "authority_basis": "normative_artifact_inspection",
+      "claims": [
+        "release decision is produced by status evidence, declared policy, materialized required gates, and strict CI checking"
+      ],
+      "condition": "mechanism_first",
+      "normative_artifacts_available": true,
+      "normative_path": "status.json -> declared policy -> materialized required gate set -> strict CI checking",
+      "recognition_surface_available": false,
+      "run_id": "mechanism-first",
+      "system_classification": "artifact-bound release authority"
+    },
+    {
+      "authority_basis": "normative_artifact_inspection",
+      "claims": [
+        "release decision is produced by status evidence, declared policy, materialized required gates, and strict CI checking"
+      ],
+      "condition": "recognition_surface_variant",
+      "normative_artifacts_available": true,
+      "normative_path": "status.json -> declared policy -> materialized required gate set -> strict CI checking",
+      "recognition_surface_available": true,
+      "run_id": "recognition-aware",
+      "system_classification": "artifact-bound release authority"
+    }
+  ],
+  "notes": "Recognition surface did not alter the mechanism-first classification."
+}

--- a/tests/test_build_recognition_surface_drift_v0.py
+++ b/tests/test_build_recognition_surface_drift_v0.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Smoke tests for build_recognition_surface_drift_v0.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER = ROOT / "scripts" / "build_recognition_surface_drift_v0.py"
+CHECKER = ROOT / "scripts" / "check_recognition_surface_drift_v0_contract.py"
+
+STABLE_INPUT = (
+    ROOT
+    / "tests"
+    / "fixtures"
+    / "recognition_surface_drift_v0"
+    / "builder_stable_input.json"
+)
+CONTAMINATED_INPUT = (
+    ROOT
+    / "tests"
+    / "fixtures"
+    / "recognition_surface_drift_v0"
+    / "builder_contaminated_input.json"
+)
+
+
+def _read(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _run_builder(input_path: Path, out_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(BUILDER),
+            "--input",
+            str(input_path),
+            "--out",
+            str(out_path),
+        ],
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _run_checker(out_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--in",
+            str(out_path),
+        ],
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_builder_outputs_stable_valid_artifact() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        out_path = Path(td) / "recognition_surface_drift_v0.json"
+
+        result = _run_builder(STABLE_INPUT, out_path)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+
+        check = _run_checker(out_path)
+        assert check.returncode == 0, check.stderr + check.stdout
+
+        artifact = _read(out_path)
+        assert artifact["schema"] == "recognition_surface_drift_v0"
+        assert artifact["authority_status"] == "diagnostic_non_normative"
+        assert artifact["result"] == "stable"
+        assert artifact["drift"]["drift_score"] == 0
+        assert artifact["drift"]["identity_classification_changed"] is False
+        assert artifact["drift"]["authority_boundary_changed"] is False
+        assert artifact["drift"]["normative_path_changed"] is False
+        assert artifact["drift"]["mechanical_claims_changed"] is False
+
+
+def test_builder_outputs_contaminated_valid_artifact() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        out_path = Path(td) / "recognition_surface_drift_v0.json"
+
+        result = _run_builder(CONTAMINATED_INPUT, out_path)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+
+        check = _run_checker(out_path)
+        assert check.returncode == 0, check.stderr + check.stdout
+
+        artifact = _read(out_path)
+        assert artifact["schema"] == "recognition_surface_drift_v0"
+        assert artifact["authority_status"] == "diagnostic_non_normative"
+        assert artifact["result"] == "contaminated"
+        assert artifact["drift"]["drift_score"] >= 0.5
+        assert artifact["drift"]["identity_classification_changed"] is True
+        assert artifact["drift"]["authority_boundary_changed"] is True
+        assert artifact["drift"]["normative_path_changed"] is True
+        assert artifact["drift"]["mechanical_claims_changed"] is True
+
+
+def test_builder_rejects_input_without_mechanism_first_baseline() -> None:
+    payload = _read(STABLE_INPUT)
+    for run in payload["analysis_runs"]:
+        run["condition"] = "recognition_surface_variant"
+
+    with tempfile.TemporaryDirectory() as td:
+        input_path = Path(td) / "bad_input.json"
+        out_path = Path(td) / "recognition_surface_drift_v0.json"
+        _write(input_path, payload)
+
+        result = _run_builder(input_path, out_path)
+
+    assert result.returncode == 1
+    assert "mechanism_first" in (result.stderr + result.stdout)
+
+
+def test_smoke() -> None:
+    test_builder_outputs_stable_valid_artifact()
+    test_builder_outputs_contaminated_valid_artifact()
+    test_builder_rejects_input_without_mechanism_first_baseline()
+
+
+def main() -> int:
+    try:
+        test_smoke()
+    except AssertionError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    print("OK: build_recognition_surface_drift_v0 smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds an on-demand builder for `recognition_surface_drift_v0` diagnostic artifacts.

The previous PR defined and validated the recognition-surface drift contract.

This PR adds a producer that can build the diagnostic artifact from a structured input bundle.

## Mechanical purpose

The builder compares a mechanism-first baseline analysis against recognition-surface analysis variants.

It records whether changing the recognition surface changed:

- system classification;
- authority-boundary reading;
- normative-path reading;
- mechanical claims.

Core invariant:

`non-normative recognition surfaces must not override normative artifact inspection`

PULSE form:

`unsupported recognition state → no analytic authority`

## Added artifacts

This PR adds:

- `scripts/build_recognition_surface_drift_v0.py`
- stable and contaminated builder input fixtures
- `tests/test_build_recognition_surface_drift_v0.py`
- tools-test manifest entry
- docs wording updated from defined/validated to defined/built-on-demand/validated

## Authority boundary

This is a diagnostic, non-normative surface.

It does not authorize, block, override, or create release authority.

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Scope

Changed:

- diagnostic builder
- diagnostic fixtures
- diagnostic tests
- diagnostic docs wording
- tools-test manifest

Not changed:

- release policy
- gate registry
- `check_gates.py`
- status schema
- primary CI release decision semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Expected:

- stable input produces a stable diagnostic artifact;
- contaminated input produces a contaminated diagnostic artifact;
- generated artifacts pass the `recognition_surface_drift_v0` contract checker;
- missing mechanism-first baseline fails closed;
- no release-authority semantics change.