### PR TITLE
fix: update Zenodo metadata for current PULSE release identity

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,8 +1,6 @@
 {
   "title": "PULSE: Deterministic Release Gates for Safe & Useful AI",
-  "publication_date": "2025-10-18",
-  "version": "v1.0.2",
-  "description": "PULSE provides deterministic, fail-closed release gates across Safety (I2–I7), Utility (Q1–Q4) and SLO dimensions. It produces audit artefacts including a human-readable Quality Ledger and SVG badges that summarise pass/fail states. This software package allows developers to enforce safety invariants, utility budgets and service level objectives prior to shipment.",
+  "description": "PULSE is an artifact-bound release-authority mechanism for AI release decisions. Recorded release evidence is evaluated through status.json, declared gate policy, materialized required gates, and strict fail-closed CI checking to produce a deterministic CI allow/block release decision before deployment.",
   "upload_type": "software",
   "language": "eng",
   "license": "Apache-2.0",
@@ -21,20 +19,18 @@
     }
   ],
   "keywords": [
-    "release-governance",
-    "ai-safety",
-    "evaluations",
-    "guardrails",
-    "SLO",
-    "deterministic",
-    "fail-closed",
-    "reproducibility",
-    "auditability",
+    "pulsemech",
+    "artifact-bound",
+    "release-authority",
+    "ai-release-decisions",
+    "evidence-bound",
+    "materialized-gates",
+    "policy-declared",
+    "fail-closed-ci",
     "quality-ledger",
-    "badges",
-    "mlops",
-    "artificial intelligence",
-    "computer science"
+    "rdsi",
+    "auditability",
+    "reproducibility"
   ],
   "related_identifiers": [
     {
@@ -51,13 +47,7 @@
       "identifier": "https://github.com/HKati/pulse-release-gates-0.1",
       "relation": "isSupplementTo",
       "scheme": "url"
-    },
-    {
-      "identifier": "https://github.com/HKati/pulse-guard-pack",
-      "relation": "hasPart",
-      "resource_type": "software",
-      "scheme": "url"
     }
   ],
-  "notes": "This software release is accompanied by a cs.AI preprint archived as a separate Zenodo publication. Reproducibility instructions and CI/CD integration details are provided in the repository README."
+  "notes": "The stable Concept DOI preserves the PULSE version family. Release-specific version and publication date are derived from the GitHub release/tag by Zenodo. The normative PULSE release decision remains bound to the PULSEmech path: recorded release evidence -> status.json -> declared gate policy -> materialized required gate set -> strict fail-closed CI checking -> CI allow/block release decision."
 }


### PR DESCRIPTION
## Summary

Updates the active `.zenodo.json` metadata used by Zenodo for future GitHub release imports.

The previous metadata still described the older v1.0.2 release state and caused new Zenodo-imported releases to inherit stale title/version/description/keyword surfaces.

## Purpose

The repository route and Concept DOI family remain stable.

This change ensures future Zenodo releases describe the current PULSE release-authority identity while keeping release-specific values derived from the GitHub release/tag.

## Mechanical change

This PR updates the active `.zenodo.json` so that:

- `version` is removed from active metadata;
- `publication_date` is removed from active metadata;
- stale v1.0.2 release-specific description is replaced;
- stale generic keywords are replaced with current PULSE metadata keywords;
- `pulse-guard-pack` is removed from active `related_identifiers`;
- the stable Concept DOI relation remains preserved;
- the PULSE repository URL remains preserved.

## Authority boundary

This is metadata maintenance only.

It does not change PULSE release authority.

The normative release decision remains:

recorded release evidence  
→ `status.json`  
→ declared gate policy  
→ materialized required gate set  
→ strict fail-closed CI checking  
→ CI allow/block release decision

## Scope

Changed:

- `.zenodo.json`

Not changed:

- release-authority behavior
- gate policy semantics
- status schema semantics
- `check_gates.py`
- CI allow/block semantics
- Quality Ledger authority status
- release-authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Expected:

- `.zenodo.json` remains valid JSON;
- future Zenodo imports derive version and publication date from the GitHub release/tag;
- future Zenodo imports no longer inherit stale v1.0.2 metadata;
- future Zenodo imports no longer associate the active PULSE release metadata with `pulse-guard-pack`;
- no release-authority semantics change.