### PR TITLE
feat: add evidence fold-in admissibility contract

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -58,6 +58,7 @@ tests/test_recognition_surface_drift_v0_contract.py
 tests/test_analysis_dependency_manifest.py
 tests/test_pulse_pd_toy_generator_no_numpy.py
 tests/test_hpc_evidence_bundle_v0_contract.py
+tests/test_evidence_fold_in_admissibility_v0_contract.py
 
 tools/operator_handoff_smoke.py
 

--- a/docs/PULSE_EVIDENCE_FOLD_IN_ADMISSIBILITY_v0.md
+++ b/docs/PULSE_EVIDENCE_FOLD_IN_ADMISSIBILITY_v0.md
@@ -1,0 +1,146 @@
+# PULSE Evidence Fold-In Admissibility v0
+
+Status: diagnostic admissibility contract  
+Scope: diagnostic / HPC / PULSE-PD / recognition / external evidence fold-in boundary  
+Authority status: non-normative evidence-admissibility surface
+
+## Core statement
+
+A diagnostic surface may observe the field.
+
+Only policy-routed, schema-valid, digest-backed, verified, materialized evidence may enter the recorded release-evidence path.
+
+This document defines the boundary between:
+
+- non-normative diagnostic evidence;
+- advisory evidence;
+- evidence that is admissible for future fold-in into `status.json`;
+- evidence that must remain rejected.
+
+This contract does not fold evidence into `status.json`.
+
+It only records whether a candidate evidence item is admissible for fold-in.
+
+## Normative release path
+
+The normative PULSE release decision remains:
+
+recorded release evidence  
+→ `status.json`  
+→ declared gate policy  
+→ materialized required gate set  
+→ strict fail-closed CI checking  
+→ CI allow/block release decision
+
+The fold-in admissibility contract does not authorize, block, override, or create release authority.
+
+## Why this exists
+
+PULSE contains role-bearing field points:
+
+- external detector summaries;
+- HPC evidence bundles;
+- PULSE-PD analysis artifacts;
+- recognition-surface drift diagnostics;
+- RA1 verifier reports;
+- audit bundles;
+- publication snapshots;
+- diagnostic overlays.
+
+These surfaces may be useful.
+
+They are not release authority by existing.
+
+Before any diagnostic or analysis artifact can become recorded release evidence, it must pass an admissibility boundary.
+
+## Core rule
+
+Unsupported fold-in state  
+→ no recorded release evidence
+
+Fold-in requires:
+
+- source artifact path;
+- SHA-256 digest;
+- source surface role;
+- source authority status;
+- schema-valid evidence where a schema exists;
+- explicit verification status;
+- explicit policy route if fold-in is requested;
+- explicit target gate if policy-routed;
+- explicit non-authority status for the admissibility artifact itself.
+
+## Recognition surfaces
+
+Recognition surfaces are not authority.
+
+A recognition surface may orient attention.
+
+It must not become recorded release evidence by itself.
+
+Examples of recognition surfaces include:
+
+- title;
+- summary;
+- About text;
+- badge;
+- DOI metadata;
+- citation metadata;
+- social preview;
+- visual presentation;
+- dashboard appearance.
+
+Every recognition claim requires mechanical evidence.
+
+Recognition-surface diagnostics may be recorded as diagnostic artifacts, but a recognition surface itself is not admissible for release-evidence fold-in unless a separate mechanical evidence artifact is provided and policy-routed.
+
+## HPC evidence
+
+HPC output is evidence only when it is materialized, recorded, digest-backed, reconstructable, and role-classified.
+
+An `hpc_evidence_bundle_v0` artifact may become a candidate evidence source.
+
+It is admissible for fold-in only if the specific candidate evidence item has a valid digest, verified status, schema-valid supporting contract, and explicit policy route.
+
+HPC output does not create release authority.
+
+## PULSE-PD evidence
+
+PULSE-PD is an optional analysis surface.
+
+PULSE-PD artifacts may support field diagnostics or evidence exploration.
+
+They do not create release authority.
+
+A PULSE-PD artifact is admissible for fold-in only when it is digest-backed, schema-valid or contract-checked where applicable, verified, and explicitly routed to declared policy.
+
+## External detector evidence
+
+External detector summaries may become release-relevant only through declared evidence contracts.
+
+A detector summary is not admissible merely because it exists.
+
+It must be canonical, schema-valid where applicable, digest-backed, verified, and policy-routed before it can support a required gate.
+
+## Result states
+
+An admissibility artifact may report:
+
+- `admissible` — all candidates are admissible for fold-in;
+- `advisory_only` — candidates may support review or diagnosis but are not admissible for fold-in;
+- `rejected` — one or more candidates violate admissibility rules;
+- `mixed` — at least one candidate is admissible and at least one candidate is advisory-only or rejected.
+
+A result of `admissible` does not mean release is allowed.
+
+It only means the candidate evidence is allowed to enter a future recorded-evidence fold-in process.
+
+## Invariant
+
+Non-normative field points must not enter recorded release evidence without mechanical admissibility.
+
+Admissibility requires mechanical proof.
+
+Every fold-in claim requires mechanical evidence.
+
+Mechanism first; fold-in second; authority only through declared policy.

--- a/schemas/evidence_fold_in_admissibility_v0.schema.json
+++ b/schemas/evidence_fold_in_admissibility_v0.schema.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hkati.github.io/pulse-release-gates-0.1/schemas/evidence_fold_in_admissibility_v0.schema.json",
+  "title": "PULSE Evidence Fold-In Admissibility v0",
+  "type": "object",
+  "required": [
+    "schema",
+    "authority_status",
+    "creates_release_authority",
+    "invariant",
+    "candidates",
+    "result"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema": {
+      "const": "evidence_fold_in_admissibility_v0"
+    },
+    "authority_status": {
+      "const": "diagnostic_non_normative"
+    },
+    "creates_release_authority": {
+      "const": false
+    },
+    "invariant": {
+      "const": "non_normative_field_points_must_not_enter_recorded_release_evidence_without_mechanical_admissibility"
+    },
+    "candidates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "candidate_id",
+          "source_surface_type",
+          "source_authority_status",
+          "evidence_role",
+          "source_artifact",
+          "schema_valid",
+          "digest_valid",
+          "verification_status",
+          "folded_into_status_requested",
+          "admissibility"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "candidate_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source_surface_type": {
+            "enum": [
+              "external_detector_summary",
+              "hpc_evidence_bundle",
+              "pulse_pd_artifact",
+              "recognition_surface",
+              "recognition_surface_drift",
+              "ra1_verifier_report",
+              "audit_bundle",
+              "publication_snapshot",
+              "diagnostic_overlay",
+              "other"
+            ]
+          },
+          "source_authority_status": {
+            "enum": [
+              "non_normative",
+              "diagnostic_non_normative",
+              "audit_non_normative",
+              "publication_non_normative",
+              "recognition_non_normative"
+            ]
+          },
+          "evidence_role": {
+            "enum": [
+              "detector_evidence",
+              "hpc_evidence",
+              "analysis_evidence",
+              "recognition_diagnostic",
+              "audit_evidence",
+              "publication_evidence",
+              "other"
+            ]
+          },
+          "source_artifact": {
+            "type": "object",
+            "required": [
+              "path",
+              "sha256"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "path": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sha256": {
+                "type": ["string", "null"],
+                "pattern": "^[0-9a-f]{64}$"
+              }
+            }
+          },
+          "schema_path": {
+            "type": ["string", "null"]
+          },
+          "schema_valid": {
+            "type": "boolean"
+          },
+          "digest_valid": {
+            "type": "boolean"
+          },
+          "verification_status": {
+            "enum": [
+              "verified",
+              "unverified",
+              "failed",
+              "not_applicable"
+            ]
+          },
+          "folded_into_status_requested": {
+            "type": "boolean"
+          },
+          "policy_route": {
+            "type": ["object", "null"],
+            "required": [
+              "policy_path",
+              "gate_id"
+            ],
+            "additionalProperties": true,
+            "properties": {
+              "policy_path": {
+                "type": "string",
+                "minLength": 1
+              },
+              "gate_id": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "admissibility": {
+            "enum": [
+              "admissible_for_fold_in",
+              "advisory_only",
+              "rejected"
+            ]
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "result": {
+      "enum": [
+        "admissible",
+        "advisory_only",
+        "rejected",
+        "mixed"
+      ]
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/scripts/check_evidence_fold_in_admissibility_v0_contract.py
+++ b/scripts/check_evidence_fold_in_admissibility_v0_contract.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Contract checker for evidence_fold_in_admissibility_v0 artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "schemas" / "evidence_fold_in_admissibility_v0.schema.json"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    obj = json.loads(path.read_text(encoding="utf-8"))
+
+    if not isinstance(obj, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+
+    return obj
+
+
+def _is_sha256(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    if len(value) != 64:
+        return False
+    return all(char in "0123456789abcdef" for char in value)
+
+
+def _schema_errors(instance: dict[str, Any]) -> list[str]:
+    schema = _load_json(SCHEMA_PATH)
+    Draft202012Validator.check_schema(schema)
+
+    validator = Draft202012Validator(schema)
+    errors = sorted(
+        validator.iter_errors(instance),
+        key=lambda error: list(error.absolute_path),
+    )
+
+    return [
+        f"{list(error.absolute_path)}: {error.message}"
+        for error in errors
+    ]
+
+
+def _expected_result(admissibilities: list[str]) -> str:
+    if all(item == "admissible_for_fold_in" for item in admissibilities):
+        return "admissible"
+
+    if all(item == "advisory_only" for item in admissibilities):
+        return "advisory_only"
+
+    if all(item == "rejected" for item in admissibilities):
+        return "rejected"
+
+    return "mixed"
+
+
+def _semantic_errors(instance: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    if instance.get("authority_status") != "diagnostic_non_normative":
+        errors.append("authority_status must be diagnostic_non_normative")
+
+    if instance.get("creates_release_authority") is not False:
+        errors.append("creates_release_authority must be false")
+
+    candidates = instance.get("candidates")
+    if not isinstance(candidates, list):
+        return errors
+
+    admissibilities: list[str] = []
+
+    for index, candidate in enumerate(candidates):
+        if not isinstance(candidate, dict):
+            errors.append(f"candidates[{index}] must be an object")
+            continue
+
+        candidate_id = candidate.get("candidate_id", f"index-{index}")
+        admissibility = candidate.get("admissibility")
+        admissibilities.append(str(admissibility))
+
+        source_surface_type = candidate.get("source_surface_type")
+        source_artifact = candidate.get("source_artifact")
+        sha256 = None
+        if isinstance(source_artifact, dict):
+            sha256 = source_artifact.get("sha256")
+
+        schema_valid = candidate.get("schema_valid")
+        digest_valid = candidate.get("digest_valid")
+        verification_status = candidate.get("verification_status")
+        folded_requested = candidate.get("folded_into_status_requested")
+        policy_route = candidate.get("policy_route")
+
+        if source_surface_type == "recognition_surface":
+            if admissibility == "admissible_for_fold_in":
+                errors.append(
+                    f"{candidate_id}: recognition surfaces are not admissible for fold-in by themselves"
+                )
+            if folded_requested is True:
+                errors.append(
+                    f"{candidate_id}: recognition surfaces must not request status fold-in"
+                )
+
+        if folded_requested is True:
+            if not isinstance(policy_route, dict):
+                errors.append(
+                    f"{candidate_id}: folded evidence requires policy_route"
+                )
+            else:
+                if not policy_route.get("policy_path"):
+                    errors.append(
+                        f"{candidate_id}: policy_route.policy_path is required"
+                    )
+                if not policy_route.get("gate_id"):
+                    errors.append(
+                        f"{candidate_id}: policy_route.gate_id is required"
+                    )
+
+        if admissibility == "admissible_for_fold_in":
+            if folded_requested is not True:
+                errors.append(
+                    f"{candidate_id}: admissible evidence must request status fold-in"
+                )
+            if not _is_sha256(sha256):
+                errors.append(
+                    f"{candidate_id}: admissible evidence requires valid source_artifact.sha256"
+                )
+            if schema_valid is not True:
+                errors.append(
+                    f"{candidate_id}: admissible evidence requires schema_valid=true"
+                )
+            if digest_valid is not True:
+                errors.append(
+                    f"{candidate_id}: admissible evidence requires digest_valid=true"
+                )
+            if verification_status != "verified":
+                errors.append(
+                    f"{candidate_id}: admissible evidence requires verification_status=verified"
+                )
+            if not isinstance(policy_route, dict):
+                errors.append(
+                    f"{candidate_id}: admissible evidence requires policy_route"
+                )
+
+        if admissibility == "advisory_only" and folded_requested is True:
+            errors.append(
+                f"{candidate_id}: advisory-only evidence must not request status fold-in"
+            )
+
+        if admissibility == "rejected" and folded_requested is True:
+            errors.append(
+                f"{candidate_id}: rejected evidence must not request status fold-in"
+            )
+
+    if admissibilities:
+        expected = _expected_result(admissibilities)
+        if instance.get("result") != expected:
+            errors.append(
+                f"result must be {expected!r} for candidate admissibility mix, "
+                f"found {instance.get('result')!r}"
+            )
+
+    return errors
+
+
+def check(path: Path) -> tuple[bool, list[str]]:
+    instance = _load_json(path)
+    errors = _schema_errors(instance)
+    errors.extend(_semantic_errors(instance))
+    return errors == [], errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate an evidence_fold_in_admissibility_v0 artifact."
+    )
+    parser.add_argument("--in", dest="input_path", required=True)
+    args = parser.parse_args()
+
+    try:
+        ok, errors = check(Path(args.input_path))
+    except Exception as exc:
+        print(f"::error::failed to check evidence_fold_in_admissibility_v0: {exc}")
+        return 1
+
+    if not ok:
+        print("::error::evidence_fold_in_admissibility_v0 contract failed")
+        for error in errors:
+            print(f" - {error}")
+        return 1
+
+    print(f"OK: evidence_fold_in_admissibility_v0 contract valid: {args.input_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/evidence_fold_in_admissibility_v0/admissible.json
+++ b/tests/fixtures/evidence_fold_in_admissibility_v0/admissible.json
@@ -1,0 +1,31 @@
+{
+  "schema": "evidence_fold_in_admissibility_v0",
+  "authority_status": "diagnostic_non_normative",
+  "creates_release_authority": false,
+  "invariant": "non_normative_field_points_must_not_enter_recorded_release_evidence_without_mechanical_admissibility",
+  "candidates": [
+    {
+      "candidate_id": "hpc-detector-summary",
+      "source_surface_type": "hpc_evidence_bundle",
+      "source_authority_status": "diagnostic_non_normative",
+      "evidence_role": "hpc_evidence",
+      "source_artifact": {
+        "path": "hpc/artifacts/detector_summary.json",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "schema_path": "schemas/hpc_evidence_bundle_v0.schema.json",
+      "schema_valid": true,
+      "digest_valid": true,
+      "verification_status": "verified",
+      "folded_into_status_requested": true,
+      "policy_route": {
+        "policy_path": "pulse_gate_policy_v0.yml",
+        "gate_id": "external_all_pass"
+      },
+      "admissibility": "admissible_for_fold_in",
+      "reason": "Digest-backed, schema-valid, verified evidence with explicit policy route."
+    }
+  ],
+  "result": "admissible",
+  "notes": "Admissible evidence may enter a future fold-in process, but this artifact does not create release authority."
+}

--- a/tests/fixtures/evidence_fold_in_admissibility_v0/advisory_only.json
+++ b/tests/fixtures/evidence_fold_in_admissibility_v0/advisory_only.json
@@ -1,0 +1,28 @@
+{
+  "schema": "evidence_fold_in_admissibility_v0",
+  "authority_status": "diagnostic_non_normative",
+  "creates_release_authority": false,
+  "invariant": "non_normative_field_points_must_not_enter_recorded_release_evidence_without_mechanical_admissibility",
+  "candidates": [
+    {
+      "candidate_id": "pulse-pd-summary",
+      "source_surface_type": "pulse_pd_artifact",
+      "source_authority_status": "diagnostic_non_normative",
+      "evidence_role": "analysis_evidence",
+      "source_artifact": {
+        "path": "pulse_pd/artifacts/pd_summary.json",
+        "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "schema_path": null,
+      "schema_valid": false,
+      "digest_valid": true,
+      "verification_status": "not_applicable",
+      "folded_into_status_requested": false,
+      "policy_route": null,
+      "admissibility": "advisory_only",
+      "reason": "Digest-backed diagnostic artifact without schema-valid policy-routed fold-in."
+    }
+  ],
+  "result": "advisory_only",
+  "notes": "Advisory diagnostic evidence remains outside recorded release evidence."
+}

--- a/tests/fixtures/evidence_fold_in_admissibility_v0/rejected_recognition_surface.json
+++ b/tests/fixtures/evidence_fold_in_admissibility_v0/rejected_recognition_surface.json
@@ -1,0 +1,28 @@
+{
+  "schema": "evidence_fold_in_admissibility_v0",
+  "authority_status": "diagnostic_non_normative",
+  "creates_release_authority": false,
+  "invariant": "non_normative_field_points_must_not_enter_recorded_release_evidence_without_mechanical_admissibility",
+  "candidates": [
+    {
+      "candidate_id": "readme-title",
+      "source_surface_type": "recognition_surface",
+      "source_authority_status": "recognition_non_normative",
+      "evidence_role": "recognition_diagnostic",
+      "source_artifact": {
+        "path": "README.md",
+        "sha256": null
+      },
+      "schema_path": null,
+      "schema_valid": false,
+      "digest_valid": false,
+      "verification_status": "not_applicable",
+      "folded_into_status_requested": false,
+      "policy_route": null,
+      "admissibility": "rejected",
+      "reason": "Recognition surfaces are not admissible for release-evidence fold-in by themselves."
+    }
+  ],
+  "result": "rejected",
+  "notes": "Recognition surfaces may orient attention but are not release evidence by themselves."
+}

--- a/tests/test_evidence_fold_in_admissibility_v0_contract.py
+++ b/tests/test_evidence_fold_in_admissibility_v0_contract.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Smoke tests for evidence_fold_in_admissibility_v0 contract checker."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER = ROOT / "scripts" / "check_evidence_fold_in_admissibility_v0_contract.py"
+
+FIXTURE_DIR = ROOT / "tests" / "fixtures" / "evidence_fold_in_admissibility_v0"
+ADMISSIBLE = FIXTURE_DIR / "admissible.json"
+ADVISORY_ONLY = FIXTURE_DIR / "advisory_only.json"
+REJECTED_RECOGNITION = FIXTURE_DIR / "rejected_recognition_surface.json"
+
+
+def _run(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), "--in", str(path)],
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _read(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_admissible_fixture_is_valid() -> None:
+    result = _run(ADMISSIBLE)
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_advisory_only_fixture_is_valid() -> None:
+    result = _run(ADVISORY_ONLY)
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_rejected_recognition_surface_fixture_is_valid() -> None:
+    result = _run(REJECTED_RECOGNITION)
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_admissible_candidate_requires_policy_route() -> None:
+    payload = _read(ADMISSIBLE)
+    payload["candidates"][0]["policy_route"] = None
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "bad.json"
+        _write(path, payload)
+        result = _run(path)
+
+    assert result.returncode == 1
+    assert "policy_route" in (result.stderr + result.stdout)
+
+
+def test_admissible_candidate_requires_verified_status() -> None:
+    payload = _read(ADMISSIBLE)
+    payload["candidates"][0]["verification_status"] = "unverified"
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "bad.json"
+        _write(path, payload)
+        result = _run(path)
+
+    assert result.returncode == 1
+    assert "verification_status=verified" in (result.stderr + result.stdout)
+
+
+def test_advisory_only_candidate_must_not_request_fold_in() -> None:
+    payload = _read(ADVISORY_ONLY)
+    payload["candidates"][0]["folded_into_status_requested"] = True
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "bad.json"
+        _write(path, payload)
+        result = _run(path)
+
+    assert result.returncode == 1
+    assert "advisory-only evidence must not request status fold-in" in (
+        result.stderr + result.stdout
+    )
+
+
+def test_recognition_surface_cannot_be_admissible_for_fold_in() -> None:
+    payload = _read(REJECTED_RECOGNITION)
+    payload["candidates"][0]["admissibility"] = "admissible_for_fold_in"
+    payload["candidates"][0]["result"] = "admissible"
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "bad.json"
+        _write(path, payload)
+        result = _run(path)
+
+    assert result.returncode == 1
+    assert "recognition surfaces are not admissible" in (
+        result.stderr + result.stdout
+    )
+
+
+def test_result_must_match_candidate_admissibility_mix() -> None:
+    payload = _read(ADMISSIBLE)
+    payload["result"] = "advisory_only"
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "bad.json"
+        _write(path, payload)
+        result = _run(path)
+
+    assert result.returncode == 1
+    assert "result must be" in (result.stderr + result.stdout)
+
+
+def main() -> int:
+    try:
+        test_admissible_fixture_is_valid()
+        test_advisory_only_fixture_is_valid()
+        test_rejected_recognition_surface_fixture_is_valid()
+        test_admissible_candidate_requires_policy_route()
+        test_admissible_candidate_requires_verified_status()
+        test_advisory_only_candidate_must_not_request_fold_in()
+        test_recognition_surface_cannot_be_admissible_for_fold_in()
+        test_result_must_match_candidate_admissibility_mix()
+    except AssertionError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    print("OK: evidence_fold_in_admissibility_v0 contract smoke passed")
+    return 0
+
+
+def test_smoke() -> None:
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds `evidence_fold_in_admissibility_v0`, a diagnostic admissibility contract for the boundary between non-normative field points and recorded release evidence.

The contract answers this question:

When may a diagnostic / HPC / PULSE-PD / recognition / external / audit / publication artifact become admissible for future fold-in into recorded release evidence?

## Mechanical purpose

The contract records candidate evidence items with:

- source surface type;
- source authority status;
- evidence role;
- source artifact path and digest;
- schema validity;
- digest validity;
- verification status;
- fold-in request state;
- policy route when fold-in is requested;
- admissibility result.

Core rule:

`unsupported fold-in state → no recorded release evidence`

## Contract behavior

The checker enforces that:

- admissible evidence must be schema-valid, digest-valid, verified, and policy-routed;
- advisory-only evidence must not request status fold-in;
- rejected evidence must not request status fold-in;
- recognition surfaces are not admissible for release-evidence fold-in by themselves;
- result state matches the candidate admissibility mix;
- `creates_release_authority=false`.

## Added artifacts

Changed:

- `docs/PULSE_EVIDENCE_FOLD_IN_ADMISSIBILITY_v0.md`
- `schemas/evidence_fold_in_admissibility_v0.schema.json`
- `scripts/check_evidence_fold_in_admissibility_v0_contract.py`
- `tests/fixtures/evidence_fold_in_admissibility_v0/admissible.json`
- `tests/fixtures/evidence_fold_in_admissibility_v0/advisory_only.json`
- `tests/fixtures/evidence_fold_in_admissibility_v0/rejected_recognition_surface.json`
- `tests/test_evidence_fold_in_admissibility_v0_contract.py`
- `ci/tools-tests.list`

## Authority boundary

This is diagnostic only.

It does not fold evidence into `status.json`.

It does not authorize, block, override, or create release authority.

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Scope

Not changed:

- README
- workflows
- release policy
- gate registry
- `check_gates.py`
- status schemas
- release gates
- RA1 verifier
- primary CI release-decision semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Expected validation:

- `python -m py_compile scripts/check_evidence_fold_in_admissibility_v0_contract.py tests/test_evidence_fold_in_admissibility_v0_contract.py`
- `python tests/test_evidence_fold_in_admissibility_v0_contract.py`
- `python -m pytest -q tests/test_evidence_fold_in_admissibility_v0_contract.py`

Expected results:

- admissible fixture validates;
- advisory-only fixture validates;
- rejected recognition surface fixture validates;
- admissible candidate requires `policy_route`;
- admissible candidate requires `verification_status=verified`;
- advisory-only candidate cannot request fold-in;
- recognition surface cannot be admissible for fold-in by itself;
- result must match candidate admissibility mix.