### PR TITLE
feat: add evidence fold-in admissibility builder

### DIFF
--- a/scripts/build_evidence_fold_in_admissibility_v0.py
+++ b/scripts/build_evidence_fold_in_admissibility_v0.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Build evidence_fold_in_admissibility_v0 diagnostic artifacts.
+
+This builder does not fold evidence into status.json.
+
+It materializes a non-normative admissibility artifact from structured candidate
+input. The output states whether each candidate is admissible for future fold-in,
+advisory-only, or rejected.
+
+The produced artifact does not create release authority.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "evidence_fold_in_admissibility_v0"
+AUTHORITY_STATUS = "diagnostic_non_normative"
+INVARIANT = (
+    "non_normative_field_points_must_not_enter_recorded_release_evidence_"
+    "without_mechanical_admissibility"
+)
+
+SOURCE_SURFACE_TYPES = {
+    "external_detector_summary",
+    "hpc_evidence_bundle",
+    "pulse_pd_artifact",
+    "recognition_surface",
+    "recognition_surface_drift",
+    "ra1_verifier_report",
+    "audit_bundle",
+    "publication_snapshot",
+    "diagnostic_overlay",
+    "other",
+}
+
+SOURCE_AUTHORITY_STATUSES = {
+    "non_normative",
+    "diagnostic_non_normative",
+    "audit_non_normative",
+    "publication_non_normative",
+    "recognition_non_normative",
+}
+
+EVIDENCE_ROLES = {
+    "detector_evidence",
+    "hpc_evidence",
+    "analysis_evidence",
+    "recognition_diagnostic",
+    "audit_evidence",
+    "publication_evidence",
+    "other",
+}
+
+VERIFICATION_STATUSES = {
+    "verified",
+    "unverified",
+    "failed",
+    "not_applicable",
+}
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    obj = json.loads(path.read_text(encoding="utf-8"))
+
+    if not isinstance(obj, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+
+    return obj
+
+
+def _write_json(path: Path, obj: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(obj, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _require_candidates(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ValueError("candidates must be an array")
+
+    if not value:
+        raise ValueError("candidates must not be empty")
+
+    out: list[dict[str, Any]] = []
+
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise ValueError(f"candidates[{index}] must be an object")
+        out.append(item)
+
+    return out
+
+
+def _is_sha256(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    if len(value) != 64:
+        return False
+    return all(char in "0123456789abcdef" for char in value)
+
+
+def _enum(value: Any, allowed: set[str], default: str) -> str:
+    if isinstance(value, str) and value in allowed:
+        return value
+    return default
+
+
+def _source_authority_default(source_surface_type: str) -> str:
+    if source_surface_type == "recognition_surface":
+        return "recognition_non_normative"
+    if source_surface_type in {"audit_bundle", "ra1_verifier_report"}:
+        return "audit_non_normative"
+    if source_surface_type == "publication_snapshot":
+        return "publication_non_normative"
+    if source_surface_type in {
+        "hpc_evidence_bundle",
+        "pulse_pd_artifact",
+        "recognition_surface_drift",
+        "diagnostic_overlay",
+        "external_detector_summary",
+    }:
+        return "diagnostic_non_normative"
+    return "non_normative"
+
+
+def _evidence_role_default(source_surface_type: str) -> str:
+    if source_surface_type == "external_detector_summary":
+        return "detector_evidence"
+    if source_surface_type == "hpc_evidence_bundle":
+        return "hpc_evidence"
+    if source_surface_type == "pulse_pd_artifact":
+        return "analysis_evidence"
+    if source_surface_type in {"recognition_surface", "recognition_surface_drift"}:
+        return "recognition_diagnostic"
+    if source_surface_type in {"audit_bundle", "ra1_verifier_report"}:
+        return "audit_evidence"
+    if source_surface_type == "publication_snapshot":
+        return "publication_evidence"
+    return "other"
+
+
+def _source_artifact(candidate: dict[str, Any]) -> dict[str, Any]:
+    raw = candidate.get("source_artifact")
+    if isinstance(raw, dict):
+        path = raw.get("path")
+        sha256 = raw.get("sha256")
+    else:
+        path = candidate.get("path")
+        sha256 = candidate.get("sha256")
+
+    if not isinstance(path, str) or not path:
+        path = "_missing_source_artifact_path"
+
+    if not _is_sha256(sha256):
+        sha256 = None
+
+    return {
+        "path": path,
+        "sha256": sha256,
+    }
+
+
+def _policy_route(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+
+    policy_path = value.get("policy_path")
+    gate_id = value.get("gate_id")
+
+    if not isinstance(policy_path, str) or not policy_path:
+        return None
+    if not isinstance(gate_id, str) or not gate_id:
+        return None
+
+    out = dict(value)
+    out["policy_path"] = policy_path
+    out["gate_id"] = gate_id
+    return out
+
+
+def _wants_fold_in(candidate: dict[str, Any]) -> bool:
+    for key in (
+        "folded_into_status_requested",
+        "fold_into_status_requested",
+        "request_status_fold_in",
+    ):
+        if candidate.get(key) is True:
+            return True
+    return False
+
+
+def _candidate_result(candidate: dict[str, Any]) -> dict[str, Any]:
+    candidate_id = candidate.get("candidate_id")
+    if not isinstance(candidate_id, str) or not candidate_id:
+        candidate_id = "candidate"
+
+    source_surface_type = _enum(
+        candidate.get("source_surface_type"),
+        SOURCE_SURFACE_TYPES,
+        "other",
+    )
+
+    source_authority_status = _enum(
+        candidate.get("source_authority_status"),
+        SOURCE_AUTHORITY_STATUSES,
+        _source_authority_default(source_surface_type),
+    )
+
+    evidence_role = _enum(
+        candidate.get("evidence_role"),
+        EVIDENCE_ROLES,
+        _evidence_role_default(source_surface_type),
+    )
+
+    source_artifact = _source_artifact(candidate)
+    sha256 = source_artifact["sha256"]
+
+    schema_path = candidate.get("schema_path")
+    if not isinstance(schema_path, str):
+        schema_path = None
+
+    schema_valid = candidate.get("schema_valid") is True
+    digest_valid = candidate.get("digest_valid") is True and _is_sha256(sha256)
+
+    verification_status = _enum(
+        candidate.get("verification_status"),
+        VERIFICATION_STATUSES,
+        "unverified",
+    )
+
+    fold_requested = _wants_fold_in(candidate)
+    policy_route = _policy_route(candidate.get("policy_route"))
+
+    missing: list[str] = []
+
+    if not _is_sha256(sha256):
+        missing.append("valid source_artifact.sha256")
+    if not schema_valid:
+        missing.append("schema_valid=true")
+    if not digest_valid:
+        missing.append("digest_valid=true")
+    if verification_status != "verified":
+        missing.append("verification_status=verified")
+    if policy_route is None:
+        missing.append("policy_route")
+
+    if source_surface_type == "recognition_surface":
+        admissibility = "rejected"
+        folded_into_status_requested = False
+        reason = (
+            "Recognition surfaces are not admissible for release-evidence "
+            "fold-in by themselves."
+        )
+    elif fold_requested and not missing:
+        admissibility = "admissible_for_fold_in"
+        folded_into_status_requested = True
+        reason = (
+            "Digest-backed, schema-valid, verified evidence with explicit "
+            "policy route."
+        )
+    elif fold_requested:
+        admissibility = "rejected"
+        folded_into_status_requested = False
+        reason = (
+            "Fold-in requested but mechanical admissibility is incomplete: "
+            + ", ".join(missing)
+            + "."
+        )
+    elif _is_sha256(sha256) or digest_valid or schema_valid or verification_status in {
+        "verified",
+        "not_applicable",
+    }:
+        admissibility = "advisory_only"
+        folded_into_status_requested = False
+        reason = (
+            "Candidate remains advisory-only because status fold-in was not "
+            "requested with a complete policy route."
+        )
+    else:
+        admissibility = "rejected"
+        folded_into_status_requested = False
+        reason = "Candidate lacks sufficient mechanical evidence for admissibility."
+
+    return {
+        "candidate_id": candidate_id,
+        "source_surface_type": source_surface_type,
+        "source_authority_status": source_authority_status,
+        "evidence_role": evidence_role,
+        "source_artifact": source_artifact,
+        "schema_path": schema_path,
+        "schema_valid": schema_valid,
+        "digest_valid": digest_valid,
+        "verification_status": verification_status,
+        "folded_into_status_requested": folded_into_status_requested,
+        "policy_route": policy_route,
+        "admissibility": admissibility,
+        "reason": reason,
+    }
+
+
+def _overall_result(candidates: list[dict[str, Any]]) -> str:
+    values = [candidate["admissibility"] for candidate in candidates]
+
+    if all(value == "admissible_for_fold_in" for value in values):
+        return "admissible"
+
+    if all(value == "advisory_only" for value in values):
+        return "advisory_only"
+
+    if all(value == "rejected" for value in values):
+        return "rejected"
+
+    return "mixed"
+
+
+def build(input_obj: dict[str, Any]) -> dict[str, Any]:
+    raw_candidates = _require_candidates(input_obj.get("candidates"))
+    candidates = [_candidate_result(candidate) for candidate in raw_candidates]
+
+    out: dict[str, Any] = {
+        "schema": SCHEMA,
+        "authority_status": AUTHORITY_STATUS,
+        "creates_release_authority": False,
+        "invariant": INVARIANT,
+        "candidates": candidates,
+        "result": _overall_result(candidates),
+    }
+
+    notes = input_obj.get("notes")
+    if isinstance(notes, str) and notes:
+        out["notes"] = notes
+
+    return out
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build an evidence_fold_in_admissibility_v0 diagnostic artifact."
+    )
+    parser.add_argument("--input", required=True, help="Input candidate bundle JSON.")
+    parser.add_argument("--out", required=True, help="Output diagnostic JSON.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        input_obj = _load_json_object(Path(args.input))
+        output_obj = build(input_obj)
+        _write_json(Path(args.out), output_obj)
+    except Exception as exc:
+        print(f"::error::failed to build evidence_fold_in_admissibility_v0: {exc}")
+        return 1
+
+    print(f"OK: wrote evidence_fold_in_admissibility_v0 artifact: {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_evidence_fold_in_admissibility_v0.py
+++ b/scripts/build_evidence_fold_in_admissibility_v0.py
@@ -146,7 +146,7 @@ def _evidence_role_default(source_surface_type: str) -> str:
     return "other"
 
 
-def _source_artifact(candidate: dict[str, Any]) -> dict[str, Any]:
+def _source_artifact(candidate: dict[str, Any]) -> tuple[dict[str, Any], bool]:
     raw = candidate.get("source_artifact")
     if isinstance(raw, dict):
         path = raw.get("path")
@@ -155,7 +155,9 @@ def _source_artifact(candidate: dict[str, Any]) -> dict[str, Any]:
         path = candidate.get("path")
         sha256 = candidate.get("sha256")
 
-    if not isinstance(path, str) or not path:
+    path_valid = isinstance(path, str) and bool(path.strip())
+
+    if not path_valid:
         path = "_missing_source_artifact_path"
 
     if not _is_sha256(sha256):
@@ -164,7 +166,7 @@ def _source_artifact(candidate: dict[str, Any]) -> dict[str, Any]:
     return {
         "path": path,
         "sha256": sha256,
-    }
+    }, path_valid
 
 
 def _policy_route(value: Any) -> dict[str, Any] | None:
@@ -219,7 +221,7 @@ def _candidate_result(candidate: dict[str, Any]) -> dict[str, Any]:
         _evidence_role_default(source_surface_type),
     )
 
-    source_artifact = _source_artifact(candidate)
+    source_artifact, source_artifact_path_valid = _source_artifact(candidate)
     sha256 = source_artifact["sha256"]
 
     schema_path = candidate.get("schema_path")
@@ -257,6 +259,11 @@ def _candidate_result(candidate: dict[str, Any]) -> dict[str, Any]:
         reason = (
             "Recognition surfaces are not admissible for release-evidence "
             "fold-in by themselves."
+     if not source_artifact_path_valid:
+        admissibility = "rejected"
+        folded_into_status_requested = False
+        reason = "Candidate lacks valid source_artifact.path."
+    elif source_surface_type == "recognition_surface":  
         )
     elif fold_requested and not missing:
         admissibility = "admissible_for_fold_in"

--- a/scripts/check_evidence_fold_in_admissibility_v0_contract.py
+++ b/scripts/check_evidence_fold_in_admissibility_v0_contract.py
@@ -32,6 +32,14 @@ def _is_sha256(value: Any) -> bool:
     return all(char in "0123456789abcdef" for char in value)
 
 
+def _is_real_artifact_path(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and bool(value.strip())
+        and value != "_missing_source_artifact_path"
+    )
+
+
 def _schema_errors(instance: dict[str, Any]) -> list[str]:
     schema = _load_json(SCHEMA_PATH)
     Draft202012Validator.check_schema(schema)
@@ -87,9 +95,14 @@ def _semantic_errors(instance: dict[str, Any]) -> list[str]:
 
         source_surface_type = candidate.get("source_surface_type")
         source_artifact = candidate.get("source_artifact")
+
+        artifact_path = None
         sha256 = None
         if isinstance(source_artifact, dict):
+            artifact_path = source_artifact.get("path")
             sha256 = source_artifact.get("sha256")
+
+        artifact_path_valid = _is_real_artifact_path(artifact_path)
 
         schema_valid = candidate.get("schema_valid")
         digest_valid = candidate.get("digest_valid")
@@ -126,6 +139,10 @@ def _semantic_errors(instance: dict[str, Any]) -> list[str]:
             if folded_requested is not True:
                 errors.append(
                     f"{candidate_id}: admissible evidence must request status fold-in"
+                )
+            if not artifact_path_valid:
+                errors.append(
+                    f"{candidate_id}: admissible evidence requires valid source_artifact.path"
                 )
             if not _is_sha256(sha256):
                 errors.append(

--- a/tests/fixtures/evidence_fold_in_admissibility_v0/builder_admissible_input.json
+++ b/tests/fixtures/evidence_fold_in_admissibility_v0/builder_admissible_input.json
@@ -1,0 +1,24 @@
+{
+  "candidates": [
+    {
+      "candidate_id": "hpc-detector-summary",
+      "source_surface_type": "hpc_evidence_bundle",
+      "source_authority_status": "diagnostic_non_normative",
+      "evidence_role": "hpc_evidence",
+      "source_artifact": {
+        "path": "hpc/artifacts/detector_summary.json",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "schema_path": "schemas/hpc_evidence_bundle_v0.schema.json",
+      "schema_valid": true,
+      "digest_valid": true,
+      "verification_status": "verified",
+      "folded_into_status_requested": true,
+      "policy_route": {
+        "policy_path": "pulse_gate_policy_v0.yml",
+        "gate_id": "external_all_pass"
+      }
+    }
+  ],
+  "notes": "Builder input for admissible fold-in evidence."
+}

--- a/tests/fixtures/evidence_fold_in_admissibility_v0/builder_mixed_input.json
+++ b/tests/fixtures/evidence_fold_in_admissibility_v0/builder_mixed_input.json
@@ -1,0 +1,59 @@
+{
+  "candidates": [
+    {
+      "candidate_id": "hpc-detector-summary",
+      "source_surface_type": "hpc_evidence_bundle",
+      "source_authority_status": "diagnostic_non_normative",
+      "evidence_role": "hpc_evidence",
+      "source_artifact": {
+        "path": "hpc/artifacts/detector_summary.json",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "schema_path": "schemas/hpc_evidence_bundle_v0.schema.json",
+      "schema_valid": true,
+      "digest_valid": true,
+      "verification_status": "verified",
+      "folded_into_status_requested": true,
+      "policy_route": {
+        "policy_path": "pulse_gate_policy_v0.yml",
+        "gate_id": "external_all_pass"
+      }
+    },
+    {
+      "candidate_id": "pulse-pd-summary",
+      "source_surface_type": "pulse_pd_artifact",
+      "source_authority_status": "diagnostic_non_normative",
+      "evidence_role": "analysis_evidence",
+      "source_artifact": {
+        "path": "pulse_pd/artifacts/pd_summary.json",
+        "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      },
+      "schema_path": null,
+      "schema_valid": false,
+      "digest_valid": true,
+      "verification_status": "not_applicable",
+      "folded_into_status_requested": false,
+      "policy_route": null
+    },
+    {
+      "candidate_id": "readme-title",
+      "source_surface_type": "recognition_surface",
+      "source_authority_status": "recognition_non_normative",
+      "evidence_role": "recognition_diagnostic",
+      "source_artifact": {
+        "path": "README.md",
+        "sha256": null
+      },
+      "schema_path": null,
+      "schema_valid": false,
+      "digest_valid": false,
+      "verification_status": "not_applicable",
+      "folded_into_status_requested": true,
+      "policy_route": {
+        "policy_path": "pulse_gate_policy_v0.yml",
+        "gate_id": "external_all_pass"
+      }
+    }
+  ],
+  "notes": "Builder input with admissible, advisory-only, and rejected candidates."
+}

--- a/tests/test_build_evidence_fold_in_admissibility_v0.py
+++ b/tests/test_build_evidence_fold_in_admissibility_v0.py
@@ -168,12 +168,38 @@ def test_recognition_surface_fold_in_request_is_rejected() -> None:
     assert recognition["folded_into_status_requested"] is False
     assert "Recognition surfaces are not admissible" in recognition["reason"]
 
+def test_builder_rejects_fold_in_request_without_source_artifact_path() -> None:
+    payload = _read(ADMISSIBLE_INPUT)
+    payload["candidates"][0]["source_artifact"].pop("path", None)
+
+    with tempfile.TemporaryDirectory() as td:
+        input_path = Path(td) / "input.json"
+        out_path = Path(td) / "evidence_fold_in_admissibility_v0.json"
+        _write(input_path, payload)
+
+        result = _run_builder(input_path, out_path)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+
+        check = _run_checker(out_path)
+        assert check.returncode == 0, check.stderr + check.stdout
+
+        artifact = _read(out_path)
+
+    candidate = artifact["candidates"][0]
+    assert artifact["result"] == "rejected"
+    assert candidate["admissibility"] == "rejected"
+    assert candidate["folded_into_status_requested"] is False
+    assert candidate["source_artifact"]["path"] == "_missing_source_artifact_path"
+    assert "source_artifact.path" in candidate["reason"]
+
 
 def main() -> int:
     try:
         test_builder_outputs_admissible_valid_artifact()
         test_builder_outputs_mixed_valid_artifact()
         test_builder_rejects_input_without_candidates()
+        test_builder_rejects_fold_in_request_without_source_artifact_path()
         test_builder_rejects_fold_in_request_without_policy_route()
         test_recognition_surface_fold_in_request_is_rejected()
     except AssertionError as exc:

--- a/tests/test_build_evidence_fold_in_admissibility_v0.py
+++ b/tests/test_build_evidence_fold_in_admissibility_v0.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Smoke tests for build_evidence_fold_in_admissibility_v0.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER = ROOT / "scripts" / "build_evidence_fold_in_admissibility_v0.py"
+CHECKER = ROOT / "scripts" / "check_evidence_fold_in_admissibility_v0_contract.py"
+
+FIXTURE_DIR = ROOT / "tests" / "fixtures" / "evidence_fold_in_admissibility_v0"
+ADMISSIBLE_INPUT = FIXTURE_DIR / "builder_admissible_input.json"
+MIXED_INPUT = FIXTURE_DIR / "builder_mixed_input.json"
+
+
+def _read(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _run_builder(input_path: Path, out_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(BUILDER),
+            "--input",
+            str(input_path),
+            "--out",
+            str(out_path),
+        ],
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _run_checker(out_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--in",
+            str(out_path),
+        ],
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_builder_outputs_admissible_valid_artifact() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        out_path = Path(td) / "evidence_fold_in_admissibility_v0.json"
+
+        result = _run_builder(ADMISSIBLE_INPUT, out_path)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+
+        check = _run_checker(out_path)
+        assert check.returncode == 0, check.stderr + check.stdout
+
+        artifact = _read(out_path)
+        assert artifact["schema"] == "evidence_fold_in_admissibility_v0"
+        assert artifact["authority_status"] == "diagnostic_non_normative"
+        assert artifact["creates_release_authority"] is False
+        assert artifact["result"] == "admissible"
+
+        candidate = artifact["candidates"][0]
+        assert candidate["admissibility"] == "admissible_for_fold_in"
+        assert candidate["folded_into_status_requested"] is True
+        assert candidate["policy_route"]["gate_id"] == "external_all_pass"
+
+
+def test_builder_outputs_mixed_valid_artifact() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        out_path = Path(td) / "evidence_fold_in_admissibility_v0.json"
+
+        result = _run_builder(MIXED_INPUT, out_path)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+
+        check = _run_checker(out_path)
+        assert check.returncode == 0, check.stderr + check.stdout
+
+        artifact = _read(out_path)
+        assert artifact["schema"] == "evidence_fold_in_admissibility_v0"
+        assert artifact["authority_status"] == "diagnostic_non_normative"
+        assert artifact["creates_release_authority"] is False
+        assert artifact["result"] == "mixed"
+
+        admissibilities = {
+            candidate["candidate_id"]: candidate["admissibility"]
+            for candidate in artifact["candidates"]
+        }
+
+        assert admissibilities["hpc-detector-summary"] == "admissible_for_fold_in"
+        assert admissibilities["pulse-pd-summary"] == "advisory_only"
+        assert admissibilities["readme-title"] == "rejected"
+
+
+def test_builder_rejects_input_without_candidates() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        input_path = Path(td) / "bad_input.json"
+        out_path = Path(td) / "evidence_fold_in_admissibility_v0.json"
+
+        _write(input_path, {"candidates": []})
+
+        result = _run_builder(input_path, out_path)
+
+    assert result.returncode == 1
+    assert "candidates" in (result.stderr + result.stdout)
+
+
+def test_builder_rejects_fold_in_request_without_policy_route() -> None:
+    payload = _read(ADMISSIBLE_INPUT)
+    payload["candidates"][0]["policy_route"] = None
+
+    with tempfile.TemporaryDirectory() as td:
+        input_path = Path(td) / "input.json"
+        out_path = Path(td) / "evidence_fold_in_admissibility_v0.json"
+        _write(input_path, payload)
+
+        result = _run_builder(input_path, out_path)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+
+        check = _run_checker(out_path)
+        assert check.returncode == 0, check.stderr + check.stdout
+
+        artifact = _read(out_path)
+
+    assert artifact["result"] == "rejected"
+    assert artifact["candidates"][0]["admissibility"] == "rejected"
+    assert artifact["candidates"][0]["folded_into_status_requested"] is False
+    assert "policy_route" in artifact["candidates"][0]["reason"]
+
+
+def test_recognition_surface_fold_in_request_is_rejected() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        out_path = Path(td) / "evidence_fold_in_admissibility_v0.json"
+
+        result = _run_builder(MIXED_INPUT, out_path)
+        assert result.returncode == 0, result.stderr + result.stdout
+
+        artifact = _read(out_path)
+        recognition = next(
+            candidate
+            for candidate in artifact["candidates"]
+            if candidate["candidate_id"] == "readme-title"
+        )
+
+    assert recognition["admissibility"] == "rejected"
+    assert recognition["folded_into_status_requested"] is False
+    assert "Recognition surfaces are not admissible" in recognition["reason"]
+
+
+def main() -> int:
+    try:
+        test_builder_outputs_admissible_valid_artifact()
+        test_builder_outputs_mixed_valid_artifact()
+        test_builder_rejects_input_without_candidates()
+        test_builder_rejects_fold_in_request_without_policy_route()
+        test_recognition_surface_fold_in_request_is_rejected()
+    except AssertionError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    print("OK: build_evidence_fold_in_admissibility_v0 smoke passed")
+    return 0
+
+
+def test_smoke() -> None:
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_evidence_fold_in_admissibility_v0_contract.py
+++ b/tests/test_evidence_fold_in_admissibility_v0_contract.py
@@ -126,6 +126,19 @@ def test_result_must_match_candidate_admissibility_mix() -> None:
     assert "result must be" in (result.stderr + result.stdout)
 
 
+def test_admissible_candidate_requires_real_source_artifact_path() -> None:
+    payload = _read(ADMISSIBLE)
+    payload["candidates"][0]["source_artifact"]["path"] = "_missing_source_artifact_path"
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "bad.json"
+        _write(path, payload)
+        result = _run(path)
+
+    assert result.returncode == 1
+    assert "source_artifact.path" in (result.stderr + result.stdout)
+
+
 def main() -> int:
     try:
         test_admissible_fixture_is_valid()
@@ -135,6 +148,7 @@ def main() -> int:
         test_admissible_candidate_requires_verified_status()
         test_advisory_only_candidate_must_not_request_fold_in()
         test_recognition_surface_cannot_be_admissible_for_fold_in()
+        test_admissible_candidate_requires_real_source_artifact_path()
         test_result_must_match_candidate_admissibility_mix()
     except AssertionError as exc:
         print(f"ERROR: {exc}")


### PR DESCRIPTION
## Summary

This PR adds an on-demand builder for `evidence_fold_in_admissibility_v0` diagnostic artifacts.

The previous contract defines the admissibility boundary between non-normative field points and recorded release evidence.

This PR adds a builder that materializes that diagnostic artifact from structured candidate input.

## Mechanical purpose

The builder classifies each candidate as:

- `admissible_for_fold_in`;
- `advisory_only`;
- `rejected`.

It evaluates each candidate using:

- source surface type;
- source authority status;
- evidence role;
- source artifact path and digest;
- schema validity;
- digest validity;
- verification status;
- fold-in request state;
- policy route.

Core rule:

`unsupported fold-in state → no recorded release evidence`

## Builder behavior

Expected behavior:

- fully verified, schema-valid, digest-valid, policy-routed evidence requesting fold-in becomes `admissible_for_fold_in`;
- diagnostic evidence without fold-in request remains `advisory_only`;
- recognition surfaces are rejected for release-evidence fold-in by themselves;
- fold-in requests without complete policy routes are rejected;
- output artifacts always set `creates_release_authority=false`.

## Added artifacts

Changed:

- `scripts/build_evidence_fold_in_admissibility_v0.py`
- `tests/fixtures/evidence_fold_in_admissibility_v0/builder_admissible_input.json`
- `tests/fixtures/evidence_fold_in_admissibility_v0/builder_mixed_input.json`
- `tests/test_build_evidence_fold_in_admissibility_v0.py`
- `ci/tools-tests.list`

## Authority boundary

This is diagnostic only.

The builder does not fold evidence into `status.json`.

It does not authorize, block, override, or create release authority.

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Scope

Not changed:

- README
- workflows
- release policy
- gate registry
- `check_gates.py`
- status schemas
- release gates
- RA1 verifier
- primary CI release-decision semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Expected validation:

- `python -m py_compile scripts/build_evidence_fold_in_admissibility_v0.py tests/test_build_evidence_fold_in_admissibility_v0.py`
- `python tests/test_build_evidence_fold_in_admissibility_v0.py`
- `python -m pytest -q tests/test_build_evidence_fold_in_admissibility_v0.py tests/test_evidence_fold_in_admissibility_v0_contract.py`

Expected results:

- admissible input produces an admissible valid artifact;
- mixed input produces a mixed valid artifact;
- empty candidate input fails the builder;
- fold-in request without `policy_route` becomes rejected;
- recognition surface fold-in request becomes rejected;
- generated artifacts pass the existing contract checker.