### PR TITLE
refactor(ref): remove duplicate schema-aligned packet checker definit…

### DIFF
--- a/scripts/check_pulse_ref_schema_aligned_packet_v0.py
+++ b/scripts/check_pulse_ref_schema_aligned_packet_v0.py
@@ -216,42 +216,6 @@ def _validate_policy_derived_materialized_gates(packet_root: Path) -> list[str]:
     return errors
 
 
-def _validate_artifact_ref(
-    *,
-    packet_root: Path,
-    ref: Any,
-    field: str,
-    optional: bool,
-) -> list[str]:
-    errors: list[str] = []
-
-    label = "optional artifact ref" if optional else "artifact ref"
-
-    if not isinstance(ref, dict):
-        errors.append(f"package_manifest.json: invalid {label} {field}")
-        return errors
-
-    rel_path = ref.get("path")
-    expected_sha = ref.get("sha256")
-
-    if not isinstance(rel_path, str) or not isinstance(expected_sha, str):
-        errors.append(f"package_manifest.json: invalid {label} {field}")
-        return errors
-
-    artifact = packet_root / rel_path
-    if not artifact.is_file():
-        errors.append(
-            f"package_manifest.json: {label} {field} points to missing {rel_path}"
-        )
-        return errors
-
-    actual_sha = _sha256_file(artifact)
-    if actual_sha != expected_sha:
-        errors.append(f"package_manifest.json: sha256 mismatch for {field}")
-
-    return errors
-
-
 def _is_safe_packet_relative_path(rel_path: str) -> bool:
     if not rel_path:
         return False

--- a/tests/test_check_pulse_ref_schema_aligned_packet_v0.py
+++ b/tests/test_check_pulse_ref_schema_aligned_packet_v0.py
@@ -191,24 +191,6 @@ def test_checker_rejects_materialized_gates_not_policy_derived() -> None:
         td.cleanup()
 
 
-def test_checker_rejects_publication_snapshot_manifest_sha_mismatch() -> None:
-    td, packet_root = _copy_package()
-    try:
-        manifest_path = packet_root / "package_manifest.json"
-        payload = _read_json(manifest_path)
-        payload["publication_snapshot"]["sha256"] = "0" * 64
-        _write_json(manifest_path, payload)
-
-        result = _run_checker(packet_root)
-        combined = result.stdout + result.stderr
-
-        assert result.returncode == 1, combined
-        assert "package_manifest.json" in combined, combined
-        assert "sha256 mismatch for publication_snapshot" in combined, combined
-    finally:
-        td.cleanup()
-
-
 def main() -> int:
     try:
         test_checker_accepts_ra1_minimal_package_fixture()


### PR DESCRIPTION
## Summary

Pre-regression hygiene cleanup for the PULSE-REF schema-aligned packet checker line.

This PR removes two duplicate definitions:

- the older dead `_validate_artifact_ref` implementation in `scripts/check_pulse_ref_schema_aligned_packet_v0.py`;
- the duplicate `test_checker_rejects_publication_snapshot_manifest_sha_mismatch` definition in `tests/test_check_pulse_ref_schema_aligned_packet_v0.py`.

## Why

The next PULSE-REF step is a generated schema-aligned packet fixture regression.

Before adding that regression, the checker/test surface should be mechanically clean so the regression is added on top of a non-duplicated validator field.

## What changed

### Checker cleanup

Removes the older `_validate_artifact_ref` implementation that did not support `expected_path` and did not include the stronger package-relative path-safety checks.

Keeps the later implementation with:

```python
expected_path: str | None = None
```

and the existing safe path / canonical path / packet-root containment / sha256 checks.

### Test cleanup

Removes the duplicate second definition of:

```python
test_checker_rejects_publication_snapshot_manifest_sha_mismatch
```

Keeps one coverage point for publication snapshot manifest sha mismatch.

## Authority boundary

This PR is hygiene-only.

It does not change release-authority semantics.

It does not change builder behavior.

It does not change validator semantics.

It does not change declared policy, gate registry, status schema, RA1 behavior, CI workflow behavior, or PULSEmech release-authority semantics.

The normative PULSEmech path remains unchanged:

recorded release evidence  
→ recorded `status.json` artifact  
→ declared gate policy  
→ materialized required gate set  
→ strict fail-closed CI gate enforcement  
→ declared-policy CI allow/block release decision

## Validation

Run:

```bash
grep -n "def _validate_artifact_ref" scripts/check_pulse_ref_schema_aligned_packet_v0.py
grep -n "expected_path: str | None = None" scripts/check_pulse_ref_schema_aligned_packet_v0.py
grep -n "def test_checker_rejects_publication_snapshot_manifest_sha_mismatch" tests/test_check_pulse_ref_schema_aligned_packet_v0.py
```

Expected:

- `_validate_artifact_ref`: 1 occurrence
- `expected_path: str | None = None`: 1 occurrence
- `test_checker_rejects_publication_snapshot_manifest_sha_mismatch`: 1 occurrence

Then run:

```bash
python tests/test_check_pulse_ref_schema_aligned_packet_v0.py
python -m pytest -q tests/test_check_pulse_ref_schema_aligned_packet_v0.py
```