### PR TITLE
docs(ref): repair release-grade next run authority path

### DIFF
--- a/docs/PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md
+++ b/docs/PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md
@@ -17,7 +17,7 @@ recorded release evidence
 → declared gate policy  
 → materialized required gate set  
 → strict fail-closed CI checking  
-docs/PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md
+→ declared-policy CI allow/block release decision
 
 The release-grade reference run is the next anchor for fellowship-stage and HPC-supported validation work.
 
@@ -32,8 +32,6 @@ It does not mean an ephemeral CI event by itself.
 A release-grade reference run is accepted only when its recorded artifacts reconstruct the declared-policy release decision.
 
 ## Core thesis
-
-## Run terminology
 
 PULSE already has a working release-authority materialization path.
 
@@ -64,7 +62,7 @@ recorded release evidence
 → declared gate policy  
 → materialized required gate set  
 → strict fail-closed CI checking  
-PULSE already has a working release-authority materialization path.
+→ declared-policy CI allow/block release decision
 
 Reader, audit, preservation, publication, HPC, and diagnostic surfaces may render, preserve, inspect, or support reconstruction and consistency review of the decision.
 


### PR DESCRIPTION
## Summary

Repairs `docs/PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md`.

The previous merged document had an insertion error in the opening PULSEmech release-authority path and a duplicated section heading.

## Why

The release-grade next run plan is intended to become the anchor for the next PULSE proof state.

Because this document defines the release-grade reference-state semantics, the authority path must be exact.

The merged version accidentally placed:

- the file path where the declared-policy CI allow/block release decision should be
- a duplicated `## Run terminology` heading under `## Core thesis`
- an unrelated materialization-path sentence at the end of the Authority boundary decision path

## Fix

This repair restores the intended PULSEmech path:

recorded release evidence  
→ recorded `status.json` artifact  
→ declared gate policy  
→ materialized required gate set  
→ strict fail-closed CI checking  
→ declared-policy CI allow/block release decision

It also keeps the intended clarification that a release-grade “run” means the recorded, artifact-bound reference state produced by a run, not an ephemeral CI event by itself.

## Authority boundary

The normative PULSEmech path remains unchanged.

Reader, audit, preservation, publication, HPC, and diagnostic surfaces may render, preserve, inspect, or support reconstruction and consistency review of the decision.

They do not create a second release-decision engine.

## Scope

Documentation-only repair.

No changes to:

- gate logic
- policy enforcement
- CI behavior
- schemas
- workflows
- release-decision semantics
- normative authority boundaries