### PR TITLE
docs(readme): restore evidence-materialization positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,26 @@
 # PULSE — Artifact-Bound Release Authority for AI Release Decisions
 
-
 Release authority in PULSE is a materialized evidence state: recorded release evidence is bound to `status.json`, declared gate policy, materialized required gates, and strict fail-closed CI gate enforcement before the declared-policy CI outcome becomes the release decision.
 
-PULSE is an evolving artifact-bound release-authority field instrument for AI applications and AI-enabled systems.
+PULSE is an artifact-bound release-authority system for AI applications and AI-enabled systems.
 
-PULSE fills the structural gap between probabilistic AI behavior and deterministic software release permission.
+
+The evidence-producing surfaces for PULSE include AI applications, model behavior, evaluation suites, detector systems, review processes, logs, dashboards, and deployment pipelines.
+
+These surfaces produce, record, or render candidate release evidence: behavior records, scores, summaries, traces, reviews, CI records, and stability signals.
+
+PULSE materializes recorded candidate release evidence into artifact-bound release-authority state before deployment, under declared policy and materialized required gates.
+
+Release permission is produced by the complete materialization path: recorded evidence, machine-readable release state, declared policy, materialized required gates, and strict fail-closed CI enforcement.
+
+The declared-policy CI outcome is the terminal enforcement record of that materialization path.
+
+The transition handled by PULSE is:
+
+probabilistic AI behavior  
+→ recorded candidate release evidence  
+→ artifact-bound release-authority state  
+→ deterministic software release permission
 
 PULSEmech is the mechanism: an artifact-bound, policy-declared, gate-materialized, CI-enforced evidence-to-decision path.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Release permission is produced by the complete materialization path: recorded ev
 
 The declared-policy CI outcome is the terminal enforcement record of that materialization path.
 
+PULSE fills the structural gap between probabilistic AI behavior and deterministic software release permission.
+
 The transition handled by PULSE is:
 
 probabilistic AI behavior  

--- a/tests/test_readme_release_authority_category_signal_v0.py
+++ b/tests/test_readme_release_authority_category_signal_v0.py
@@ -36,8 +36,17 @@ FRONT_DOOR_END_MARKERS = [
 
 REQUIRED_FRONT_DOOR_ANCHORS = [
     "PULSE — Artifact-Bound Release Authority for AI Release Decisions",
-    "PULSE is an evolving artifact-bound release-authority field instrument",
+    "PULSE is an artifact-bound release-authority system for AI applications and AI-enabled systems",
     "PULSE fills the structural gap between probabilistic AI behavior and deterministic software release permission",
+    "The evidence-producing surfaces for PULSE include AI applications, model behavior, evaluation suites, detector systems, review processes, logs, dashboards, and deployment pipelines",
+    "These surfaces produce, record, or render candidate release evidence",
+    "PULSE materializes recorded candidate release evidence into artifact-bound release-authority state before deployment",
+    "Release permission is produced by the complete materialization path",
+    "The declared-policy CI outcome is the terminal enforcement record of that materialization path",
+    "probabilistic AI behavior",
+    "recorded candidate release evidence",
+    "artifact-bound release-authority state",
+    "deterministic software release permission",
     "Release authority in PULSE is a materialized evidence state",
     "recorded release evidence is bound to `status.json`, declared gate policy, materialized required gates, and strict fail-closed CI gate enforcement",
     "the declared-policy CI outcome becomes the release decision",


### PR DESCRIPTION
## Summary

Restores evidence-materialization positioning in the README front door.

## Why

The current README correctly foregrounds artifact-bound PULSEmech release authority, but the opening can be read too narrowly as a conventional deterministic CI gate.

This PR restores the system-level materialization reading:

AI applications, model behavior, evaluation suites, detector systems, review processes, logs, dashboards, and deployment pipelines produce, record, or render candidate release evidence. PULSE materializes recorded candidate release evidence into artifact-bound release-authority state before deployment.

## What changes

The README opening now describes:

- evidence-producing surfaces around PULSE
- candidate release evidence as behavior records, scores, summaries, traces, reviews, CI records, and stability signals
- recorded candidate evidence being materialized into artifact-bound release-authority state
- release permission arising from the complete materialization path
- the declared-policy CI outcome as the terminal enforcement record of that path
- the transition from probabilistic AI behavior to deterministic software release permission

## Authority boundary

The normative PULSEmech path remains unchanged:

recorded release evidence  
→ recorded `status.json` artifact  
→ declared gate policy  
→ materialized required gate set  
→ strict fail-closed CI gate enforcement  
→ declared-policy CI allow/block release decision

## Scope

README positioning only.

Existing gate logic, fixture behavior, CI workflow behavior, RA1 behavior, declared gate policy, gate registry, status schema, and release-authority semantics remain unchanged.