### PR TITLE
feat: add HPC evidence bundle builder

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -22,6 +22,7 @@ tests/test_validate_space_relation_map_tool.py
 tests/test_render_space_relation_map_summary_tool.py
 tests/test_build_space_relation_map_summary_tool.py
 tests/test_build_recognition_surface_drift_v0.py
+tests/test_build_hpc_evidence_bundle_v0.py
 tests/test_no_legacy_status_schema_refs_smoke.py
 tests/test_pack_tools_compile.py
 tests/test_paradox_diagram_example_v0_smoke.py

--- a/scripts/build_hpc_evidence_bundle_v0.py
+++ b/scripts/build_hpc_evidence_bundle_v0.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Build hpc_evidence_bundle_v0 diagnostic evidence bundles.
+
+This builder does not run HPC jobs.
+
+It materializes a diagnostic evidence bundle from structured run input:
+- run identity;
+- code identity;
+- input manifest identity;
+- environment identity;
+- evidence items;
+- summary metrics;
+- provenance;
+- reconstruction instructions.
+
+The produced artifact is non-normative and does not create release authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "hpc_evidence_bundle_v0"
+AUTHORITY_STATUS = "diagnostic_non_normative"
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    obj = json.loads(path.read_text(encoding="utf-8"))
+
+    if not isinstance(obj, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+
+    return obj
+
+
+def _write_json(path: Path, obj: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(obj, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _require_object(name: str, value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must be an object")
+
+    return value
+
+
+def _require_list(name: str, value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be an array")
+
+    if not value:
+        raise ValueError(f"{name} must not be empty")
+
+    out: list[dict[str, Any]] = []
+
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise ValueError(f"{name}[{index}] must be an object")
+        out.append(item)
+
+    return out
+
+
+def _evidence_result(evidence_items: list[dict[str, Any]]) -> str:
+    statuses = [item.get("evidence_status") for item in evidence_items]
+
+    if all(status == "present" for status in statuses):
+        return "complete"
+
+    return "incomplete"
+
+
+def build(input_obj: dict[str, Any]) -> dict[str, Any]:
+    run_identity = _require_object(
+        "run_identity",
+        input_obj.get("run_identity"),
+    )
+    code_identity = _require_object(
+        "code_identity",
+        input_obj.get("code_identity"),
+    )
+    input_manifest = _require_object(
+        "input_manifest",
+        input_obj.get("input_manifest"),
+    )
+    environment = _require_object(
+        "environment",
+        input_obj.get("environment"),
+    )
+    evidence_items = _require_list(
+        "evidence_items",
+        input_obj.get("evidence_items"),
+    )
+    summary_metrics = _require_object(
+        "summary_metrics",
+        input_obj.get("summary_metrics"),
+    )
+    provenance = _require_object(
+        "provenance",
+        input_obj.get("provenance"),
+    )
+    reconstruction = _require_object(
+        "reconstruction",
+        input_obj.get("reconstruction"),
+    )
+
+    result = _evidence_result(evidence_items)
+
+    out: dict[str, Any] = {
+        "schema": SCHEMA,
+        "authority_status": AUTHORITY_STATUS,
+        "creates_release_authority": False,
+        "run_identity": run_identity,
+        "code_identity": code_identity,
+        "input_manifest": input_manifest,
+        "environment": environment,
+        "evidence_items": evidence_items,
+        "summary_metrics": summary_metrics,
+        "provenance": provenance,
+        "reconstruction": reconstruction,
+        "result": result,
+    }
+
+    notes = input_obj.get("notes")
+    if isinstance(notes, str) and notes:
+        out["notes"] = notes
+
+    return out
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build an hpc_evidence_bundle_v0 diagnostic evidence artifact."
+    )
+    parser.add_argument("--input", required=True, help="Input bundle JSON.")
+    parser.add_argument("--out", required=True, help="Output diagnostic JSON.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        input_obj = _load_json_object(Path(args.input))
+        output_obj = build(input_obj)
+        _write_json(Path(args.out), output_obj)
+    except Exception as exc:
+        print(f"::error::failed to build hpc_evidence_bundle_v0: {exc}")
+        return 1
+
+    print(f"OK: wrote hpc_evidence_bundle_v0 artifact: {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/hpc_evidence_bundle_v0/builder_complete_input.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/builder_complete_input.json
@@ -1,0 +1,61 @@
+{
+  "run_identity": {
+    "run_id": "hpc-builder-complete-001",
+    "run_started_utc": "2026-05-19T00:00:00Z",
+    "run_completed_utc": "2026-05-19T00:05:00Z",
+    "run_mode": "local_hpc_sim"
+  },
+  "code_identity": {
+    "repository": "HKati/pulse-release-gates-0.1",
+    "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "ref": "refs/heads/main"
+  },
+  "input_manifest": {
+    "path": "hpc/input_manifest.builder.complete.json",
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "dataset_identity": "builder-demo-dataset",
+    "sample_identity": "builder-demo-sample"
+  },
+  "environment": {
+    "runtime_surface": "local_hpc_sim",
+    "scheduler": "local",
+    "node_count": 1,
+    "accelerator_class": "cpu"
+  },
+  "evidence_items": [
+    {
+      "path": "hpc/artifacts/detector_summary.json",
+      "role": "detector_summary",
+      "evidence_status": "present",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "schema_path": "schemas/external_detector_summary_v0.schema.json",
+      "folded_into_status": false
+    },
+    {
+      "path": "hpc/artifacts/pulse_pd_summary.json",
+      "role": "pulse_pd_artifact",
+      "evidence_status": "present",
+      "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "folded_into_status": false
+    }
+  ],
+  "summary_metrics": {
+    "num_trials": 128,
+    "detector_pass_rate": 1.0,
+    "max_observed_failure_rate": 0.0
+  },
+  "provenance": {
+    "command": "python scripts/run_hpc_demo.py --config hpc/input_manifest.builder.complete.json",
+    "seed": 0,
+    "detector_config": "demo-detector-config",
+    "threshold_ref": "pulse_gate_policy_v0.yml"
+  },
+  "reconstruction": {
+    "instructions": [
+      "Checkout the recorded repository revision.",
+      "Install the declared runtime surface.",
+      "Run the recorded command with the recorded input manifest."
+    ]
+  },
+  "notes": "Complete builder input. Generated bundle must remain diagnostic and non-normative."
+}

--- a/tests/fixtures/hpc_evidence_bundle_v0/builder_incomplete_input.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/builder_incomplete_input.json
@@ -1,0 +1,60 @@
+{
+  "run_identity": {
+    "run_id": "hpc-builder-incomplete-001",
+    "run_started_utc": "2026-05-19T00:00:00Z",
+    "run_mode": "local_hpc_sim"
+  },
+  "code_identity": {
+    "repository": "HKati/pulse-release-gates-0.1",
+    "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "ref": "refs/heads/main"
+  },
+  "input_manifest": {
+    "path": "hpc/input_manifest.builder.incomplete.json",
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "dataset_identity": "builder-demo-dataset",
+    "sample_identity": "builder-demo-sample"
+  },
+  "environment": {
+    "runtime_surface": "local_hpc_sim",
+    "scheduler": "local",
+    "node_count": 1,
+    "accelerator_class": "cpu"
+  },
+  "evidence_items": [
+    {
+      "path": "hpc/artifacts/detector_summary.json",
+      "role": "detector_summary",
+      "evidence_status": "missing",
+      "sha256": null,
+      "schema_path": "schemas/external_detector_summary_v0.schema.json",
+      "folded_into_status": false
+    },
+    {
+      "path": "hpc/artifacts/pulse_pd_summary.json",
+      "role": "pulse_pd_artifact",
+      "evidence_status": "present",
+      "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "folded_into_status": false
+    }
+  ],
+  "summary_metrics": {
+    "num_trials": 64,
+    "detector_pass_rate": null,
+    "max_observed_failure_rate": null
+  },
+  "provenance": {
+    "command": "python scripts/run_hpc_demo.py --config hpc/input_manifest.builder.incomplete.json",
+    "seed": 0,
+    "detector_config": "demo-detector-config",
+    "threshold_ref": "pulse_gate_policy_v0.yml"
+  },
+  "reconstruction": {
+    "instructions": [
+      "Evidence bundle is incomplete.",
+      "Restore the missing detector output.",
+      "Rerun the recorded command with the recorded input manifest."
+    ]
+  },
+  "notes": "Incomplete builder input. Missing evidence must not become release authority."
+}

--- a/tests/test_build_hpc_evidence_bundle_v0.py
+++ b/tests/test_build_hpc_evidence_bundle_v0.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Smoke tests for build_hpc_evidence_bundle_v0.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER = ROOT / "scripts" / "build_hpc_evidence_bundle_v0.py"
+CHECKER = ROOT / "scripts" / "check_hpc_evidence_bundle_v0_contract.py"
+
+COMPLETE_INPUT = (
+    ROOT
+    / "tests"
+    / "fixtures"
+    / "hpc_evidence_bundle_v0"
+    / "builder_complete_input.json"
+)
+INCOMPLETE_INPUT = (
+    ROOT
+    / "tests"
+    / "fixtures"
+    / "hpc_evidence_bundle_v0"
+    / "builder_incomplete_input.json"
+)
+
+
+def _read(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _run_builder(input_path: Path, out_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(BUILDER),
+            "--input",
+            str(input_path),
+            "--out",
+            str(out_path),
+        ],
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _run_checker(out_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--in",
+            str(out_path),
+        ],
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_builder_outputs_complete_valid_bundle() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        out_path = Path(td) / "hpc_evidence_bundle_v0.json"
+
+        result = _run_builder(COMPLETE_INPUT, out_path)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+
+        check = _run_checker(out_path)
+        assert check.returncode == 0, check.stderr + check.stdout
+
+        artifact = _read(out_path)
+        assert artifact["schema"] == "hpc_evidence_bundle_v0"
+        assert artifact["authority_status"] == "diagnostic_non_normative"
+        assert artifact["creates_release_authority"] is False
+        assert artifact["result"] == "complete"
+        assert all(
+            item["evidence_status"] == "present"
+            for item in artifact["evidence_items"]
+        )
+
+
+def test_builder_outputs_incomplete_valid_bundle() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        out_path = Path(td) / "hpc_evidence_bundle_v0.json"
+
+        result = _run_builder(INCOMPLETE_INPUT, out_path)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+
+        check = _run_checker(out_path)
+        assert check.returncode == 0, check.stderr + check.stdout
+
+        artifact = _read(out_path)
+        assert artifact["schema"] == "hpc_evidence_bundle_v0"
+        assert artifact["authority_status"] == "diagnostic_non_normative"
+        assert artifact["creates_release_authority"] is False
+        assert artifact["result"] == "incomplete"
+        assert any(
+            item["evidence_status"] != "present"
+            for item in artifact["evidence_items"]
+        )
+
+
+def test_builder_rejects_input_without_evidence_items() -> None:
+    payload = _read(COMPLETE_INPUT)
+    payload["evidence_items"] = []
+
+    with tempfile.TemporaryDirectory() as td:
+        input_path = Path(td) / "bad_input.json"
+        out_path = Path(td) / "hpc_evidence_bundle_v0.json"
+        _write(input_path, payload)
+
+        result = _run_builder(input_path, out_path)
+
+    assert result.returncode == 1
+    assert "evidence_items" in (result.stderr + result.stdout)
+
+
+def test_builder_output_with_folded_evidence_without_policy_route_fails_checker() -> None:
+    payload = _read(COMPLETE_INPUT)
+    payload["evidence_items"][0]["folded_into_status"] = True
+    payload["evidence_items"][0].pop("policy_route", None)
+
+    with tempfile.TemporaryDirectory() as td:
+        input_path = Path(td) / "input.json"
+        out_path = Path(td) / "hpc_evidence_bundle_v0.json"
+        _write(input_path, payload)
+
+        result = _run_builder(input_path, out_path)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+
+        check = _run_checker(out_path)
+
+    assert check.returncode == 1
+    assert "lacks policy_route" in (check.stderr + check.stdout)
+
+
+def test_builder_output_with_folded_evidence_and_policy_route_passes_checker() -> None:
+    payload = _read(COMPLETE_INPUT)
+    payload["evidence_items"][0]["folded_into_status"] = True
+    payload["evidence_items"][0]["policy_route"] = {
+        "policy_path": "pulse_gate_policy_v0.yml",
+        "gate_id": "external_all_pass"
+    }
+
+    with tempfile.TemporaryDirectory() as td:
+        input_path = Path(td) / "input.json"
+        out_path = Path(td) / "hpc_evidence_bundle_v0.json"
+        _write(input_path, payload)
+
+        result = _run_builder(input_path, out_path)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+
+        check = _run_checker(out_path)
+
+    assert check.returncode == 0, check.stderr + check.stdout
+
+
+def main() -> int:
+    try:
+        test_builder_outputs_complete_valid_bundle()
+        test_builder_outputs_incomplete_valid_bundle()
+        test_builder_rejects_input_without_evidence_items()
+        test_builder_output_with_folded_evidence_without_policy_route_fails_checker()
+        test_builder_output_with_folded_evidence_and_policy_route_passes_checker()
+    except AssertionError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    print("OK: build_hpc_evidence_bundle_v0 smoke passed")
+    return 0
+
+
+def test_smoke() -> None:
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds an on-demand builder for `hpc_evidence_bundle_v0` diagnostic evidence bundles.

The previous contract defines how HPC / compute-scale evidence is recorded and validated.

This PR adds a producer that materializes the bundle from structured run input.

## Mechanical purpose

The builder records:

- run identity;
- code identity;
- input manifest identity;
- environment identity;
- evidence items;
- summary metrics;
- provenance;
- reconstruction instructions;
- completion status.

It computes whether the generated bundle is:

- `complete` when all evidence items are present;
- `incomplete` when one or more evidence items are missing, failed, or unverified.

## Added artifacts

Changed:

- `scripts/build_hpc_evidence_bundle_v0.py`
- `tests/fixtures/hpc_evidence_bundle_v0/builder_complete_input.json`
- `tests/fixtures/hpc_evidence_bundle_v0/builder_incomplete_input.json`
- `tests/test_build_hpc_evidence_bundle_v0.py`
- `ci/tools-tests.list`

## Authority boundary

This is diagnostic only.

HPC output does not create release authority.

The generated bundle sets:

`creates_release_authority=false`

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Contract behavior

Expected behavior:

- complete input produces a complete valid bundle;
- incomplete input produces an incomplete valid diagnostic bundle;
- generated bundles pass the existing `hpc_evidence_bundle_v0` contract checker;
- empty `evidence_items` input fails;
- folded evidence without `policy_route` fails the checker;
- folded evidence with an explicit `policy_route` passes the checker.

## Scope

Not changed:

- README
- workflows
- release policy
- gate registry
- `check_gates.py`
- status schemas
- release gates
- RA1 verifier
- primary CI release-decision semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Expected validation:

- `python -m py_compile scripts/build_hpc_evidence_bundle_v0.py tests/test_build_hpc_evidence_bundle_v0.py`
- `python tests/test_build_hpc_evidence_bundle_v0.py`
- `python -m pytest -q tests/test_build_hpc_evidence_bundle_v0.py tests/test_hpc_evidence_bundle_v0_contract.py`

This preserves the PULSE rule:

unsupported compute output
→ no release authority