### PR TITLE
docs: align Zenodo metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
-  "title": "PULSE: Deterministic Release Gates for Safe & Useful AI",
-  "description": "PULSE is an artifact-bound release-authority mechanism for AI release decisions. Recorded release evidence is evaluated through status.json, declared gate policy, materialized required gates, and strict fail-closed CI checking to produce a deterministic CI allow/block release decision before deployment.",
+  "title": "PULSE: Artifact-Bound Release Authority for AI Release Decisions",
+  "description": "PULSE is an artifact-bound release-authority system for AI release decisions. It structures recorded safety, quality, detector, stability, CI, and review evidence into deterministic, fail-closed CI allow/block release decisions under declared policy. Release authority is bound to recorded evidence, status.json, declared gate policy, a materialized required gate set, and strict fail-closed CI enforcement.",
   "upload_type": "software",
   "language": "eng",
   "license": "Apache-2.0",
@@ -30,7 +30,9 @@
     "quality-ledger",
     "rdsi",
     "auditability",
-    "reproducibility"
+    "reproducibility",
+    "hpc-evidence",
+    "recognition-surface-drift"
   ],
   "related_identifiers": [
     {


### PR DESCRIPTION
## Summary

This PR aligns `.zenodo.json` with the current PULSE artifact-bound release-authority identity.

Zenodo uses `.zenodo.json` as the metadata source for GitHub release archiving when both `.zenodo.json` and `CITATION.cff` are present, so this is the primary Zenodo-facing metadata surface.

## Mechanical change

The Zenodo metadata title is updated from the older deterministic release-gates framing to:

`PULSE: Artifact-Bound Release Authority for AI Release Decisions`

The description now matches the current PULSE A-B identity:

recorded evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI enforcement
→ CI allow/block release decision

The Concept DOI / all versions remains referenced as:

`10.5281/zenodo.17214908`

## Scope

Changed:

- `.zenodo.json`

Not changed:

- README
- CITATION.cff
- workflows
- Pages
- release policy
- gate registry
- status schemas
- release gates
- CI release-decision semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics

## Validation

Expected:

- `.zenodo.json` parses with `python -m json.tool`;
- Zenodo-facing metadata reflects Artifact-Bound Release Authority;
- no release-authority semantics change.