### PR TITLE
docs(paper): add PULSEmech cs.SE paper skeleton

### DIFF
--- a/docs/papers/PULSEMECH_CS_SE_PAPER_SKELETON_v0.md
+++ b/docs/papers/PULSEMECH_CS_SE_PAPER_SKELETON_v0.md
@@ -1,0 +1,429 @@
+# PULSEmech cs.SE Paper Skeleton v0
+
+Status: paper skeleton  
+Paper status: pre-draft  
+Primary category target: cs.SE  
+Scope: PULSEmech / artifact-bound release authority / AI release decisions / software engineering  
+Authority status: non-normative paper-planning document  
+Repository status: does not change PULSE release-authority semantics
+
+## Working title
+
+Artifact-Bound Release Authority for AI Applications:  
+A Fail-Closed Evidence-to-Decision Mechanism
+
+## Short title
+
+PULSEmech: Artifact-Bound Release Authority for AI Release Decisions
+
+## Primary category
+
+Primary category target:
+
+`cs.SE` — Software Engineering
+
+## Category rationale
+
+The paper is primarily about software release engineering for AI applications and AI-enabled systems.
+
+The technical center is not a new machine learning model, training method, benchmark score, or runtime guardrail.
+
+The technical center is a release-decision mechanism:
+
+recorded release evidence  
+→ machine-readable release-state artifact  
+→ declared gate policy  
+→ materialized required gate set  
+→ strict fail-closed CI enforcement  
+→ declared-policy CI allow/block release decision
+
+The paper therefore belongs first in software engineering because it concerns:
+
+- release decision integrity;
+- artifact-bound release state;
+- policy-declared gate enforcement;
+- CI-enforced fail-closed release permission;
+- reproducible release evidence packets;
+- validator and regression surfaces;
+- software release boundary mechanics for AI systems.
+
+## Core contribution statement
+
+PULSE introduces an artifact-bound release-authority mechanism for AI applications and AI-enabled systems.
+
+The mechanism converts recorded release evidence into a deterministic, fail-closed CI allow/block release decision under declared policy.
+
+The release decision is not inferred from a score, dashboard, report, review statement, or post-outcome explanation.
+
+The release decision materializes only when recorded evidence, a machine-readable status artifact, declared policy, materialized required gates, and strict fail-closed CI enforcement are bound together before release effects propagate.
+
+## One-sentence paper claim
+
+PULSEmech is an artifact-bound, policy-declared, gate-materialized, CI-enforced evidence-to-decision mechanism for AI release decisions.
+
+## Mechanical identity
+
+PULSE release-authority identity is defined by the PULSEmech deterministic decision tuple:
+
+```text
+(recorded release evidence,
+ status.json,
+ declared gate policy,
+ materialized required gate set,
+ strict fail-closed CI checking)
+→ CI allow/block release decision
+```
+
+## Normative decision path
+
+The normative PULSEmech release-authority path is:
+
+```text
+recorded release evidence
+→ recorded status.json artifact
+→ declared gate policy
+→ materialized required gate set
+→ strict fail-closed CI gate enforcement
+→ declared-policy CI allow/block release decision
+```
+
+## Problem statement
+
+AI applications and AI-enabled systems often produce probabilistic behavior, evolving evaluation outputs, detector summaries, review records, CI artifacts, and operational evidence.
+
+Classical software release processes often treat release permission as a procedural conclusion produced by review, dashboard status, score thresholds, or pipeline success.
+
+This leaves a structural gap:
+
+```text
+probabilistic AI behavior
+→ recorded candidate release evidence
+→ deterministic software release permission
+```
+
+PULSE addresses this gap by making release permission an artifact-bound release-authority state rather than a detached post-hoc label.
+
+## Workshop principle translated into paper mechanics
+
+Workshop rule:
+
+```text
+Nem az eredményt magyarázzuk. A viszonyt mérjük.
+```
+
+Paper translation:
+
+A release outcome is not equivalent to the release mechanism.
+
+PULSE evaluates the measurable pre-release relation between recorded evidence, declared policy, materialized gates, and fail-closed CI enforcement before release effects propagate.
+
+The paper does not explain outcomes after the event.
+
+It defines a mechanism for evaluating release permission before the event boundary is crossed.
+
+## What PULSE is measuring
+
+PULSE does not measure the post-event crater.
+
+PULSE measures whether release permission can materialize from the pre-release evidence relation.
+
+The measured relation is:
+
+```text
+candidate release evidence
+↔ recorded release-state artifact
+↔ declared policy
+↔ materialized required gates
+↔ strict fail-closed CI enforcement
+↔ release-authority state
+```
+
+## What the paper does not claim
+
+This paper does not claim that PULSE proves an AI system is safe.
+
+This paper does not claim that PULSE replaces model evaluation.
+
+This paper does not claim that PULSE replaces human review.
+
+This paper does not claim that PULSE is a runtime guardrail.
+
+This paper does not claim that PULSE is a training method.
+
+This paper does not claim that PULSE is a general AI governance framework.
+
+This paper does not claim that dashboards, reports, ledgers, manifests, or audit bundles create release authority by themselves.
+
+This paper claims that release permission can be made artifact-bound, policy-declared, gate-materialized, and fail-closed before deployment.
+
+## Terminology boundary
+
+Preferred terms:
+
+- artifact-bound release authority
+- release-authority mechanism
+- evidence-to-decision mechanism
+- declared policy
+- materialized required gates
+- strict fail-closed CI enforcement
+- recorded release evidence
+- machine-readable release-state artifact
+- release boundary
+- reconstructable evidence packet
+- normalized generated-packet regression
+
+Avoid as identity terms:
+
+- framework
+- governance framework
+- dashboard
+- scorecard
+- checklist
+- post-hoc audit system
+- runtime guardrail
+- model safety proof
+
+## Authority boundary
+
+Normative release-authority surfaces:
+
+| Surface | Role |
+|---|---|
+| recorded release evidence | candidate evidence recorded before release |
+| `status.json` | machine-readable release-state artifact |
+| declared gate policy | declares required gate sets |
+| materialized required gate set | concrete enforced required gates |
+| strict fail-closed CI checking | enforces literal true-only required gates |
+| CI allow/block result | declared-policy release decision |
+
+Non-normative trace / reader / preservation surfaces:
+
+| Surface | Role |
+|---|---|
+| Quality Ledger | reader surface |
+| release authority manifest | trace surface |
+| audit bundle | preservation surface |
+| dashboards / badges / Pages | presentation surfaces |
+| diagnostic overlays | candidate evidence or diagnostic surfaces unless explicitly folded into required gates under declared policy |
+| PULSE-REF packet builder | artifact preparation / reconstruction surface |
+| packet validator | artifact-shape and reconstruction-readiness checker |
+| generated packet regression | drift guard for generated packet output |
+
+## PULSE-REF support layer
+
+The current PULSE-REF support layer provides a reference path for reconstructable release evidence packets.
+
+Current closed chain:
+
+```text
+release_reference_v1/pass fixture
+→ release-reference completeness guard
+→ policy-derived materialized gates
+→ schema-aligned packet builder
+→ canonical packet artifacts
+→ schema-aligned packet validator
+→ publication_snapshot manifest-ref hardening
+→ checkpoint doc
+→ hygiene cleanup
+→ current v0 packet-completeness boundary
+→ normalized generated packet regression
+```
+
+This chain supports the paper by showing that the mechanism is not only described but also artifact-backed.
+
+## Current v0 packet-regression state
+
+The schema-aligned pass-fixture packet builder now has a normalized generated-packet regression.
+
+The regression protects the current generated packet output from silent mechanical drift.
+
+The regression records:
+
+- packet root name;
+- required generated paths;
+- JSON artifact schema identifiers;
+- package manifest named references;
+- policy-derived required / release_required / effective gate sets;
+- CI outcome core;
+- release-authority decision core;
+- handoff command kinds and normalized command paths;
+- digest artifact keys;
+- source fixture identity;
+- authority-boundary flags.
+
+The regression intentionally avoids raw full-tree byte-for-byte comparison because generated handoff paths can include environment-specific values.
+
+## Artifact-to-claim table placeholder
+
+| Paper claim | Repository artifact / evidence | Status |
+|---|---|---|
+| PULSEmech defines an artifact-bound release-authority path | README mechanical identity / PULSEmech tuple | to verify |
+| Release state is machine-readable | `status.json` / status contract / status schema | to verify |
+| Required gates are declared by policy | `pulse_gate_policy_v0.yml` | to verify |
+| Required gate sets are materialized from policy | policy materializer / materialized gate set artifact | to verify |
+| Required gates are checked fail-closed | `check_gates.py` / CI enforcement | to verify |
+| Release authority manifest is trace, not a second decision engine | manifest docs / schema / checker | to verify |
+| PULSE-REF packet is reconstructable | schema-aligned builder / packet validator | to verify |
+| Publication snapshot refs are hardened | publication snapshot manifest-ref validation | to verify |
+| Generated packet output is drift-guarded | normalized generated-packet regression | to verify |
+
+## Draft section outline
+
+### Abstract
+
+Summarize the problem, mechanism, artifact path, and contribution.
+
+Key sentence:
+
+PULSEmech converts recorded AI release evidence into deterministic, fail-closed CI allow/block release decisions under declared policy.
+
+### 1. Introduction
+
+Introduce the release-decision gap for AI applications.
+
+Core contrast:
+
+```text
+probabilistic AI behavior
+vs.
+deterministic software release permission
+```
+
+State that PULSE addresses release decision integrity before deployment.
+
+### 2. Release-authority model
+
+Define:
+
+- release evidence;
+- release-state artifact;
+- declared policy;
+- materialized required gates;
+- fail-closed CI checking;
+- release decision.
+
+Include the PULSEmech tuple.
+
+### 3. Authority boundary
+
+Separate normative decision surfaces from trace, audit, reader, diagnostic, and packet-preparation surfaces.
+
+Clarify that manifests and audit bundles preserve/reconstruct the decision path but do not create release authority.
+
+### 4. Implementation artifacts
+
+Describe the repository-level implementation:
+
+- status artifact;
+- policy;
+- gate registry;
+- gate checker;
+- CI workflow;
+- release authority manifest;
+- audit bundle;
+- packet builder;
+- packet validator;
+- generated packet regression.
+
+### 5. PULSE-REF evidence packet path
+
+Describe the PULSE-REF chain:
+
+```text
+release_reference_v1/pass fixture
+→ completeness guard
+→ policy-derived gates
+→ schema-aligned packet builder
+→ packet validator
+→ publication snapshot ref hardening
+→ normalized generated packet regression
+```
+
+Explain why the packet is reconstructable and why the builder is not a second decision engine.
+
+### 6. Validation and regression strategy
+
+Describe validation as release-decision integrity testing, not model-performance benchmarking.
+
+Validation classes:
+
+- missing required gate;
+- false required gate;
+- non-literal true;
+- missing detector evidence;
+- missing external summary;
+- stubbed / scaffolded state;
+- malformed packet artifact;
+- stale or mismatched publication snapshot ref;
+- generated packet drift.
+
+### 7. Limitations
+
+PULSE does not prove model safety.
+
+PULSE does not replace human review.
+
+PULSE does not replace model evaluation.
+
+PULSE does not operate as a runtime guardrail.
+
+PULSE does not turn dashboards or ledgers into authority.
+
+PULSE currently demonstrates release-authority mechanics and reference packet construction at repository artifact scale.
+
+### 8. Related work placeholder
+
+Areas to review:
+
+- software release engineering;
+- CI/CD release gates;
+- software assurance;
+- policy-as-code;
+- software supply-chain provenance;
+- reproducible artifacts;
+- AI evaluation infrastructure;
+- AI safety release practices;
+- auditability and traceability in software systems.
+
+### 9. Conclusion
+
+Restate the contribution:
+
+PULSEmech makes AI release permission artifact-bound, policy-declared, gate-materialized, and fail-closed before release effects propagate.
+
+## Abstract v0
+
+AI applications and AI-enabled systems produce probabilistic behavior, evolving evaluation records, detector summaries, review signals, and CI artifacts, while software release permission requires a deterministic decision at the release boundary. This paper introduces PULSEmech, an artifact-bound release-authority mechanism that converts recorded AI release evidence into a deterministic, fail-closed CI allow/block release decision under declared policy. PULSEmech binds recorded release evidence to a machine-readable `status.json` artifact, declared gate policy, policy-derived materialized required gates, and strict true-only CI enforcement before release effects propagate. The mechanism separates normative release-authority surfaces from trace, audit, reader, diagnostic, and packet-preparation surfaces. We describe the PULSE-REF reference path, including guarded pass fixtures, policy-derived gate materialization, schema-aligned packet construction, packet validation, publication-reference hardening, and normalized generated-packet regression. The contribution is not a model-safety proof or runtime guardrail, but a software-engineering mechanism for making AI release permission reconstructable, evidence-bound, and fail-closed.
+
+## Contribution bullets v0
+
+This paper contributes:
+
+1. an artifact-bound release-authority model for AI applications;
+2. the PULSEmech deterministic evidence-to-decision tuple;
+3. a strict authority boundary separating release authority from trace, reader, audit, and diagnostic surfaces;
+4. a reference implementation pattern using `status.json`, declared policy, materialized gates, and fail-closed CI checking;
+5. a PULSE-REF evidence-packet path for reconstructable release-state preservation;
+6. a normalized generated-packet regression strategy to detect silent packet-builder drift.
+
+## Claim boundary checklist
+
+Before a claim enters the paper, it must be classified as one of:
+
+- mechanically defined by PULSEmech;
+- supported by repository artifact;
+- supported by test / CI / regression;
+- stated as limitation;
+- stated as future work.
+
+Claims outside these classes should not enter the paper.
+
+## AI-assisted drafting disclosure placeholder
+
+The author used AI-assisted drafting and technical editing during manuscript preparation. All claims, artifact references, code paths, repository links, and conclusions were reviewed and approved by the human author, who takes full responsibility for the submitted work.
+
+## Next paper step
+
+Next step after this skeleton:
+
+Create the artifact-to-claim table as a separate review document and verify every paper claim against repository artifacts before expanding the draft.


### PR DESCRIPTION
## Summary

Adds the initial PULSEmech cs.SE paper skeleton.

This is a pre-draft planning document for a future technical paper on PULSEmech as an artifact-bound release-authority mechanism for AI release decisions.

## Why

The PULSE-REF schema-aligned packet-builder bridge is now closed, checkpointed, and protected by a normalized generated-packet regression.

The next safe step is not a full paper draft yet.

The next safe step is a professional paper skeleton that fixes the paper scope, claim boundary, category rationale, contribution statement, artifact-to-claim structure, and section outline before prose expansion begins.

## What this adds

Adds:

- `docs/papers/PULSEMECH_CS_SE_PAPER_SKELETON_v0.md`

The skeleton defines:

- working title;
- short title;
- primary category target: `cs.SE`;
- category rationale;
- core contribution statement;
- one-sentence paper claim;
- PULSEmech mechanical identity;
- normative decision path;
- problem statement;
- workshop principle translated into paper mechanics;
- authority boundary;
- PULSE-REF support layer;
- current v0 generated-packet regression state;
- artifact-to-claim table placeholder;
- draft section outline;
- abstract v0;
- contribution bullets v0;
- claim boundary checklist;
- AI-assisted drafting disclosure placeholder;
- next paper step.

## Authority boundary

Documentation only.

This PR does not change PULSE release-authority semantics.

It does not change builder behavior.

It does not change validator behavior.

It does not change declared policy, gate registry, status schema, RA1 behavior, CI workflow behavior, or PULSEmech semantics.

The document is a non-normative paper-planning artifact.

## Validation

Manual doc check:

```bash
grep -n "Primary category target" docs/papers/PULSEMECH_CS_SE_PAPER_SKELETON_v0.md
grep -n "PULSEmech deterministic decision tuple" docs/papers/PULSEMECH_CS_SE_PAPER_SKELETON_v0.md
grep -n "Artifact-to-claim table placeholder" docs/papers/PULSEMECH_CS_SE_PAPER_SKELETON_v0.md
grep -n "Abstract v0" docs/papers/PULSEMECH_CS_SE_PAPER_SKELETON_v0.md
```