### PR TITLE
test(readme): sync category signal guard with evidence-materializatio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ PULSE materializes recorded candidate release evidence into artifact-bound relea
 
 Release permission is produced by the complete materialization path: recorded evidence, machine-readable release state, declared policy, materialized required gates, and strict fail-closed CI enforcement.
 
-The declared-policy CI outcome is the terminal enforcement record of that materialization path.
+The declared-policy CI outcome is the terminal enforcement resoult of that materialization path.
 
 PULSE fills the structural gap between probabilistic AI behavior and deterministic software release permission.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # PULSE — Artifact-Bound Release Authority for AI Release Decisions
 
+
 Release authority in PULSE is a materialized evidence state: recorded release evidence is bound to `status.json`, declared gate policy, materialized required gates, and strict fail-closed CI gate enforcement before the declared-policy CI outcome becomes the release decision.
 
 PULSE is an artifact-bound release-authority system for AI applications and AI-enabled systems.
-
 
 The evidence-producing surfaces for PULSE include AI applications, model behavior, evaluation suites, detector systems, review processes, logs, dashboards, and deployment pipelines.
 
@@ -13,7 +13,7 @@ PULSE materializes recorded candidate release evidence into artifact-bound relea
 
 Release permission is produced by the complete materialization path: recorded evidence, machine-readable release state, declared policy, materialized required gates, and strict fail-closed CI enforcement.
 
-The declared-policy CI outcome is the terminal enforcement resoult of that materialization path.
+The declared-policy CI outcome is the terminal enforcement record of that materialization path.
 
 PULSE fills the structural gap between probabilistic AI behavior and deterministic software release permission.
 


### PR DESCRIPTION
## Repair

Syncs the README front-door category-signal guard with the updated evidence-materialization wording.

The smoke test was still requiring the old phrase:

`PULSE is an evolving artifact-bound release-authority field instrument`

The README now uses the more stable category definition:

`PULSE is an artifact-bound release-authority system for AI applications and AI-enabled systems`

This update changes the guard to protect the new evidence-materialization anchors and restores the structural gap sentence in the README.

No release-authority semantics change.