### PR TITLE
docs(ref): repair release-grade next run authority path

### DIFF
--- a/docs/PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md
+++ b/docs/PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md
@@ -35,7 +35,7 @@ A release-grade reference run is accepted only when its recorded artifacts recon
 
 PULSE already has a working release-authority materialization path.
 
-The next step is to produce a reference run where that core operates on materialized release-grade evidence rather than scaffolded or stubbed surfaces.
+The next step is to produce a reference run where that materialization path operates on release-grade evidence rather than scaffolded or stubbed surfaces.
 
 The release-grade next run must show that PULSE can preserve:
 
@@ -47,7 +47,7 @@ The release-grade next run must show that PULSE can preserve:
 - audit reconstruction
 - reader-surface parity
 - archived artifact identity
-- deterministic allow/block decision
+- deterministic declared-policy allow/block decision  
 
 The run should be small enough to audit and strong enough to serve as the baseline for later HPC candidate-state validation.
 
@@ -641,7 +641,7 @@ The reference run is successful when:
 10. reader parity is verified
 11. decision is reconstructable
 12. archived artifacts preserve run identity
-13. CI decision and reconstructed decision match
+13. declared-policy CI decision and reconstructed decision match
 14. the resulting reference state can anchor HPC validation
 
 ## Follow-up work


### PR DESCRIPTION
## Summary

Repairs `docs/PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md`.

The previous merged document had an insertion error in the opening PULSEmech release-authority path and a duplicated section heading.

## Why

The release-grade next run plan is intended to become the anchor for the next PULSE proof state.

Because this document defines the release-grade reference-state semantics, the authority path must be exact.

The merged version accidentally placed:

- the file path where the declared-policy CI allow/block release decision should be
- a duplicated `## Run terminology` heading under `## Core thesis`
- an unrelated materialization-path sentence at the end of the Authority boundary decision path

## Fix

This repair restores the intended PULSEmech path:

recorded release evidence  
→ recorded `status.json` artifact  
→ declared gate policy  
→ materialized required gate set  
→ strict fail-closed CI checking  
→ declared-policy CI allow/block release decision

It also keeps the intended clarification that a release-grade “run” means the recorded, artifact-bound reference state produced by a run, not an ephemeral CI event by itself.

## Authority boundary

The normative PULSEmech path remains unchanged.

Reader, audit, preservation, publication, HPC, and diagnostic surfaces may render, preserve, inspect, or support reconstruction and consistency review of the decision.

They do not create a second release-decision engine.

## Scope

Documentation-only repair.

No changes to:

- gate logic
- policy enforcement
- CI behavior
- schemas
- workflows
- release-decision semantics
- normative authority boundaries