### PR TITLE
fix(zenodo): restore legacy repository badge crawler surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Required gates are explicit, materialized, and checked before release effects ca
 
 [![DOI](https://doi.org/badge/DOI/10.5281/zenodo.17373002.svg)](https://doi.org/10.5281/zenodo.17373002)
 
+[![DOI](https://zenodo.org/badge/1061766508.svg)](https://zenodo.org/badge/latestdoi/1061766508)
 ---
 
 <details>

--- a/tests/test_readme_doi_badge_contract.py
+++ b/tests/test_readme_doi_badge_contract.py
@@ -26,8 +26,11 @@ ACCIDENTAL_CURRENT_RELEASE_RECORD = (
     "- **Current release DOI / v1.1.1:** "
     "https://doi.org/10.5281/zenodo.18203404"
 )
-ACCIDENTAL_LATEST_DOI_ROUTE = "https://zenodo.org/badge/latestdoi/1061766508"
-ACCIDENTAL_REPOSITORY_BADGE = "https://zenodo.org/badge/1061766508.svg"
+LEGACY_REPOSITORY_LATESTDOI_ROUTE = "https://zenodo.org/badge/latestdoi/1061766508"
+LEGACY_REPOSITORY_BADGE = "https://zenodo.org/badge/1061766508.svg"
+LEGACY_REPOSITORY_MARKDOWN_BADGE = (
+    f"[![DOI]({LEGACY_REPOSITORY_BADGE})]({LEGACY_REPOSITORY_LATESTDOI_ROUTE})"
+)
 
 
 def _read(path: Path) -> str:
@@ -49,12 +52,18 @@ def test_readme_zenodo_records_match_april_known_good_release_identity() -> None
     assert PREPRINT_RECORD in text
 
 
-def test_readme_does_not_use_accidental_current_release_or_latestdoi_route() -> None:
+def test_readme_blocks_accidental_current_release_but_preserves_legacy_repository_badge_surface() -> None:
     text = _read(README)
 
     assert ACCIDENTAL_CURRENT_RELEASE_RECORD not in text
-    assert ACCIDENTAL_LATEST_DOI_ROUTE not in text
-    assert ACCIDENTAL_REPOSITORY_BADGE not in text
+    assert LEGACY_REPOSITORY_MARKDOWN_BADGE in text
+
+
+def test_readme_exposes_legacy_repository_badge_routes_for_crawlers() -> None:
+    text = _read(README)
+
+    assert LEGACY_REPOSITORY_BADGE in text
+    assert LEGACY_REPOSITORY_LATESTDOI_ROUTE in text
 
 
 def test_docs_index_doi_badge_uses_versioned_release_doi() -> None:
@@ -64,8 +73,8 @@ def test_docs_index_doi_badge_uses_versioned_release_doi() -> None:
     assert VERSIONED_RELEASE_BADGE in text
 
 
-def test_docs_index_does_not_use_accidental_latestdoi_route() -> None:
+def test_docs_index_does_not_use_legacy_repository_badge_routes() -> None:
     text = _read(DOCS_INDEX)
 
-    assert ACCIDENTAL_LATEST_DOI_ROUTE not in text
-    assert ACCIDENTAL_REPOSITORY_BADGE not in text
+    assert LEGACY_REPOSITORY_LATESTDOI_ROUTE not in text
+    assert LEGACY_REPOSITORY_BADGE not in text


### PR DESCRIPTION
## Motivation

Restore the legacy Zenodo repository badge route family as a durable public
crawler/indexing surface, while keeping the canonical versioned DOI badge
contract intact for release identity.

## What changed

- Re-added the legacy Zenodo repository badge markdown to `README.md`:
  - `https://zenodo.org/badge/1061766508.svg`
  - `https://zenodo.org/badge/latestdoi/1061766508`
- Updated `tests/test_readme_doi_badge_contract.py` so these routes are no
  longer treated as forbidden in README contract checks.
- Added/updated assertions so the legacy repository badge route is preserved
  as an explicit README surface for crawlers/indexers.
- Kept `docs/index.html` constraints unchanged regarding legacy route usage.

## Contract/scope guarantees

No changes to:
- PULSE identity
- README technical description
- `status.json`
- gate policy
- CI release mechanics
- robots/sitemap
- `CITATION.cff`
- Kaggle DOI links
- Zenodo concept/version DOI contract

## Validation

- `rg -n "zenodo.org/badge|latestdoi|1061766508|doi.org/badge" README.md tests .github docs`
- `pytest -q tests/test_readme_doi_badge_contract.py`
- `git status --short`