### PR TITLE
docs(readme): clarify terminal enforcement result wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ PULSE materializes recorded candidate release evidence into artifact-bound relea
 
 Release permission is produced by the complete materialization path: recorded evidence, machine-readable release state, declared policy, materialized required gates, and strict fail-closed CI enforcement.
 
-The declared-policy CI outcome is the terminal enforcement record of that materialization path.
+The declared-policy CI outcome is the recorded terminal enforcement result of that materialization path.
 
 PULSE fills the structural gap between probabilistic AI behavior and deterministic software release permission.
 

--- a/tests/test_readme_release_authority_category_signal_v0.py
+++ b/tests/test_readme_release_authority_category_signal_v0.py
@@ -42,7 +42,7 @@ REQUIRED_FRONT_DOOR_ANCHORS = [
     "These surfaces produce, record, or render candidate release evidence",
     "PULSE materializes recorded candidate release evidence into artifact-bound release-authority state before deployment",
     "Release permission is produced by the complete materialization path",
-    "The declared-policy CI outcome is the terminal enforcement record of that materialization path",
+    "The declared-policy CI outcome is the recorded terminal enforcement result of that materialization path",
     "probabilistic AI behavior",
     "recorded candidate release evidence",
     "artifact-bound release-authority state",


### PR DESCRIPTION
## Summary

Clarifies one README front-door sentence and syncs the README category-signal guard.

## Why

The README currently says:

`The declared-policy CI outcome is the terminal enforcement record of that materialization path.`

This is close, but “record” can sound too audit-only.

The intended PULSE meaning is that the declared-policy CI outcome is both:

- the terminal enforcement result of the materialization path
- recorded as part of the artifact-bound release-authority trail

## Change

Updates the README wording to:

`The declared-policy CI outcome is the recorded terminal enforcement result of that materialization path.`

Also updates `tests/test_readme_release_authority_category_signal_v0.py` so the front-door guard protects the new wording.

## Authority boundary

The normative PULSEmech path remains unchanged:

recorded release evidence  
→ recorded `status.json` artifact  
→ declared gate policy  
→ materialized required gate set  
→ strict fail-closed CI gate enforcement  
→ declared-policy CI allow/block release decision

## Scope

README wording and guard sync only.

No changes to:

- gate logic
- fixture behavior
- CI workflow behavior
- RA1 behavior
- declared gate policy
- gate registry
- status schema
- release-authority semantics