### PR TITLE
docs(pulse-compute): refine compute-admission research note

### DIFF
--- a/docs/PULSE_COMPUTE_ADMISSION_v0.md
+++ b/docs/PULSE_COMPUTE_ADMISSION_v0.md
@@ -8,7 +8,9 @@ Primary role: preserve a future development thread for compute-admission mechani
 
 This document preserves a PULSE development thread around pre-compute admission.
 
-The idea is not to replace PULSE release authority, and not to redefine the current PULSEmech release-decision path. The purpose is to record a possible future extension: using PULSE-style evidence, policy, gate materialization, and fail-closed logic before high-cost AI execution is allowed to consume compute.
+The idea is not to replace PULSE release authority, and not to redefine the current PULSEmech release-decision path.
+
+The purpose is to record a possible future direction: using PULSE-style evidence, declared policy, gate materialization, and fail-closed logic before high-cost AI execution is allowed to consume compute.
 
 The core question is:
 
@@ -16,15 +18,19 @@ When is a request, candidate state, or execution plan justified to consume high-
 
 ## Current PULSE identity remains unchanged
 
-PULSE remains an artifact-first release-governance / release-authority system for AI applications.
+PULSE remains artifact-bound release authority for AI release decisions.
+
+AI release decisions are made from recorded evidence, declared policy, materialized required gate set, and fail-closed CI enforcement.
+
+PULSEmech converts recorded release evidence into deterministic, fail-closed CI allow/block release decisions before deployment under declared policy.
 
 The current PULSEmech decision path remains:
 
-(recorded release evidence,
- status.json,
- declared gate policy,
- materialized required gate set,
- strict fail-closed CI checking)
+(recorded release evidence,  
+ status.json,  
+ declared gate policy,  
+ materialized required gate set,  
+ strict fail-closed CI checking)  
 → CI allow/block release decision
 
 PULSE-COMPUTE does not change this release-authority identity.
@@ -33,7 +39,9 @@ PULSE-COMPUTE does not change this release-authority identity.
 
 This note is not a final mechanism.
 
-In this workshop, no development direction is treated as permanently fixed. A statement, structure, or mechanism is valid only until a better, more precise, more mechanically sound version replaces it.
+It preserves an open development direction. No research direction, phrase, structure, or mechanism in this note is treated as permanently fixed.
+
+A mechanism remains useful only while it is the most mechanically precise available version. If a better version appears, the better version should replace it.
 
 The purpose of this document is therefore not to close the idea, but to preserve it without forcing it prematurely into the normative release-authority core.
 
@@ -46,10 +54,18 @@ More compute can help, but linear accumulation of compute does not automatically
 The relevant mechanical shift is:
 
 from:
-more requests → more model runs → more GPU use
+
+more requests  
+→ more model runs  
+→ more GPU use
 
 to:
-request state → evidence state → declared policy → required compute gates → model / review / execution path
+
+request state  
+→ evidence state  
+→ declared policy  
+→ required compute gates  
+→ model / review / execution path
 
 The goal is not to replace GPUs.
 
@@ -69,18 +85,18 @@ It would determine, before high-cost AI execution:
 
 A possible future decision path:
 
-request / candidate state
-→ evidence state
-→ declared compute policy
-→ materialized compute gate set
-→ required model capacity / review depth / execution path
+request / candidate state  
+→ evidence state  
+→ declared compute policy  
+→ materialized compute gate set  
+→ required model capacity / review depth / execution path  
 → allow / block / escalate / route
 
 ## Not a compute router
 
 PULSE-COMPUTE should not be reduced to ordinary model routing.
 
-A model router typically optimizes cost, latency, or model selection.
+A model router typically optimizes cost, latency, model choice, or throughput.
 
 PULSE-COMPUTE would instead ask a release-authority-style question before compute is consumed:
 
@@ -117,6 +133,10 @@ High-cost compute may be authorized only when:
 - all required compute gates are literal boolean `true`,
 - the declared compute policy permits the selected execution path.
 
+Any future implementation should treat non-literal truth values as non-PASS.
+
+For required compute gates, only literal boolean `true` should count as PASS. Missing, false, null, string, number, inferred, fallback, or unknown values must not authorize high-cost compute.
+
 ## DEGRADED is never authorizing
 
 `DEGRADED` must not be a decision verdict.
@@ -129,10 +149,12 @@ For PULSE-COMPUTE, `DEGRADED` means that the artifact, input state, evidence sta
 
 The state:
 
-verdict: ALLOW
-diagnostic_state: DEGRADED
+- `verdict: ALLOW`
+- `diagnostic_state: DEGRADED`
 
 should be treated as invalid or fail-closed.
+
+A degraded artifact may help explain why a decision cannot be authorized, but it must not become an authorization path.
 
 ## ROUTE is not a bypass
 
@@ -142,19 +164,39 @@ should be treated as invalid or fail-closed.
 
 A routed execution path must still be policy-declared.
 
+Routing must not silently convert missing evidence, degraded state, or insufficient review into authorization.
+
+The original high-cost execution remains unauthorized unless a declared policy, required compute gate set, and valid artifact state explicitly authorize it.
+
+## ESCALATE is not ALLOW
+
+`ESCALATE` means the current artifact state is insufficient for an allow decision and requires deeper review, stronger evidence, higher-capacity evaluation, human review, or another declared escalation path.
+
+`ESCALATE` does not authorize the requested high-cost execution.
+
+A future implementation should make the escalation target explicit.
+
+Examples:
+
+- escalate to human review,
+- escalate to stronger evidence collection,
+- escalate to a higher-assurance validation path,
+- escalate to a more capable model for evaluation only,
+- escalate to block if required evidence cannot be produced.
+
 ## Relationship to PULSEmech
 
-PULSE-COMPUTE is a possible extension of PULSEmech logic from release authorization to compute admission.
+PULSE-COMPUTE is a possible extension of PULSEmech-style mechanics from release authorization toward compute admission.
 
 Release authority asks:
 
-Is this candidate release authorized under recorded evidence, declared policy, materialized gates, and fail-closed CI checking?
+Is this candidate release authorized under recorded evidence, declared policy, materialized required gates, and fail-closed CI checking?
 
 Compute admission asks:
 
 Is this candidate execution authorized to consume this level of compute under recorded evidence, declared compute policy, materialized compute gates, and fail-closed checking?
 
-The mechanics are related, but the authority surfaces must remain separate unless a future policy explicitly connects them.
+The mechanics are related, but the authority surfaces must remain separate unless a future declared policy explicitly connects them.
 
 ## Non-normative boundary
 
@@ -162,39 +204,53 @@ This document does not define release authority.
 
 It does not change `status.json`.
 
+It does not change declared gate policy.
+
+It does not change materialized required gate sets.
+
 It does not change `check_gates.py`.
 
 It does not change CI release decisions.
 
 It does not add a new normative gate.
 
+It does not create a new release-authority surface.
+
 It preserves a development direction for future implementation.
 
-## Future implementation sketch
+This document is a preservation note, not an implementation contract.
 
-A future implementation may add:
+Any future implementation must introduce its own schema, checker, fixture matrix, and explicit non-interference proof before it can be treated as a contracted shadow surface.
 
-- `schemas/compute_admission_v0.schema.json`
-- `PULSE_safe_pack_v0/tools/check_compute_admission_v0_contract.py`
-- `tests/fixtures/compute_admission_v0/`
-- `tests/test_check_compute_admission_v0_contract.py`
-- optional shadow registry entry with `normative: false`
+A future implementation should test at least the following cases:
 
-The first implementation should remain shadow-only unless explicitly promoted by declared policy.
+- low-risk request allowed on a lower-cost path,
+- cached or small-model route under declared policy,
+- uncertain high-value request escalated rather than allowed,
+- missing required evidence blocked,
+- high-cost execution blocked without required review depth,
+- degraded artifact state treated as non-authorizing,
+- `ALLOW` with `diagnostic_state: DEGRADED` treated as invalid or fail-closed,
+- non-literal truth values rejected for required compute gates.
 
 ## Working sentence
 
-PULSE-COMPUTE extends PULSEmech from release authorization toward compute admission: before high-cost AI execution, it can determine the required evidence, model capacity, review depth, and execution path under declared policy, then allow, block, escalate, or route fail-closed.
+PULSE-COMPUTE preserves a possible extension of PULSEmech from release authorization toward compute admission: before high-cost AI execution, it can determine the required evidence, model capacity, review depth, and execution path under declared policy, then allow, block, escalate, or route fail-closed.
 
-## Short Hungarian summary
+## Short summary
 
-A PULSE-COMPUTE nem a GPU-k kiváltása.
+PULSE-COMPUTE does not replace GPUs.
 
-A PULSE-COMPUTE célja annak vizsgálata, hogy a nagy költségű AI-futtatás előtt megállapítható-e: milyen bizonyíték, modellkapacitás, ellenőrzési mélység és futtatási út indokolt.
+PULSE-COMPUTE preserves a possible future shadow-only direction for determining, before high-cost AI execution, what evidence, model capacity, review depth, and execution path are justified under declared policy.
 
-A lényeg:
+The core principle is:
 
-nem minden kéréshez teljes gép kell,
-hanem jogosult, elégséges és policy által engedett számítási út.
+not every request requires full-machine execution; compute should follow an authorized, sufficient, and policy-declared execution path.
 
-Ez a dokumentum csak rögzíti az irányt, hogy később vissza lehessen térni rá.
+`DEGRADED` is not an authorizing verdict. It is a diagnostic state only.
+
+`ROUTE` is not a bypass. It is a declared alternative execution path.
+
+`ESCALATE` is not authorization. It means the current state is insufficient for an allow decision and requires deeper review, stronger evidence, higher-assurance validation, human review, or another declared escalation path.
+
+This document preserves the direction for future work without changing the current PULSE release-authority core.


### PR DESCRIPTION
## Summary

Refines `docs/PULSE_COMPUTE_ADMISSION_v0.md` to preserve the PULSE-COMPUTE pre-compute admission direction more precisely.

The note now aligns with the current PULSE identity:

- PULSE is artifact-bound release authority for AI release decisions.
- AI release decisions are made from recorded evidence, declared policy, materialized required gate set, and fail-closed CI enforcement.
- PULSEmech converts recorded release evidence into deterministic, fail-closed CI allow/block release decisions before deployment under declared policy.

This remains a non-normative research / preservation note. It does not implement compute admission and does not change the PULSE release-authority core.

## Scope

Updates:

- `docs/PULSE_COMPUTE_ADMISSION_v0.md`

## What changed

This update:

- replaces older identity wording with the current artifact-bound release-authority identity
- improves Markdown structure and readability
- clarifies that the document is a preservation note, not an implementation contract
- keeps PULSE-COMPUTE as a future shadow-only / research direction
- separates decision verdicts from diagnostic states
- defines `DEGRADED` as diagnostic-only and never authorizing
- clarifies that `ROUTE` is not a bypass
- clarifies that `ESCALATE` is not `ALLOW`
- preserves strict fail-closed semantics for any future required compute gates

## Authority boundary

This PR does not redefine PULSE.

The current PULSE release-authority identity remains unchanged:

- recorded release evidence
- `status.json`
- declared gate policy
- materialized required gate set
- strict fail-closed CI checking
- CI allow/block release decision before deployment

This PR does not modify:

- `status.json`
- declared gate policy
- materialized required gate sets
- `check_gates.py`
- CI release decisions
- required release gates
- any normative release-authority surface

## PULSE-COMPUTE boundary

PULSE-COMPUTE is preserved here as a possible future extension of PULSEmech-style mechanics from release authorization toward compute admission.

The note asks:

> When is a request, candidate state, or execution plan justified to consume high-cost AI compute under declared policy?

This is not ordinary model routing.

Routing may optimize cost, latency, model choice, or throughput. PULSE-COMPUTE instead asks whether a request state is authorized to consume a given level of compute under declared policy and recorded evidence.

## Decision and diagnostic semantics

The note keeps decision verdicts separate from diagnostic states.

Candidate decision verdicts:

- `ALLOW`
- `BLOCK`
- `ESCALATE`
- `ROUTE`

Candidate diagnostic states:

- `OK`
- `DEGRADED`
- `INVALID_INPUT`
- `INCOMPLETE_EVIDENCE`

Diagnostic states are non-authorizing.

High-cost compute may be authorized only when:

- the decision verdict is `ALLOW`
- the diagnostic state is `OK`
- all required compute gates are literal boolean `true`
- the declared compute policy permits the selected execution path

## DEGRADED boundary

`DEGRADED` is not a decision verdict.

For PULSE-COMPUTE, `DEGRADED` means that the artifact, input state, evidence state, validation path, or execution context is impaired, incomplete, inconsistent, or partially unavailable.

`DEGRADED` is diagnostic-only and never authorizes high-cost compute.

The state:

- `verdict: ALLOW`
- `diagnostic_state: DEGRADED`

should be treated as invalid or fail-closed in any future implementation.

## ROUTE and ESCALATE boundaries

`ROUTE` must not become a hidden authorization path.

A routed execution path must still be policy-declared, and routing must not silently convert missing evidence, degraded state, or insufficient review into authorization.

`ESCALATE` is also not an allow decision. It means the current artifact state is insufficient for authorization and requires deeper review, stronger evidence, higher-capacity evaluation, human review, or another declared escalation path.

## Future implementation boundary

This document is not an implementation contract.

Any future implementation must introduce its own:

- schema
- checker
- fixture matrix
- explicit non-interference proof

before it can be treated as a contracted shadow surface.

## Testing

Not run.

Documentation-only change.