### PR TITLE
docs: add missing PULSE-REF gap-map anchor

### DIFF
--- a/docs/PULSE_REF_EVIDENCE_PACKET_GAP_MAP_v0.md
+++ b/docs/PULSE_REF_EVIDENCE_PACKET_GAP_MAP_v0.md
@@ -7,6 +7,7 @@ Authority status: non-normative planning and diagnostic document
 ## Core statement
 
 A release-grade PULSE reference is not merely a run.
+A release-grade reference is not merely a run.
 
 A release-grade reference is a closed, reconstructable evidence packet.
 


### PR DESCRIPTION
## Summary

This PR adds a missing anchor sentence to `docs/PULSE_REF_EVIDENCE_PACKET_GAP_MAP_v0.md`.

The validation check expected the exact phrase:

`A release-grade reference is not merely a run.`

The document already states that a release-grade reference is a closed, digest-backed, reconstructable evidence packet, but the exact anchor sentence was missing.

## Mechanical purpose

This keeps the PULSE-REF gap map aligned with the checkpoint language:

- release-grade reference is not merely a run;
- release-grade reference is a closed, reconstructable evidence packet;
- the packet preserves the evidence-to-decision path;
- the document remains non-normative.

## Authority boundary

This is a documentation-only anchor fix.

It does not authorize, block, override, or create release authority.

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI gate enforcement
→ declared-policy CI allow/block decision

## Scope

Changed:

- `docs/PULSE_REF_EVIDENCE_PACKET_GAP_MAP_v0.md`

Not changed:

- release policy
- gate registry
- `check_gates.py`
- status schema semantics
- workflows
- release gates
- RA1 verifier
- primary CI release-decision semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- shadow-layer authority semantics

## Validation

Validation before fix:

- anchor check failed with missing phrase:
  `release-grade reference is not merely a run`

Validation after fix:

- anchor check passed:
  `OK: PULSE-REF evidence packet gap map anchors present`