### PR TITLE
fix(ledger): harden public reader surface authority boundary

### DIFF
--- a/PULSE_safe_pack_v0/tools/render_quality_ledger.py
+++ b/PULSE_safe_pack_v0/tools/render_quality_ledger.py
@@ -201,92 +201,119 @@ def surface_run_grade(status: Dict[str, Any]) -> str:
     return run_mode or "unknown"
 
 
-def is_release_grade_surface(status: Dict[str, Any]) -> bool:
-    """
-    Return whether the rendered public surface may be read as release-grade.
+def marker_is_active(value: Any) -> bool:
+    if value is True:
+        return True
+    if value is False or value is None:
+        return False
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        return normalized not in {"", "false", "none", "null", "0", "no"}
+    return bool(value)
 
-    This is a public-surface interpretation guard, not the release decision
-    function. The release decision remains decision_from_status/check_gates.py.
-    """
-    gates = as_dict(status.get("gates"))
+
+def active_stub_scaffold_markers(status: Dict[str, Any]) -> List[str]:
+    metrics = as_dict(status.get("metrics"))
     diagnostics = as_dict(status.get("diagnostics"))
+    meta_diagnostics = as_dict(as_dict(status.get("meta")).get("diagnostics"))
 
+    marker_paths = [
+        ("diagnostics.gates_stubbed", diagnostics.get("gates_stubbed")),
+        ("metrics.gates_stubbed", metrics.get("gates_stubbed")),
+        ("meta.diagnostics.gates_stubbed", meta_diagnostics.get("gates_stubbed")),
+        ("diagnostics.scaffold", diagnostics.get("scaffold")),
+        ("metrics.scaffold", metrics.get("scaffold")),
+        ("meta.diagnostics.scaffold", meta_diagnostics.get("scaffold")),
+        ("diagnostics.stub_profile", diagnostics.get("stub_profile")),
+        ("metrics.stub_profile", metrics.get("stub_profile")),
+        ("meta.diagnostics.stub_profile", meta_diagnostics.get("stub_profile")),
+    ]
+    return [name for name, value in marker_paths if marker_is_active(value)]
+
+
+def has_materialized_release_surface(status: Dict[str, Any], decision_label: str) -> bool:
+    gates = as_dict(status.get("gates"))
     return (
         surface_run_grade(status) == "prod"
-        and diagnostics.get("gates_stubbed") is not True
-        and diagnostics.get("scaffold") is not True
+        and decision_label == "PROD-PASS"
+        and not active_stub_scaffold_markers(status)
         and gates.get("detectors_materialized_ok") is True
         and gates.get("external_summaries_present") is True
         and gates.get("external_all_pass") is True
     )
 
 
-def surface_evidence_state(status: Dict[str, Any]) -> str:
-    if is_release_grade_surface(status):
-        return "materialized"
+def public_surface_profile(status: Dict[str, Any], decision_label: str) -> str:
+    if has_materialized_release_surface(status, decision_label):
+        return "PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE"
+
+    run_grade = surface_run_grade(status)
+    markers = active_stub_scaffold_markers(status)
+
+    if run_grade == "core":
+        if markers:
+            return "CORE READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE"
+        return "CORE READER SURFACE"
+    if run_grade == "demo":
+        if markers:
+            return "DEMO READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE"
+        return "DEMO READER SURFACE"
+    if run_grade == "prod":
+        return "PROD READER SURFACE — MATERIALIZATION PENDING"
+    return "RECORDED READER SURFACE"
+
+
+def public_evidence_profile(status: Dict[str, Any], decision_label: str) -> str:
+    if has_materialized_release_surface(status, decision_label):
+        return "materialized detector and external evidence"
 
     gates = as_dict(status.get("gates"))
-    diagnostics = as_dict(status.get("diagnostics"))
+    markers = active_stub_scaffold_markers(status)
+    parts: List[str] = []
 
-    states: List[str] = []
-    if diagnostics.get("gates_stubbed") is True:
-        states.append("stubbed")
-    if diagnostics.get("scaffold") is True:
-        states.append("scaffolded")
-    if gates.get("detectors_materialized_ok") is not True:
-        states.append("non-materialized detector evidence")
-    if gates.get("external_summaries_present") is not True:
-        states.append("external summaries incomplete")
-    if gates.get("external_all_pass") is not True:
-        states.append("external evidence incomplete")
+    if markers:
+        parts.append("stub/scaffold markers recorded")
+    if gates.get("detectors_materialized_ok") is True:
+        parts.append("detector evidence materialized")
+    else:
+        parts.append("detector evidence pending")
+    if gates.get("external_summaries_present") is True:
+        parts.append("external summaries present")
+    elif "external_summaries_present" in gates:
+        parts.append("external summaries pending")
+    if gates.get("external_all_pass") is True:
+        parts.append("external evidence passing")
+    elif "external_all_pass" in gates:
+        parts.append("external evidence pending")
+    if decision_label != "PROD-PASS":
+        parts.append(f"declared-policy decision display: {decision_label}")
 
-    return " / ".join(states) if states else "non-release"
-
-
-def public_decision_label(decision_label: str, status: Dict[str, Any]) -> str:
-    suffix = (
-        "RELEASE-GRADE VIEW" if is_release_grade_surface(status) else "NON-RELEASE VIEW"
-    )
-    return f"{decision_label} — {suffix}"
-
-
-def public_decision_class(decision_class: str, status: Dict[str, Any]) -> str:
-    if is_release_grade_surface(status):
-        return decision_class
-    if decision_class == "badge-fail":
-        return "badge-fail"
-    return "badge-reader"
+    return "; ".join(parts)
 
 
-def render_public_surface_boundary(status: Dict[str, Any], decision_label: str) -> str:
-    release_grade_label = (
-        "RELEASE-GRADE" if is_release_grade_surface(status) else "NOT RELEASE-GRADE"
-    )
+def render_public_surface_state(status: Dict[str, Any], decision_label: str) -> str:
+    marker_summary = ", ".join(active_stub_scaffold_markers(status)) or "clear"
     rows_html = render_meta_list(
         [
-            ("Surface role", "Public reader surface"),
-            ("Authority scope", "Non-normative display surface"),
-            ("Run grade", surface_run_grade(status)),
-            ("Release-grade status", release_grade_label),
-            ("Evidence state", surface_evidence_state(status)),
-            ("Public verdict display", public_decision_label(decision_label, status)),
+            ("Public surface", public_surface_profile(status, decision_label)),
+            ("Recorded run mode", surface_run_grade(status)),
+            ("Evidence materialization", public_evidence_profile(status, decision_label)),
+            ("Stub/scaffold marker state", marker_summary),
+            ("Decision display", decision_label),
+            (
+                "Authority carrier",
+                "status.json → declared gate policy → materialized required gate set → strict fail-closed CI enforcement",
+            ),
         ]
     )
     return (
         '<div class="surface-boundary">'
-        "<h2>PUBLIC READER SURFACE — NON-NORMATIVE</h2>"
-        "<p>This page displays a recorded <code>status.json</code> artifact. "
-        "It is not itself the release authority.</p>"
-        "<p>Release authority remains the PULSEmech path: "
-        "<code>status.json</code> → declared gate policy → materialized required gate set "
-        "→ strict fail-closed CI enforcement.</p>"
+        "<h2>PULSE PUBLIC SURFACE STATE</h2>"
+        "<p>The Quality Ledger presents the recorded <code>status.json</code> "
+        "state as a public reader surface.</p>"
         f'<div class="meta-grid">{rows_html}</div>'
-        '<p class="subtle">This public surface is release-grade only when it is bound '
-        "to a prod run with non-stubbed, non-scaffolded, materialized detector evidence "
-        "and passing external evidence gates.</p>"
         "</div>"
     )
-
 
 def render_meta_list(rows: Iterable[Tuple[str, Any]]) -> str:
     items = []
@@ -462,16 +489,16 @@ def render_q1_reference_shadow_section(status: Dict[str, Any]) -> str:
         ("meta.q1_reference_shadow.pass", html_text(q1.get("pass"))),
         ("meta.q1_reference_shadow.grounded_rate", html_text(q1.get("grounded_rate"))),
         (
-         "meta.q1_reference_shadow.wilson_lower_bound",
-         html_text(q1.get("wilson_lower_bound")),
+            "meta.q1_reference_shadow.wilson_lower_bound",
+            html_text(q1.get("wilson_lower_bound")),
         ),
         ("meta.q1_reference_shadow.n_eligible", html_text(q1.get("n_eligible"))),
         ("meta.q1_reference_shadow.threshold", html_text(q1.get("threshold"))),
         (
-        (
-         "meta.q1_reference_shadow.summary_artifact.path",
-         html_text(summary_artifact.get("path")),
+            "meta.q1_reference_shadow.summary_artifact.path",
+            html_text(summary_artifact.get("path")),
         ),
+        (
             "meta.q1_reference_shadow.summary_artifact.sha256",
             html_short_hash(summary_artifact.get("sha256")),
         ),
@@ -591,8 +618,6 @@ def render_quality_ledger(status: Dict[str, Any], *, status_path: Path) -> str:
     decision_label, decision_class = decision_from_status(
         status, status_path=status_path
     )
-    public_label = public_decision_label(decision_label, status)
-    public_class = public_decision_class(decision_class, status)
     gate_buckets = build_gate_buckets(gates)
 
     header_meta = render_meta_list(
@@ -699,10 +724,6 @@ def render_quality_ledger(status: Dict[str, Any], *, status_path: Path) -> str:
       background: var(--note-bg);
       color: var(--muted);
     }}
-    .badge-reader {{
-      background: var(--note-bg);
-      color: var(--reader-fg);
-    }}
     .meta-grid {{
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -783,14 +804,14 @@ def render_quality_ledger(status: Dict[str, Any], *, status_path: Path) -> str:
           <h1>PULSE Quality Ledger</h1>
           <p class="subtle">Human-readable view over a single immutable status.json artefact.</p>
         </div>
-        <div class="badge {public_class}">{escape(public_label)}</div>
+        <div class="badge {decision_class}">{escape(decision_label)}</div>
       </div>
       <div class="meta-grid">
         {header_meta}
       </div>
     
     </section>
-    {render_public_surface_boundary(status, decision_label)}
+    {render_public_surface_state(status, decision_label)}
     {render_gate_table("Safety gates", gate_buckets["safety"])}
     {render_gate_table("Quality gates", gate_buckets["quality"])}
     {render_refusal_delta_section(metrics, gates)}

--- a/PULSE_safe_pack_v0/tools/render_quality_ledger.py
+++ b/PULSE_safe_pack_v0/tools/render_quality_ledger.py
@@ -128,7 +128,9 @@ def gate_status_parts(ok: bool) -> Tuple[str, str]:
     return ("PASS", "status-pass") if ok else ("FAIL", "status-fail")
 
 
-def select_required_gates(status: Dict[str, Any], *, status_path: Path) -> tuple[List[str], str]:
+def select_required_gates(
+    status: Dict[str, Any], *, status_path: Path
+) -> tuple[List[str], str]:
     """
     Resolve the gate IDs that are actually decision-bearing for the ledger banner.
 
@@ -167,11 +169,15 @@ def select_required_gates(status: Dict[str, Any], *, status_path: Path) -> tuple
     return [], "unresolved"
 
 
-def decision_from_status(status: Dict[str, Any], *, status_path: Path) -> Tuple[str, str]:
+def decision_from_status(
+    status: Dict[str, Any], *, status_path: Path
+) -> Tuple[str, str]:
     metrics = as_dict(status.get("metrics"))
     gates = as_dict(status.get("gates"))
 
-    required_gate_ids, _decision_source = select_required_gates(status, status_path=status_path)
+    required_gate_ids, _decision_source = select_required_gates(
+        status, status_path=status_path
+    )
     if not required_gate_ids:
         return "UNKNOWN", "badge-unknown"
 
@@ -187,6 +193,99 @@ def decision_from_status(status: Dict[str, Any], *, status_path: Path) -> Tuple[
     if run_mode == "demo":
         return "DEMO-PASS", "badge-pass"
     return "PASS", "badge-pass"
+
+
+def surface_run_grade(status: Dict[str, Any]) -> str:
+    metrics = as_dict(status.get("metrics"))
+    run_mode = str(metrics.get("run_mode", "")).strip().lower()
+    return run_mode or "unknown"
+
+
+def is_release_grade_surface(status: Dict[str, Any]) -> bool:
+    """
+    Return whether the rendered public surface may be read as release-grade.
+
+    This is a public-surface interpretation guard, not the release decision
+    function. The release decision remains decision_from_status/check_gates.py.
+    """
+    gates = as_dict(status.get("gates"))
+    diagnostics = as_dict(status.get("diagnostics"))
+
+    return (
+        surface_run_grade(status) == "prod"
+        and diagnostics.get("gates_stubbed") is not True
+        and diagnostics.get("scaffold") is not True
+        and gates.get("detectors_materialized_ok") is True
+        and gates.get("external_summaries_present") is True
+        and gates.get("external_all_pass") is True
+    )
+
+
+def surface_evidence_state(status: Dict[str, Any]) -> str:
+    if is_release_grade_surface(status):
+        return "materialized"
+
+    gates = as_dict(status.get("gates"))
+    diagnostics = as_dict(status.get("diagnostics"))
+
+    states: List[str] = []
+    if diagnostics.get("gates_stubbed") is True:
+        states.append("stubbed")
+    if diagnostics.get("scaffold") is True:
+        states.append("scaffolded")
+    if gates.get("detectors_materialized_ok") is not True:
+        states.append("non-materialized detector evidence")
+    if gates.get("external_summaries_present") is not True:
+        states.append("external summaries incomplete")
+    if gates.get("external_all_pass") is not True:
+        states.append("external evidence incomplete")
+
+    return " / ".join(states) if states else "non-release"
+
+
+def public_decision_label(decision_label: str, status: Dict[str, Any]) -> str:
+    suffix = (
+        "RELEASE-GRADE VIEW" if is_release_grade_surface(status) else "NON-RELEASE VIEW"
+    )
+    return f"{decision_label} — {suffix}"
+
+
+def public_decision_class(decision_class: str, status: Dict[str, Any]) -> str:
+    if is_release_grade_surface(status):
+        return decision_class
+    if decision_class == "badge-fail":
+        return "badge-fail"
+    return "badge-reader"
+
+
+def render_public_surface_boundary(status: Dict[str, Any], decision_label: str) -> str:
+    release_grade_label = (
+        "RELEASE-GRADE" if is_release_grade_surface(status) else "NOT RELEASE-GRADE"
+    )
+    rows_html = render_meta_list(
+        [
+            ("Surface role", "Public reader surface"),
+            ("Authority scope", "Non-normative display surface"),
+            ("Run grade", surface_run_grade(status)),
+            ("Release-grade status", release_grade_label),
+            ("Evidence state", surface_evidence_state(status)),
+            ("Public verdict display", public_decision_label(decision_label, status)),
+        ]
+    )
+    return (
+        '<div class="surface-boundary">'
+        "<h2>PUBLIC READER SURFACE — NON-NORMATIVE</h2>"
+        "<p>This page displays a recorded <code>status.json</code> artifact. "
+        "It is not itself the release authority.</p>"
+        "<p>Release authority remains the PULSEmech path: "
+        "<code>status.json</code> → declared gate policy → materialized required gate set "
+        "→ strict fail-closed CI enforcement.</p>"
+        f'<div class="meta-grid">{rows_html}</div>'
+        '<p class="subtle">This public surface is release-grade only when it is bound '
+        "to a prod run with non-stubbed, non-scaffolded, materialized detector evidence "
+        "and passing external evidence gates.</p>"
+        "</div>"
+    )
 
 
 def render_meta_list(rows: Iterable[Tuple[str, Any]]) -> str:
@@ -362,21 +461,24 @@ def render_q1_reference_shadow_section(status: Dict[str, Any]) -> str:
     rows = [
         ("meta.q1_reference_shadow.pass", html_text(q1.get("pass"))),
         ("meta.q1_reference_shadow.grounded_rate", html_text(q1.get("grounded_rate"))),
-        ("meta.q1_reference_shadow.wilson_lower_bound", html_text(q1.get("wilson_lower_bound"))),
+        (
+         "meta.q1_reference_shadow.wilson_lower_bound",
+         html_text(q1.get("wilson_lower_bound")),
+        ),
         ("meta.q1_reference_shadow.n_eligible", html_text(q1.get("n_eligible"))),
         ("meta.q1_reference_shadow.threshold", html_text(q1.get("threshold"))),
-        ("meta.q1_reference_shadow.summary_artifact.path", html_text(summary_artifact.get("path"))),
         (
+        (
+         "meta.q1_reference_shadow.summary_artifact.path",
+         html_text(summary_artifact.get("path")),
+        ),
             "meta.q1_reference_shadow.summary_artifact.sha256",
             html_short_hash(summary_artifact.get("sha256")),
         ),
     ]
 
     body = "".join(
-        "<tr>"
-        f"<td><code>{escape(name)}</code></td>"
-        f"<td>{value_html}</td>"
-        "</tr>"
+        "<tr>" f"<td><code>{escape(name)}</code></td>" f"<td>{value_html}</td>" "</tr>"
         for name, value_html in rows
     )
 
@@ -423,7 +525,10 @@ def render_hazard_section(metrics: Dict[str, Any]) -> str:
         ("metrics.hazard_baseline_ok", metrics.get("hazard_baseline_ok")),
         ("metrics.hazard_gate_id", metrics.get("hazard_gate_id")),
         ("metrics.hazard_T_scaled", metrics.get("hazard_T_scaled")),
-        ("metrics.hazard_stability_map_schema", metrics.get("hazard_stability_map_schema")),
+        (
+         "metrics.hazard_stability_map_schema",
+          metrics.get("hazard_stability_map_schema"),
+        ),
         ("metrics.hazard_stability_map_path", metrics.get("hazard_stability_map_path")),
     ]
 
@@ -483,7 +588,11 @@ def render_quality_ledger(status: Dict[str, Any], *, status_path: Path) -> str:
     gates = as_dict(status.get("gates"))
     diagnostics = as_dict(status.get("diagnostics"))
 
-    decision_label, decision_class = decision_from_status(status, status_path=status_path)
+    decision_label, decision_class = decision_from_status(
+        status, status_path=status_path
+    )
+    public_label = public_decision_label(decision_label, status)
+    public_class = public_decision_class(decision_class, status)
     gate_buckets = build_gate_buckets(gates)
 
     header_meta = render_meta_list(
@@ -590,6 +699,10 @@ def render_quality_ledger(status: Dict[str, Any], *, status_path: Path) -> str:
       background: var(--note-bg);
       color: var(--muted);
     }}
+    .badge-reader {{
+      background: var(--note-bg);
+      color: var(--reader-fg);
+    }}
     .meta-grid {{
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -640,6 +753,21 @@ def render_quality_ledger(status: Dict[str, Any], *, status_path: Path) -> str:
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       font-size: 0.92em;
     }}
+    .surface-boundary {{
+      margin-top: 16px;
+      padding: 14px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--note-bg);
+    }}
+    .surface-boundary h2 {{
+      font-size: 1.05rem;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+    }}
+    .surface-boundary p {{
+      margin: 0 0 12px 0;
+    }}
     .footer {{
       color: var(--muted);
       font-size: 0.92rem;
@@ -655,13 +783,14 @@ def render_quality_ledger(status: Dict[str, Any], *, status_path: Path) -> str:
           <h1>PULSE Quality Ledger</h1>
           <p class="subtle">Human-readable view over a single immutable status.json artefact.</p>
         </div>
-        <div class="badge {decision_class}">{escape(decision_label)}</div>
+        <div class="badge {public_class}">{escape(public_label)}</div>
       </div>
       <div class="meta-grid">
         {header_meta}
       </div>
+    
     </section>
-
+    {render_public_surface_boundary(status, decision_label)}
     {render_gate_table("Safety gates", gate_buckets["safety"])}
     {render_gate_table("Quality gates", gate_buckets["quality"])}
     {render_refusal_delta_section(metrics, gates)}


### PR DESCRIPTION
````markdown
## Summary

This PR hardens the generated PULSE Quality Ledger public surface so reader/publication views cannot be misread as release-grade release authority.

The generated HTML now exposes:

- surface role,
- authority scope,
- run grade,
- release-grade status,
- evidence state,
- public verdict display.

Non-release states are rendered with explicit `NON-RELEASE VIEW` labels.

`RELEASE-GRADE VIEW` is reserved for prod runs with non-stubbed, non-scaffolded, materialized detector evidence and passing external evidence gates.

## Why

The public Quality Ledger is a reader surface over a recorded `status.json` artifact.

It must not appear as an independent release-authority surface.

This PR makes the authority boundary visible at the public HTML surface itself, before any cryptographic attestation/provenance work is added.

## Authority boundary

Unchanged:

```text
status.json
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI enforcement
→ CI allow/block release decision
````

This PR does not change:

* PULSEmech decision semantics,
* gate policy,
* `check_gates.py`,
* required gate evaluation,
* CI allow/block behavior,
* cryptographic attestation.

## Changes

* Adds a public surface boundary block to the Quality Ledger renderer.
* Labels non-release public views as `NON-RELEASE VIEW`.
* Labels release-grade public views as `RELEASE-GRADE VIEW` only when release-grade surface conditions are satisfied.
* Adds `docs/PUBLIC_SURFACE_AUTHORITY_BOUNDARY_v0.md`.
* Updates README wording from public/live release surfaces to public reader surfaces.
* Updates renderer tests for the hardened public display semantics.

## Validation

```bash
python -m py_compile PULSE_safe_pack_v0/tools/render_quality_ledger.py

python -m pytest -q \
  tests/test_render_quality_ledger.py \
  tests/test_render_quality_ledger_cli.py \
  tests/test_render_quality_ledger_decision_logic.py \
  tests/test_render_quality_ledger_decision_edges.py \
  tests/test_render_quality_ledger_diagnostic_sections.py
```

## Acceptance criteria

* The public Ledger cannot show naked `STAGE-PASS` or `DEMO-PASS` as a release-looking verdict.
* Core/demo/stubbed/scaffolded/incomplete states are visibly marked `NOT RELEASE-GRADE`.
* Public reader surfaces are explicitly labeled non-normative.
* Release-grade labeling requires:

  * prod mode,
  * non-stubbed diagnostics,
  * non-scaffolded diagnostics,
  * materialized detector evidence,
  * passing external evidence gates.
* PULSEmech decision semantics remain unchanged.

```
```
