### PR TITLE
docs(ref): sharpen release-grade reference state semantics

### DIFF
--- a/docs/PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md
+++ b/docs/PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md
@@ -17,13 +17,25 @@ recorded release evidence
 → declared gate policy  
 → materialized required gate set  
 → strict fail-closed CI checking  
-→ CI allow/block release decision
+docs/PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md
 
 The release-grade reference run is the next anchor for fellowship-stage and HPC-supported validation work.
 
+## Run terminology
+
+In this plan, “run” means the recorded, artifact-bound reference state produced by a run.
+
+It includes the preserved `status.json`, declared policy, materialized required gate set, declared-policy gate-enforcement CI outcome, release authority manifest, audit bundle, artifact hashes, reader-surface parity checks, and reconstruction evidence.
+
+It does not mean an ephemeral CI event by itself.
+
+A release-grade reference run is accepted only when its recorded artifacts reconstruct the declared-policy release decision.
+
 ## Core thesis
 
-PULSE already has a working release-authority core.
+## Run terminology
+
+PULSE already has a working release-authority materialization path.
 
 The next step is to produce a reference run where that core operates on materialized release-grade evidence rather than scaffolded or stubbed surfaces.
 
@@ -52,9 +64,9 @@ recorded release evidence
 → declared gate policy  
 → materialized required gate set  
 → strict fail-closed CI checking  
-→ CI allow/block release decision
+PULSE already has a working release-authority materialization path.
 
-Reader, audit, preservation, publication, HPC, and diagnostic surfaces may render, preserve, inspect, or validate the decision.
+Reader, audit, preservation, publication, HPC, and diagnostic surfaces may render, preserve, inspect, or support reconstruction and consistency review of the decision.
 
 They do not create a second release-decision engine.
 
@@ -207,8 +219,9 @@ A release-grade candidate must block if required evidence is represented only by
 
 The run should explicitly check:
 
-- `gates_stubbed` is absent or false according to the status contract
-- `scaffold` is absent or false according to the status contract
+- `diagnostics.gates_stubbed` is explicitly `false`, or an equivalent current status-contract field explicitly records non-stubbed evidence
+- `diagnostics.scaffold` is explicitly `false`, or an equivalent current status-contract field explicitly records non-scaffolded evidence
+- missing, malformed, non-boolean, stripped, or fallback release-grade diagnostics fail closed unless the current status contract defines a stricter equivalent field
 - stub profile markers are absent from release-grade evidence
 - detector materialization evidence is present when required
 - required external summaries are present when required
@@ -309,7 +322,7 @@ Pass criteria:
 18. artifact hashes are recorded
 19. run identity is preserved
 20. release decision can be reconstructed from archived artifacts
-21. CI outcome matches reconstructed gate evaluation
+21. declared-policy gate-enforcement CI outcome matches reconstructed gate evaluation
 
 A release-grade reference run is not accepted merely because a public page displays a passing state.
 
@@ -384,7 +397,7 @@ The release authority manifest should record:
 - recorded `status.json` hash
 - materialized required gate set
 - materialized required gate set hash
-- CI outcome
+- declared-policy gate-enforcement CI outcome
 - gate evaluation result
 - external summary references when required
 - audit bundle reference
@@ -469,7 +482,7 @@ A reconstruction check should verify:
 - enforced gate set equals materialized required gate set
 - all required gates are literal boolean `true` for pass candidates
 - block candidates fail closed
-- CI outcome matches reconstructed gate result
+- declared-policy gate-enforcement CI outcome matches reconstructed gate result 
 - manifest hashes match artifact hashes
 - audit bundle contains required artifacts
 - reader surfaces match recorded source artifacts


### PR DESCRIPTION
## Summary

Refines `docs/PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md`.

This PR sharpens the release-grade reference-state semantics before the document becomes the anchor for fellowship/HPC validation work.

## Why

The release-grade next run plan correctly defines the next PULSE proof state: a recorded, non-stubbed, non-scaffolded, release-grade reference state.

This refinement closes a few possible authority-boundary misreadings:

- a release-grade “run” is not merely an ephemeral CI event
- the release decision is not any CI green state
- reader, audit, preservation, publication, HPC, and diagnostic surfaces do not validate or authorize release by themselves
- release-grade non-stubbed / non-scaffolded diagnostics should be explicit, not inferred from missing fields

## Key changes

- Adds a run terminology section.
- Clarifies that “run” means the recorded, artifact-bound reference state produced by a run.
- Clarifies that the recorded reference state includes:
  - preserved `status.json`
  - declared policy
  - materialized required gate set
  - declared-policy gate-enforcement CI outcome
  - release authority manifest
  - audit bundle
  - artifact hashes
  - reader-surface parity checks
  - reconstruction evidence
- Replaces “release-authority core” with “release-authority materialization path”.
- Clarifies the declared-policy CI allow/block release decision.
- Replaces broad “validate the decision” language with reconstruction and consistency review language.
- Tightens non-stubbed and non-scaffolded release-grade diagnostics.

## Authority boundary

The normative PULSEmech path remains unchanged:

recorded release evidence  
→ recorded `status.json` artifact  
→ declared gate policy  
→ materialized required gate set  
→ strict fail-closed CI checking  
→ declared-policy CI allow/block release decision

Reader, audit, preservation, publication, HPC, and diagnostic surfaces may render, preserve, inspect, or support reconstruction and consistency review of the decision.

They do not create a second release-decision engine.

## Scope

Documentation-only refinement.

No changes to:

- gate logic
- policy enforcement
- CI behavior
- schemas
- workflows
- release-decision semantics
- normative authority boundaries