### PR TITLE
test(ref): restore missing_external fixture isolation

### DIFF
--- a/tests/fixtures/release_reference_v1/missing_external/status.json
+++ b/tests/fixtures/release_reference_v1/missing_external/status.json
@@ -9,6 +9,7 @@
   },
   "diagnostics": {
     "gates_stubbed": false,
+    "scaffold": false,
     "fixture_note": "This fixture is non-stubbed and isolates missing external summary presence as the only intended failing gate."
   },
   "gates": {


### PR DESCRIPTION
## Summary

Restores isolation for the `release_reference_v1/missing_external` fixture.

Adds explicit `diagnostics.scaffold=false` to:

`tests/fixtures/release_reference_v1/missing_external/status.json`

## Why

The release-reference diagnostics hardening introduced explicit non-stubbed and non-scaffolded checks.

After that change, the `missing_external` negative fixture was no longer isolated: it failed both the intended `external_summaries_present=false` condition and an unintended `--require-nonscaffolded` condition.

This PR restores the fixture to a single intended failure target.

## Fixture behavior

The intended fixture behavior is:

- `missing_external` isolates `external_summaries_present=false`
- `diagnostics.gates_stubbed=false`
- `diagnostics.scaffold=false`
- non-target required and release_required gates remain passing

## Authority boundary

This fixture does not define release authority.

It exercises the release-reference completeness guard for a controlled negative evidence state.

The normative PULSEmech path remains unchanged:

recorded release evidence  
→ recorded `status.json` artifact  
→ declared gate policy  
→ materialized required gate set  
→ strict fail-closed CI checking  
→ declared-policy CI allow/block release decision

## Scope

Data-only fixture correction.

No changes to:

- release-authority semantics
- gate policy semantics
- status schema semantics
- CI workflow behavior
- reader/audit/HPC authority boundaries