### PR TITLE
ci(ref): require explicit non-stubbed release-reference diagnostics

### DIFF
--- a/ci/check_release_reference_complete_v1.py
+++ b/ci/check_release_reference_complete_v1.py
@@ -176,7 +176,13 @@ def main() -> int:
     parser.add_argument(
         "--require-nonstubbed",
         action="store_true",
-        help="Require diagnostics.gates_stubbed != true.",
+        help="Require diagnostics.gates_stubbed == false.",
+    )
+
+    parser.add_argument(
+        "--require-nonscaffolded",
+        action="store_true",
+        help="Require diagnostics.scaffold == false.",
     )
 
     parser.add_argument(
@@ -256,10 +262,23 @@ def main() -> int:
 
     if args.require_nonstubbed:
         gates_stubbed = diagnostics.get("gates_stubbed")
-        if gates_stubbed is True:
-            errors.append("diagnostics.gates_stubbed is true; release-grade reference must be non-stubbed.")
+        if gates_stubbed is not False:
+            errors.append(
+                "diagnostics.gates_stubbed must be literal boolean false "
+                f"for release-grade reference; got {gates_stubbed!r}."
+            )
         else:
-            notes.append("non-stubbed check passed: diagnostics.gates_stubbed is not true.")
+            notes.append("non-stubbed check passed: diagnostics.gates_stubbed is literal false.")
+
+    if args.require_nonscaffolded:
+        scaffold = diagnostics.get("scaffold")
+        if scaffold is not False:
+            errors.append(
+                "diagnostics.scaffold must be literal boolean false "
+                f"for release-grade reference; got {scaffold!r}."
+            )
+        else:
+            notes.append("non-scaffolded check passed: diagnostics.scaffold is literal false.")
 
     if args.require_detectors_materialized:
         value = gates.get("detectors_materialized_ok")

--- a/tests/fixtures/release_reference_v1/false_gate/status.json
+++ b/tests/fixtures/release_reference_v1/false_gate/status.json
@@ -9,7 +9,8 @@
   },
   "diagnostics": {
     "gates_stubbed": false,
-    "fixture_note": "This fixture isolates one required gate set to false as the only intended failing condition."
+    "fixture_note": "This fixture isolates one required gate set to false as the only intended failing condition.",
+    "scaffold": false
   },
   "gates": {
     "pass_controls_refusal": false,

--- a/tests/fixtures/release_reference_v1/implicit_fallback_attempt/status.json
+++ b/tests/fixtures/release_reference_v1/implicit_fallback_attempt/status.json
@@ -14,6 +14,7 @@
   },
   "gates": {
     "pass_controls_refusal": true,
+    "refusal_delta_pass": true,
     "refusal_delta_evidence_present": true, 
     "effect_present": true,
     "psf_monotonicity_ok": true,

--- a/tests/fixtures/release_reference_v1/implicit_fallback_attempt/status.json
+++ b/tests/fixtures/release_reference_v1/implicit_fallback_attempt/status.json
@@ -9,11 +9,12 @@
   },
   "diagnostics": {
     "gates_stubbed": false,
-    "fixture_note": "This fixture isolates detectors_materialized_ok=false as the intended failing condition while keeping non-target gates passing."
+    "fixture_note": "This fixture isolates detectors_materialized_ok=false as the intended failing condition while keeping non-target gates passing.",
+    "scaffold": false
   },
   "gates": {
     "pass_controls_refusal": true,
-    "refusal_delta_pass": true,
+    "refusal_delta_evidence_present": true,
     "refusal_delta_evidence_present": true,  
     "effect_present": true,
     "psf_monotonicity_ok": true,

--- a/tests/fixtures/release_reference_v1/implicit_fallback_attempt/status.json
+++ b/tests/fixtures/release_reference_v1/implicit_fallback_attempt/status.json
@@ -14,8 +14,7 @@
   },
   "gates": {
     "pass_controls_refusal": true,
-    "refusal_delta_evidence_present": true,
-    "refusal_delta_evidence_present": true,  
+    "refusal_delta_evidence_present": true, 
     "effect_present": true,
     "psf_monotonicity_ok": true,
     "psf_mono_shift_resilient": true,

--- a/tests/fixtures/release_reference_v1/malformed_summary/status.json
+++ b/tests/fixtures/release_reference_v1/malformed_summary/status.json
@@ -9,7 +9,8 @@
   },
   "diagnostics": {
     "gates_stubbed": false,
-    "fixture_note": "This fixture isolates external_all_pass=false as the intended failing release-required gate while keeping external_summaries_present=true and non-target gates passing."
+    "fixture_note": "This fixture is non-stubbed and isolates missing external summary presence as the only intended failing gate.",
+    "scaffold": false
   },
   "gates": {
     "pass_controls_refusal": true,

--- a/tests/fixtures/release_reference_v1/malformed_summary/status.json
+++ b/tests/fixtures/release_reference_v1/malformed_summary/status.json
@@ -9,7 +9,7 @@
   },
   "diagnostics": {
     "gates_stubbed": false,
-    "fixture_note": "This fixture is non-stubbed and isolates missing external summary presence as the only intended failing gate.",
+    "fixture_note": "This fixture is non-stubbed and isolates external_all_pass=false as the only intended failing release-required gate.",
     "scaffold": false
   },
   "gates": {

--- a/tests/fixtures/release_reference_v1/missing_refusal_delta/status.json
+++ b/tests/fixtures/release_reference_v1/missing_refusal_delta/status.json
@@ -9,7 +9,8 @@
   },
   "diagnostics": {
     "gates_stubbed": false,
-    "fixture_note": "This fixture isolates refusal_delta_evidence_present=false as the intended failing release-grade evidence-presence gate while keeping refusal_delta_pass=true and non-target gates passing."
+    "fixture_note": "This fixture isolates refusal_delta_evidence_present=false as the intended failing release-grade evidence-presence gate while keeping refusal_delta_pass=true and non-target gates passing.",
+    "scaffold": false
   },
   "gates": {
     "pass_controls_refusal": true,

--- a/tests/fixtures/release_reference_v1/pass/status.json
+++ b/tests/fixtures/release_reference_v1/pass/status.json
@@ -9,7 +9,8 @@
   },
   "diagnostics": {
     "gates_stubbed": false,
-    "fixture_note": "This fixture is intentionally non-stubbed for release-reference guard validation."
+    "fixture_note": "This fixture is intentionally non-stubbed for release-reference guard validation.",
+    "scaffold": false
   },
   "gates": {
     "pass_controls_refusal": true,

--- a/tests/fixtures/release_reference_v1/refusal_delta_evidence_present/status.json
+++ b/tests/fixtures/release_reference_v1/refusal_delta_evidence_present/status.json
@@ -9,7 +9,8 @@
   },
   "diagnostics": {
     "gates_stubbed": false,
-    "fixture_note": "This fixture validates the positive control for refusal_delta_evidence_present=true while all required and release_required gates pass."
+    "fixture_note": "This fixture validates the positive control for refusal_delta_evidence_present=true while all required and release_required gates pass.",
+    "scaffold": false
   },
   "gates": {
     "pass_controls_refusal": true,

--- a/tests/fixtures/release_reference_v1/stubbed/status.json
+++ b/tests/fixtures/release_reference_v1/stubbed/status.json
@@ -9,7 +9,8 @@
   },
   "diagnostics": {
     "gates_stubbed": true,
-    "fixture_note": "This fixture isolates gates_stubbed=true as the only intended failing condition."
+    "fixture_note": "This fixture isolates gates_stubbed=true as the only intended failing condition.",
+    "scaffold": false
   },
   "gates": {
     "pass_controls_refusal": true,

--- a/tests/fixtures/release_reference_v1/unsigned_summary/status.json
+++ b/tests/fixtures/release_reference_v1/unsigned_summary/status.json
@@ -14,6 +14,7 @@
   },
   "gates": {
     "pass_controls_refusal": true,
+    "refusal_delta_pass": true,
     "refusal_delta_evidence_present": true, 
     "effect_present": true,
     "psf_monotonicity_ok": true,

--- a/tests/fixtures/release_reference_v1/unsigned_summary/status.json
+++ b/tests/fixtures/release_reference_v1/unsigned_summary/status.json
@@ -9,11 +9,12 @@
   },
   "diagnostics": {
     "gates_stubbed": false,
-    "fixture_note": "This fixture isolates external_all_pass=false as the intended failing release-required gate for unsigned or signer-policy-invalid external evidence."
+    "fixture_note": "This fixture isolates external_all_pass=false as the intended failing release-required gate for unsigned or signer-policy-invalid external evidence.",
+    "scaffold": false
   },
   "gates": {
     "pass_controls_refusal": true,
-    "refusal_delta_pass": true,
+    "refusal_delta_evidence_present": true,
     "refusal_delta_evidence_present": true,  
     "effect_present": true,
     "psf_monotonicity_ok": true,

--- a/tests/fixtures/release_reference_v1/unsigned_summary/status.json
+++ b/tests/fixtures/release_reference_v1/unsigned_summary/status.json
@@ -14,8 +14,7 @@
   },
   "gates": {
     "pass_controls_refusal": true,
-    "refusal_delta_evidence_present": true,
-    "refusal_delta_evidence_present": true,  
+    "refusal_delta_evidence_present": true, 
     "effect_present": true,
     "psf_monotonicity_ok": true,
     "psf_mono_shift_resilient": true,

--- a/tests/test_release_reference_fixture_matrix_v1.py
+++ b/tests/test_release_reference_fixture_matrix_v1.py
@@ -118,6 +118,7 @@ class TestReleaseReferenceFixtureMatrixV1(unittest.TestCase):
                     "--allowed-run-modes",
                     "prod",
                     "--require-nonstubbed",
+                    "--require-nonscaffolded",
                     "--require-detectors-materialized",
                     "--require-external-summaries",
                 ]


### PR DESCRIPTION
## Summary

Tightens PULSE-REF release-reference completeness checks so release-grade fixture validation requires explicit non-stubbed and non-scaffolded diagnostics.

## Why

The release-grade next-run plan defines the reference state as a recorded, artifact-bound release-grade evidence state, not an ephemeral CI event.

For release-grade reference validation, non-stubbed and non-scaffolded evidence must be explicit. Missing, malformed, fallback, or stripped diagnostics must not be treated as release-grade PASS.

The existing `check_release_reference_complete_v1.py` only rejected `diagnostics.gates_stubbed is True`. This update aligns the release-reference completeness guard with the stricter no-stub release-grade guard already present in `ci/check_release_no_stub_status.py`.

## Changes

- Tightens `--require-nonstubbed` so `diagnostics.gates_stubbed` must be literal boolean `false`.
- Adds `--require-nonscaffolded` so `diagnostics.scaffold` must be literal boolean `false`.
- Updates the release-reference fixture matrix runner to use `--require-nonscaffolded`.
- Updates active release-reference fixtures so non-target fixtures explicitly declare `diagnostics.scaffold: false`.
- Preserves isolated negative fixture semantics: each negative fixture should fail for its intended target, not for unrelated missing diagnostics.

## Authority boundary

This does not define release authority.

It strengthens release-grade reference validation for the declared-policy gate-enforcement path.

The normative PULSEmech path remains:

recorded release evidence  
→ recorded `status.json` artifact  
→ declared gate policy  
→ materialized required gate set  
→ strict fail-closed CI checking  
→ declared-policy CI allow/block release decision

## Scope

Guard and fixture hardening.

No changes to:

- declared gate policy semantics
- status schema semantics
- release-decision authority
- CI workflow behavior outside this guard invocation
- reader/audit/HPC surface authority boundaries