### PR TITLE
test: guard analysis dependency manifest

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -54,6 +54,7 @@ tests/test_pulse_ref_ra1_operating_proof_smoke.py
 tests/test_agent_orchestration_evidence_schema_v0.py
 tests/test_check_agent_orchestration_evidence_v0.py
 tests/test_recognition_surface_drift_v0_contract.py
+tests/test_analysis_dependency_manifest.py
 
 tools/operator_handoff_smoke.py
 

--- a/tests/test_analysis_dependency_manifest.py
+++ b/tests/test_analysis_dependency_manifest.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 
 
@@ -12,8 +13,67 @@ ANALYSIS_REQ = ROOT / "requirements-analysis.txt"
 PULSE_PD_WORKFLOW = ROOT / ".github" / "workflows" / "pulse_pd_smoke.yml"
 
 
+ANALYSIS_PACKAGES = {"numpy", "matplotlib"}
+
+
 def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
+
+
+def _package_name(token: str) -> str:
+    """Return the normalized package name from a pip requirement token."""
+    token = token.strip()
+
+    for separator in ("==", ">=", "<=", "~=", "!=", ">", "<", "["):
+        if separator in token:
+            token = token.split(separator, 1)[0]
+
+    return token.strip().lower().replace("_", "-")
+
+
+def _is_pip_install_line(line: str) -> bool:
+    try:
+        parts = shlex.split(line)
+    except ValueError:
+        return False
+
+    if not parts:
+        return False
+
+    # python -m pip install ...
+    if len(parts) >= 4 and parts[0] == "python" and parts[1:4] == ["-m", "pip", "install"]:
+        return True
+
+    # pip install ...
+    if len(parts) >= 2 and parts[0] == "pip" and parts[1] == "install":
+        return True
+
+    return False
+
+
+def _inline_analysis_installs(workflow_text: str) -> list[str]:
+    offenders: list[str] = []
+
+    for raw_line in workflow_text.splitlines():
+        line = raw_line.strip()
+
+        if not line or line.startswith("#"):
+            continue
+
+        if not _is_pip_install_line(line):
+            continue
+
+        try:
+            parts = shlex.split(line)
+        except ValueError:
+            continue
+
+        normalized_tokens = {_package_name(part) for part in parts}
+
+        if normalized_tokens & ANALYSIS_PACKAGES:
+            offenders.append(line)
+
+    return offenders
 
 
 def test_analysis_requirements_manifest_exists_and_extends_core() -> None:
@@ -40,7 +100,13 @@ def test_pulse_pd_workflow_installs_analysis_manifest_not_inline_packages() -> N
     text = _read(PULSE_PD_WORKFLOW)
 
     assert "python -m pip install -r requirements-analysis.txt" in text
-    assert "python -m pip install numpy matplotlib" not in text
+
+    offenders = _inline_analysis_installs(text)
+    assert offenders == [], (
+        "PULSE-PD workflow must not install analysis packages inline. "
+        "Use requirements-analysis.txt instead. Offending lines: "
+        + "; ".join(offenders)
+    )
 
 
 def main() -> int:

--- a/tests/test_analysis_dependency_manifest.py
+++ b/tests/test_analysis_dependency_manifest.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Guard the split between core and optional analysis dependencies."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CORE_REQ = ROOT / "requirements.txt"
+ANALYSIS_REQ = ROOT / "requirements-analysis.txt"
+PULSE_PD_WORKFLOW = ROOT / ".github" / "workflows" / "pulse_pd_smoke.yml"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_analysis_requirements_manifest_exists_and_extends_core() -> None:
+    text = _read(ANALYSIS_REQ)
+
+    assert "-r requirements.txt" in text
+    assert "numpy>=" in text
+    assert "matplotlib>=" in text
+
+
+def test_core_requirements_remain_minimal_release_authority_runtime() -> None:
+    text = _read(CORE_REQ).lower()
+
+    assert "pyyaml" in text
+    assert "jsonschema" in text
+
+    # Optional analysis dependencies must not be promoted into the minimal
+    # release-authority runtime.
+    assert "numpy" not in text
+    assert "matplotlib" not in text
+
+
+def test_pulse_pd_workflow_installs_analysis_manifest_not_inline_packages() -> None:
+    text = _read(PULSE_PD_WORKFLOW)
+
+    assert "python -m pip install -r requirements-analysis.txt" in text
+    assert "python -m pip install numpy matplotlib" not in text
+
+
+def main() -> int:
+    try:
+        test_analysis_requirements_manifest_exists_and_extends_core()
+        test_core_requirements_remain_minimal_release_authority_runtime()
+        test_pulse_pd_workflow_installs_analysis_manifest_not_inline_packages()
+    except AssertionError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    print("OK: analysis dependency manifest guard passed")
+    return 0
+
+
+def test_smoke() -> None:
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds a regression guard for the optional analysis dependency manifest.

The repository now separates:

- minimal core release-authority runtime: `requirements.txt`;
- optional PULSE-PD analysis runtime: `requirements-analysis.txt`.

## Mechanical purpose

The test ensures that optional analysis dependencies remain declared in the analysis manifest instead of drifting back into inline workflow installs or the minimal core runtime.

The guard checks that:

- `requirements-analysis.txt` exists;
- it extends `requirements.txt`;
- it declares `numpy` and `matplotlib`;
- `requirements.txt` remains minimal and does not include analysis dependencies;
- `.github/workflows/pulse_pd_smoke.yml` installs from `requirements-analysis.txt`.

## Authority boundary

This PR does not change PULSE release authority.

It only guards dependency-manifest consistency for the optional analysis / PULSE-PD surface.

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Scope

Changed:

- `tests/test_analysis_dependency_manifest.py`
- `ci/tools-tests.list`

Not changed:

- `requirements.txt`
- `requirements-analysis.txt`
- workflows
- schemas
- policies
- gate registry
- release gates
- CI release-decision semantics
- dashboard / ledger / manifest / audit-bundle authority status

## Validation

Expected:

- analysis dependency manifest guard passes;
- core runtime remains minimal;
- optional analysis runtime remains explicit;
- no release-authority semantics change.