### PR TITLE
docs(pulse): add relational evidence-field principle

### DIFF
--- a/docs/PULSE_RELATIONAL_EVIDENCE_FIELD_PRINCIPLE_v0.md
+++ b/docs/PULSE_RELATIONAL_EVIDENCE_FIELD_PRINCIPLE_v0.md
@@ -1,0 +1,356 @@
+# PULSE Relational Evidence-Field Principle v0
+
+Status: principle anchor  
+Authority status: non-normative field principle  
+Scope: PULSE / PULSE-REF / release-authority materialization / evidence-field reconstruction  
+Release-grade status: field interpretation principle  
+Decision status: preserves the declared PULSEmech release-authority path
+
+## Purpose
+
+This document defines the PULSE relational evidence-field principle.
+
+The principle protects the mechanical distinction between a release-decision label and the evidence field that produces it.
+
+PULSE release authority is read through the materialized field behind the terminal result.
+
+The terminal result is meaningful because its generation relation is preserved.
+
+## Core statement
+
+PULSE does not treat a release decision as an isolated endpoint.
+
+PULSE treats a release decision as the recorded terminal state of a materialized evidence field.
+
+The decision label is the visible enforcement result.
+
+The decision field is the reconstructable relation that produced it.
+
+The PULSE pattern is therefore:
+
+result  
+→ reason for the result  
+→ evidence relation that produced the result  
+→ boundary pressure and stability context  
+→ materialized authority state  
+→ allow / block decision and repair-route context
+
+The release decision is strongest when the origin relation remains visible.
+
+## PULSEmech path
+
+The PULSEmech release-authority path remains:
+
+recorded release evidence  
+→ recorded `status.json` artifact  
+→ declared gate policy  
+→ materialized required gate set  
+→ strict fail-closed CI gate enforcement  
+→ declared-policy CI allow/block release decision
+
+This path produces the terminal decision.
+
+The relational evidence field preserves how the terminal decision was produced.
+
+## Relational evidence field
+
+The PULSE evidence field contains interacting release-state surfaces.
+
+Core field relation:
+
+candidate evidence  
+↔ declared policy  
+↔ materialized required gates  
+↔ boundary pressure  
+↔ stability signals  
+↔ release-authority state
+
+This relation is the mechanical source of the release decision.
+
+The decision result is the recorded terminal enforcement result of this field.
+
+## Candidate evidence
+
+Candidate evidence includes recorded or recordable surfaces around an AI system.
+
+Examples:
+
+- model behavior;
+- evaluation outputs;
+- detector summaries;
+- review records;
+- CI records;
+- quality signals;
+- refusal-delta signals;
+- stability signals;
+- audit traces;
+- external evidence summaries;
+- operator handoff records;
+- packet reconstruction artifacts.
+
+Candidate evidence becomes release-relevant through recording, typing, policy routing, gate materialization, and fail-closed enforcement.
+
+## Declared policy relation
+
+Declared policy gives structure to the candidate evidence field.
+
+Policy defines:
+
+- which gates are required;
+- which gates are release-required;
+- which evidence surfaces can enter the enforced path;
+- which signals remain diagnostic;
+- which missing or non-true states fail closed;
+- which lane or release state is being evaluated.
+
+Policy is therefore not an external label on top of evidence.
+
+Policy is one of the relations that shapes the evidence field into a release-authority state.
+
+## Materialized gates relation
+
+Materialized required gates are the concrete gate set produced from declared policy.
+
+They connect policy to recorded evidence.
+
+They define the enforced release-authority surface.
+
+A gate result carries meaning through its relation to:
+
+- the declared policy source;
+- the recorded `status.json` artifact;
+- the materialized required gate set;
+- the evidence field behind the gate value;
+- the fail-closed CI enforcement result.
+
+The gate value is the visible value.
+
+The materialized relation is the release-authority structure.
+
+## Boundary pressure
+
+Boundary pressure is the field condition created when candidate evidence, declared policy, required gates, stability signals, and release permission meet at the release boundary.
+
+Boundary pressure appears when:
+
+- evidence is incomplete;
+- evidence is contradictory;
+- evidence is unstable;
+- evidence is present but not policy-routed;
+- diagnostic evidence approaches release relevance;
+- required gates cannot be materialized;
+- the release state cannot be reconstructed.
+
+Boundary pressure is not a separate decision engine.
+
+It is the field condition that PULSE records and resolves through materialized release-authority mechanics.
+
+## Stability signals
+
+Stability signals help preserve the decision field over time.
+
+Examples:
+
+- refusal-delta evidence;
+- Release Decision Stability Index signals;
+- detector stability;
+- external evidence consistency;
+- schema stability;
+- packet reconstruction stability;
+- reader-surface parity;
+- audit-bundle integrity.
+
+A stability signal is strongest when it is recorded, bound to the candidate state, and classified by authority role.
+
+## Release-authority state
+
+The release-authority state is the materialized state produced by the relation between:
+
+- recorded evidence;
+- machine-readable release state;
+- declared policy;
+- materialized required gates;
+- strict fail-closed CI enforcement;
+- reconstruction surfaces.
+
+The release-authority state carries the decision.
+
+The PASS / FAIL label displays the terminal result.
+
+The recorded evidence field preserves the generation path.
+
+## Classical gate comparison
+
+A classical gate primarily exposes:
+
+input  
+→ check  
+→ output
+
+PULSE preserves:
+
+candidate evidence  
+↔ declared policy  
+↔ materialized required gates  
+↔ boundary pressure  
+↔ stability signal  
+↔ release-authority state  
+→ terminal enforcement result
+
+This is the PULSE field pattern.
+
+The value of the result comes from the preserved relation.
+
+## Evidence packet relation
+
+A PULSE-REF evidence packet preserves the decision field in artifact form.
+
+The packet carries:
+
+- recorded status;
+- declared policy;
+- materialized gate sets;
+- CI outcome;
+- release authority manifest;
+- audit bundle;
+- package digests;
+- operator handoff report;
+- field-point authority map;
+- reconstruction instructions.
+
+The packet preserves the transition field so the release decision can be reconstructed from its evidence relations.
+
+## Manifest relation
+
+The release authority manifest records the relation between:
+
+- run identity;
+- recorded status;
+- declared policy;
+- materialized required gates;
+- gate evaluation;
+- decision state;
+- diagnostic and publication surfaces.
+
+The manifest is useful because it preserves the path from evidence to decision.
+
+The manifest is a trace surface for the relational field.
+
+## Audit bundle relation
+
+The audit bundle preserves the evidence field for later reconstruction.
+
+It keeps the decision connected to:
+
+- the recorded artifacts;
+- the manifest;
+- CI outcome;
+- digests;
+- reader surfaces;
+- reconstruction instructions.
+
+The audit bundle protects the decision from becoming a detached label.
+
+## Operator handoff relation
+
+The operator handoff report preserves the practical reconstruction route.
+
+It records:
+
+- what was evaluated;
+- which status source was used;
+- which gate sets were materialized;
+- which commands were run;
+- which files were involved;
+- which warnings or errors were present.
+
+The handoff report connects the evidence field to operator action.
+
+## Repair-route context
+
+A blocked release state can carry repair-route context.
+
+Repair-route context is not release permission.
+
+It is the recorded field information that shows where the release-authority state failed to become complete.
+
+Repair-route context may include:
+
+- missing evidence;
+- failing required gates;
+- malformed artifacts;
+- schema conflicts;
+- missing materialized gate sets;
+- unstable evidence;
+- reader-surface mismatch;
+- audit-bundle incompleteness.
+
+The repair route is valuable because it follows the evidence relation rather than treating the terminal failure label as the whole state.
+
+## Relation to schema alignment
+
+Schema alignment protects the artifact shape of the relational field.
+
+A schema-aligned packet is stronger because its canonical paths preserve canonical artifact contracts.
+
+Schema alignment supports:
+
+- reconstruction;
+- verifier compatibility;
+- digest integrity;
+- manifest consistency;
+- handoff consistency;
+- field-point classification;
+- future HPC validation.
+
+Schema alignment preserves the evidence field.
+
+PULSE identity remains the release-authority materialization path.
+
+## Relation to HPC validation
+
+HPC validation scales candidate-state evaluation.
+
+The relational evidence-field principle defines what must remain visible during scaling.
+
+HPC candidate batches should preserve:
+
+- candidate evidence identity;
+- declared policy identity;
+- materialized gate-set identity;
+- boundary-pressure signals;
+- stability signals;
+- release-authority state;
+- reconstruction artifacts;
+- terminal enforcement result.
+
+HPC validates decision fields, not isolated labels.
+
+## Practical rule
+
+When extending PULSE, preserve the generation relation behind the result.
+
+A change is mechanically stronger when it keeps visible:
+
+- what evidence was recorded;
+- how policy routed it;
+- which gates materialized;
+- what boundary pressure appeared;
+- what stability signal existed;
+- what release-authority state formed;
+- what terminal enforcement result was recorded;
+- what repair-route context remains.
+
+This is the PULSE relational evidence-field rule.
+
+## Closing statement
+
+PULSE computes more than a terminal result.
+
+PULSE preserves the field that produces the result.
+
+The release decision is the visible endpoint.
+
+The relational evidence field is the materialized origin.
+
+The strength of PULSE comes from preserving both.


### PR DESCRIPTION
## Summary

Adds `docs/PULSE_RELATIONAL_EVIDENCE_FIELD_PRINCIPLE_v0.md`.

This document records the PULSE relational evidence-field principle.

## Why

PULSE should preserve the relation that produces a release decision, not only the terminal PASS/FAIL label.

The principle defines the field behind a release decision:

candidate evidence  
↔ declared policy  
↔ materialized required gates  
↔ boundary pressure  
↔ stability signals  
↔ release-authority state

The terminal decision is the visible enforcement result of that field.

## What this defines

The document defines:

- the relational evidence-field principle
- the PULSEmech path relation
- candidate evidence relation
- declared policy relation
- materialized gates relation
- boundary pressure
- stability signals
- release-authority state
- evidence packet relation
- manifest relation
- audit bundle relation
- operator handoff relation
- repair-route context
- schema alignment relation
- HPC validation relation
- practical rule for future PULSE extensions

## Authority boundary

The normative PULSEmech path remains unchanged:

recorded release evidence  
→ recorded `status.json` artifact  
→ declared gate policy  
→ materialized required gate set  
→ strict fail-closed CI gate enforcement  
→ declared-policy CI allow/block release decision

## Scope

Documentation-only principle anchor.

No changes to:

- fixture behavior
- guard logic
- builder behavior
- CI workflow behavior
- RA1 behavior
- declared gate policy
- gate registry
- status schema
- release-authority semantics