### PR TITLE
docs: put README release-authority mechanics first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # PULSE — Artifact-Bound Release Authority for AI Release Decisions
 
+
+Release authority in PULSE is a materialized evidence state: recorded release evidence is bound to `status.json`, declared gate policy, materialized required gates, and strict fail-closed CI gate enforcement before the declared-policy CI outcome becomes the release decision.
+
 PULSE is an evolving artifact-bound release-authority field instrument for AI applications and AI-enabled systems.
 
 PULSE fills the structural gap between probabilistic AI behavior and deterministic software release permission.
-
-Release authority in PULSE is a materialized evidence state: recorded release evidence is bound to `status.json`, declared gate policy, materialized required gates, and strict fail-closed CI gate enforcement before the declared-policy CI outcome becomes the release decision.
 
 PULSEmech is the mechanism: an artifact-bound, policy-declared, gate-materialized, CI-enforced evidence-to-decision path.
 


### PR DESCRIPTION
## Summary

This PR tightens the README front-door ordering.

The README now opens with the PULSE release-authority mechanics before the category description.

## Why

The front door should show what makes a PULSE decision mechanically valid before naming the broader category.

The first content sentence now states:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gates
→ strict fail-closed CI gate enforcement
→ declared-policy CI outcome
→ release decision

## Changed files

- `README.md`
- `tests/test_readme_release_authority_category_signal_v0.py` only if the old process-based-trust anchor was still present

## Authority boundary

This is README front-door recognition-surface stabilization only.

This PR does not authorize, block, override, or create release authority.

The normative PULSE release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI gate enforcement
→ declared-policy CI allow/block release decision

## Scope

Not changed:

- `.zenodo.json`
- `CITATION.cff`
- DOI records
- GitHub releases
- release policy
- gate registry
- `check_gates.py`
- status schema semantics
- workflows
- release gates
- RA1 verifier
- PULSE-REF skeleton checker
- primary CI release-decision semantics
- Quality Ledger authority status
- release authority manifest authority status
- audit bundle authority status
- release semantics
- Zenodo integration behavior

## Validation

Expected validation:

- `python -m py_compile tests/test_readme_release_authority_category_signal_v0.py`
- `python tests/test_readme_release_authority_category_signal_v0.py`
- `python -m pytest -q tests/test_readme_release_authority_category_signal_v0.py`