### PR TITLE
docs(ref): sync fixture matrix docs with nonscaffolded guard

### DIFF
--- a/docs/pulse_ref_fixture_matrix_v1.md
+++ b/docs/pulse_ref_fixture_matrix_v1.md
@@ -24,7 +24,8 @@ python ci/check_release_reference_complete_v1.py \
   --required-sets required,release_required \
   --allowed-run-modes prod \
   --require-nonstubbed \
-  --require-detectors-materialized \
+ --require-nonscaffolded \
+ --require-detectors-materialized \
   --require-external-summaries
 ```
 
@@ -203,12 +204,14 @@ Covered fixture cases:
 - positive release-grade reference candidate
 - missing external summary presence
 - stubbed diagnostics
+- scaffolded release-grade diagnostics
 - false required gate
 - non-materialized detector evidence / implicit fallback attempt
 
 Covered PULSE-REF hardening properties:
 
 - non-stubbed release-grade qualification
+- explicit non-scaffolded release-grade qualification
 - explicit external evidence presence
 - strict required-gate literal-true semantics
 - detector materialization requirement


### PR DESCRIPTION
## Summary

Syncs `docs/pulse_ref_fixture_matrix_v1.md` with the current release-reference fixture matrix behavior.

## Why

The release-reference completeness guard now supports explicit non-scaffolded validation through:

`--require-nonscaffolded`

The executable fixture matrix already uses this guard behavior, and the scaffolded negative fixture now covers `diagnostics.scaffold=true`.

This PR updates the documentation so the documented command and coverage summary match the current executable matrix.

## Changes

- Adds `--require-nonscaffolded` to the documented fixture matrix command.
- Adds `scaffolded release-grade diagnostics` to covered fixture cases.
- Adds `explicit non-scaffolded release-grade qualification` to covered hardening properties.

## Authority boundary

This documentation does not define release authority.

The fixture matrix remains a regression layer for release-grade evidence-to-decision behavior.

The normative PULSEmech path remains unchanged:

recorded release evidence  
→ recorded `status.json` artifact  
→ declared gate policy  
→ materialized required gate set  
→ strict fail-closed CI checking  
→ declared-policy CI allow/block release decision

## Scope

Documentation only.

No changes to:

- fixture behavior
- guard logic
- gate policy semantics
- status schema semantics
- CI workflow behavior
- release-authority semantics