### PR TITLE
docs: add field-instrument development checkpoint

### DIFF
--- a/docs/PULSE_FIELD_INSTRUMENT_DEVELOPMENT_CHECKPOINT_2026-05-21.md
+++ b/docs/PULSE_FIELD_INSTRUMENT_DEVELOPMENT_CHECKPOINT_2026-05-21.md
@@ -1,0 +1,213 @@
+# PULSE Field-Instrument Development Checkpoint — 2026-05-21
+
+Status: workshop development checkpoint  
+Scope: PULSE field-instrument development / diagnostic contracts / authority-boundary consolidation  
+Authority status: non-normative explanatory checkpoint
+
+## Core statement
+
+PULSE is a field instrument, not a layered tool.
+
+The current development checkpoint records the field-instrument surfaces that were defined, validated, and made buildable during this phase.
+
+The checkpoint does not create release authority.
+
+The normative release decision remains bound to:
+
+recorded release evidence  
+→ `status.json`  
+→ declared gate policy  
+→ materialized required gate set  
+→ strict fail-closed CI checking  
+→ CI allow/block release decision
+
+## Closed field-instrument surfaces
+
+### recognition_surface_drift_v0
+
+Purpose:
+
+Detect whether non-normative recognition surfaces alter an analyzer’s classification, authority-boundary reading, normative-path reading, or mechanical claims while the internal artifact basis remains unchanged.
+
+Rule:
+
+unsupported recognition state  
+→ no analytic authority
+
+Role:
+
+diagnostic / non-normative
+
+Status:
+
+defined  
+validated  
+buildable
+
+### hpc_evidence_bundle_v0
+
+Purpose:
+
+Record HPC / compute-scale evidence as a diagnostic evidence bundle with run identity, code identity, input manifest, environment, evidence items, summary metrics, provenance, and reconstruction instructions.
+
+Rule:
+
+HPC produces evidence.  
+HPC does not create release authority.
+
+unsupported compute output  
+→ no release authority
+
+Role:
+
+diagnostic evidence surface / non-normative
+
+Status:
+
+defined  
+validated  
+buildable
+
+### evidence_fold_in_admissibility_v0
+
+Purpose:
+
+Define whether a diagnostic, HPC, PULSE-PD, recognition, external detector, audit, publication, or other non-normative field point may become admissible for future fold-in into recorded release evidence.
+
+Rule:
+
+unsupported fold-in state  
+→ no recorded release evidence
+
+Every fold-in claim requires mechanical evidence.
+
+Role:
+
+diagnostic admissibility surface / non-normative
+
+Status:
+
+defined  
+validated  
+buildable
+
+### field_point_authority_map_v0
+
+Purpose:
+
+Classify PULSE field points by role, authority status, and relation to the normative materialization path.
+
+Rule:
+
+Every field-point claim requires authority-role classification.
+
+Role:
+
+diagnostic authority-role surface / non-normative
+
+Status:
+
+defined  
+validated  
+buildable
+
+## Shared invariants
+
+The following invariants now hold across the field-instrument development chain:
+
+- recognition surfaces are not authority;
+- every recognition claim requires mechanical evidence;
+- compute output is evidence only after materialization, recording, verification, and role classification;
+- diagnostic evidence does not create release authority;
+- advisory evidence must not silently enter recorded release evidence;
+- fold-in requires mechanical admissibility;
+- non-normative field points cannot affect release decisions without explicit policy routing;
+- publication, ledger, dashboard, DOI, README, About, badge, and social surfaces remain recognition / publication surfaces unless policy-routed;
+- audit bundles and manifests reconstruct or preserve decision trails but do not create a second release-decision path;
+- builders materialize diagnostic artifacts only;
+- generated diagnostic artifacts must set `creates_release_authority=false` where the contract uses that field.
+
+## Relation to pre-materialization mechanics
+
+PULSE pre-materialization mechanics prevents unsupported authority from materializing.
+
+This checkpoint extends the same discipline across the field-instrument surfaces:
+
+unsupported evidence state  
+→ no release authority
+
+unsupported recognition state  
+→ no analytic authority
+
+unsupported compute output  
+→ no release authority
+
+unsupported fold-in state  
+→ no recorded release evidence
+
+unclassified field point  
+→ no authority-role interpretation
+
+## Current development boundary
+
+This checkpoint does not promote any diagnostic surface into release authority.
+
+It does not modify:
+
+- release policy;
+- gate registry;
+- `check_gates.py`;
+- status schema semantics;
+- workflow release-gating semantics;
+- Quality Ledger authority status;
+- release authority manifest authority status;
+- audit bundle authority status;
+- publication surface authority semantics;
+- shadow-layer authority semantics.
+
+## What is now safe to say
+
+It is now accurate to say:
+
+PULSE contains diagnostic contracts and builders for recognition-surface drift, HPC evidence bundles, evidence fold-in admissibility, and field-point authority mapping.
+
+It is not accurate to say:
+
+These diagnostic surfaces create release authority.
+
+It is not accurate to say:
+
+A diagnostic artifact, publication surface, ledger, DOI record, badge, README, dashboard, or audit bundle can authorize release by itself.
+
+## Next careful boundary
+
+The next possible development direction is not immediate release-gate promotion.
+
+The next careful boundary would be:
+
+field-instrument diagnostic bundle  
+→ integrated field map / checkpoint report  
+→ still non-normative
+
+Only later, if needed, a specific diagnostic output may become release-relevant through:
+
+explicit evidence contract  
+→ digest-backed artifact  
+→ schema validation  
+→ verification  
+→ evidence fold-in admissibility  
+→ declared policy route  
+→ materialized required gate  
+→ strict fail-closed CI checking
+
+## Summary
+
+PULSE is not a pile of layers.
+
+PULSE is a field instrument.
+
+Each field point matters by role, authority status, and relation to the normative materialization path.
+
+The release decision does not come from a box, a badge, a report, a DOI, a dashboard, or a diagnostic artifact.
+
+The release decision materializes only along the declared normative path.


### PR DESCRIPTION
## Summary

This PR adds a non-normative field-instrument development checkpoint.

The checkpoint records the diagnostic contract + builder chain now present in PULSE:

- `recognition_surface_drift_v0`
- `hpc_evidence_bundle_v0`
- `evidence_fold_in_admissibility_v0`
- `field_point_authority_map_v0`

## Purpose

The goal is to preserve the current workshop development state without promoting any diagnostic surface into release authority.

The checkpoint records what is now defined, validated, and buildable, and keeps the authority boundary explicit.

## Shared invariants

The checkpoint preserves these PULSE rules:

- `unsupported evidence state → no release authority`
- `unsupported recognition state → no analytic authority`
- `unsupported compute output → no release authority`
- `unsupported fold-in state → no recorded release evidence`
- `Every field-point claim requires authority-role classification`

## Authority boundary

This document is non-normative.

It does not authorize, block, override, or create release authority.

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Scope

Changed:

- `docs/PULSE_FIELD_INSTRUMENT_DEVELOPMENT_CHECKPOINT_2026-05-21.md`

Not changed:

- release policy
- gate registry
- `check_gates.py`
- status schema semantics
- workflows
- release gates
- RA1 verifier
- primary CI release-decision semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Expected:

- checkpoint contains the four closed diagnostic surfaces;
- checkpoint states the normative release path;
- checkpoint states diagnostic surfaces remain non-normative;
- no release-authority semantics change.