### PR TITLE
test(ref): add scaffolded release-reference fixture

### DIFF
--- a/docs/pulse_ref_fixture_matrix_v1.md
+++ b/docs/pulse_ref_fixture_matrix_v1.md
@@ -79,6 +79,22 @@ This fixture isolates:
 
 All required and release_required gates remain passing.
 
+### scaffolded
+
+Expected result: FAIL.
+
+Purpose:
+
+Validates fail-closed behavior when diagnostics indicate scaffolded release-grade evidence.
+
+This fixture isolates:
+
+- `diagnostics.scaffold: true`
+
+All required and release_required gates remain passing.
+
+Release-grade reference validation must not infer PASS from scaffolded evidence even when gate values appear passing.
+
 ### false_gate
 
 Expected result: FAIL.

--- a/tests/fixtures/release_reference_v1/README.md
+++ b/tests/fixtures/release_reference_v1/README.md
@@ -47,6 +47,14 @@ Represents a release-grade candidate where gates or detector outputs are stubbed
 
 Release-grade paths must not pass when `gates_stubbed=true` or equivalent stub indicators are present.
 
+### scaffolded
+
+Expected outcome: FAIL.
+
+Represents a release-grade candidate where diagnostics mark the state as scaffolded.
+
+Release-grade paths must not pass when `diagnostics.scaffold=true` or equivalent scaffold indicators are present.
+
 ### malformed_summary
 
 Expected outcome: FAIL.

--- a/tests/fixtures/release_reference_v1/scaffolded/expected_outcome.json
+++ b/tests/fixtures/release_reference_v1/scaffolded/expected_outcome.json
@@ -1,0 +1,24 @@
+{
+  "fixture_id": "release_reference_v1/scaffolded",
+  "expected_result": "FAIL",
+  "expected_reason": "diagnostics.scaffold is true. This fixture isolates scaffolded diagnostics as the only intended failing condition while keeping all required and release_required gates passing.",
+  "expected_guard": "ci/check_release_reference_complete_v1.py",
+  "expected_checks": {
+    "run_mode": "prod",
+    "gates_stubbed": false,
+    "scaffold": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true,
+    "required_gates_literal_true": true,
+    "release_required_gates_literal_true": true
+  },
+  "expected_failure": {
+    "field": "diagnostics.scaffold",
+    "value": true,
+    "failure_mode": "scaffolded_release_grade_evidence",
+    "non_target_required_gates_passing": true,
+    "non_target_release_required_gates_passing": true
+  },
+  "authority_boundary": "This fixture does not define release authority. It exercises fail-closed behavior for scaffolded diagnostics through the declared-policy gate-enforcement path and the PULSE-REF release-grade completeness guard."
+}

--- a/tests/fixtures/release_reference_v1/scaffolded/status.json
+++ b/tests/fixtures/release_reference_v1/scaffolded/status.json
@@ -1,0 +1,48 @@
+{
+  "version": "1.0",
+  "created_utc": "2026-05-04T00:00:00Z",
+  "metrics": {
+    "run_mode": "prod",
+    "fixture_id": "release_reference_v1/scaffolded",
+    "fixture_kind": "negative_release_reference",
+    "description": "Negative PULSE-REF release-grade reference fixture where diagnostics.scaffold=true while required and release_required gates appear passing. Release-grade validation must fail closed on scaffolded evidence."
+  },
+  "diagnostics": {
+    "gates_stubbed": false,
+    "scaffold": true,
+    "fixture_note": "This fixture isolates diagnostics.scaffold=true as the only intended failing condition while keeping all required and release_required gates passing."
+  },
+  "gates": {
+    "pass_controls_refusal": true,
+    "refusal_delta_pass": true,
+    "refusal_delta_evidence_present": true,
+    "effect_present": true,
+    "psf_monotonicity_ok": true,
+    "psf_mono_shift_resilient": true,
+    "pass_controls_comm": true,
+    "psf_commutativity_ok": true,
+    "psf_comm_shift_resilient": true,
+    "pass_controls_sanit": true,
+    "sanitization_effective": true,
+    "sanit_shift_resilient": true,
+    "psf_action_monotonicity_ok": true,
+    "psf_idempotence_ok": true,
+    "psf_path_independence_ok": true,
+    "psf_pii_monotonicity_ok": true,
+    "q1_grounded_ok": true,
+    "q2_consistency_ok": true,
+    "q3_fairness_ok": true,
+    "q4_slo_ok": true,
+    "detectors_materialized_ok": true,
+    "external_summaries_present": true,
+    "external_all_pass": true
+  },
+  "evidence": {
+    "detectors_materialized": true,
+    "external_summaries_present": true,
+    "external_summary_mode": "fixture",
+    "scaffold_evidence_mode": "scaffolded_fixture",
+    "expected_behavior": "scaffolded release-grade evidence must fail closed even when required and release_required gates appear passing",
+    "authority_boundary": "This fixture does not define release authority. It exercises fail-closed release-grade behavior when diagnostics.scaffold=true."
+  }
+}


### PR DESCRIPTION
## Summary

Adds an isolated `release_reference_v1/scaffolded` negative fixture.

The fixture validates that release-grade reference validation fails closed when `diagnostics.scaffold=true`.

## Why

The release-reference completeness guard now supports explicit non-scaffolded validation through `--require-nonscaffolded`.

This PR adds the direct fixture coverage for that guard behavior.

The new fixture keeps all required and release_required gates passing while setting:

`diagnostics.scaffold=true`

This ensures the failure is isolated to the scaffolded evidence condition.

## Added

- `tests/fixtures/release_reference_v1/scaffolded/status.json`
- `tests/fixtures/release_reference_v1/scaffolded/expected_outcome.json`

## Updated

- fixture matrix documentation to include the scaffolded case
- optional fixture README coverage for the scaffolded category

## Expected behavior

The fixture should fail through:

`diagnostics.scaffold`

and should not fail because of unrelated required gates, external evidence, detector materialization, or stubbed diagnostics.

## Authority boundary

This fixture does not define release authority.

It exercises the release-reference completeness guard for a controlled negative evidence state.

The normative PULSEmech path remains unchanged:

recorded release evidence  
→ recorded `status.json` artifact  
→ declared gate policy  
→ materialized required gate set  
→ strict fail-closed CI checking  
→ declared-policy CI allow/block release decision

## Scope

Test fixture and documentation only.

No changes to:

- release-authority semantics
- gate policy semantics
- status schema semantics
- CI workflow behavior
- reader/audit/HPC authority boundaries