### PR TITLE
fix(ref): validate publication snapshot manifest ref

### DIFF
--- a/scripts/check_pulse_ref_schema_aligned_packet_v0.py
+++ b/scripts/check_pulse_ref_schema_aligned_packet_v0.py
@@ -216,12 +216,49 @@ def _validate_policy_derived_materialized_gates(packet_root: Path) -> list[str]:
     return errors
 
 
+def _validate_artifact_ref(
+    *,
+    packet_root: Path,
+    ref: Any,
+    field: str,
+    optional: bool,
+) -> list[str]:
+    errors: list[str] = []
+
+    label = "optional artifact ref" if optional else "artifact ref"
+
+    if not isinstance(ref, dict):
+        errors.append(f"package_manifest.json: invalid {label} {field}")
+        return errors
+
+    rel_path = ref.get("path")
+    expected_sha = ref.get("sha256")
+
+    if not isinstance(rel_path, str) or not isinstance(expected_sha, str):
+        errors.append(f"package_manifest.json: invalid {label} {field}")
+        return errors
+
+    artifact = packet_root / rel_path
+    if not artifact.is_file():
+        errors.append(
+            f"package_manifest.json: {label} {field} points to missing {rel_path}"
+        )
+        return errors
+
+    actual_sha = _sha256_file(artifact)
+    if actual_sha != expected_sha:
+        errors.append(f"package_manifest.json: sha256 mismatch for {field}")
+
+    return errors
+
+
 def _validate_package_manifest_refs(packet_root: Path) -> list[str]:
     manifest_path = packet_root / "package_manifest.json"
     if not manifest_path.is_file():
         return []
 
     manifest = _load_json(manifest_path)
+
     ref_fields = [
         "status_artifact",
         "gate_policy",
@@ -233,6 +270,10 @@ def _validate_package_manifest_refs(packet_root: Path) -> list[str]:
         "package_digests",
     ]
 
+    optional_ref_fields = [
+        "publication_snapshot",
+    ]
+
     errors: list[str] = []
 
     for field in ref_fields:
@@ -241,21 +282,27 @@ def _validate_package_manifest_refs(packet_root: Path) -> list[str]:
             errors.append(f"package_manifest.json: missing artifact ref {field}")
             continue
 
-        rel_path = ref.get("path")
-        expected_sha = ref.get("sha256")
+        errors.extend(
+            _validate_artifact_ref(
+                packet_root=packet_root,
+                ref=ref,
+                field=field,
+                optional=False,
+            )
+        )
 
-        if not isinstance(rel_path, str) or not isinstance(expected_sha, str):
-            errors.append(f"package_manifest.json: invalid artifact ref {field}")
+    for field in optional_ref_fields:
+        if field not in manifest:
             continue
 
-        artifact = packet_root / rel_path
-        if not artifact.is_file():
-            errors.append(f"package_manifest.json: ref {field} points to missing {rel_path}")
-            continue
-
-        actual_sha = _sha256_file(artifact)
-        if actual_sha != expected_sha:
-            errors.append(f"package_manifest.json: sha256 mismatch for {field}")
+        errors.extend(
+            _validate_artifact_ref(
+                packet_root=packet_root,
+                ref=manifest.get(field),
+                field=field,
+                optional=True,
+            )
+        )
 
     return errors
 

--- a/scripts/check_pulse_ref_schema_aligned_packet_v0.py
+++ b/scripts/check_pulse_ref_schema_aligned_packet_v0.py
@@ -252,6 +252,77 @@ def _validate_artifact_ref(
     return errors
 
 
+def _is_safe_packet_relative_path(rel_path: str) -> bool:
+    if not rel_path:
+        return False
+
+    if "\\" in rel_path:
+        return False
+
+    path = Path(rel_path)
+
+    if path.is_absolute():
+        return False
+
+    return ".." not in path.parts
+
+
+def _validate_artifact_ref(
+    *,
+    packet_root: Path,
+    ref: Any,
+    field: str,
+    optional: bool,
+    expected_path: str | None = None,
+) -> list[str]:
+    errors: list[str] = []
+
+    label = "optional artifact ref" if optional else "artifact ref"
+
+    if not isinstance(ref, dict):
+        errors.append(f"package_manifest.json: invalid {label} {field}")
+        return errors
+
+    rel_path = ref.get("path")
+    expected_sha = ref.get("sha256")
+
+    if not isinstance(rel_path, str) or not isinstance(expected_sha, str):
+        errors.append(f"package_manifest.json: invalid {label} {field}")
+        return errors
+
+    if not _is_safe_packet_relative_path(rel_path):
+        errors.append(f"package_manifest.json: unsafe {label} {field} path {rel_path!r}")
+        return errors
+
+    if expected_path is not None and rel_path != expected_path:
+        errors.append(
+            f"package_manifest.json: {field} must reference canonical path "
+            f"{expected_path}, got {rel_path}"
+        )
+        return errors
+
+    packet_root_resolved = packet_root.resolve()
+    artifact = (packet_root_resolved / rel_path).resolve()
+
+    try:
+        artifact.relative_to(packet_root_resolved)
+    except ValueError:
+        errors.append(f"package_manifest.json: unsafe {label} {field} path {rel_path!r}")
+        return errors
+
+    if not artifact.is_file():
+        errors.append(
+            f"package_manifest.json: {label} {field} points to missing {rel_path}"
+        )
+        return errors
+
+    actual_sha = _sha256_file(artifact)
+    if actual_sha != expected_sha:
+        errors.append(f"package_manifest.json: sha256 mismatch for {field}")
+
+    return errors
+
+
 def _validate_package_manifest_refs(packet_root: Path) -> list[str]:
     manifest_path = packet_root / "package_manifest.json"
     if not manifest_path.is_file():
@@ -270,9 +341,9 @@ def _validate_package_manifest_refs(packet_root: Path) -> list[str]:
         "package_digests",
     ]
 
-    optional_ref_fields = [
-        "publication_snapshot",
-    ]
+    optional_ref_fields = {
+        "publication_snapshot": "publication/publication_snapshot.json",
+    }
 
     errors: list[str] = []
 
@@ -291,7 +362,7 @@ def _validate_package_manifest_refs(packet_root: Path) -> list[str]:
             )
         )
 
-    for field in optional_ref_fields:
+    for field, expected_path in optional_ref_fields.items():
         if field not in manifest:
             continue
 
@@ -301,10 +372,12 @@ def _validate_package_manifest_refs(packet_root: Path) -> list[str]:
                 ref=manifest.get(field),
                 field=field,
                 optional=True,
+                expected_path=expected_path,
             )
         )
 
     return errors
+
 
 
 def _validate_package_digest_refs(packet_root: Path) -> list[str]:

--- a/tests/test_check_pulse_ref_schema_aligned_packet_v0.py
+++ b/tests/test_check_pulse_ref_schema_aligned_packet_v0.py
@@ -128,6 +128,24 @@ def test_checker_rejects_materialized_gates_not_policy_derived() -> None:
         td.cleanup()
 
 
+def test_checker_rejects_publication_snapshot_manifest_sha_mismatch() -> None:
+    td, packet_root = _copy_package()
+    try:
+        manifest_path = packet_root / "package_manifest.json"
+        payload = _read_json(manifest_path)
+        payload["publication_snapshot"]["sha256"] = "0" * 64
+        _write_json(manifest_path, payload)
+
+        result = _run_checker(packet_root)
+        combined = result.stdout + result.stderr
+
+        assert result.returncode == 1, combined
+        assert "package_manifest.json" in combined, combined
+        assert "sha256 mismatch for publication_snapshot" in combined, combined
+    finally:
+        td.cleanup()
+
+
 def main() -> int:
     try:
         test_checker_accepts_ra1_minimal_package_fixture()

--- a/tests/test_check_pulse_ref_schema_aligned_packet_v0.py
+++ b/tests/test_check_pulse_ref_schema_aligned_packet_v0.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import Any
+import hashlib
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -48,6 +49,68 @@ def _read_json(path: Path) -> dict[str, Any]:
 
 def _write_json(path: Path, obj: dict[str, Any]) -> None:
     path.write_text(json.dumps(obj, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_checker_rejects_publication_snapshot_manifest_sha_mismatch() -> None:
+    td, packet_root = _copy_package()
+    try:
+        manifest_path = packet_root / "package_manifest.json"
+        payload = _read_json(manifest_path)
+        payload["publication_snapshot"]["sha256"] = "0" * 64
+        _write_json(manifest_path, payload)
+
+        result = _run_checker(packet_root)
+        combined = result.stdout + result.stderr
+
+        assert result.returncode == 1, combined
+        assert "package_manifest.json" in combined, combined
+        assert "sha256 mismatch for publication_snapshot" in combined, combined
+    finally:
+        td.cleanup()
+
+
+def test_checker_rejects_publication_snapshot_manifest_unsafe_path() -> None:
+    td, packet_root = _copy_package()
+    try:
+        manifest_path = packet_root / "package_manifest.json"
+        payload = _read_json(manifest_path)
+        payload["publication_snapshot"]["path"] = "../publication_snapshot.json"
+        payload["publication_snapshot"]["sha256"] = "0" * 64
+        _write_json(manifest_path, payload)
+
+        result = _run_checker(packet_root)
+        combined = result.stdout + result.stderr
+
+        assert result.returncode == 1, combined
+        assert "package_manifest.json" in combined, combined
+        assert "unsafe optional artifact ref publication_snapshot path" in combined, combined
+    finally:
+        td.cleanup()
+
+
+def test_checker_rejects_publication_snapshot_wrong_canonical_path() -> None:
+    td, packet_root = _copy_package()
+    try:
+        manifest_path = packet_root / "package_manifest.json"
+        payload = _read_json(manifest_path)
+        payload["publication_snapshot"]["path"] = "status/status.json"
+        payload["publication_snapshot"]["sha256"] = _sha256_file(
+            packet_root / "status/status.json"
+        )
+        _write_json(manifest_path, payload)
+
+        result = _run_checker(packet_root)
+        combined = result.stdout + result.stderr
+
+        assert result.returncode == 1, combined
+        assert "publication_snapshot must reference canonical path" in combined, combined
+        assert "publication/publication_snapshot.json" in combined, combined
+    finally:
+        td.cleanup()
 
 
 def test_checker_accepts_ra1_minimal_package_fixture() -> None:
@@ -153,6 +216,9 @@ def main() -> int:
         test_checker_rejects_noncanonical_digest_shape()
         test_checker_rejects_package_manifest_missing_named_ref()
         test_checker_rejects_materialized_gates_not_policy_derived()
+        test_checker_rejects_publication_snapshot_manifest_sha_mismatch()
+        test_checker_rejects_publication_snapshot_manifest_unsafe_path()
+        test_checker_rejects_publication_snapshot_wrong_canonical_path()
     except AssertionError as exc:
         print(f"ERROR: {exc}")
         return 1


### PR DESCRIPTION
## Summary

Adds validation for the optional `publication_snapshot` named artifact reference in `package_manifest.json`.

## Why

The schema-aligned packet checker validates required named artifact refs, but did not cross-check the optional `publication_snapshot` ref when present.

That allowed a packet manifest to carry a stale or incorrect `publication_snapshot.sha256` while the publication snapshot payload itself remained schema-valid.

## Changes

- Adds optional `publication_snapshot` ref validation in `scripts/check_pulse_ref_schema_aligned_packet_v0.py`.
- Adds a regression test that corrupts `publication_snapshot.sha256` and verifies the checker rejects the packet.

## Authority boundary

This checker validates packet artifact shape and reconstruction readiness.

It does not define release authority.

The normative PULSEmech path remains unchanged.

## Scope

Validator and smoke test only.

No changes to:

- builder behavior
- fixture behavior
- schema semantics
- RA1 behavior
- CI workflow behavior
- release-authority semantics