### PR TITLE
fix: harden PULSE-REF skeleton authority-boundary checks

### DIFF
--- a/scripts/check_pulse_ref_evidence_packet_layout_skeleton_v0.py
+++ b/scripts/check_pulse_ref_evidence_packet_layout_skeleton_v0.py
@@ -103,25 +103,34 @@ ALLOWED_AUTHORITY_DISCLAIMER_PHRASES = [
 
 CONTRADICTORY_AUTHORITY_PATTERNS = [
     (
-         re.compile(r"\bcreates?\s+release[-\s]authority\b", re.IGNORECASE),
+        re.compile(r"\bcreates?\s+release[-\s]+authority\b", re.IGNORECASE),
         "must not claim it creates release authority",
     ),
     (
-         re.compile(r"\bcan\s+create\s+release[-\s]authority\b", re.IGNORECASE),
+        re.compile(r"\bcan\s+create\s+release[-\s]+authority\b", re.IGNORECASE),
         "must not claim it can create release authority",
     ),
     (
-         re.compile(r"\bmay\s+create\s+release[-\s]authority\b", re.IGNORECASE),
+        re.compile(r"\bmay\s+create\s+release[-\s]+authority\b", re.IGNORECASE),
         "must not claim it may create release authority",
     ),
     (
-         re.compile(r"\bwill\s+create\s+release[-\s]authority\b", re.IGNORECASE),
+        re.compile(r"\bwill\s+create\s+release[-\s]+authority\b", re.IGNORECASE),
         "must not claim it will create release authority",
+    ),
+    (
+        re.compile(r"\bauthorizes?\s+release[-\s]+authority\b", re.IGNORECASE),
+        "must not claim it authorizes release authority",
+    ),
+    (
+        re.compile(r"\boverrides?\s+release[-\s]+authority\b", re.IGNORECASE),
+        "must not claim it overrides release authority",
     ),
     (
         re.compile(r"\bis\s+release-grade\s+evidence\b", re.IGNORECASE),
         "must not claim it is release-grade evidence",
     ),
+    (
         re.compile(r"\bis\s+a\s+release-grade\s+audit\s+bundle\b", re.IGNORECASE),
         "must not claim it is a release-grade audit bundle",
     ),
@@ -137,7 +146,7 @@ CONTRADICTORY_AUTHORITY_PATTERNS = [
         "must not claim it satisfies release-grade external evidence requirements",
     ),
     (
-         re.compile(
+        re.compile(
             r"\bis\s+reconstructable\s+release-grade\s+evidence\b",
             re.IGNORECASE,
         ),

--- a/scripts/check_pulse_ref_evidence_packet_layout_skeleton_v0.py
+++ b/scripts/check_pulse_ref_evidence_packet_layout_skeleton_v0.py
@@ -84,6 +84,12 @@ def _load_json(path: Path, errors: list[str]) -> dict[str, Any] | None:
         return None
 
     return obj
+def _read_text(path: Path, errors: list[str]) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception as exc:
+        errors.append(f"{path}: text read failed: {exc}")
+        return ""
 
 ALLOWED_AUTHORITY_DISCLAIMER_PHRASES = [
     "does not authorize, block, override, or create release authority",
@@ -97,32 +103,31 @@ ALLOWED_AUTHORITY_DISCLAIMER_PHRASES = [
 
 CONTRADICTORY_AUTHORITY_PATTERNS = [
     (
-        re.compile(r"\bcreates\s+release\s+authority\b", re.IGNORECASE),
+         re.compile(r"\bcreates?\s+release[-\s]authority\b", re.IGNORECASE),
         "must not claim it creates release authority",
     ),
     (
-        re.compile(r"\bcan\s+create\s+release\s+authority\b", re.IGNORECASE),
+         re.compile(r"\bcan\s+create\s+release[-\s]authority\b", re.IGNORECASE),
         "must not claim it can create release authority",
     ),
     (
-        re.compile(r"\bmay\s+create\s+release\s+authority\b", re.IGNORECASE),
+         re.compile(r"\bmay\s+create\s+release[-\s]authority\b", re.IGNORECASE),
         "must not claim it may create release authority",
     ),
     (
-        re.compile(r"\bwill\s+create\s+release\s+authority\b", re.IGNORECASE),
+         re.compile(r"\bwill\s+create\s+release[-\s]authority\b", re.IGNORECASE),
         "must not claim it will create release authority",
     ),
     (
+        re.compile(r"\bis\s+release-grade\s+evidence\b", re.IGNORECASE),
+        "must not claim it is release-grade evidence",
+    ),
         re.compile(r"\bis\s+a\s+release-grade\s+audit\s+bundle\b", re.IGNORECASE),
         "must not claim it is a release-grade audit bundle",
     ),
     (
         re.compile(r"\bis\s+a\s+release-grade\s+report\s+card\b", re.IGNORECASE),
         "must not claim it is a release-grade report card",
-    ),
-    (
-        re.compile(r"\bis\s+release-grade\s+evidence\b", re.IGNORECASE),
-        "must not claim it is release-grade evidence",
     ),
     (
         re.compile(
@@ -132,7 +137,10 @@ CONTRADICTORY_AUTHORITY_PATTERNS = [
         "must not claim it satisfies release-grade external evidence requirements",
     ),
     (
-        re.compile(r"\bis\s+reconstructable\s+release-grade\s+evidence\b", re.IGNORECASE),
+         re.compile(
+            r"\bis\s+reconstructable\s+release-grade\s+evidence\b",
+            re.IGNORECASE,
+        ),
         "must not claim it is reconstructable release-grade evidence",
     ),
 ]
@@ -156,7 +164,7 @@ def _text_without_allowed_disclaimers(text: str) -> str:
     lowered = text.lower()
 
     for phrase in ALLOWED_AUTHORITY_DISCLAIMER_PHRASES:
-        lowered = lowered.replace(phrase, "")
+        lowered = lowered.replace(phrase.lower(), "")
 
     return lowered
 
@@ -171,13 +179,9 @@ def _check_no_contradictory_authority_claims(
 
     for pattern, message in CONTRADICTORY_AUTHORITY_PATTERNS:
         if pattern.search(checked):
-            errors.append(f"{rel_path}: contradictory authority claim detected: {message}")
-def _read_text(path: Path, errors: list[str]) -> str:
-    try:
-        return path.read_text(encoding="utf-8")
-    except Exception as exc:
-        errors.append(f"{path}: text read failed: {exc}")
-        return ""
+            errors.append(
+                f"{rel_path}: contradictory authority claim detected: {message}"
+            )
 
 
 def _package_file_inventory(packet_root: Path) -> set[str]:

--- a/tests/test_pulse_ref_evidence_packet_layout_skeleton_v0.py
+++ b/tests/test_pulse_ref_evidence_packet_layout_skeleton_v0.py
@@ -297,6 +297,28 @@ def test_checker_rejects_report_card_contradictory_authority_claim() -> None:
     finally:
         td.cleanup()
 
+
+def test_checker_rejects_repeated_whitespace_authority_claim() -> None:
+    td, packet_root = _copy_skeleton()
+
+    try:
+        readme_path = packet_root / "README.md"
+        readme_path.write_text(
+            readme_path.read_text(encoding="utf-8")
+            + "\n\nThis skeleton creates release  authority.\n",
+            encoding="utf-8",
+        )
+
+        result = _run_checker(packet_root)
+
+        combined = result.stdout + result.stderr
+        assert result.returncode == 1
+        assert "README.md" in combined
+        assert "contradictory authority claim" in combined
+    finally:
+        td.cleanup()
+
+
 def main() -> int:
     try:
         test_layout_skeleton_root_exists()
@@ -311,6 +333,7 @@ def main() -> int:
         test_checker_rejects_external_summaries_readme_contradictory_authority_claim()
         test_checker_rejects_reconstruction_contradictory_authority_claim()
         test_checker_rejects_report_card_contradictory_authority_claim()
+        test_checker_rejects_repeated_whitespace_authority_claim()
     except AssertionError as exc:
         print(f"ERROR: {exc}")
         return 1

--- a/tests/test_pulse_ref_evidence_packet_layout_skeleton_v0.py
+++ b/tests/test_pulse_ref_evidence_packet_layout_skeleton_v0.py
@@ -4,6 +4,9 @@
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -41,6 +44,27 @@ CANONICAL_PATHS = [
     "recognition/recognition_surface_drift_v0.json",
     "reconstruction/reconstruction_instructions.md",
 ]
+
+
+def _copy_skeleton() -> tuple[tempfile.TemporaryDirectory[str], Path]:
+    td = tempfile.TemporaryDirectory()
+    packet_root = Path(td.name) / "pulse_ref_evidence_packet_v0"
+    shutil.copytree(PACKET_ROOT, packet_root)
+    return td, packet_root
+
+
+def _run_checker(packet_root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "python3",
+            str(ROOT / "scripts" / "check_pulse_ref_evidence_packet_layout_skeleton_v0.py"),
+            "--packet-root",
+            str(packet_root),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
 
 def _read_json(path: Path) -> dict[str, Any]:
@@ -121,6 +145,158 @@ def test_reconstruction_instructions_disclaim_release_authority() -> None:
     assert "This skeleton does not create release authority." in text
 
 
+
+def test_checker_rejects_yaml_placeholder_structural_authority_claim() -> None:
+    td, packet_root = _copy_skeleton()
+
+    try:
+        policy_path = packet_root / "policy" / "pulse_gate_policy_v0.yml"
+
+        policy_path.write_text(
+            "schema: pulse_ref_evidence_packet_layout_placeholder_v0\n"
+            "fixture_type: layout_skeleton_placeholder\n"
+            "release_grade_evidence: false\n"
+            "creates_release_authority: true\n"
+            "authority_boundary:\n"
+            "  creates_release_authority: true\n"
+            "  note: \"contains creates_release_authority: false as text only\"\n"
+            "placeholder_path: policy/pulse_gate_policy_v0.yml\n",
+            encoding="utf-8",
+        )
+
+        result = _run_checker(packet_root)
+
+        combined = result.stdout + result.stderr
+        assert result.returncode == 1
+        assert "policy/pulse_gate_policy_v0.yml" in combined
+        assert "creates_release_authority" in combined
+        assert "authority_boundary.creates_release_authority must be false" in combined
+    finally:
+        td.cleanup()
+
+
+def test_checker_rejects_root_readme_contradictory_authority_claim() -> None:
+    td, packet_root = _copy_skeleton()
+
+    try:
+        readme_path = packet_root / "README.md"
+        readme_path.write_text(
+            readme_path.read_text(encoding="utf-8")
+            + "\n\nThis skeleton creates release authority.\n",
+            encoding="utf-8",
+        )
+
+        result = _run_checker(packet_root)
+
+        combined = result.stdout + result.stderr
+        assert result.returncode == 1
+        assert "README.md" in combined
+        assert "contradictory authority claim" in combined
+    finally:
+        td.cleanup()
+
+
+def test_checker_rejects_audit_readme_contradictory_authority_claim() -> None:
+    td, packet_root = _copy_skeleton()
+
+    try:
+        audit_readme_path = (
+            packet_root
+            / "audit"
+            / "release_authority_audit_bundle"
+            / "README.md"
+        )
+
+        audit_readme_path.write_text(
+            audit_readme_path.read_text(encoding="utf-8")
+            + "\n\nThis audit bundle creates release authority.\n",
+            encoding="utf-8",
+        )
+
+        result = _run_checker(packet_root)
+
+        combined = result.stdout + result.stderr
+        assert result.returncode == 1
+        assert "audit/release_authority_audit_bundle/README.md" in combined
+        assert "contradictory authority claim" in combined
+    finally:
+        td.cleanup()
+
+
+def test_checker_rejects_external_summaries_readme_contradictory_authority_claim() -> None:
+    td, packet_root = _copy_skeleton()
+
+    try:
+        external_readme_path = packet_root / "external" / "summaries" / "README.md"
+
+        external_readme_path.write_text(
+            external_readme_path.read_text(encoding="utf-8")
+            + "\n\nThis external summaries directory satisfies release-grade external evidence requirements.\n",
+            encoding="utf-8",
+        )
+
+        result = _run_checker(packet_root)
+
+        combined = result.stdout + result.stderr
+        assert result.returncode == 1
+        assert "external/summaries/README.md" in combined
+        assert "contradictory authority claim" in combined
+    finally:
+        td.cleanup()
+
+
+def test_checker_rejects_reconstruction_contradictory_authority_claim() -> None:
+    td, packet_root = _copy_skeleton()
+
+    try:
+        reconstruction_path = (
+            packet_root
+            / "reconstruction"
+            / "reconstruction_instructions.md"
+        )
+
+        reconstruction_path.write_text(
+            reconstruction_path.read_text(encoding="utf-8")
+            + "\n\nThis skeleton is reconstructable release-grade evidence.\n",
+            encoding="utf-8",
+        )
+
+        result = _run_checker(packet_root)
+
+        combined = result.stdout + result.stderr
+        assert result.returncode == 1
+        assert "reconstruction/reconstruction_instructions.md" in combined
+        assert "contradictory authority claim" in combined
+    finally:
+        td.cleanup()
+
+
+def test_checker_rejects_report_card_contradictory_authority_claim() -> None:
+    td, packet_root = _copy_skeleton()
+
+    try:
+        report_path = (
+            packet_root
+            / "audit"
+            / "release_authority_audit_bundle"
+            / "report_card.html"
+        )
+
+        report_path.write_text(
+            report_path.read_text(encoding="utf-8")
+            + "\n<p>This report card creates release authority.</p>\n",
+            encoding="utf-8",
+        )
+
+        result = _run_checker(packet_root)
+
+        combined = result.stdout + result.stderr
+        assert result.returncode == 1
+        assert "audit/release_authority_audit_bundle/report_card.html" in combined
+        assert "contradictory authority claim" in combined
+    finally:
+        td.cleanup()
+
 def main() -> int:
     try:
         test_layout_skeleton_root_exists()
@@ -129,6 +305,12 @@ def main() -> int:
         test_json_placeholders_do_not_create_release_authority()
         test_root_readme_disclaims_release_grade_authority()
         test_reconstruction_instructions_disclaim_release_authority()
+        test_checker_rejects_yaml_placeholder_structural_authority_claim()
+        test_checker_rejects_root_readme_contradictory_authority_claim()
+        test_checker_rejects_audit_readme_contradictory_authority_claim()
+        test_checker_rejects_external_summaries_readme_contradictory_authority_claim()
+        test_checker_rejects_reconstruction_contradictory_authority_claim()
+        test_checker_rejects_report_card_contradictory_authority_claim()
     except AssertionError as exc:
         print(f"ERROR: {exc}")
         return 1


### PR DESCRIPTION
## Summary

This PR hardens the PULSE-REF evidence packet layout skeleton checker.

It addresses Codex review feedback about substring-only validation in the skeleton checker.

## What changed

The checker now parses YAML placeholders structurally instead of relying on substring presence.

It verifies that YAML placeholders set:

- `creates_release_authority=false`
- `authority_boundary.creates_release_authority=false`
- expected `placeholder_path`

The checker also rejects contradictory authority claims in text surfaces.

Required disclaimers are still required, but the following files can no longer pass if they also claim to create release authority or to be release-grade evidence:

- `README.md`
- `audit/release_authority_audit_bundle/README.md`
- `external/summaries/README.md`
- `reconstruction/reconstruction_instructions.md`
- `audit/release_authority_audit_bundle/report_card.html`

## Test coverage

Regression coverage is added to the existing skeleton layout test file:

- YAML placeholder structural authority claim;
- root README contradictory authority claim;
- audit bundle README contradictory authority claim;
- external summaries README contradictory authority claim;
- reconstruction contradictory authority claim;
- report-card contradictory authority claim.

No new test file is introduced.

## Authority boundary

This is layout-skeleton validation only.

It does not validate release-grade evidence.

It does not run the RA1 verifier.

It does not authorize, block, override, or create release authority.

The normative PULSE release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI gate enforcement
→ declared-policy CI allow/block release decision

## Scope

Changed:

- `scripts/check_pulse_ref_evidence_packet_layout_skeleton_v0.py`
- `tests/test_pulse_ref_evidence_packet_layout_skeleton_v0.py`

Not changed:

- `ci/tools-tests.list`
- README front-door wording
- `.zenodo.json`
- `CITATION.cff`
- DOI records
- GitHub releases
- release policy
- gate registry
- `check_gates.py`
- status schema semantics
- workflows
- release gates
- RA1 verifier
- release semantics
- Zenodo integration behavior

## Validation

Expected validation:

- `python -m py_compile scripts/check_pulse_ref_evidence_packet_layout_skeleton_v0.py tests/test_pulse_ref_evidence_packet_layout_skeleton_v0.py`
- `python tests/test_pulse_ref_evidence_packet_layout_skeleton_v0.py`
- `python -m pytest -q tests/test_pulse_ref_evidence_packet_layout_skeleton_v0.py`