### PR TITLE
docs(ref): clarify current v0 packet-completeness boundary

### DIFF
--- a/docs/PULSE_REF_SCHEMA_ALIGNED_PACKET_BUILDER_CHECKPOINT_v0.md
+++ b/docs/PULSE_REF_SCHEMA_ALIGNED_PACKET_BUILDER_CHECKPOINT_v0.md
@@ -210,6 +210,21 @@ The generated packet includes:
 
 The publication snapshot surface is omitted by the builder until a canonical publication surface exists.
 
+## Current v0 packet-completeness boundary
+
+The current schema-aligned pass-fixture packet builder emits a reconstructable v0 packet candidate.
+
+The current v0 output contract covers recorded status, source expected-outcome metadata, declared policy, gate registry, policy-derived materialized gate sets, CI outcome, release-authority manifest, operator handoff report, package digests, audit bundle, external summary note, and reconstruction instructions.
+
+Field-point authority-map and evidence-fold-in admissibility artifacts are reserved for the next packet-completeness layer.
+
+The reserved next-layer surfaces are:
+
+- `field/field_point_authority_map_v0.json`
+- `admissibility/evidence_fold_in_admissibility_v0.json`
+
+This boundary preserves the earlier packet-baseline and handoff direction while keeping the current v0 builder contract mechanically accurate.
+
 ## Builder hardening now included
 
 The builder now protects the reviewed failure modes:


### PR DESCRIPTION
## Summary

Clarifies the current v0 packet-completeness boundary in the PULSE-REF schema-aligned packet builder checkpoint.

## Why

The current schema-aligned pass-fixture packet builder emits a reconstructable v0 packet candidate.

Earlier packet-baseline and handoff documents point toward fuller packet-completeness surfaces, including field-point authority-map and evidence-fold-in admissibility artifacts.

This checkpoint note prevents that direction from being misread as a current v0 builder output requirement.

## What changed

Adds a new checkpoint section:

```text
Current v0 packet-completeness boundary
```

The section states that the current v0 output contract covers:

- recorded status;
- source expected-outcome metadata;
- declared policy;
- gate registry;
- policy-derived materialized gate sets;
- CI outcome;
- release-authority manifest;
- operator handoff report;
- package digests;
- audit bundle;
- external summary note;
- reconstruction instructions.

It also clarifies that these surfaces are reserved for the next packet-completeness layer:

- `field/field_point_authority_map_v0.json`
- `admissibility/evidence_fold_in_admissibility_v0.json`

## Authority boundary

Documentation only.

No builder behavior change.

No validator behavior change.

No release-authority semantics change.

No declared policy, gate registry, status schema, RA1 behavior, CI workflow behavior, or PULSEmech release-authority semantics change.

## Validation

Manual doc check:

```bash
grep -n "Current v0 packet-completeness boundary" docs/PULSE_REF_SCHEMA_ALIGNED_PACKET_BUILDER_CHECKPOINT_v0.md
grep -n "field/field_point_authority_map_v0.json" docs/PULSE_REF_SCHEMA_ALIGNED_PACKET_BUILDER_CHECKPOINT_v0.md
grep -n "admissibility/evidence_fold_in_admissibility_v0.json" docs/PULSE_REF_SCHEMA_ALIGNED_PACKET_BUILDER_CHECKPOINT_v0.md
```