### PR TITLE
fix(ledger): expose public surface evidence state

### DIFF
--- a/PULSE_safe_pack_v0/tools/render_quality_ledger.py
+++ b/PULSE_safe_pack_v0/tools/render_quality_ledger.py
@@ -259,7 +259,9 @@ def public_surface_profile(status: Dict[str, Any], decision_label: str) -> str:
             return "DEMO READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE"
         return "DEMO READER SURFACE"
     if run_grade == "prod":
-        return "PROD READER SURFACE — MATERIALIZATION PENDING"
+        if markers:
+            return "PROD READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE"
+      return "PROD READER SURFACE — MATERIALIZATION PENDING"
     return "RECORDED READER SURFACE"
 
 

--- a/PULSE_safe_pack_v0/tools/render_quality_ledger.py
+++ b/PULSE_safe_pack_v0/tools/render_quality_ledger.py
@@ -201,13 +201,24 @@ def surface_run_grade(status: Dict[str, Any]) -> str:
     return run_mode or "unknown"
 
 
-def marker_is_active(value: Any) -> bool:
+NEUTRAL_STUB_PROFILES = {
+    "",
+    "none",
+    "false",
+    "real",
+    "not_stubbed",
+}
+
+
+def marker_is_active(value: Any, *, marker_kind: str = "flag") -> bool:
     if value is True:
         return True
     if value is False or value is None:
         return False
     if isinstance(value, str):
         normalized = value.strip().lower()
+        if marker_kind == "stub_profile":
+            return normalized not in NEUTRAL_STUB_PROFILES
         return normalized not in {"", "false", "none", "null", "0", "no"}
     return bool(value)
 
@@ -218,17 +229,33 @@ def active_stub_scaffold_markers(status: Dict[str, Any]) -> List[str]:
     meta_diagnostics = as_dict(as_dict(status.get("meta")).get("diagnostics"))
 
     marker_paths = [
-        ("diagnostics.gates_stubbed", diagnostics.get("gates_stubbed")),
-        ("metrics.gates_stubbed", metrics.get("gates_stubbed")),
-        ("meta.diagnostics.gates_stubbed", meta_diagnostics.get("gates_stubbed")),
-        ("diagnostics.scaffold", diagnostics.get("scaffold")),
-        ("metrics.scaffold", metrics.get("scaffold")),
-        ("meta.diagnostics.scaffold", meta_diagnostics.get("scaffold")),
-        ("diagnostics.stub_profile", diagnostics.get("stub_profile")),
-        ("metrics.stub_profile", metrics.get("stub_profile")),
-        ("meta.diagnostics.stub_profile", meta_diagnostics.get("stub_profile")),
+        ("diagnostics.gates_stubbed", diagnostics.get("gates_stubbed"), "flag"),
+        ("metrics.gates_stubbed", metrics.get("gates_stubbed"), "flag"),
+        (
+            "meta.diagnostics.gates_stubbed",
+            meta_diagnostics.get("gates_stubbed"),
+            "flag",
+        ),
+        ("diagnostics.scaffold", diagnostics.get("scaffold"), "flag"),
+        ("metrics.scaffold", metrics.get("scaffold"), "flag"),
+        ("meta.diagnostics.scaffold", meta_diagnostics.get("scaffold"), "flag"),
+        (
+            "diagnostics.stub_profile",
+            diagnostics.get("stub_profile"),
+            "stub_profile",
+        ),
+        ("metrics.stub_profile", metrics.get("stub_profile"), "stub_profile"),
+        (
+            "meta.diagnostics.stub_profile",
+            meta_diagnostics.get("stub_profile"),
+            "stub_profile",
+        ),
     ]
-    return [name for name, value in marker_paths if marker_is_active(value)]
+    return [
+        name
+        for name, value, marker_kind in marker_paths
+        if marker_is_active(value, marker_kind=marker_kind)
+    ]
 
 
 def has_materialized_release_surface(status: Dict[str, Any], decision_label: str) -> bool:
@@ -261,7 +288,7 @@ def public_surface_profile(status: Dict[str, Any], decision_label: str) -> str:
     if run_grade == "prod":
         if markers:
             return "PROD READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE"
-      return "PROD READER SURFACE — MATERIALIZATION PENDING"
+        return "PROD READER SURFACE — MATERIALIZATION PENDING"
     return "RECORDED READER SURFACE"
 
 

--- a/tests/test_render_quality_ledger_public_surface_state.py
+++ b/tests/test_render_quality_ledger_public_surface_state.py
@@ -10,6 +10,13 @@ if str(REPO_ROOT) not in sys.path:
 from PULSE_safe_pack_v0.tools.render_quality_ledger import write_quality_ledger  # noqa: E402
 
 
+MATERIALIZED_PROD_SURFACE = (
+    "PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE"
+)
+STUBBED_PROD_SURFACE = "PROD READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE"
+PENDING_PROD_SURFACE = "PROD READER SURFACE — MATERIALIZATION PENDING"
+
+
 def render(status: dict) -> str:
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
@@ -21,6 +28,13 @@ def render(status: dict) -> str:
         )
         write_quality_ledger(status_path, out_path)
         return out_path.read_text(encoding="utf-8")
+
+
+def set_nested(obj: dict, path: tuple[str, ...], value: object) -> None:
+    current = obj
+    for key in path[:-1]:
+        current = current.setdefault(key, {})
+    current[path[-1]] = value
 
 
 def base_prod_status() -> dict:
@@ -48,7 +62,7 @@ def test_clean_prod_surface_reports_materialized_reader_evidence_state() -> None
     html = render(base_prod_status())
 
     assert "PROD-PASS" in html
-    assert "PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE" in html
+    assert MATERIALIZED_PROD_SURFACE in html
     assert "PROD MATERIALIZED RELEASE-GRADE SURFACE" not in html
 
 
@@ -59,8 +73,8 @@ def test_stubbed_prod_surface_keeps_reader_surface_without_materialized_wording(
     html = render(status)
 
     assert "PROD-PASS" in html
-    assert "PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE" not in html
-    assert "PROD READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE" in html
+    assert MATERIALIZED_PROD_SURFACE not in html
+    assert STUBBED_PROD_SURFACE in html
     assert "STUBBED/SCAFFOLD" in html
 
 
@@ -71,8 +85,8 @@ def test_meta_diagnostics_stubbed_prod_surface_keeps_reader_surface() -> None:
     html = render(status)
 
     assert "PROD-PASS" in html
-    assert "PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE" not in html
-    assert "PROD READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE" in html
+    assert MATERIALIZED_PROD_SURFACE not in html
+    assert STUBBED_PROD_SURFACE in html
     assert "STUBBED/SCAFFOLD" in html
 
 
@@ -82,17 +96,14 @@ def test_prod_surface_requires_declared_policy_pass_before_materialized_wording(
     fail_html = render(required_gate_fail)
 
     assert "FAIL" in fail_html
-    assert "PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE" not in fail_html
+    assert MATERIALIZED_PROD_SURFACE not in fail_html
 
     unresolved = base_prod_status()
     unresolved["metrics"].pop("required_gates", None)
     unresolved_html = render(unresolved)
 
     assert "UNKNOWN" in unresolved_html
-    assert (
-        "PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE"
-        not in unresolved_html
-    )
+    assert MATERIALIZED_PROD_SURFACE not in unresolved_html
 
 
 def test_core_stubbed_surface_uses_positive_reader_state_wording() -> None:
@@ -127,7 +138,7 @@ def test_core_stubbed_surface_uses_positive_reader_state_wording() -> None:
     ]:
         assert bad not in html
 
- 
+
 def test_prod_surface_blocks_materialized_wording_for_all_stub_scaffold_marker_paths() -> None:
     marker_cases = [
         (("diagnostics", "gates_stubbed"), True),
@@ -141,13 +152,6 @@ def test_prod_surface_blocks_materialized_wording_for_all_stub_scaffold_marker_p
         (("meta", "diagnostics", "stub_profile"), "stubbed"),
     ]
 
- 
-  def set_nested(obj: dict, path: tuple[str, ...], value: object) -> None:
-        current = obj
-        for key in path[:-1]:
-            current = current.setdefault(key, {})
-        current[path[-1]] = value
-
     for path, value in marker_cases:
         status = base_prod_status()
         set_nested(status, path, value)
@@ -155,8 +159,31 @@ def test_prod_surface_blocks_materialized_wording_for_all_stub_scaffold_marker_p
         html = render(status)
 
         assert "PROD-PASS" in html
-        assert (
-            "PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE"
-            not in html
-        ), path
-        assert "PROD READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE" in html, path
+        assert MATERIALIZED_PROD_SURFACE not in html, path
+        assert STUBBED_PROD_SURFACE in html, path
+
+
+def test_prod_surface_keeps_pending_wording_for_neutral_stub_profiles() -> None:
+    neutral_cases = [
+        (("diagnostics", "stub_profile"), ""),
+        (("diagnostics", "stub_profile"), "none"),
+        (("diagnostics", "stub_profile"), "false"),
+        (("diagnostics", "stub_profile"), "real"),
+        (("diagnostics", "stub_profile"), "not_stubbed"),
+        (("metrics", "stub_profile"), "real"),
+        (("metrics", "stub_profile"), "not_stubbed"),
+        (("meta", "diagnostics", "stub_profile"), "real"),
+        (("meta", "diagnostics", "stub_profile"), "not_stubbed"),
+    ]
+
+    for path, value in neutral_cases:
+        status = base_prod_status()
+        status["gates"]["detectors_materialized_ok"] = False
+        set_nested(status, path, value)
+
+        html = render(status)
+
+        assert "PROD-PASS" in html
+        assert PENDING_PROD_SURFACE in html, path
+        assert STUBBED_PROD_SURFACE not in html, path
+        assert MATERIALIZED_PROD_SURFACE not in html, path

--- a/tests/test_render_quality_ledger_public_surface_state.py
+++ b/tests/test_render_quality_ledger_public_surface_state.py
@@ -1,0 +1,162 @@
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from PULSE_safe_pack_v0.tools.render_quality_ledger import write_quality_ledger  # noqa: E402
+
+
+def render(status: dict) -> str:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        status_path = root / "status.json"
+        out_path = root / "report_card.html"
+        status_path.write_text(
+            json.dumps(status, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        write_quality_ledger(status_path, out_path)
+        return out_path.read_text(encoding="utf-8")
+
+
+def base_prod_status() -> dict:
+    return {
+        "version": "1.0.0-prod",
+        "created_utc": "2026-02-17T12:34:56Z",
+        "metrics": {
+            "run_mode": "prod",
+            "required_gates": ["prod_gate_ok"],
+        },
+        "diagnostics": {
+            "gates_stubbed": False,
+            "scaffold": False,
+        },
+        "gates": {
+            "prod_gate_ok": True,
+            "detectors_materialized_ok": True,
+            "external_summaries_present": True,
+            "external_all_pass": True,
+        },
+    }
+
+
+def test_clean_prod_surface_reports_materialized_reader_evidence_state() -> None:
+    html = render(base_prod_status())
+
+    assert "PROD-PASS" in html
+    assert "PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE" in html
+    assert "PROD MATERIALIZED RELEASE-GRADE SURFACE" not in html
+
+
+def test_stubbed_prod_surface_keeps_reader_surface_without_materialized_wording() -> None:
+    status = base_prod_status()
+    status["metrics"]["gates_stubbed"] = True
+
+    html = render(status)
+
+    assert "PROD-PASS" in html
+    assert "PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE" not in html
+    assert "PROD READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE" in html
+    assert "STUBBED/SCAFFOLD" in html
+
+
+def test_meta_diagnostics_stubbed_prod_surface_keeps_reader_surface() -> None:
+    status = base_prod_status()
+    status["meta"] = {"diagnostics": {"gates_stubbed": True}}
+
+    html = render(status)
+
+    assert "PROD-PASS" in html
+    assert "PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE" not in html
+    assert "PROD READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE" in html
+    assert "STUBBED/SCAFFOLD" in html
+
+
+def test_prod_surface_requires_declared_policy_pass_before_materialized_wording() -> None:
+    required_gate_fail = base_prod_status()
+    required_gate_fail["gates"]["prod_gate_ok"] = False
+    fail_html = render(required_gate_fail)
+
+    assert "FAIL" in fail_html
+    assert "PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE" not in fail_html
+
+    unresolved = base_prod_status()
+    unresolved["metrics"].pop("required_gates", None)
+    unresolved_html = render(unresolved)
+
+    assert "UNKNOWN" in unresolved_html
+    assert (
+        "PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE"
+        not in unresolved_html
+    )
+
+
+def test_core_stubbed_surface_uses_positive_reader_state_wording() -> None:
+    status = {
+        "version": "1.0.0-core",
+        "created_utc": "2026-02-17T12:34:56Z",
+        "metrics": {
+            "run_mode": "core",
+            "required_gates": ["core_gate_ok"],
+        },
+        "diagnostics": {
+            "gates_stubbed": True,
+            "scaffold": True,
+        },
+        "gates": {
+            "core_gate_ok": True,
+            "detectors_materialized_ok": False,
+        },
+    }
+
+    html = render(status)
+
+    assert "STAGE-PASS" in html
+    assert "CORE READER SURFACE" in html
+    assert "STUBBED/SCAFFOLD" in html
+    for bad in [
+        "PUBLIC READER SURFACE — NON-NORMATIVE",
+        "NON-RELEASE VIEW",
+        "NOT RELEASE-GRADE",
+        "Non-normative display surface",
+        "It is not itself the release authority",
+    ]:
+        assert bad not in html
+
+ 
+def test_prod_surface_blocks_materialized_wording_for_all_stub_scaffold_marker_paths() -> None:
+    marker_cases = [
+        (("diagnostics", "gates_stubbed"), True),
+        (("diagnostics", "scaffold"), True),
+        (("diagnostics", "stub_profile"), "stubbed"),
+        (("metrics", "gates_stubbed"), True),
+        (("metrics", "scaffold"), True),
+        (("metrics", "stub_profile"), "stubbed"),
+        (("meta", "diagnostics", "gates_stubbed"), True),
+        (("meta", "diagnostics", "scaffold"), True),
+        (("meta", "diagnostics", "stub_profile"), "stubbed"),
+    ]
+
+ 
+  def set_nested(obj: dict, path: tuple[str, ...], value: object) -> None:
+        current = obj
+        for key in path[:-1]:
+            current = current.setdefault(key, {})
+        current[path[-1]] = value
+
+    for path, value in marker_cases:
+        status = base_prod_status()
+        set_nested(status, path, value)
+
+        html = render(status)
+
+        assert "PROD-PASS" in html
+        assert (
+            "PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE"
+            not in html
+        ), path
+        assert "PROD READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE" in html, path


### PR DESCRIPTION
````markdown
## Summary

This PR exposes the Quality Ledger public surface evidence state while preserving the existing PULSEmech decision display.

The Ledger remains a public reader surface. The generated HTML now separates the visible public surface state from the underlying PULSEmech authority carrier path.

The materialized prod case is displayed as:

`PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE`

The prod stubbed/scaffolded case is displayed as:

`PROD READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE`

## Why

The public Quality Ledger can otherwise be read too strongly when a core/stubbed or prod/stubbed state appears on the public surface.

This PR makes the recorded public surface state visible without redefining release authority.

The PULSEmech authority carrier remains:

```text
status.json
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI enforcement
````

## Changes

* Keeps the existing decision badge display intact.
* Adds public surface evidence-state wording to the generated ledger.
* Distinguishes:

  * core/demo reader surfaces,
  * prod reader surfaces with materialization pending,
  * prod reader surfaces with stub/scaffold evidence state,
  * prod reader surfaces with materialized release-grade evidence state.
* Fixes the Q1 reference shadow tuple shape so rendered rows remain two-item tuples.
* Adds focused regression coverage in `tests/test_render_quality_ledger_public_surface_state.py`.

## Regression coverage

The new test file covers:

* clean prod materialized evidence state;
* metrics-level stubbed prod state;
* meta.diagnostics-level stubbed prod state;
* failed required-gate prod state;
* unresolved required-gate prod state;
* core stubbed reader-surface wording.

## Preserved

This PR does not change:

* PULSEmech decision semantics;
* gate policy;
* `check_gates.py`;
* required-gate evaluation;
* CI release authority;
* README/docs scope.

```
```
