### PR TITLE
feat: add field-point authority map contract

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -59,6 +59,7 @@ tests/test_analysis_dependency_manifest.py
 tests/test_pulse_pd_toy_generator_no_numpy.py
 tests/test_hpc_evidence_bundle_v0_contract.py
 tests/test_evidence_fold_in_admissibility_v0_contract.py
+tests/test_field_point_authority_map_v0_contract.py
 
 tools/operator_handoff_smoke.py
 

--- a/docs/PULSE_FIELD_POINT_AUTHORITY_MAP_v0.md
+++ b/docs/PULSE_FIELD_POINT_AUTHORITY_MAP_v0.md
@@ -1,0 +1,102 @@
+# PULSE Field-Point Authority Map v0
+
+Status: diagnostic authority-role contract  
+Scope: PULSE field-instrument interpretation / field-point authority roles  
+Authority status: non-normative explanatory and diagnostic surface
+
+## Core statement
+
+PULSE is a field instrument.
+
+Every PULSE element belongs to the field by role and authority status, not by architectural distance.
+
+There is no center-and-margin hierarchy here.
+
+There is a field, and each element matters by role, authority status, and relation to the normative materialization path.
+
+## Purpose
+
+The field-point authority map records how PULSE surfaces participate in the evidence-decision field.
+
+It prevents publication, recognition, diagnostic, audit, or optional analysis surfaces from being misread as release-authority engines.
+
+## Normative materialization path
+
+Release authority materializes only along the declared normative path:
+
+recorded release evidence  
+→ `status.json`  
+→ declared gate policy  
+→ materialized required gate set  
+→ strict fail-closed CI checking  
+→ CI allow/block release decision
+
+## Field-point rule
+
+Every field-point claim requires authority-role classification.
+
+A field point must declare whether it is:
+
+- part of the normative materialization path;
+- a normative input;
+- normative enforcement;
+- a diagnostic surface;
+- an audit / reconstruction surface;
+- a publication / reader surface;
+- a recognition surface;
+- an optional analysis surface;
+- a future / proposed surface.
+
+## Non-normative surfaces
+
+Non-normative surfaces may observe, explain, preserve, publish, diagnose, or orient attention.
+
+They must not authorize, block, override, or create release authority unless their outputs are explicitly routed through declared policy and enforced as required gates.
+
+Examples of non-normative field points include:
+
+- Quality Ledger;
+- release authority manifest;
+- audit bundle;
+- dashboards;
+- Pages;
+- badges;
+- DOI records;
+- README / About text;
+- recognition-surface diagnostics;
+- HPC evidence bundles;
+- PULSE-PD artifacts;
+- diagnostic overlays.
+
+## Recognition rule
+
+Recognition surfaces are not authority.
+
+A title, badge, DOI record, README, About text, social preview, or publication page may orient attention.
+
+It must not define release authority.
+
+Every recognition claim requires mechanical evidence.
+
+## Fold-in rule
+
+A diagnostic field point may become candidate evidence only through explicit admissibility and policy routing.
+
+Unsupported fold-in state  
+→ no recorded release evidence
+
+Unsupported evidence state  
+→ no release authority
+
+Unsupported recognition state  
+→ no analytic authority
+
+## Summary
+
+PULSE is not a layered tool.
+
+PULSE is a field instrument.
+
+The decision does not come from a box.
+
+The decision materializes along the normative path of the evidence-decision field.

--- a/schemas/field_point_authority_map_v0.schema.json
+++ b/schemas/field_point_authority_map_v0.schema.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hkati.github.io/pulse-release-gates-0.1/schemas/field_point_authority_map_v0.schema.json",
+  "title": "PULSE Field-Point Authority Map v0",
+  "type": "object",
+  "required": [
+    "schema",
+    "authority_status",
+    "creates_release_authority",
+    "invariant",
+    "normative_materialization_path",
+    "field_points",
+    "result"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema": {
+      "const": "field_point_authority_map_v0"
+    },
+    "authority_status": {
+      "const": "diagnostic_non_normative"
+    },
+    "creates_release_authority": {
+      "const": false
+    },
+    "invariant": {
+      "const": "field_points_must_declare_role_and_authority_status_before_interpretation"
+    },
+    "normative_materialization_path": {
+      "type": "array",
+      "minItems": 5,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "field_points": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "field_point_id",
+          "path_or_label",
+          "surface_type",
+          "authority_status",
+          "field_role",
+          "relation_to_normative_path",
+          "can_affect_release_decision",
+          "creates_release_authority"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "field_point_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "path_or_label": {
+            "type": "string",
+            "minLength": 1
+          },
+          "surface_type": {
+            "enum": [
+              "recorded_release_evidence",
+              "status_artifact",
+              "declared_policy",
+              "materialized_gate_set",
+              "ci_enforcement",
+              "ci_decision",
+              "quality_ledger",
+              "release_authority_manifest",
+              "audit_bundle",
+              "dashboard",
+              "pages",
+              "badge",
+              "doi_record",
+              "citation_metadata",
+              "readme",
+              "about",
+              "diagnostic_contract",
+              "hpc_evidence_bundle",
+              "evidence_fold_in_admissibility",
+              "pulse_pd_artifact",
+              "recognition_surface",
+              "recognition_surface_drift",
+              "optional_analysis_surface",
+              "other"
+            ]
+          },
+          "authority_status": {
+            "enum": [
+              "normative_input",
+              "normative_enforcement",
+              "normative_decision",
+              "diagnostic_non_normative",
+              "audit_non_normative",
+              "publication_non_normative",
+              "recognition_non_normative",
+              "optional_analysis_non_normative",
+              "proposed_non_normative"
+            ]
+          },
+          "field_role": {
+            "type": "string",
+            "minLength": 1
+          },
+          "relation_to_normative_path": {
+            "enum": [
+              "normative_path_member",
+              "candidate_evidence_surface",
+              "diagnostic_observer",
+              "audit_reconstruction",
+              "publication_reader",
+              "recognition_surface",
+              "optional_analysis",
+              "future_proposed"
+            ]
+          },
+          "can_affect_release_decision": {
+            "type": "boolean"
+          },
+          "creates_release_authority": {
+            "const": false
+          },
+          "policy_route": {
+            "type": ["object", "null"],
+            "required": [
+              "policy_path",
+              "gate_id"
+            ],
+            "additionalProperties": true,
+            "properties": {
+              "policy_path": {
+                "type": "string",
+                "minLength": 1
+              },
+              "gate_id": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "notes": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "result": {
+      "enum": [
+        "valid",
+        "invalid"
+      ]
+    },
+    "notes": {
+      "type": "string"
+    }
+  }
+}

--- a/scripts/check_field_point_authority_map_v0_contract.py
+++ b/scripts/check_field_point_authority_map_v0_contract.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Contract checker for field_point_authority_map_v0 artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "schemas" / "field_point_authority_map_v0.schema.json"
+
+
+NORMATIVE_STATUSES = {
+    "normative_input",
+    "normative_enforcement",
+    "normative_decision",
+}
+
+RECOGNITION_SURFACES = {
+    "recognition_surface",
+    "recognition_surface_drift",
+    "readme",
+    "about",
+    "doi_record",
+    "citation_metadata",
+    "badge",
+}
+
+PUBLICATION_SURFACES = {
+    "quality_ledger",
+    "dashboard",
+    "pages",
+    "doi_record",
+    "citation_metadata",
+    "badge",
+}
+
+AUDIT_SURFACES = {
+    "release_authority_manifest",
+    "audit_bundle",
+}
+
+DIAGNOSTIC_SURFACES = {
+    "diagnostic_contract",
+    "hpc_evidence_bundle",
+    "evidence_fold_in_admissibility",
+    "pulse_pd_artifact",
+    "recognition_surface_drift",
+    "optional_analysis_surface",
+}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    obj = json.loads(path.read_text(encoding="utf-8"))
+
+    if not isinstance(obj, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+
+    return obj
+
+
+def _schema_errors(instance: dict[str, Any]) -> list[str]:
+    schema = _load_json(SCHEMA_PATH)
+    Draft202012Validator.check_schema(schema)
+
+    validator = Draft202012Validator(schema)
+    errors = sorted(
+        validator.iter_errors(instance),
+        key=lambda error: list(error.absolute_path),
+    )
+
+    return [
+        f"{list(error.absolute_path)}: {error.message}"
+        for error in errors
+    ]
+
+
+def _has_policy_route(field_point: dict[str, Any]) -> bool:
+    route = field_point.get("policy_route")
+
+    if not isinstance(route, dict):
+        return False
+
+    policy_path = route.get("policy_path")
+    gate_id = route.get("gate_id")
+
+    return (
+        isinstance(policy_path, str)
+        and bool(policy_path.strip())
+        and isinstance(gate_id, str)
+        and bool(gate_id.strip())
+    )
+
+
+def _semantic_errors(instance: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    if instance.get("authority_status") != "diagnostic_non_normative":
+        errors.append("authority_status must be diagnostic_non_normative")
+
+    if instance.get("creates_release_authority") is not False:
+        errors.append("creates_release_authority must be false")
+
+    field_points = instance.get("field_points")
+    if not isinstance(field_points, list):
+        return errors
+
+    path_ids = instance.get("normative_materialization_path")
+    if not isinstance(path_ids, list):
+        return errors
+
+    by_id: dict[str, dict[str, Any]] = {}
+    seen: set[str] = set()
+
+    for index, point in enumerate(field_points):
+        if not isinstance(point, dict):
+            errors.append(f"field_points[{index}] must be an object")
+            continue
+
+        field_point_id = point.get("field_point_id")
+        if not isinstance(field_point_id, str) or not field_point_id:
+            errors.append(f"field_points[{index}].field_point_id must be a non-empty string")
+            continue
+
+        if field_point_id in seen:
+            errors.append(f"duplicate field_point_id: {field_point_id}")
+            continue
+
+        seen.add(field_point_id)
+        by_id[field_point_id] = point
+
+    for field_point_id in path_ids:
+        if not isinstance(field_point_id, str):
+            errors.append("normative_materialization_path entries must be strings")
+            continue
+
+        point = by_id.get(field_point_id)
+        if point is None:
+            errors.append(
+                f"normative_materialization_path references unknown field point: {field_point_id}"
+            )
+            continue
+
+        authority_status = point.get("authority_status")
+        relation = point.get("relation_to_normative_path")
+        can_affect = point.get("can_affect_release_decision")
+
+        if authority_status not in NORMATIVE_STATUSES:
+            errors.append(
+                f"{field_point_id}: normative path member must have normative authority status"
+            )
+
+        if relation != "normative_path_member":
+            errors.append(
+                f"{field_point_id}: normative path member must declare relation_to_normative_path=normative_path_member"
+            )
+
+        if can_affect is not True:
+            errors.append(
+                f"{field_point_id}: normative path member must set can_affect_release_decision=true"
+            )
+
+    for point in field_points:
+        if not isinstance(point, dict):
+            continue
+
+        field_point_id = point.get("field_point_id", "<unknown>")
+        surface_type = point.get("surface_type")
+        authority_status = point.get("authority_status")
+        relation = point.get("relation_to_normative_path")
+        can_affect = point.get("can_affect_release_decision")
+        creates_release_authority = point.get("creates_release_authority")
+        in_normative_path = field_point_id in path_ids
+
+        if creates_release_authority is not False:
+            errors.append(f"{field_point_id}: creates_release_authority must be false")
+
+        if authority_status in NORMATIVE_STATUSES and not in_normative_path:
+            errors.append(
+                f"{field_point_id}: normative authority status is only allowed for normative path members"
+            )
+
+        if relation == "normative_path_member" and not in_normative_path:
+            errors.append(
+                f"{field_point_id}: relation_to_normative_path=normative_path_member requires inclusion in normative_materialization_path"
+            )
+
+        if surface_type in RECOGNITION_SURFACES:
+            if authority_status == "normative_input" or authority_status == "normative_enforcement" or authority_status == "normative_decision":
+                errors.append(
+                    f"{field_point_id}: recognition surfaces must not declare normative authority"
+                )
+            if can_affect is True:
+                errors.append(
+                    f"{field_point_id}: recognition surfaces must not affect release decisions directly"
+                )
+
+        if surface_type in PUBLICATION_SURFACES:
+            if authority_status in NORMATIVE_STATUSES:
+                errors.append(
+                    f"{field_point_id}: publication surfaces must not declare normative authority"
+                )
+            if can_affect is True:
+                errors.append(
+                    f"{field_point_id}: publication surfaces must not affect release decisions directly"
+                )
+
+        if surface_type in AUDIT_SURFACES:
+            if authority_status in NORMATIVE_STATUSES:
+                errors.append(
+                    f"{field_point_id}: audit/reconstruction surfaces must not declare normative authority"
+                )
+            if can_affect is True:
+                errors.append(
+                    f"{field_point_id}: audit/reconstruction surfaces must not affect release decisions directly"
+                )
+
+        if surface_type in DIAGNOSTIC_SURFACES:
+            if authority_status in NORMATIVE_STATUSES:
+                errors.append(
+                    f"{field_point_id}: diagnostic surfaces must not declare normative authority"
+                )
+
+            if can_affect is True and not _has_policy_route(point):
+                errors.append(
+                    f"{field_point_id}: diagnostic surfaces that affect release decisions require explicit policy_route"
+                )
+
+        if can_affect is True and not in_normative_path and not _has_policy_route(point):
+            errors.append(
+                f"{field_point_id}: non-normative field point cannot affect release decisions without policy_route"
+            )
+
+    expected_result = "invalid" if errors else "valid"
+    if instance.get("result") != expected_result:
+        errors.append(
+            f"result must be {expected_result!r} for this field-point map, found {instance.get('result')!r}"
+        )
+
+    return errors
+
+
+def check(path: Path) -> tuple[bool, list[str]]:
+    instance = _load_json(path)
+    errors = _schema_errors(instance)
+    errors.extend(_semantic_errors(instance))
+    return errors == [], errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate a field_point_authority_map_v0 artifact."
+    )
+    parser.add_argument("--in", dest="input_path", required=True)
+    args = parser.parse_args()
+
+    try:
+        ok, errors = check(Path(args.input_path))
+    except Exception as exc:
+        print(f"::error::failed to check field_point_authority_map_v0: {exc}")
+        return 1
+
+    if not ok:
+        print("::error::field_point_authority_map_v0 contract failed")
+        for error in errors:
+            print(f" - {error}")
+        return 1
+
+    print(f"OK: field_point_authority_map_v0 contract valid: {args.input_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/field_point_authority_map_v0/invalid_publication_surface_affects_release.json
+++ b/tests/fixtures/field_point_authority_map_v0/invalid_publication_surface_affects_release.json
@@ -1,0 +1,83 @@
+{
+  "schema": "field_point_authority_map_v0",
+  "authority_status": "diagnostic_non_normative",
+  "creates_release_authority": false,
+  "invariant": "field_points_must_declare_role_and_authority_status_before_interpretation",
+  "normative_materialization_path": [
+    "status-json",
+    "declared-gate-policy",
+    "strict-ci-checking",
+    "ci-allow-block-decision",
+    "recorded-release-evidence"
+  ],
+  "field_points": [
+    {
+      "field_point_id": "recorded-release-evidence",
+      "path_or_label": "recorded release evidence",
+      "surface_type": "recorded_release_evidence",
+      "authority_status": "normative_input",
+      "field_role": "Recorded evidence.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "status-json",
+      "path_or_label": "status.json",
+      "surface_type": "status_artifact",
+      "authority_status": "normative_input",
+      "field_role": "Machine-readable release state artifact.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "declared-gate-policy",
+      "path_or_label": "pulse_gate_policy_v0.yml",
+      "surface_type": "declared_policy",
+      "authority_status": "normative_input",
+      "field_role": "Declared gate policy.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "strict-ci-checking",
+      "path_or_label": "check_gates.py",
+      "surface_type": "ci_enforcement",
+      "authority_status": "normative_enforcement",
+      "field_role": "Strict CI checking.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "ci-allow-block-decision",
+      "path_or_label": "CI allow/block decision",
+      "surface_type": "ci_decision",
+      "authority_status": "normative_decision",
+      "field_role": "CI decision.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "quality-ledger",
+      "path_or_label": "Quality Ledger",
+      "surface_type": "quality_ledger",
+      "authority_status": "publication_non_normative",
+      "field_role": "Invalid: publication surface affects release decision.",
+      "relation_to_normative_path": "publication_reader",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    }
+  ],
+  "result": "invalid",
+  "notes": "Invalid fixture: Quality Ledger must remain reader surface."
+}

--- a/tests/fixtures/field_point_authority_map_v0/invalid_recognition_surface_authority.json
+++ b/tests/fixtures/field_point_authority_map_v0/invalid_recognition_surface_authority.json
@@ -1,0 +1,72 @@
+{
+  "schema": "field_point_authority_map_v0",
+  "authority_status": "diagnostic_non_normative",
+  "creates_release_authority": false,
+  "invariant": "field_points_must_declare_role_and_authority_status_before_interpretation",
+  "normative_materialization_path": [
+    "status-json",
+    "declared-gate-policy",
+    "strict-ci-checking",
+    "ci-allow-block-decision",
+    "readme"
+  ],
+  "field_points": [
+    {
+      "field_point_id": "status-json",
+      "path_or_label": "status.json",
+      "surface_type": "status_artifact",
+      "authority_status": "normative_input",
+      "field_role": "Machine-readable release state artifact.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "declared-gate-policy",
+      "path_or_label": "pulse_gate_policy_v0.yml",
+      "surface_type": "declared_policy",
+      "authority_status": "normative_input",
+      "field_role": "Declared gate policy.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "strict-ci-checking",
+      "path_or_label": "check_gates.py",
+      "surface_type": "ci_enforcement",
+      "authority_status": "normative_enforcement",
+      "field_role": "Strict CI checking.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "ci-allow-block-decision",
+      "path_or_label": "CI allow/block release decision",
+      "surface_type": "ci_decision",
+      "authority_status": "normative_decision",
+      "field_role": "CI decision.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "readme",
+      "path_or_label": "README.md",
+      "surface_type": "readme",
+      "authority_status": "normative_input",
+      "field_role": "Invalid: recognition surface claims normative authority.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    }
+  ],
+  "result": "invalid",
+  "notes": "Invalid fixture: README must not become normative release authority."
+}

--- a/tests/fixtures/field_point_authority_map_v0/pass.json
+++ b/tests/fixtures/field_point_authority_map_v0/pass.json
@@ -1,0 +1,183 @@
+{
+  "schema": "field_point_authority_map_v0",
+  "authority_status": "diagnostic_non_normative",
+  "creates_release_authority": false,
+  "invariant": "field_points_must_declare_role_and_authority_status_before_interpretation",
+  "normative_materialization_path": [
+    "recorded-release-evidence",
+    "status-json",
+    "declared-gate-policy",
+    "materialized-required-gate-set",
+    "strict-ci-checking",
+    "ci-allow-block-decision"
+  ],
+  "field_points": [
+    {
+      "field_point_id": "recorded-release-evidence",
+      "path_or_label": "recorded release evidence",
+      "surface_type": "recorded_release_evidence",
+      "authority_status": "normative_input",
+      "field_role": "Safety, quality, detector, stability, CI, and review evidence recorded before deployment.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "status-json",
+      "path_or_label": "status.json",
+      "surface_type": "status_artifact",
+      "authority_status": "normative_input",
+      "field_role": "Machine-readable release state artifact.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "declared-gate-policy",
+      "path_or_label": "pulse_gate_policy_v0.yml",
+      "surface_type": "declared_policy",
+      "authority_status": "normative_input",
+      "field_role": "Declared gate policy defining required gate sets by release lane.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "materialized-required-gate-set",
+      "path_or_label": "materialized required gate set",
+      "surface_type": "materialized_gate_set",
+      "authority_status": "normative_input",
+      "field_role": "Concrete gate set derived from declared policy.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "strict-ci-checking",
+      "path_or_label": "check_gates.py / CI enforcement",
+      "surface_type": "ci_enforcement",
+      "authority_status": "normative_enforcement",
+      "field_role": "True-only fail-closed enforcement over materialized required gates.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "ci-allow-block-decision",
+      "path_or_label": "CI allow/block release decision",
+      "surface_type": "ci_decision",
+      "authority_status": "normative_decision",
+      "field_role": "Deterministic release decision emitted by CI.",
+      "relation_to_normative_path": "normative_path_member",
+      "can_affect_release_decision": true,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "quality-ledger",
+      "path_or_label": "Quality Ledger",
+      "surface_type": "quality_ledger",
+      "authority_status": "publication_non_normative",
+      "field_role": "Human-readable reader surface for the decision trail.",
+      "relation_to_normative_path": "publication_reader",
+      "can_affect_release_decision": false,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "release-authority-manifest",
+      "path_or_label": "release_authority_v0.json",
+      "surface_type": "release_authority_manifest",
+      "authority_status": "audit_non_normative",
+      "field_role": "Trace surface recording decision-path metadata.",
+      "relation_to_normative_path": "audit_reconstruction",
+      "can_affect_release_decision": false,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "audit-bundle",
+      "path_or_label": "release-authority-audit-bundle",
+      "surface_type": "audit_bundle",
+      "authority_status": "audit_non_normative",
+      "field_role": "Reconstructable evidence trail bundle.",
+      "relation_to_normative_path": "audit_reconstruction",
+      "can_affect_release_decision": false,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "recognition-surface-drift",
+      "path_or_label": "recognition_surface_drift_v0",
+      "surface_type": "recognition_surface_drift",
+      "authority_status": "diagnostic_non_normative",
+      "field_role": "Diagnostic contract for presentation-layer capture / recognition-surface drift.",
+      "relation_to_normative_path": "diagnostic_observer",
+      "can_affect_release_decision": false,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "hpc-evidence-bundle",
+      "path_or_label": "hpc_evidence_bundle_v0",
+      "surface_type": "hpc_evidence_bundle",
+      "authority_status": "diagnostic_non_normative",
+      "field_role": "Diagnostic evidence surface for HPC / compute-scale outputs.",
+      "relation_to_normative_path": "candidate_evidence_surface",
+      "can_affect_release_decision": false,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "evidence-fold-in-admissibility",
+      "path_or_label": "evidence_fold_in_admissibility_v0",
+      "surface_type": "evidence_fold_in_admissibility",
+      "authority_status": "diagnostic_non_normative",
+      "field_role": "Diagnostic admissibility boundary before non-normative evidence can approach recorded release evidence.",
+      "relation_to_normative_path": "diagnostic_observer",
+      "can_affect_release_decision": false,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "pulse-pd",
+      "path_or_label": "pulse_pd/",
+      "surface_type": "pulse_pd_artifact",
+      "authority_status": "optional_analysis_non_normative",
+      "field_role": "Optional analysis surface for decision-field exploration.",
+      "relation_to_normative_path": "optional_analysis",
+      "can_affect_release_decision": false,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "readme",
+      "path_or_label": "README.md",
+      "surface_type": "readme",
+      "authority_status": "recognition_non_normative",
+      "field_role": "Recognition and orientation surface.",
+      "relation_to_normative_path": "recognition_surface",
+      "can_affect_release_decision": false,
+      "creates_release_authority": false,
+      "policy_route": null
+    },
+    {
+      "field_point_id": "concept-doi",
+      "path_or_label": "10.5281/zenodo.17214908",
+      "surface_type": "doi_record",
+      "authority_status": "publication_non_normative",
+      "field_role": "Publication and citation surface.",
+      "relation_to_normative_path": "publication_reader",
+      "can_affect_release_decision": false,
+      "creates_release_authority": false,
+      "policy_route": null
+    }
+  ],
+  "result": "valid",
+  "notes": "Field points are classified by role and authority status, not architectural distance."
+}

--- a/tests/test_field_point_authority_map_v0_contract.py
+++ b/tests/test_field_point_authority_map_v0_contract.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Smoke tests for field_point_authority_map_v0 contract checker."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER = ROOT / "scripts" / "check_field_point_authority_map_v0_contract.py"
+
+FIXTURE_DIR = ROOT / "tests" / "fixtures" / "field_point_authority_map_v0"
+PASS = FIXTURE_DIR / "pass.json"
+INVALID_RECOGNITION = FIXTURE_DIR / "invalid_recognition_surface_authority.json"
+INVALID_PUBLICATION = FIXTURE_DIR / "invalid_publication_surface_affects_release.json"
+
+
+def _run(path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), "--in", str(path)],
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _read(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_pass_fixture_is_valid() -> None:
+    result = _run(PASS)
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_invalid_recognition_surface_authority_fails() -> None:
+    result = _run(INVALID_RECOGNITION)
+    assert result.returncode == 1
+    assert "recognition surfaces must not declare normative authority" in (
+        result.stderr + result.stdout
+    )
+
+
+def test_invalid_publication_surface_affects_release_fails() -> None:
+    result = _run(INVALID_PUBLICATION)
+    assert result.returncode == 1
+    assert "publication surfaces must not affect release decisions directly" in (
+        result.stderr + result.stdout
+    )
+
+
+def test_unknown_normative_path_member_fails() -> None:
+    payload = _read(PASS)
+    payload["normative_materialization_path"].append("missing-field-point")
+    payload["result"] = "invalid"
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "bad.json"
+        _write(path, payload)
+        result = _run(path)
+
+    assert result.returncode == 1
+    assert "unknown field point" in (result.stderr + result.stdout)
+
+
+def test_non_normative_field_point_cannot_affect_release_without_policy_route() -> None:
+    payload = _read(PASS)
+
+    for point in payload["field_points"]:
+        if point["field_point_id"] == "hpc-evidence-bundle":
+            point["can_affect_release_decision"] = True
+            point["policy_route"] = None
+
+    payload["result"] = "invalid"
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "bad.json"
+        _write(path, payload)
+        result = _run(path)
+
+    assert result.returncode == 1
+    assert "policy_route" in (result.stderr + result.stdout)
+
+
+def test_policy_routed_diagnostic_candidate_can_affect_release_decision() -> None:
+    payload = _read(PASS)
+
+    for point in payload["field_points"]:
+        if point["field_point_id"] == "hpc-evidence-bundle":
+            point["can_affect_release_decision"] = True
+            point["policy_route"] = {
+                "policy_path": "pulse_gate_policy_v0.yml",
+                "gate_id": "external_all_pass"
+            }
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "good.json"
+        _write(path, payload)
+        result = _run(path)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_result_must_match_semantic_validity() -> None:
+    payload = _read(PASS)
+    payload["result"] = "invalid"
+
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "bad.json"
+        _write(path, payload)
+        result = _run(path)
+
+    assert result.returncode == 1
+    assert "result must be" in (result.stderr + result.stdout)
+
+
+def main() -> int:
+    try:
+        test_pass_fixture_is_valid()
+        test_invalid_recognition_surface_authority_fails()
+        test_invalid_publication_surface_affects_release_fails()
+        test_unknown_normative_path_member_fails()
+        test_non_normative_field_point_cannot_affect_release_without_policy_route()
+        test_policy_routed_diagnostic_candidate_can_affect_release_decision()
+        test_result_must_match_semantic_validity()
+    except AssertionError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    print("OK: field_point_authority_map_v0 contract smoke passed")
+    return 0
+
+
+def test_smoke() -> None:
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds `field_point_authority_map_v0`, a diagnostic authority-role contract for PULSE field points.

The goal is to make the PULSE field-instrument interpretation machine-checkable:

PULSE elements belong to the field by role and authority status, not by architectural distance from a core.

## Mechanical purpose

The contract records each field point with:

- field point ID;
- path or label;
- surface type;
- authority status;
- field role;
- relation to the normative materialization path;
- whether it can affect release decisions;
- whether it creates release authority;
- optional policy route.

Core rule:

`Every field-point claim requires authority-role classification.`

## Normative materialization path

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Contract behavior

The checker enforces that:

- normative path members must have normative authority status;
- normative path members must set `can_affect_release_decision=true`;
- recognition surfaces cannot declare normative authority;
- recognition surfaces cannot affect release decisions directly;
- publication surfaces cannot declare normative authority;
- publication surfaces cannot affect release decisions directly;
- audit / reconstruction surfaces cannot declare normative authority;
- diagnostic surfaces cannot declare normative authority;
- diagnostic surfaces that affect release decisions require explicit `policy_route`;
- non-normative field points cannot affect release decisions without `policy_route`;
- the artifact-level `creates_release_authority` flag remains false;
- result state matches semantic validity.

## Added artifacts

Changed:

- `docs/PULSE_FIELD_POINT_AUTHORITY_MAP_v0.md`
- `schemas/field_point_authority_map_v0.schema.json`
- `scripts/check_field_point_authority_map_v0_contract.py`
- `tests/fixtures/field_point_authority_map_v0/pass.json`
- `tests/fixtures/field_point_authority_map_v0/invalid_recognition_surface_authority.json`
- `tests/fixtures/field_point_authority_map_v0/invalid_publication_surface_affects_release.json`
- `tests/test_field_point_authority_map_v0_contract.py`
- `ci/tools-tests.list`

## Authority boundary

This is diagnostic only.

It does not authorize, block, override, or create release authority.

The field-point authority map does not create a second release-decision path.

## Scope

Not changed:

- README
- workflows
- release policy
- gate registry
- `check_gates.py`
- status schemas
- release gates
- RA1 verifier
- primary CI release-decision semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Expected validation:

- `python -m py_compile scripts/check_field_point_authority_map_v0_contract.py tests/test_field_point_authority_map_v0_contract.py`
- `python tests/test_field_point_authority_map_v0_contract.py`
- `python -m pytest -q tests/test_field_point_authority_map_v0_contract.py`

Expected results:

- valid field-point authority map passes;
- recognition surface cannot claim normative authority;
- publication surface cannot affect release decision;
- unknown normative path member fails;
- non-normative field point cannot affect release decision without `policy_route`;
- policy-routed diagnostic candidate may affect release decision;
- result must match semantic validity.