### PR TITLE
fix: make toy PD export runnable without NumPy

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -55,6 +55,7 @@ tests/test_agent_orchestration_evidence_schema_v0.py
 tests/test_check_agent_orchestration_evidence_v0.py
 tests/test_recognition_surface_drift_v0_contract.py
 tests/test_analysis_dependency_manifest.py
+tests/test_pulse_pd_toy_generator_no_numpy.py
 
 tools/operator_handoff_smoke.py
 

--- a/pulse_pd/__init__.py
+++ b/pulse_pd/__init__.py
@@ -6,7 +6,47 @@ Core metrics:
 - MI: Model Inconsistency
 - GF: Gate Friction
 - PI: Paradox Index
+
+The NumPy-backed public exports are lazy-loaded so lightweight submodules
+such as pulse_pd.examples.make_toy_X can run before optional analysis
+dependencies are installed.
 """
 
-from .pd import compute_ds, compute_mi, compute_gf, compute_pi  # noqa: F401
-from .cut_adapter import run_pd_from_cuts  # noqa: F401
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+
+__all__ = [
+    "compute_ds",
+    "compute_mi",
+    "compute_gf",
+    "compute_pi",
+    "run_pd_from_cuts",
+]
+
+
+_EXPORTS: dict[str, tuple[str, str]] = {
+    "compute_ds": ("pulse_pd.pd", "compute_ds"),
+    "compute_mi": ("pulse_pd.pd", "compute_mi"),
+    "compute_gf": ("pulse_pd.pd", "compute_gf"),
+    "compute_pi": ("pulse_pd.pd", "compute_pi"),
+    "run_pd_from_cuts": ("pulse_pd.cut_adapter", "run_pd_from_cuts"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name not in _EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module_name, attr_name = _EXPORTS[name]
+    module = import_module(module_name)
+    value = getattr(module, attr_name)
+
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/pulse_pd/examples/make_toy_X.py
+++ b/pulse_pd/examples/make_toy_X.py
@@ -14,16 +14,36 @@ Run:
 
 Or as a module:
   python -m pulse_pd.examples.make_toy_X --out pulse_pd/examples/X_toy.npz --n 5000 --seed 0
+
+If NumPy is installed, the existing NumPy-backed implementation is used.
+If NumPy is unavailable, the command falls back to a deterministic standard-library
+implementation and writes an NPZ/NPY-compatible output file.
 """
 
 from __future__ import annotations
 
 import argparse
 import os
-import numpy as np
+import random
+import struct
+import zipfile
+from pathlib import Path
+from typing import Any, Iterable, Sequence
 
 
-def make_synthetic_data(n: int, seed: int) -> tuple[np.ndarray, np.ndarray]:
+def _try_import_numpy(force_stdlib: bool) -> Any | None:
+    if force_stdlib:
+        return None
+
+    try:
+        import numpy as np  # type: ignore
+    except ModuleNotFoundError:
+        return None
+
+    return np
+
+
+def make_synthetic_data_numpy(np: Any, n: int, seed: int) -> tuple[Any, Any]:
     """
     Mixture of two Gaussians (background + signal-like cluster).
     Returns X (n,2) and y (n,) in {0,1}.
@@ -49,7 +69,42 @@ def make_synthetic_data(n: int, seed: int) -> tuple[np.ndarray, np.ndarray]:
     return X[idx], y[idx]
 
 
-def make_event_ids(n: int, seed: int) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+def make_synthetic_data_stdlib(n: int, seed: int) -> tuple[list[list[float]], list[int]]:
+    """
+    Deterministic standard-library fallback.
+
+    This is intentionally a lightweight toy generator, not a full statistical
+    replacement for the NumPy-backed multivariate-normal implementation.
+    """
+    rng = random.Random(seed)
+
+    n_sig = n // 2
+    n_bkg = n - n_sig
+
+    rows: list[list[float]] = []
+    labels: list[int] = []
+
+    for _ in range(n_bkg):
+        rows.append([
+            rng.gauss(-1.0, 1.0),
+            rng.gauss(-0.5, 0.9),
+        ])
+        labels.append(0)
+
+    for _ in range(n_sig):
+        rows.append([
+            rng.gauss(1.2, 0.95),
+            rng.gauss(0.8, 0.95),
+        ])
+        labels.append(1)
+
+    order = list(range(n))
+    rng.shuffle(order)
+
+    return [rows[i] for i in order], [labels[i] for i in order]
+
+
+def make_event_ids_numpy(np: Any, n: int, seed: int) -> tuple[Any, Any, Any, Any]:
     """
     Deterministic, HEP-like identifiers:
     - run: constant per file (derived from seed)
@@ -57,43 +112,193 @@ def make_event_ids(n: int, seed: int) -> tuple[np.ndarray, np.ndarray, np.ndarra
     - event: strictly increasing unique id
     - event_id: "run:lumi:event" as string
     """
-    # Keep deterministic but "HEP-looking"
     run_number = 320000 + (seed % 1000)
     run = np.full(n, run_number, dtype=np.int64)
 
-    # lumi sections: 1..ceil(n/250)
     block = 250
     lumi = (np.arange(n, dtype=np.int64) // block) + 1
 
-    # event numbers: unique increasing
     event = np.arange(n, dtype=np.int64) + 1
 
-    event_id = np.array([f"{run_number}:{int(l)}:{int(e)}" for l, e in zip(lumi, event)], dtype=object)
+    event_id = np.array(
+        [f"{run_number}:{int(l)}:{int(e)}" for l, e in zip(lumi, event)],
+        dtype=object,
+    )
     return run, lumi, event, event_id
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--out", default="pulse_pd/examples/X_toy.npz", help="Output .npz path")
-    ap.add_argument("--n", type=int, default=5000, help="Number of samples")
-    ap.add_argument("--seed", type=int, default=0, help="RNG seed")
-    args = ap.parse_args()
+def make_event_ids_stdlib(n: int, seed: int) -> tuple[list[int], list[int], list[int], list[str]]:
+    run_number = 320000 + (seed % 1000)
 
-    X, y = make_synthetic_data(args.n, args.seed)
-    feature_names = np.array(["x1", "x2"], dtype=object)
+    run = [run_number for _ in range(n)]
+    lumi = [(i // 250) + 1 for i in range(n)]
+    event = [i + 1 for i in range(n)]
+    event_id = [f"{run_number}:{l}:{e}" for l, e in zip(lumi, event)]
 
-    run, lumi, event, event_id = make_event_ids(args.n, args.seed)
+    return run, lumi, event, event_id
 
-    rng = np.random.default_rng(args.seed)
-    # Optional weights: close to 1.0, deterministic by seed
-    weight = rng.uniform(0.8, 1.2, size=args.n).astype(float)
 
-    out_dir = os.path.dirname(args.out)
-    if out_dir:
-        os.makedirs(out_dir, exist_ok=True)
+def make_weights_numpy(np: Any, n: int, seed: int) -> Any:
+    rng = np.random.default_rng(seed)
+    return rng.uniform(0.8, 1.2, size=n).astype(float)
+
+
+def make_weights_stdlib(n: int, seed: int) -> list[float]:
+    rng = random.Random(seed + 17)
+    return [0.8 + (0.4 * rng.random()) for _ in range(n)]
+
+
+def _shape(value: Any) -> tuple[int, ...]:
+    shape = getattr(value, "shape", None)
+    if shape is not None:
+        return tuple(int(item) for item in shape)
+
+    if isinstance(value, list):
+        if value and isinstance(value[0], list):
+            return (len(value), len(value[0]))
+        return (len(value),)
+
+    return ()
+
+
+def _tolist(value: Any) -> list[Any]:
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        return list(tolist())
+
+    if isinstance(value, list):
+        return value
+
+    return [value]
+
+
+def _shape_repr(shape: Sequence[int]) -> str:
+    if len(shape) == 1:
+        return f"({int(shape[0])},)"
+    return str(tuple(int(item) for item in shape))
+
+
+def _npy_header(descr: str, shape: Sequence[int]) -> bytes:
+    header_dict = (
+        "{'descr': "
+        + repr(descr)
+        + ", 'fortran_order': False, 'shape': "
+        + _shape_repr(shape)
+        + ", }"
+    )
+
+    header_len_without_padding = len(header_dict) + 1
+    padding = (16 - ((10 + header_len_without_padding) % 16)) % 16
+    header = header_dict + (" " * padding) + "\n"
+    header_bytes = header.encode("latin1")
+
+    if len(header_bytes) > 65535:
+        raise ValueError("NPY v1.0 header too large")
+
+    return b"\x93NUMPY" + bytes([1, 0]) + struct.pack("<H", len(header_bytes)) + header_bytes
+
+
+def _npy_float64_1d(values: Iterable[float]) -> bytes:
+    vals = [float(value) for value in values]
+    out = bytearray(_npy_header("<f8", (len(vals),)))
+
+    for value in vals:
+        out.extend(struct.pack("<d", value))
+
+    return bytes(out)
+
+
+def _npy_float64_2d(values: Sequence[Sequence[float]]) -> bytes:
+    rows = [[float(item) for item in row] for row in values]
+    cols = len(rows[0]) if rows else 0
+
+    for row in rows:
+        if len(row) != cols:
+            raise ValueError("2D float array rows must have equal length")
+
+    out = bytearray(_npy_header("<f8", (len(rows), cols)))
+
+    for row in rows:
+        for value in row:
+            out.extend(struct.pack("<d", value))
+
+    return bytes(out)
+
+
+def _npy_int64_1d(values: Iterable[int]) -> bytes:
+    vals = [int(value) for value in values]
+    out = bytearray(_npy_header("<i8", (len(vals),)))
+
+    for value in vals:
+        out.extend(struct.pack("<q", value))
+
+    return bytes(out)
+
+
+def _npy_unicode_1d(values: Iterable[str]) -> bytes:
+    vals = [str(value) for value in values]
+    max_len = max([1] + [len(value) for value in vals])
+    item_width = max_len * 4
+
+    out = bytearray(_npy_header(f"<U{max_len}", (len(vals),)))
+
+    for value in vals:
+        encoded = value.encode("utf-32le")
+        if len(encoded) > item_width:
+            encoded = encoded[:item_width]
+        out.extend(encoded)
+        out.extend(b"\x00" * (item_width - len(encoded)))
+
+    return bytes(out)
+
+
+def _write_npz_stdlib(
+    *,
+    out_path: Path,
+    X: Sequence[Sequence[float]],
+    y: Sequence[int],
+    feature_names: Sequence[str],
+    run: Sequence[int],
+    lumi: Sequence[int],
+    event: Sequence[int],
+    event_id: Sequence[str],
+    weight: Sequence[float],
+) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    arrays = {
+        "X.npy": _npy_float64_2d(X),
+        "y.npy": _npy_int64_1d(y),
+        "feature_names.npy": _npy_unicode_1d(feature_names),
+        "run.npy": _npy_int64_1d(run),
+        "lumi.npy": _npy_int64_1d(lumi),
+        "event.npy": _npy_int64_1d(event),
+        "event_id.npy": _npy_unicode_1d(event_id),
+        "weight.npy": _npy_float64_1d(weight),
+    }
+
+    with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name, payload in arrays.items():
+            zf.writestr(name, payload)
+
+
+def _write_npz_numpy(
+    *,
+    np: Any,
+    out_path: Path,
+    X: Any,
+    y: Any,
+    feature_names: Any,
+    run: Any,
+    lumi: Any,
+    event: Any,
+    event_id: Any,
+    weight: Any,
+) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
 
     np.savez(
-        args.out,
+        out_path,
         X=X,
         y=y,
         feature_names=feature_names,
@@ -104,14 +309,73 @@ def main() -> int:
         weight=weight,
     )
 
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="pulse_pd/examples/X_toy.npz", help="Output .npz path")
+    ap.add_argument("--n", type=int, default=5000, help="Number of samples")
+    ap.add_argument("--seed", type=int, default=0, help="RNG seed")
+    ap.add_argument(
+        "--force-stdlib",
+        action="store_true",
+        help="Use the standard-library fallback even when NumPy is installed.",
+    )
+    args = ap.parse_args()
+
+    if args.n <= 0:
+        print("ERROR: --n must be positive")
+        return 1
+
+    np = _try_import_numpy(args.force_stdlib)
+    out_path = Path(args.out)
+
+    if np is not None:
+        X, y = make_synthetic_data_numpy(np, args.n, args.seed)
+        feature_names = np.array(["x1", "x2"], dtype=object)
+        run, lumi, event, event_id = make_event_ids_numpy(np, args.n, args.seed)
+        weight = make_weights_numpy(np, args.n, args.seed)
+
+        _write_npz_numpy(
+            np=np,
+            out_path=out_path,
+            X=X,
+            y=y,
+            feature_names=feature_names,
+            run=run,
+            lumi=lumi,
+            event=event,
+            event_id=event_id,
+            weight=weight,
+        )
+        mode = "numpy"
+    else:
+        X, y = make_synthetic_data_stdlib(args.n, args.seed)
+        feature_names = ["x1", "x2"]
+        run, lumi, event, event_id = make_event_ids_stdlib(args.n, args.seed)
+        weight = make_weights_stdlib(args.n, args.seed)
+
+        _write_npz_stdlib(
+            out_path=out_path,
+            X=X,
+            y=y,
+            feature_names=feature_names,
+            run=run,
+            lumi=lumi,
+            event=event,
+            event_id=event_id,
+            weight=weight,
+        )
+        mode = "stdlib"
+
     print("Wrote:", os.path.abspath(args.out))
+    print("Mode:", mode)
     print("Keys: X, y, feature_names, run, lumi, event, event_id, weight")
-    print(" - X:", X.shape)
-    print(" - y:", y.shape)
-    print(" - feature_names:", feature_names.tolist())
-    print(" - run/lumi/event:", run.shape, lumi.shape, event.shape)
-    print(" - event_id:", event_id.shape)
-    print(" - weight:", weight.shape)
+    print(" - X:", _shape(X))
+    print(" - y:", _shape(y))
+    print(" - feature_names:", _tolist(feature_names))
+    print(" - run/lumi/event:", _shape(run), _shape(lumi), _shape(event))
+    print(" - event_id:", _shape(event_id))
+    print(" - weight:", _shape(weight))
     return 0
 
 

--- a/tests/test_pulse_pd_toy_generator_no_numpy.py
+++ b/tests/test_pulse_pd_toy_generator_no_numpy.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Regression tests for the lightweight PULSE-PD toy generator fallback path."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_make_toy(out_path: Path, *, force_stdlib: bool = True) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        sys.executable,
+        "-m",
+        "pulse_pd.examples.make_toy_X",
+        "--out",
+        str(out_path),
+        "--n",
+        "20",
+        "--seed",
+        "0",
+    ]
+
+    if force_stdlib:
+        cmd.append("--force-stdlib")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT)
+
+    return subprocess.run(
+        cmd,
+        cwd=str(ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_pulse_pd_package_import_does_not_require_numpy() -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys\n"
+                "sys.modules['numpy'] = None\n"
+                "import pulse_pd\n"
+                "print('OK: pulse_pd imported without eager NumPy import')\n"
+            ),
+        ],
+        cwd=str(ROOT),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "OK: pulse_pd imported without eager NumPy import" in result.stdout
+
+
+def test_make_toy_x_stdlib_fallback_writes_npz() -> None:
+    with tempfile.TemporaryDirectory(prefix="pulse-pd-toy-") as td:
+        out_path = Path(td) / "X_toy_ci.npz"
+
+        result = _run_make_toy(out_path, force_stdlib=True)
+
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+        assert "Mode: stdlib" in result.stdout
+
+        with zipfile.ZipFile(out_path, "r") as zf:
+            names = set(zf.namelist())
+
+        assert names == {
+            "X.npy",
+            "y.npy",
+            "feature_names.npy",
+            "run.npy",
+            "lumi.npy",
+            "event.npy",
+            "event_id.npy",
+            "weight.npy",
+        }
+
+
+def test_make_toy_x_stdlib_npz_is_numpy_loadable_when_numpy_available() -> None:
+    try:
+        import numpy as np  # type: ignore
+    except ModuleNotFoundError:
+        return
+
+    with tempfile.TemporaryDirectory(prefix="pulse-pd-toy-") as td:
+        out_path = Path(td) / "X_toy_ci.npz"
+
+        result = _run_make_toy(out_path, force_stdlib=True)
+
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+
+        with np.load(out_path, allow_pickle=False) as data:
+            assert data["X"].shape == (20, 2)
+            assert data["y"].shape == (20,)
+            assert data["feature_names"].tolist() == ["x1", "x2"]
+            assert data["run"].shape == (20,)
+            assert data["lumi"].shape == (20,)
+            assert data["event"].shape == (20,)
+            assert data["event_id"].shape == (20,)
+            assert data["weight"].shape == (20,)
+
+
+def main() -> int:
+    try:
+        test_pulse_pd_package_import_does_not_require_numpy()
+        test_make_toy_x_stdlib_fallback_writes_npz()
+        test_make_toy_x_stdlib_npz_is_numpy_loadable_when_numpy_available()
+    except AssertionError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    print("OK: PULSE-PD toy generator NumPy fallback tests passed")
+    return 0
+
+
+def test_smoke() -> None:
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR makes the lightweight PULSE-PD toy dataset generator runnable when NumPy is unavailable.

The existing NumPy implementation remains the preferred path when NumPy is installed.

When NumPy is unavailable, `pulse_pd.examples.make_toy_X` now uses a deterministic standard-library fallback and still writes an NPZ/NPY-compatible output file.

## Mechanical change

This PR updates:

- `pulse_pd/__init__.py`
- `pulse_pd/examples/make_toy_X.py`
- `tests/test_pulse_pd_toy_generator_no_numpy.py`
- `ci/tools-tests.list`

The package initializer now lazy-loads NumPy-backed public exports so lightweight submodules can be imported before optional analysis dependencies are installed.

The toy generator now supports:

- NumPy-backed generation when NumPy is available;
- standard-library fallback generation when NumPy is unavailable;
- deterministic fallback data generation;
- fallback NPY/NPZ writing for float, integer, and Unicode arrays;
- consistent shape summaries across both paths.

## Why this matters

The optional PULSE-PD analysis runtime depends on analysis packages such as NumPy.

However, the lightweight toy dataset export path should not fail at import time in restricted environments where optional analysis dependencies cannot be installed.

This PR makes that entry point resilient without promoting analysis dependencies into the minimal core release-authority runtime.

## Authority boundary

This PR does not change PULSE release authority.

It only improves optional PULSE-PD runtime resilience.

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Scope

Changed:

- `pulse_pd/__init__.py`
- `pulse_pd/examples/make_toy_X.py`
- `tests/test_pulse_pd_toy_generator_no_numpy.py`
- `ci/tools-tests.list`

Not changed:

- `requirements.txt`
- `requirements-analysis.txt`
- workflows
- release policy
- gate registry
- status schemas
- release gates
- RA1 verifier
- README
- dashboard semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Expected:

- `pulse_pd` package import does not require eager NumPy import;
- `make_toy_X --force-stdlib` writes an NPZ file;
- fallback NPZ contains the expected keys;
- fallback NPZ can be loaded with `np.load(..., allow_pickle=False)` when NumPy is available;
- no release-authority semantics change.