### PR TITLE
feat: add HPC evidence bundle contract

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -56,6 +56,7 @@ tests/test_check_agent_orchestration_evidence_v0.py
 tests/test_recognition_surface_drift_v0_contract.py
 tests/test_analysis_dependency_manifest.py
 tests/test_pulse_pd_toy_generator_no_numpy.py
+tests/test_hpc_evidence_bundle_v0_contract.py
 
 tools/operator_handoff_smoke.py
 

--- a/docs/PULSE_HPC_EVIDENCE_BUNDLE_v0.md
+++ b/docs/PULSE_HPC_EVIDENCE_BUNDLE_v0.md
@@ -1,0 +1,107 @@
+# PULSE HPC Evidence Bundle v0
+
+Status: diagnostic evidence contract  
+Scope: HPC / compute-scale evidence production  
+Authority status: non-normative evidence surface
+
+## Core statement
+
+HPC produces evidence.
+
+HPC does not create release authority.
+
+PULSE release authority materializes only through the declared normative path:
+
+recorded release evidence  
+→ `status.json`  
+→ declared gate policy  
+→ materialized required gate set  
+→ strict fail-closed CI checking  
+→ CI allow/block release decision
+
+## Purpose
+
+`hpc_evidence_bundle_v0` defines a machine-readable contract for recording HPC or compute-scale evidence before that evidence can support release-grade validation.
+
+The bundle records:
+
+- run identity;
+- code identity;
+- input manifest identity;
+- environment identity;
+- evidence artifacts;
+- summary metrics;
+- provenance;
+- reconstruction instructions;
+- completion status.
+
+The bundle is non-normative by default.
+
+It may support review, diagnostics, reproducibility, or later fold-in work.
+
+It does not authorize, block, override, or create release authority.
+
+## Core rule
+
+Unsupported compute output must not become release authority.
+
+Unrecorded HPC output is not release evidence.
+
+Unverified HPC output is not release evidence.
+
+Unfolded HPC output is not release authority.
+
+Only materialized, policy-routed, gate-enforced evidence can participate in release authority.
+
+## Contract states
+
+The bundle result may be:
+
+- `complete` — declared evidence items are present and digest-backed;
+- `incomplete` — one or more evidence items are missing, failed, or unverified;
+- `invalid` — the bundle exists but should not be treated as usable diagnostic evidence without repair.
+
+A `complete` bundle is still non-normative.
+
+It means the bundle is internally complete as a diagnostic evidence surface.
+
+It does not mean release is allowed.
+
+## Evidence items
+
+Each evidence item records:
+
+- artifact path;
+- evidence role;
+- evidence status;
+- SHA-256 digest when present;
+- whether it has been folded into `status.json`;
+- optional policy route if it is folded.
+
+If an evidence item is folded into `status.json`, it must have a declared policy route.
+
+Folded evidence without a policy route is invalid.
+
+## Relation to PULSE-PD
+
+PULSE-PD may produce analysis artifacts that later become part of an HPC evidence bundle.
+
+PULSE-PD remains an optional analysis surface.
+
+Its artifacts do not create release authority unless explicitly folded into recorded release evidence and enforced as required gates under declared policy.
+
+## Relation to recognition surfaces
+
+Large compute runs, polished plots, institutional context, dashboards, and reports may create recognition surfaces.
+
+Recognition surfaces are not authority.
+
+Every recognition claim requires mechanical evidence.
+
+## Summary
+
+HPC output becomes useful to PULSE only when it is materialized, recorded, digest-backed, reconstructable, and role-classified.
+
+HPC produces evidence.
+
+PULSE decides only through the normative evidence-policy-gate-CI path.

--- a/schemas/hpc_evidence_bundle_v0.schema.json
+++ b/schemas/hpc_evidence_bundle_v0.schema.json
@@ -1,0 +1,226 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hkati.github.io/pulse-release-gates-0.1/schemas/hpc_evidence_bundle_v0.schema.json",
+  "title": "PULSE HPC Evidence Bundle v0",
+  "type": "object",
+  "required": [
+    "schema",
+    "authority_status",
+    "creates_release_authority",
+    "run_identity",
+    "code_identity",
+    "input_manifest",
+    "environment",
+    "evidence_items",
+    "summary_metrics",
+    "provenance",
+    "reconstruction",
+    "result"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema": {
+      "const": "hpc_evidence_bundle_v0"
+    },
+    "authority_status": {
+      "const": "diagnostic_non_normative"
+    },
+    "creates_release_authority": {
+      "const": false
+    },
+    "run_identity": {
+      "type": "object",
+      "required": ["run_id", "run_started_utc"],
+      "additionalProperties": true,
+      "properties": {
+        "run_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "run_started_utc": {
+          "type": "string",
+          "minLength": 1
+        },
+        "run_completed_utc": {
+          "type": "string"
+        },
+        "run_mode": {
+          "enum": ["local_hpc_sim", "compute_scale", "hpc"]
+        }
+      }
+    },
+    "code_identity": {
+      "type": "object",
+      "required": ["repository", "git_sha"],
+      "additionalProperties": true,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "git_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "ref": {
+          "type": "string"
+        }
+      }
+    },
+    "input_manifest": {
+      "type": "object",
+      "required": ["path", "sha256"],
+      "additionalProperties": true,
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "dataset_identity": {
+          "type": "string"
+        },
+        "sample_identity": {
+          "type": "string"
+        }
+      }
+    },
+    "environment": {
+      "type": "object",
+      "required": ["runtime_surface"],
+      "additionalProperties": true,
+      "properties": {
+        "runtime_surface": {
+          "enum": ["local_hpc_sim", "compute_scale", "hpc"]
+        },
+        "scheduler": {
+          "type": "string"
+        },
+        "node_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "accelerator_class": {
+          "type": "string"
+        },
+        "container_digest": {
+          "type": "string"
+        }
+      }
+    },
+    "evidence_items": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "path",
+          "role",
+          "evidence_status",
+          "folded_into_status"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "role": {
+            "enum": [
+              "detector_summary",
+              "stability_measurement",
+              "pulse_pd_artifact",
+              "raw_trace",
+              "summary_metric",
+              "provenance_record",
+              "package_manifest",
+              "audit_bundle",
+              "other"
+            ]
+          },
+          "evidence_status": {
+            "enum": ["present", "missing", "failed", "unverified"]
+          },
+          "sha256": {
+            "type": ["string", "null"],
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "schema_path": {
+            "type": "string"
+          },
+          "folded_into_status": {
+            "type": "boolean"
+          },
+          "policy_route": {
+            "type": "object",
+            "required": ["policy_path", "gate_id"],
+            "additionalProperties": true,
+            "properties": {
+              "policy_path": {
+                "type": "string",
+                "minLength": 1
+              },
+              "gate_id": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    "summary_metrics": {
+      "type": "object",
+      "additionalProperties": {
+        "type": ["number", "integer", "string", "boolean", "null"]
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["command"],
+      "additionalProperties": true,
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "seed": {
+          "type": ["integer", "string", "null"]
+        },
+        "detector_config": {
+          "type": "string"
+        },
+        "threshold_ref": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "reconstruction": {
+      "type": "object",
+      "required": ["instructions"],
+      "additionalProperties": true,
+      "properties": {
+        "instructions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "result": {
+      "enum": ["complete", "incomplete", "invalid"]
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/scripts/check_hpc_evidence_bundle_v0_contract.py
+++ b/scripts/check_hpc_evidence_bundle_v0_contract.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Contract checker for hpc_evidence_bundle_v0 diagnostic evidence bundles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "schemas" / "hpc_evidence_bundle_v0.schema.json"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    obj = json.loads(path.read_text(encoding="utf-8"))
+
+    if not isinstance(obj, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+
+    return obj
+
+
+def _is_sha256(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    if len(value) != 64:
+        return False
+    return all(char in "0123456789abcdef" for char in value)
+
+
+def _schema_errors(instance: dict[str, Any]) -> list[str]:
+    schema = _load_json(SCHEMA_PATH)
+    Draft202012Validator.check_schema(schema)
+
+    validator = Draft202012Validator(schema)
+    errors = sorted(
+        validator.iter_errors(instance),
+        key=lambda error: list(error.absolute_path),
+    )
+
+    return [
+        f"{list(error.absolute_path)}: {error.message}"
+        for error in errors
+    ]
+
+
+def _semantic_errors(instance: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    if instance.get("authority_status") != "diagnostic_non_normative":
+        errors.append("authority_status must be diagnostic_non_normative")
+
+    if instance.get("creates_release_authority") is not False:
+        errors.append("creates_release_authority must be false")
+
+    result = instance.get("result")
+    evidence_items = instance.get("evidence_items")
+
+    if not isinstance(evidence_items, list):
+        return errors
+
+    item_statuses: list[str] = []
+
+    for index, item in enumerate(evidence_items):
+        if not isinstance(item, dict):
+            errors.append(f"evidence_items[{index}] must be an object")
+            continue
+
+        status = item.get("evidence_status")
+        item_statuses.append(str(status))
+
+        sha256 = item.get("sha256")
+
+        if status == "present" and not _is_sha256(sha256):
+            errors.append(
+                f"evidence_items[{index}] is present but has no valid sha256 digest"
+            )
+
+        if item.get("folded_into_status") is True:
+            if status != "present":
+                errors.append(
+                    f"evidence_items[{index}] is folded into status but is not present"
+                )
+
+            policy_route = item.get("policy_route")
+            if not isinstance(policy_route, dict):
+                errors.append(
+                    f"evidence_items[{index}] is folded into status but lacks policy_route"
+                )
+            else:
+                if not policy_route.get("policy_path"):
+                    errors.append(
+                        f"evidence_items[{index}].policy_route.policy_path is required"
+                    )
+                if not policy_route.get("gate_id"):
+                    errors.append(
+                        f"evidence_items[{index}].policy_route.gate_id is required"
+                    )
+
+    if result == "complete":
+        for index, item in enumerate(evidence_items):
+            if isinstance(item, dict) and item.get("evidence_status") != "present":
+                errors.append(
+                    f"complete bundle cannot contain non-present evidence item at index {index}"
+                )
+
+    if result == "incomplete":
+        if all(status == "present" for status in item_statuses):
+            errors.append("incomplete bundle must contain at least one non-present evidence item")
+
+    return errors
+
+
+def check(path: Path) -> tuple[bool, list[str]]:
+    instance = _load_json(path)
+    errors = _schema_errors(instance)
+    errors.extend(_semantic_errors(instance))
+    return errors == [], errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate an hpc_evidence_bundle_v0 artifact."
+    )
+    parser.add_argument("--in", dest="input_path", required=True)
+    args = parser.parse_args()
+
+    path = Path(args.input_path)
+
+    try:
+        ok, errors = check(path)
+    except Exception as exc:
+        print(f"::error::failed to check hpc_evidence_bundle_v0: {exc}")
+        return 1
+
+    if not ok:
+        print("::error::hpc_evidence_bundle_v0 contract failed")
+        for error in errors:
+            print(f" - {error}")
+        return 1
+
+    print(f"OK: hpc_evidence_bundle_v0 contract valid: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/hpc_evidence_bundle_v0/complete.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/complete.json
@@ -1,0 +1,65 @@
+{
+  "schema": "hpc_evidence_bundle_v0",
+  "authority_status": "diagnostic_non_normative",
+  "creates_release_authority": false,
+  "run_identity": {
+    "run_id": "hpc-demo-001",
+    "run_started_utc": "2026-05-19T00:00:00Z",
+    "run_completed_utc": "2026-05-19T00:05:00Z",
+    "run_mode": "local_hpc_sim"
+  },
+  "code_identity": {
+    "repository": "HKati/pulse-release-gates-0.1",
+    "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "ref": "refs/heads/main"
+  },
+  "input_manifest": {
+    "path": "hpc/input_manifest.demo.json",
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "dataset_identity": "demo-dataset",
+    "sample_identity": "demo-sample"
+  },
+  "environment": {
+    "runtime_surface": "local_hpc_sim",
+    "scheduler": "local",
+    "node_count": 1,
+    "accelerator_class": "cpu"
+  },
+  "evidence_items": [
+    {
+      "path": "hpc/artifacts/detector_summary.json",
+      "role": "detector_summary",
+      "evidence_status": "present",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "schema_path": "schemas/external_detector_summary_v0.schema.json",
+      "folded_into_status": false
+    },
+    {
+      "path": "hpc/artifacts/pulse_pd_summary.json",
+      "role": "pulse_pd_artifact",
+      "evidence_status": "present",
+      "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "folded_into_status": false
+    }
+  ],
+  "summary_metrics": {
+    "num_trials": 128,
+    "detector_pass_rate": 1.0,
+    "max_observed_failure_rate": 0.0
+  },
+  "provenance": {
+    "command": "python scripts/run_hpc_demo.py --config hpc/input_manifest.demo.json",
+    "seed": 0,
+    "detector_config": "demo-detector-config",
+    "threshold_ref": "pulse_gate_policy_v0.yml"
+  },
+  "reconstruction": {
+    "instructions": [
+      "Checkout the recorded repository revision.",
+      "Install the declared runtime surface.",
+      "Run the recorded command with the recorded input manifest."
+    ]
+  },
+  "result": "complete",
+  "notes": "Complete diagnostic bundle. This artifact does not create release authority."
+}

--- a/tests/fixtures/hpc_evidence_bundle_v0/incomplete.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/incomplete.json
@@ -1,0 +1,45 @@
+{
+  "schema": "hpc_evidence_bundle_v0",
+  "authority_status": "diagnostic_non_normative",
+  "creates_release_authority": false,
+  "run_identity": {
+    "run_id": "hpc-demo-002",
+    "run_started_utc": "2026-05-19T00:00:00Z",
+    "run_mode": "local_hpc_sim"
+  },
+  "code_identity": {
+    "repository": "HKati/pulse-release-gates-0.1",
+    "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "input_manifest": {
+    "path": "hpc/input_manifest.demo.json",
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "environment": {
+    "runtime_surface": "local_hpc_sim",
+    "scheduler": "local"
+  },
+  "evidence_items": [
+    {
+      "path": "hpc/artifacts/detector_summary.json",
+      "role": "detector_summary",
+      "evidence_status": "missing",
+      "sha256": null,
+      "folded_into_status": false
+    }
+  ],
+  "summary_metrics": {
+    "num_trials": 0
+  },
+  "provenance": {
+    "command": "python scripts/run_hpc_demo.py --config hpc/input_manifest.demo.json",
+    "seed": 0
+  },
+  "reconstruction": {
+    "instructions": [
+      "Evidence bundle is incomplete; rerun the recorded command after restoring detector output."
+    ]
+  },
+  "result": "incomplete",
+  "notes": "Incomplete diagnostic bundle. Missing evidence must not become release authority."
+}

--- a/tests/test_hpc_evidence_bundle_v0_contract.py
+++ b/tests/test_hpc_evidence_bundle_v0_contract.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Smoke tests for hpc_evidence_bundle_v0 contract checker."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER = ROOT / "scripts" / "check_hpc_evidence_bundle_v0_contract.py"
+COMPLETE_FIXTURE = ROOT / "tests" / "fixtures" / "hpc_evidence_bundle_v0" / "complete.json"
+INCOMPLETE_FIXTURE = ROOT / "tests" / "fixtures" / "hpc_evidence_bundle_v0" / "incomplete.json"
+
+
+def _run(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), "--in", str(path)],
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _read(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_complete_fixture_is_valid() -> None:
+    result = _run(COMPLETE_FIXTURE)
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_incomplete_fixture_is_valid_diagnostic_artifact() -> None:
+    result = _run(INCOMPLETE_FIXTURE)
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_complete_bundle_rejects_missing_evidence_item() -> None:
+    payload = _read(COMPLETE_FIXTURE)
+    payload["result"] = "complete"
+    payload["evidence_items"][0]["evidence_status"] = "missing"
+    payload["evidence_items"][0]["sha256"] = None
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "bad.json"
+        _write(path, payload)
+        result = _run(path)
+
+    assert result.returncode == 1
+    assert "complete bundle cannot contain non-present evidence item" in (
+        result.stderr + result.stdout
+    )
+
+
+def test_present_evidence_requires_valid_sha256() -> None:
+    payload = _read(COMPLETE_FIXTURE)
+    payload["evidence_items"][0]["sha256"] = "not-a-sha"
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "bad.json"
+        _write(path, payload)
+        result = _run(path)
+
+    assert result.returncode == 1
+    assert "sha256" in (result.stderr + result.stdout)
+
+
+def test_folded_evidence_requires_policy_route() -> None:
+    payload = _read(COMPLETE_FIXTURE)
+    payload["evidence_items"][0]["folded_into_status"] = True
+    payload["evidence_items"][0].pop("policy_route", None)
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "bad.json"
+        _write(path, payload)
+        result = _run(path)
+
+    assert result.returncode == 1
+    assert "lacks policy_route" in (result.stderr + result.stdout)
+
+
+def test_folded_evidence_with_policy_route_is_valid() -> None:
+    payload = _read(COMPLETE_FIXTURE)
+    payload["evidence_items"][0]["folded_into_status"] = True
+    payload["evidence_items"][0]["policy_route"] = {
+        "policy_path": "pulse_gate_policy_v0.yml",
+        "gate_id": "external_all_pass"
+    }
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "good.json"
+        _write(path, payload)
+        result = _run(path)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_creates_release_authority_true_is_rejected() -> None:
+    payload = _read(COMPLETE_FIXTURE)
+    payload["creates_release_authority"] = True
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "bad.json"
+        _write(path, payload)
+        result = _run(path)
+
+    assert result.returncode == 1
+    assert "creates_release_authority" in (result.stderr + result.stdout)
+
+
+def main() -> int:
+    try:
+        test_complete_fixture_is_valid()
+        test_incomplete_fixture_is_valid_diagnostic_artifact()
+        test_complete_bundle_rejects_missing_evidence_item()
+        test_present_evidence_requires_valid_sha256()
+        test_folded_evidence_requires_policy_route()
+        test_folded_evidence_with_policy_route_is_valid()
+        test_creates_release_authority_true_is_rejected()
+    except AssertionError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    print("OK: hpc_evidence_bundle_v0 contract smoke passed")
+    return 0
+
+
+def test_smoke() -> None:
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds `hpc_evidence_bundle_v0`, a diagnostic contract for HPC / compute-scale evidence bundles.

The contract records HPC evidence without turning HPC output into release authority.

## Mechanical purpose

The new bundle records:

- run identity;
- code identity;
- input manifest identity;
- environment identity;
- evidence items;
- summary metrics;
- provenance;
- reconstruction instructions;
- completion status.

Core rule:

`HPC produces evidence. PULSE creates release authority only through the normative evidence-policy-gate-CI path.`

## Contract behavior

The checker verifies that:

- the bundle is non-normative;
- `creates_release_authority` is false;
- complete bundles contain only present evidence items;
- present evidence has valid SHA-256 digests;
- evidence folded into `status.json` has an explicit policy route;
- incomplete bundles may exist as diagnostic artifacts but do not become release authority.

## Authority boundary

This is a diagnostic evidence surface.

It does not authorize, block, override, or create release authority.

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Scope

Changed:

- `docs/PULSE_HPC_EVIDENCE_BUNDLE_v0.md`
- `schemas/hpc_evidence_bundle_v0.schema.json`
- `scripts/check_hpc_evidence_bundle_v0_contract.py`
- `tests/fixtures/hpc_evidence_bundle_v0/complete.json`
- `tests/fixtures/hpc_evidence_bundle_v0/incomplete.json`
- `tests/test_hpc_evidence_bundle_v0_contract.py`
- `ci/tools-tests.list`

Not changed:

- README
- workflows
- release policy
- gate registry
- `check_gates.py`
- status schemas
- primary CI release-decision semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Expected:

- complete fixture validates;
- incomplete fixture validates as a diagnostic artifact;
- complete bundle rejects missing evidence;
- present evidence requires a valid SHA-256 digest;
- folded evidence requires an explicit policy route;
- `creates_release_authority=true` is rejected;
- no release-authority semantics change.