### PR TITLE
docs: complete PULSE-REF minimum content contract anchors

### DIFF
--- a/docs/PULSE_REF_EVIDENCE_PACKET_MINIMUM_CONTENT_CONTRACT_v0.md
+++ b/docs/PULSE_REF_EVIDENCE_PACKET_MINIMUM_CONTENT_CONTRACT_v0.md
@@ -62,3 +62,31 @@ release-grade evidence packet
 
 release authority
 = only the declared-policy gate-enforcement CI outcome
+```
+
+## Minimum packet identity content
+
+A packet must include stable identity attributes (for example packet id, scope id, creation timestamp, and version marker) sufficient to correlate all artifacts to one evidence packet instance.
+
+## Minimum status artifact content
+
+`status.json` must include explicit outcome states, decision context pointers, and integrity references required to evaluate whether the packet can be considered complete for release evaluation.
+
+## Minimum materialized gate-set content
+
+The packet must enumerate the materialized required gate set and each gate's evaluated outcome so policy conformance can be reconstructed without inference.
+
+## Minimum CI outcome content
+
+The packet must carry the CI outcome record proving strict fail-closed CI gate enforcement and preserving the declared-policy allow/block release decision.
+
+## Minimum negative conditions
+
+A packet is not valid for release-grade use when required identity, status, gate-set, or CI outcome evidence is missing, placeholder-only, unverifiable, or contradictory.
+
+## This document does not change:
+
+- The authoritative release policy source.
+- The requirement that gate outcomes be policy-declared and fail-closed.
+- The rule that release authority is created only by the declared-policy gate-enforcement CI outcome.
+- Existing verifier responsibilities and separation of duties.


### PR DESCRIPTION
## Summary

This PR completes `docs/PULSE_REF_EVIDENCE_PACKET_MINIMUM_CONTENT_CONTRACT_v0.md`.

The previous document was structurally incomplete and missing required anchor sections.

This PR fills the missing sections and completes the document so it can serve as the non-normative planning contract between the existing layout skeleton and future content-bearing PULSE-REF evidence packets.

## Purpose

The PULSE-REF layout skeleton already proves that the canonical packet paths can physically exist.

This document defines the minimum content expectations those paths must eventually carry before a future packet can be considered content-prepared for release-grade reference evaluation.

## Authority boundary

This document is non-normative.

It does not validate release-grade evidence.

It does not run RA1.

It does not authorize, block, override, or create release authority.

The normative PULSE release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI gate enforcement
→ declared-policy CI allow/block release decision

## What changed

The document now includes the missing required anchor sections and no longer ends mid-structure.

It preserves the distinctions among:

- layout skeleton;
- minimum content contract;
- future content-bearing evidence packet;
- release-grade evidence packet;
- release authority.

## Scope

Changed:

- `docs/PULSE_REF_EVIDENCE_PACKET_MINIMUM_CONTENT_CONTRACT_v0.md`

Not changed:

- release policy
- gate registry
- `check_gates.py`
- status schemas
- workflows
- release gates
- RA1 verifier
- PULSE-REF skeleton checker
- Quality Ledger authority status
- release-authority manifest authority status
- audit bundle authority status
- publication surface authority semantics
- Zenodo metadata
- citation metadata
- DOI records
- GitHub releases
- README front-door wording
- release semantics

## Validation

Passed:

- minimum content contract anchor assertion script

The assertion confirmed that the document contains the required anchors for:

- non-normative planning status;
- normative release decision chain;
- layout skeleton / minimum content / release-grade packet distinction;
- minimum identity, status, gate-set, and CI outcome content;
- negative conditions;
- scope exclusions.