### PR TITLE
docs: add PULSE-REF evidence packet layout

### DIFF
--- a/docs/PULSE_REF_EVIDENCE_PACKET_LAYOUT_v0.md
+++ b/docs/PULSE_REF_EVIDENCE_PACKET_LAYOUT_v0.md
@@ -466,37 +466,4 @@ recorded release evidence
 → declared-policy CI allow/block release decision
 ```
 
-## Pre-merge check
 
-Docs-only anchor check:
-
-```bash
-python - <<'PY'
-from pathlib import Path
-
-p = Path("docs/PULSE_REF_EVIDENCE_PACKET_LAYOUT_v0.md")
-text = p.read_text(encoding="utf-8")
-
-required = [
-    "pulse_ref_evidence_packet_v0/",
-    "status/status.json",
-    "policy/pulse_gate_policy_v0.yml",
-    "policy/pulse_gate_registry_v0.yml",
-    "gates/materialized_gate_sets.json",
-    "ci/ci_outcome.json",
-    "release_authority/release_authority_manifest.json",
-    "digests/package_digests.json",
-    "handoff/operator_handoff_report.json",
-    "publication/publication_snapshot.json",
-    "field/field_point_authority_map_v0.json",
-    "admissibility/evidence_fold_in_admissibility_v0.json",
-    "does not create release authority",
-    "release-grade reference is not merely a run",
-]
-
-for token in required:
-    assert token in text, token
-
-print("OK: PULSE-REF evidence packet layout anchors present")
-PY
-```


### PR DESCRIPTION
## Summary

This PR adds `docs/PULSE_REF_EVIDENCE_PACKET_LAYOUT_v0.md`.

The document defines a canonical layout for a future PULSE-REF release-grade reference evidence packet.

## Core point

A release-grade PULSE reference is not merely a run.

It is a closed, digest-backed, reconstructable evidence packet.

The packet preserves the evidence-to-decision path:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI gate enforcement
→ declared-policy CI allow/block decision

## Mechanical purpose

The layout defines canonical packet paths for:

- `status/status.json`
- `policy/pulse_gate_policy_v0.yml`
- `policy/pulse_gate_registry_v0.yml`
- `gates/materialized_gate_sets.json`
- `ci/ci_outcome.json`
- `release_authority/release_authority_manifest.json`
- `audit/release_authority_audit_bundle/`
- `digests/package_digests.json`
- `handoff/operator_handoff_report.json`
- `publication/publication_snapshot.json`
- `field/field_point_authority_map_v0.json`
- `admissibility/evidence_fold_in_admissibility_v0.json`
- conditional external evidence summaries
- optional HPC evidence bundle
- optional recognition-surface drift diagnostic
- reconstruction instructions

## Why this matters

The previous gap map records what a release-grade evidence packet must contain.

This layout records where those packet components belong.

It prepares the ground for a future minimal fixture, checker, or verifier target without claiming that a release-grade packet already exists.

## Authority boundary

This document is non-normative.

It does not authorize, block, override, or create release authority.

The packet layout does not replace:

- `status.json`;
- declared gate policy;
- materialized required gates;
- strict CI gate enforcement;
- declared-policy CI allow/block decision.

## Scope

Changed:

- `docs/PULSE_REF_EVIDENCE_PACKET_LAYOUT_v0.md`

Not changed:

- release policy
- gate registry
- `check_gates.py`
- status schema semantics
- workflows
- release gates
- RA1 verifier
- primary CI release-decision semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Expected validation:

- document defines the canonical packet root;
- document contains the required packet paths;
- document states that release-grade reference is not merely a run;
- document preserves the normative materialization path;
- document states the layout does not create release authority;
- no release-authority semantics change.