### PR TITLE
feat: add field-point authority map builder

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -60,6 +60,7 @@ tests/test_pulse_pd_toy_generator_no_numpy.py
 tests/test_hpc_evidence_bundle_v0_contract.py
 tests/test_evidence_fold_in_admissibility_v0_contract.py
 tests/test_field_point_authority_map_v0_contract.py
+tests/test_build_field_point_authority_map_v0.py
 
 tools/operator_handoff_smoke.py
 

--- a/scripts/build_field_point_authority_map_v0.py
+++ b/scripts/build_field_point_authority_map_v0.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""Build field_point_authority_map_v0 diagnostic artifacts.
+
+This builder does not create release authority.
+
+It materializes a non-normative field-point authority map from structured input.
+Each PULSE field point is classified by role, authority status, and relation to
+the normative materialization path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "field_point_authority_map_v0"
+AUTHORITY_STATUS = "diagnostic_non_normative"
+INVARIANT = (
+    "field_points_must_declare_role_and_authority_status_before_interpretation"
+)
+
+SURFACE_TYPES = {
+    "recorded_release_evidence",
+    "status_artifact",
+    "declared_policy",
+    "materialized_gate_set",
+    "ci_enforcement",
+    "ci_decision",
+    "quality_ledger",
+    "release_authority_manifest",
+    "audit_bundle",
+    "dashboard",
+    "pages",
+    "badge",
+    "doi_record",
+    "citation_metadata",
+    "readme",
+    "about",
+    "diagnostic_contract",
+    "hpc_evidence_bundle",
+    "evidence_fold_in_admissibility",
+    "pulse_pd_artifact",
+    "recognition_surface",
+    "recognition_surface_drift",
+    "optional_analysis_surface",
+    "other",
+}
+
+AUTHORITY_STATUSES = {
+    "normative_input",
+    "normative_enforcement",
+    "normative_decision",
+    "diagnostic_non_normative",
+    "audit_non_normative",
+    "publication_non_normative",
+    "recognition_non_normative",
+    "optional_analysis_non_normative",
+    "proposed_non_normative",
+}
+
+NORMATIVE_STATUSES = {
+    "normative_input",
+    "normative_enforcement",
+    "normative_decision",
+}
+
+RELATIONS = {
+    "normative_path_member",
+    "candidate_evidence_surface",
+    "diagnostic_observer",
+    "audit_reconstruction",
+    "publication_reader",
+    "recognition_surface",
+    "optional_analysis",
+    "future_proposed",
+}
+
+RECOGNITION_SURFACES = {
+    "recognition_surface",
+    "recognition_surface_drift",
+    "readme",
+    "about",
+    "doi_record",
+    "citation_metadata",
+    "badge",
+}
+
+PUBLICATION_SURFACES = {
+    "quality_ledger",
+    "dashboard",
+    "pages",
+    "doi_record",
+    "citation_metadata",
+    "badge",
+}
+
+AUDIT_SURFACES = {
+    "release_authority_manifest",
+    "audit_bundle",
+}
+
+DIAGNOSTIC_SURFACES = {
+    "diagnostic_contract",
+    "hpc_evidence_bundle",
+    "evidence_fold_in_admissibility",
+    "pulse_pd_artifact",
+    "recognition_surface_drift",
+    "optional_analysis_surface",
+}
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    obj = json.loads(path.read_text(encoding="utf-8"))
+
+    if not isinstance(obj, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+
+    return obj
+
+
+def _write_json(path: Path, obj: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(obj, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _enum(value: Any, allowed: set[str], default: str) -> str:
+    if isinstance(value, str) and value in allowed:
+        return value
+    return default
+
+
+def _require_string(name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _require_string_list(name: str, value: Any) -> list[str]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be an array")
+
+    if not value:
+        raise ValueError(f"{name} must not be empty")
+
+    out: list[str] = []
+
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"{name}[{index}] must be a non-empty string")
+        out.append(item)
+
+    return out
+
+
+def _require_field_points(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ValueError("field_points must be an array")
+
+    if not value:
+        raise ValueError("field_points must not be empty")
+
+    out: list[dict[str, Any]] = []
+
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise ValueError(f"field_points[{index}] must be an object")
+        out.append(item)
+
+    return out
+
+
+def _policy_route(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+
+    policy_path = value.get("policy_path")
+    gate_id = value.get("gate_id")
+
+    if not isinstance(policy_path, str) or not policy_path.strip():
+        return None
+    if not isinstance(gate_id, str) or not gate_id.strip():
+        return None
+
+    out = dict(value)
+    out["policy_path"] = policy_path
+    out["gate_id"] = gate_id
+    return out
+
+
+def _default_authority_status(
+    surface_type: str,
+    *,
+    in_normative_path: bool,
+) -> str:
+    if in_normative_path:
+        if surface_type == "ci_enforcement":
+            return "normative_enforcement"
+        if surface_type == "ci_decision":
+            return "normative_decision"
+        return "normative_input"
+
+    if surface_type in RECOGNITION_SURFACES:
+        return "recognition_non_normative"
+    if surface_type in PUBLICATION_SURFACES:
+        return "publication_non_normative"
+    if surface_type in AUDIT_SURFACES:
+        return "audit_non_normative"
+    if surface_type in DIAGNOSTIC_SURFACES:
+        if surface_type == "optional_analysis_surface" or surface_type == "pulse_pd_artifact":
+            return "optional_analysis_non_normative"
+        return "diagnostic_non_normative"
+
+    return "diagnostic_non_normative"
+
+
+def _default_relation(
+    surface_type: str,
+    *,
+    in_normative_path: bool,
+) -> str:
+    if in_normative_path:
+        return "normative_path_member"
+
+    if surface_type in RECOGNITION_SURFACES:
+        return "recognition_surface"
+    if surface_type in PUBLICATION_SURFACES:
+        return "publication_reader"
+    if surface_type in AUDIT_SURFACES:
+        return "audit_reconstruction"
+    if surface_type in {"hpc_evidence_bundle"}:
+        return "candidate_evidence_surface"
+    if surface_type in {"pulse_pd_artifact", "optional_analysis_surface"}:
+        return "optional_analysis"
+    if surface_type in DIAGNOSTIC_SURFACES:
+        return "diagnostic_observer"
+
+    return "diagnostic_observer"
+
+
+def _normalize_field_point(
+    point: dict[str, Any],
+    *,
+    normative_ids: set[str],
+) -> dict[str, Any]:
+    field_point_id = _require_string(
+        "field_point_id",
+        point.get("field_point_id"),
+    )
+    path_or_label = _require_string(
+        f"{field_point_id}.path_or_label",
+        point.get("path_or_label"),
+    )
+    field_role = _require_string(
+        f"{field_point_id}.field_role",
+        point.get("field_role"),
+    )
+
+    surface_type = _enum(
+        point.get("surface_type"),
+        SURFACE_TYPES,
+        "other",
+    )
+
+    in_normative_path = field_point_id in normative_ids
+
+    authority_status = _enum(
+        point.get("authority_status"),
+        AUTHORITY_STATUSES,
+        _default_authority_status(
+            surface_type,
+            in_normative_path=in_normative_path,
+        ),
+    )
+
+    relation = _enum(
+        point.get("relation_to_normative_path"),
+        RELATIONS,
+        _default_relation(
+            surface_type,
+            in_normative_path=in_normative_path,
+        ),
+    )
+
+    if "can_affect_release_decision" in point:
+        can_affect = point.get("can_affect_release_decision") is True
+    else:
+        can_affect = in_normative_path
+
+    notes = point.get("notes")
+    policy_route = _policy_route(point.get("policy_route"))
+
+    out: dict[str, Any] = {
+        "field_point_id": field_point_id,
+        "path_or_label": path_or_label,
+        "surface_type": surface_type,
+        "authority_status": authority_status,
+        "field_role": field_role,
+        "relation_to_normative_path": relation,
+        "can_affect_release_decision": can_affect,
+        "creates_release_authority": False,
+        "policy_route": policy_route,
+    }
+
+    if isinstance(notes, str) and notes:
+        out["notes"] = notes
+
+    return out
+
+
+def _has_policy_route(field_point: dict[str, Any]) -> bool:
+    return _policy_route(field_point.get("policy_route")) is not None
+
+
+def _semantic_errors(
+    *,
+    normative_materialization_path: list[str],
+    field_points: list[dict[str, Any]],
+) -> list[str]:
+    errors: list[str] = []
+
+    path_ids = set(normative_materialization_path)
+    by_id: dict[str, dict[str, Any]] = {}
+    seen: set[str] = set()
+
+    for point in field_points:
+        field_point_id = point["field_point_id"]
+        if field_point_id in seen:
+            errors.append(f"duplicate field_point_id: {field_point_id}")
+            continue
+        seen.add(field_point_id)
+        by_id[field_point_id] = point
+
+    for field_point_id in normative_materialization_path:
+        point = by_id.get(field_point_id)
+        if point is None:
+            errors.append(
+                f"normative_materialization_path references unknown field point: {field_point_id}"
+            )
+            continue
+
+        if point["authority_status"] not in NORMATIVE_STATUSES:
+            errors.append(
+                f"{field_point_id}: normative path member must have normative authority status"
+            )
+        if point["relation_to_normative_path"] != "normative_path_member":
+            errors.append(
+                f"{field_point_id}: normative path member must declare relation_to_normative_path=normative_path_member"
+            )
+        if point["can_affect_release_decision"] is not True:
+            errors.append(
+                f"{field_point_id}: normative path member must set can_affect_release_decision=true"
+            )
+
+    for point in field_points:
+        field_point_id = point["field_point_id"]
+        surface_type = point["surface_type"]
+        authority_status = point["authority_status"]
+        relation = point["relation_to_normative_path"]
+        can_affect = point["can_affect_release_decision"]
+        in_normative_path = field_point_id in path_ids
+
+        if point["creates_release_authority"] is not False:
+            errors.append(f"{field_point_id}: creates_release_authority must be false")
+
+        if authority_status in NORMATIVE_STATUSES and not in_normative_path:
+            errors.append(
+                f"{field_point_id}: normative authority status is only allowed for normative path members"
+            )
+
+        if relation == "normative_path_member" and not in_normative_path:
+            errors.append(
+                f"{field_point_id}: relation_to_normative_path=normative_path_member requires inclusion in normative_materialization_path"
+            )
+
+        if surface_type in RECOGNITION_SURFACES:
+            if authority_status in NORMATIVE_STATUSES:
+                errors.append(
+                    f"{field_point_id}: recognition surfaces must not declare normative authority"
+                )
+            if can_affect is True:
+                errors.append(
+                    f"{field_point_id}: recognition surfaces must not affect release decisions directly"
+                )
+
+        if surface_type in PUBLICATION_SURFACES:
+            if authority_status in NORMATIVE_STATUSES:
+                errors.append(
+                    f"{field_point_id}: publication surfaces must not declare normative authority"
+                )
+            if can_affect is True:
+                errors.append(
+                    f"{field_point_id}: publication surfaces must not affect release decisions directly"
+                )
+
+        if surface_type in AUDIT_SURFACES:
+            if authority_status in NORMATIVE_STATUSES:
+                errors.append(
+                    f"{field_point_id}: audit/reconstruction surfaces must not declare normative authority"
+                )
+            if can_affect is True:
+                errors.append(
+                    f"{field_point_id}: audit/reconstruction surfaces must not affect release decisions directly"
+                )
+
+        if surface_type in DIAGNOSTIC_SURFACES:
+            if authority_status in NORMATIVE_STATUSES:
+                errors.append(
+                    f"{field_point_id}: diagnostic surfaces must not declare normative authority"
+                )
+            if can_affect is True and not _has_policy_route(point):
+                errors.append(
+                    f"{field_point_id}: diagnostic surfaces that affect release decisions require explicit policy_route"
+                )
+
+        if can_affect is True and not in_normative_path and not _has_policy_route(point):
+            errors.append(
+                f"{field_point_id}: non-normative field point cannot affect release decisions without policy_route"
+            )
+
+    return errors
+
+
+def build(input_obj: dict[str, Any]) -> dict[str, Any]:
+    normative_materialization_path = _require_string_list(
+        "normative_materialization_path",
+        input_obj.get("normative_materialization_path"),
+    )
+    raw_field_points = _require_field_points(input_obj.get("field_points"))
+
+    normative_ids = set(normative_materialization_path)
+
+    field_points = [
+        _normalize_field_point(point, normative_ids=normative_ids)
+        for point in raw_field_points
+    ]
+
+    errors = _semantic_errors(
+        normative_materialization_path=normative_materialization_path,
+        field_points=field_points,
+    )
+
+    out: dict[str, Any] = {
+        "schema": SCHEMA,
+        "authority_status": AUTHORITY_STATUS,
+        "creates_release_authority": False,
+        "invariant": INVARIANT,
+        "normative_materialization_path": normative_materialization_path,
+        "field_points": field_points,
+        "result": "invalid" if errors else "valid",
+    }
+
+    notes = input_obj.get("notes")
+    if isinstance(notes, str) and notes:
+        out["notes"] = notes
+
+    return out
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build a field_point_authority_map_v0 diagnostic artifact."
+    )
+    parser.add_argument("--input", required=True, help="Input field-point bundle JSON.")
+    parser.add_argument("--out", required=True, help="Output diagnostic JSON.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        input_obj = _load_json_object(Path(args.input))
+        output_obj = build(input_obj)
+        _write_json(Path(args.out), output_obj)
+    except Exception as exc:
+        print(f"::error::failed to build field_point_authority_map_v0: {exc}")
+        return 1
+
+    print(f"OK: wrote field_point_authority_map_v0 artifact: {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_field_point_authority_map_v0.py
+++ b/scripts/build_field_point_authority_map_v0.py
@@ -432,7 +432,7 @@ def _semantic_errors(
 
 
 def build(input_obj: dict[str, Any]) -> dict[str, Any]:
-     normative_materialization_path = _require_string_list(
+    normative_materialization_path = _require_string_list(
         "normative_materialization_path",
         input_obj.get("normative_materialization_path"),
         min_items=5,

--- a/scripts/build_field_point_authority_map_v0.py
+++ b/scripts/build_field_point_authority_map_v0.py
@@ -141,12 +141,14 @@ def _require_string(name: str, value: Any) -> str:
     return value
 
 
-def _require_string_list(name: str, value: Any) -> list[str]:
+def _require_string_list(
+    name: str,
+    value: Any,
+    *,
+    min_items: int = 1,
+) -> list[str]:
     if not isinstance(value, list):
         raise ValueError(f"{name} must be an array")
-
-    if not value:
-        raise ValueError(f"{name} must not be empty")
 
     out: list[str] = []
 
@@ -154,6 +156,9 @@ def _require_string_list(name: str, value: Any) -> list[str]:
         if not isinstance(item, str) or not item.strip():
             raise ValueError(f"{name}[{index}] must be a non-empty string")
         out.append(item)
+
+    if len(out) < min_items:
+        raise ValueError(f"{name} must contain at least {min_items} entries")
 
     return out
 
@@ -427,9 +432,10 @@ def _semantic_errors(
 
 
 def build(input_obj: dict[str, Any]) -> dict[str, Any]:
-    normative_materialization_path = _require_string_list(
+     normative_materialization_path = _require_string_list(
         "normative_materialization_path",
         input_obj.get("normative_materialization_path"),
+        min_items=5,
     )
     raw_field_points = _require_field_points(input_obj.get("field_points"))
 

--- a/tests/fixtures/field_point_authority_map_v0/builder_invalid_input.json
+++ b/tests/fixtures/field_point_authority_map_v0/builder_invalid_input.json
@@ -1,0 +1,63 @@
+{
+  "normative_materialization_path": [
+    "recorded-release-evidence",
+    "status-json",
+    "declared-gate-policy",
+    "materialized-required-gate-set",
+    "strict-ci-checking",
+    "ci-allow-block-decision"
+  ],
+  "field_points": [
+    {
+      "field_point_id": "recorded-release-evidence",
+      "path_or_label": "recorded release evidence",
+      "surface_type": "recorded_release_evidence",
+      "field_role": "Recorded evidence."
+    },
+    {
+      "field_point_id": "status-json",
+      "path_or_label": "status.json",
+      "surface_type": "status_artifact",
+      "field_role": "Machine-readable release state."
+    },
+    {
+      "field_point_id": "declared-gate-policy",
+      "path_or_label": "pulse_gate_policy_v0.yml",
+      "surface_type": "declared_policy",
+      "field_role": "Declared gate policy."
+    },
+    {
+      "field_point_id": "materialized-required-gate-set",
+      "path_or_label": "materialized required gate set",
+      "surface_type": "materialized_gate_set",
+      "field_role": "Materialized required gate set."
+    },
+    {
+      "field_point_id": "strict-ci-checking",
+      "path_or_label": "check_gates.py / CI enforcement",
+      "surface_type": "ci_enforcement",
+      "field_role": "Strict CI checking."
+    },
+    {
+      "field_point_id": "ci-allow-block-decision",
+      "path_or_label": "CI allow/block decision",
+      "surface_type": "ci_decision",
+      "field_role": "CI decision."
+    },
+    {
+      "field_point_id": "quality-ledger",
+      "path_or_label": "Quality Ledger",
+      "surface_type": "quality_ledger",
+      "field_role": "Invalid: publication surface claims decision effect.",
+      "can_affect_release_decision": true
+    },
+    {
+      "field_point_id": "readme",
+      "path_or_label": "README.md",
+      "surface_type": "readme",
+      "field_role": "Invalid: recognition surface claims decision effect.",
+      "can_affect_release_decision": true
+    }
+  ],
+  "notes": "Builder input for an invalid field-point authority map."
+}

--- a/tests/fixtures/field_point_authority_map_v0/builder_pass_input.json
+++ b/tests/fixtures/field_point_authority_map_v0/builder_pass_input.json
@@ -1,0 +1,103 @@
+{
+  "normative_materialization_path": [
+    "recorded-release-evidence",
+    "status-json",
+    "declared-gate-policy",
+    "materialized-required-gate-set",
+    "strict-ci-checking",
+    "ci-allow-block-decision"
+  ],
+  "field_points": [
+    {
+      "field_point_id": "recorded-release-evidence",
+      "path_or_label": "recorded release evidence",
+      "surface_type": "recorded_release_evidence",
+      "field_role": "Safety, quality, detector, stability, CI, and review evidence recorded before deployment."
+    },
+    {
+      "field_point_id": "status-json",
+      "path_or_label": "status.json",
+      "surface_type": "status_artifact",
+      "field_role": "Machine-readable release state artifact."
+    },
+    {
+      "field_point_id": "declared-gate-policy",
+      "path_or_label": "pulse_gate_policy_v0.yml",
+      "surface_type": "declared_policy",
+      "field_role": "Declared gate policy defining required gate sets by release lane."
+    },
+    {
+      "field_point_id": "materialized-required-gate-set",
+      "path_or_label": "materialized required gate set",
+      "surface_type": "materialized_gate_set",
+      "field_role": "Concrete gate set derived from declared policy."
+    },
+    {
+      "field_point_id": "strict-ci-checking",
+      "path_or_label": "check_gates.py / CI enforcement",
+      "surface_type": "ci_enforcement",
+      "field_role": "True-only fail-closed enforcement over materialized required gates."
+    },
+    {
+      "field_point_id": "ci-allow-block-decision",
+      "path_or_label": "CI allow/block release decision",
+      "surface_type": "ci_decision",
+      "field_role": "Deterministic release decision emitted by CI."
+    },
+    {
+      "field_point_id": "quality-ledger",
+      "path_or_label": "Quality Ledger",
+      "surface_type": "quality_ledger",
+      "field_role": "Human-readable reader surface for the decision trail."
+    },
+    {
+      "field_point_id": "release-authority-manifest",
+      "path_or_label": "release_authority_v0.json",
+      "surface_type": "release_authority_manifest",
+      "field_role": "Trace surface recording decision-path metadata."
+    },
+    {
+      "field_point_id": "audit-bundle",
+      "path_or_label": "release-authority-audit-bundle",
+      "surface_type": "audit_bundle",
+      "field_role": "Reconstructable evidence trail bundle."
+    },
+    {
+      "field_point_id": "recognition-surface-drift",
+      "path_or_label": "recognition_surface_drift_v0",
+      "surface_type": "recognition_surface_drift",
+      "field_role": "Diagnostic contract for presentation-layer capture / recognition-surface drift."
+    },
+    {
+      "field_point_id": "hpc-evidence-bundle",
+      "path_or_label": "hpc_evidence_bundle_v0",
+      "surface_type": "hpc_evidence_bundle",
+      "field_role": "Diagnostic evidence surface for HPC / compute-scale outputs."
+    },
+    {
+      "field_point_id": "evidence-fold-in-admissibility",
+      "path_or_label": "evidence_fold_in_admissibility_v0",
+      "surface_type": "evidence_fold_in_admissibility",
+      "field_role": "Diagnostic admissibility boundary before non-normative evidence can approach recorded release evidence."
+    },
+    {
+      "field_point_id": "pulse-pd",
+      "path_or_label": "pulse_pd/",
+      "surface_type": "pulse_pd_artifact",
+      "field_role": "Optional analysis surface for decision-field exploration."
+    },
+    {
+      "field_point_id": "readme",
+      "path_or_label": "README.md",
+      "surface_type": "readme",
+      "field_role": "Recognition and orientation surface."
+    },
+    {
+      "field_point_id": "concept-doi",
+      "path_or_label": "10.5281/zenodo.17214908",
+      "surface_type": "doi_record",
+      "field_role": "Publication and citation surface."
+    }
+  ],
+  "notes": "Builder input for a valid PULSE field-point authority map."
+}

--- a/tests/test_build_field_point_authority_map_v0.py
+++ b/tests/test_build_field_point_authority_map_v0.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Smoke tests for build_field_point_authority_map_v0.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER = ROOT / "scripts" / "build_field_point_authority_map_v0.py"
+CHECKER = ROOT / "scripts" / "check_field_point_authority_map_v0_contract.py"
+
+FIXTURE_DIR = ROOT / "tests" / "fixtures" / "field_point_authority_map_v0"
+PASS_INPUT = FIXTURE_DIR / "builder_pass_input.json"
+INVALID_INPUT = FIXTURE_DIR / "builder_invalid_input.json"
+
+
+def _read(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _run_builder(input_path: Path, out_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(BUILDER),
+            "--input",
+            str(input_path),
+            "--out",
+            str(out_path),
+        ],
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _run_checker(out_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--in",
+            str(out_path),
+        ],
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_builder_outputs_valid_authority_map() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        out_path = Path(td) / "field_point_authority_map_v0.json"
+
+        result = _run_builder(PASS_INPUT, out_path)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+
+        check = _run_checker(out_path)
+        assert check.returncode == 0, check.stderr + check.stdout
+
+        artifact = _read(out_path)
+        assert artifact["schema"] == "field_point_authority_map_v0"
+        assert artifact["authority_status"] == "diagnostic_non_normative"
+        assert artifact["creates_release_authority"] is False
+        assert artifact["result"] == "valid"
+
+        by_id = {
+            point["field_point_id"]: point
+            for point in artifact["field_points"]
+        }
+
+        assert by_id["status-json"]["authority_status"] == "normative_input"
+        assert by_id["strict-ci-checking"]["authority_status"] == "normative_enforcement"
+        assert by_id["ci-allow-block-decision"]["authority_status"] == "normative_decision"
+        assert by_id["readme"]["authority_status"] == "recognition_non_normative"
+        assert by_id["quality-ledger"]["authority_status"] == "publication_non_normative"
+        assert by_id["hpc-evidence-bundle"]["authority_status"] == "diagnostic_non_normative"
+
+
+def test_builder_outputs_invalid_authority_map_for_bad_surface_roles() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        out_path = Path(td) / "field_point_authority_map_v0.json"
+
+        result = _run_builder(INVALID_INPUT, out_path)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+
+        artifact = _read(out_path)
+        assert artifact["schema"] == "field_point_authority_map_v0"
+        assert artifact["result"] == "invalid"
+
+        check = _run_checker(out_path)
+
+    assert check.returncode == 1
+    assert "publication surfaces must not affect release decisions directly" in (
+        check.stderr + check.stdout
+    )
+    assert "recognition surfaces must not affect release decisions directly" in (
+        check.stderr + check.stdout
+    )
+
+
+def test_builder_rejects_empty_field_points() -> None:
+    payload = _read(PASS_INPUT)
+    payload["field_points"] = []
+
+    with tempfile.TemporaryDirectory() as td:
+        input_path = Path(td) / "bad_input.json"
+        out_path = Path(td) / "field_point_authority_map_v0.json"
+        _write(input_path, payload)
+
+        result = _run_builder(input_path, out_path)
+
+    assert result.returncode == 1
+    assert "field_points" in (result.stderr + result.stdout)
+
+
+def test_builder_rejects_unknown_normative_path_later_by_checker() -> None:
+    payload = _read(PASS_INPUT)
+    payload["normative_materialization_path"].append("missing-field-point")
+
+    with tempfile.TemporaryDirectory() as td:
+        input_path = Path(td) / "input.json"
+        out_path = Path(td) / "field_point_authority_map_v0.json"
+        _write(input_path, payload)
+
+        result = _run_builder(input_path, out_path)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+
+        artifact = _read(out_path)
+        assert artifact["result"] == "invalid"
+
+        check = _run_checker(out_path)
+
+    assert check.returncode == 1
+    assert "unknown field point" in (check.stderr + check.stdout)
+
+
+def test_policy_routed_diagnostic_candidate_can_affect_release_decision() -> None:
+    payload = _read(PASS_INPUT)
+
+    for point in payload["field_points"]:
+        if point["field_point_id"] == "hpc-evidence-bundle":
+            point["can_affect_release_decision"] = True
+            point["policy_route"] = {
+                "policy_path": "pulse_gate_policy_v0.yml",
+                "gate_id": "external_all_pass"
+            }
+
+    with tempfile.TemporaryDirectory() as td:
+        input_path = Path(td) / "input.json"
+        out_path = Path(td) / "field_point_authority_map_v0.json"
+        _write(input_path, payload)
+
+        result = _run_builder(input_path, out_path)
+        assert result.returncode == 0, result.stderr + result.stdout
+        assert out_path.exists()
+
+        check = _run_checker(out_path)
+
+    assert check.returncode == 0, check.stderr + check.stdout
+
+
+def test_builder_rejects_short_normative_materialization_path() -> None:
+    payload = _read(PASS_INPUT)
+    payload["normative_materialization_path"] = [
+        "recorded-release-evidence",
+        "status-json",
+        "declared-gate-policy",
+        "strict-ci-checking",
+    ]
+
+    with tempfile.TemporaryDirectory() as td:
+        input_path = Path(td) / "bad_input.json"
+        out_path = Path(td) / "field_point_authority_map_v0.json"
+        _write(input_path, payload)
+
+        result = _run_builder(input_path, out_path)
+
+    assert result.returncode == 1
+    assert "normative_materialization_path" in (result.stderr + result.stdout)
+    assert "at least 5" in (result.stderr + result.stdout)
+
+
+def main() -> int:
+    try:
+        test_builder_outputs_valid_authority_map()
+        test_builder_outputs_invalid_authority_map_for_bad_surface_roles()
+        test_builder_rejects_empty_field_points()
+        test_builder_rejects_short_normative_materialization_path()
+        test_builder_rejects_unknown_normative_path_later_by_checker()
+        test_policy_routed_diagnostic_candidate_can_affect_release_decision()
+    except AssertionError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    print("OK: build_field_point_authority_map_v0 smoke passed")
+    return 0
+
+
+def test_smoke() -> None:
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Add an on-demand builder for field_point_authority_map_v0 diagnostic artifacts.

The builder materializes a non-normative field-point authority map from structured input. Each PULSE field point is classified by role, authority status, and relation to the normative materialization path.

The builder normalizes field points into:

- normative path members;
- diagnostic surfaces;
- audit / reconstruction surfaces;
- publication / reader surfaces;
- recognition surfaces;
- optional analysis surfaces.

It assigns default authority roles where appropriate, preserves explicit policy routes, and computes whether the generated map is semantically valid or invalid.

Generated artifacts validate against the existing
field_point_authority_map_v0 contract.

This preserves the PULSE field-instrument rule:

Every field-point claim requires authority-role classification.

This is diagnostic only.

The builder does not authorize, block, override, or create release authority.

No release policy, gate registry, check_gates behavior, status schema, workflow release-gating semantics, dashboard, ledger, release authority manifest, audit bundle, publication surface authority semantics, or shadow-layer authority semantics are changed.

<!-- PULSE PR Template v1.0 — keep sections; fill what applies. -->

## Summary
<!-- Short: what changes and why? -->

## What’s included
- [ ] Code
- [ ] Docs
- [ ] CI / workflow
- Paths / files touched:

## CI usage
```yaml
# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json
```

## Impact
- Additive / backwards-compatible
- Breaking change — details:
- Performance / SLO impact:
- Security considerations:

What’s included
 Code
 Docs
 CI / workflow

Paths / files touched:

CI usage

# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json

Impact
Additive / backwards-compatible

Breaking change — details:

Performance / SLO impact:

Security considerations:

### Security Intake (v0) — dependency / external code (if applicable)
**Intake v0:** PASS | REVIEW | HARD STOP  
**Isolation used (if REVIEW):** yes / no  

**Reasons (1–3 bullets):**
- 
- 
- 

**Checks**
- [ ] No password-protected ZIP / random binary download involved
- [ ] Repo age ≥ 12 months and maintainer history looks real
- [ ] No postinstall/preinstall scripts (or justified + reviewed)
- [ ] No obfuscation / base64 blobs / runtime-downloaded binaries
- [ ] No instructions like “disable Defender/AV”
- [ ] First run done in VM/container (if REVIEW)

> If any HIGH-risk signal appears → mark **HARD STOP** and do not merge.

Notes

Follow-ups:

Risks / mitigations:

PULSE checklist (governance)
 PULSE CI is green on this PR
 Quality Ledger link (if enabled)
 Badges updated (PASS / RDSI / Q-Ledger)


## Notes
- Follow-ups:
- Risks / mitigations:

## PULSE checklist (governance)
- [ ] PULSE CI is green on this PR
- [ ] Quality Ledger link (if enabled)
- [ ] Badges updated (PASS / RDSI / Q‑Ledger)
