### PR TITLE
docs: record tools-test stability checkpoint

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -96,3 +96,10 @@ Not a product audit. Not a roadmap. Not a “finished gating engine” demand.
 - Files: `WORKLOG.md`
 - Verification: `WORKLOG.md` no longer describes snapshot umbrella wiring as pending and names `g_field_stability_v0` contract hardening as the next mechanical step.
 - Links: PR=#TBD, commit=TBD
+
+### WL-0012 — Workshop chain stability check (builders/checkers/tools-tests)
+- Request: verify that the fresh workshop chain remains stable across builder/checker and tools-test paths.
+- Change: executed the full `ci/tools-tests.list` manifest as a single pytest invocation to validate repository toolchain stability coverage.
+- Files: `ci/tools-tests.list`, `WORKLOG.md`
+- Verification: `pytest -q $(awk 'NF && $1 !~ /^#/' ci/tools-tests.list)` → 461 passed.
+- Links: PR=#TBD, commit=TBD


### PR DESCRIPTION
## Summary

This PR adds a WORKLOG entry recording a full tools-test manifest stability checkpoint.

The checkpoint documents the command:

`pytest -q $(awk 'NF && $1 !~ /^#/' ci/tools-tests.list)`

Result:

`461 passed`

## Purpose

The goal is to preserve a clear trace that the current builder/checker/tools-test surface passed after the recent field-instrument development work.

This includes the newer diagnostic and field-instrument surfaces such as:

- recognition-surface drift;
- HPC evidence bundle;
- evidence fold-in admissibility;
- field-point authority map;
- associated builders / checkers / tests.

## Changed files

- `WORKLOG.md`

## Authority boundary

This is a worklog-only documentation update.

It does not authorize, block, override, or create release authority.

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI checking
→ CI allow/block release decision

## Scope

Not changed:

- code
- workflows
- schemas
- release policy
- gate registry
- `check_gates.py`
- status schema semantics
- release gates
- RA1 verifier
- primary CI release-decision semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Recorded validation:

- `pytest -q $(awk 'NF && $1 !~ /^#/' ci/tools-tests.list)`
- result: `461 passed`