### PR TITLE
docs(surface): declare public reader carrier boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,18 +80,18 @@ See [`docs/PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md`](docs/PULSE_PRE_MATER
 
 ## Authority boundary
 
-| Surface | Mechanical role | Authority status |
+| Surface / artifact | Mechanical role | Authority boundary |
 |---|---|---|
-| PULSEmech decision tuple | Defines the release-authority mechanism | Normative |
-| `status.json` | Carries machine-readable release state | Normative input |
-| Declared gate policy | Defines required gate sets by lane | Normative input |
-| Materialized required gate set | Concrete enforced gate set | Normative input |
-| `check_gates.py` / CI enforcement | Enforces true-only required gates fail-closed | Normative |
-| Quality Ledger | Displays the decision trail | Non-normative reader surface |
-| Release authority manifest | Records the decision trail | Non-normative trace surface |
-| Audit bundle | Preserves reconstructable evidence trail | Non-normative audit surface |
-| Dashboards, badges, Pages | Publish or display release state | Non-normative presentation surfaces |
-| Diagnostic and shadow outputs | Produce candidate evidence signals | Non-normative unless explicitly folded into recorded release evidence and enforced as required gates under declared policy |
+| PULSEmech decision tuple | Defines the release-authority mechanism | Authority mechanism |
+| `status.json` | Machine-readable release-state artifact for the recorded run | Normative input carrier |
+| Declared gate policy | Defines the selected lane gate requirements | Normative policy carrier |
+| Materialized required gate set | Concrete required gate set enforced by CI | Normative gate-set carrier |
+| `check_gates.py` / CI enforcement | Strict true-only fail-closed gate enforcement | Enforcement carrier |
+| Quality Ledger | Reader carrier for recorded release-state artifacts, traceability fields, gate outcomes, and reader-visible evidence state | Non-authorizing carrier |
+| Release authority manifest | Trace carrier for release-authority reconstruction and review | No independent decision function |
+| Audit bundle | Audit / preservation carrier for reconstructable release evidence and decision artifacts | Non-authorizing carrier |
+| Dashboards, badges, Pages | Publication / reader carriers derived from recorded release-state artifacts | Derived carriers only |
+| Diagnostic and shadow outputs | Diagnostic / shadow carriers for candidate evidence signals and review state | Authority participation requires recorded evidence inclusion and required-gate enforcement under declared policy |
 
 ## Release boundary
 
@@ -102,10 +102,24 @@ PULSE acts at the release boundary, before deployment.
 | PULSE / PULSEmech | Release boundary, before deployment | Recorded release evidence + `status.json` + declared gate policy + materialized required gate set + strict fail-closed CI enforcement | Declared-policy CI allow/block release decision |
 | Runtime guardrails | Live interaction boundary, during use | Individual prompt, output, or tool-call state | Interaction-level allow, block, rewrite, route, or refuse |
 
-## Public release surfaces
+## Public reader surfaces
+
+| Public surface | Mechanical role | Authority boundary |
+|---|---|---|
+| Quality Ledger | Reader carrier for recorded `status.json` state, reader-visible evidence state, traceability fields, and gate outcomes | Non-authorizing carrier |
+| Public Status JSON | Reader / access carrier for recorded release-state data | Authority review uses the recorded artifact bound to run identity |
+
+Authority carrier:
+
+```text
+status.json
+→ declared gate policy
+→ materialized required gate set
+→ strict fail-closed CI enforcement
+```
 
 - Quality Ledger: https://hkati.github.io/pulse-release-gates-0.1/
-- Live Status JSON: https://hkati.github.io/pulse-release-gates-0.1/status.json
+- Public Status JSON: https://hkati.github.io/pulse-release-gates-0.1/status.json
 
 ## Current verification checkpoint
 
@@ -129,7 +143,7 @@ Required gates are explicit, materialized, and checked before release effects ca
 ---
 
 <details>
-  <summary><strong>Project badges, Zenodo records, and live release surfaces</strong></summary>
+  <summary><strong>Project badges, Zenodo records, and public reader surfaces</strong></summary>
 
 <p align="center">
   <img src="pulse_grail.svg" width="90" alt="Pulse Holy Grail">
@@ -149,10 +163,24 @@ Required gates are explicit, materialized, and checked before release effects ca
 - **Previous release DOI / v1.0.1:** https://doi.org/10.5281/zenodo.17214909
 - **Preprint DOI:** https://doi.org/10.5281/zenodo.17833583
 
-### Live release surfaces
+### Public reader surfaces
+
+| Public surface | Mechanical role | Authority boundary |
+|---|---|---|
+| Quality Ledger | Reader carrier for recorded release-state artifacts and reader-visible evidence state | Non-authorizing carrier |
+| Public Status JSON | Reader / access carrier for release-state data | Recorded artifact binding required for authority review |
+
+Authority carrier:
+
+```text
+status.json
+→ declared gate policy
+→ materialized required gate set
+→ strict fail-closed CI enforcement
+```
 
 - **Quality Ledger:** https://hkati.github.io/pulse-release-gates-0.1/
-- **Status JSON:** https://hkati.github.io/pulse-release-gates-0.1/status.json
+- **Public Status JSON:** https://hkati.github.io/pulse-release-gates-0.1/status.json
 
 </details>
 

--- a/docs/PULSE_FIELD_SURFACE_MAP_v0.md
+++ b/docs/PULSE_FIELD_SURFACE_MAP_v0.md
@@ -59,23 +59,27 @@ Release authority is exercised only through the declared PULSEmech path.
 
 Diagnostic, audit, preservation, publication, HPC, and shadow surfaces may inspect, preserve, stress-test, contextualize, render, or compare the decision path.
 
-They do not authorize release by themselves.
+Carrier roles remain explicit
 
-A non-normative surface may affect release authority only when a specific evidence field or gate is explicitly folded into recorded release evidence and enforced as a required gate under declared policy.
+Reader, diagnostic, publication, preservation, HPC, and shadow carriers are non-authorizing carriers unless a specific artifact field is folded into recorded release evidence and enforced as a required gate under declared policy.
 
-No whole surface is implicitly promoted into release authority.
+The PULSEmech path carries release authority.
 
-No reader, diagnostic, publication, preservation, HPC, or shadow surface creates an independent release decision engine.
+No whole surface is implicitly promoted into the release-authority path.
 
-## Recorded artifact versus live publication surface
+## Recorded artifact and public reader surface
 
-PULSE distinguishes recorded release artifacts from live publication surfaces.
+PULSE distinguishes recorded release artifacts from public reader surfaces.
 
-A recorded `status.json` artifact can be part of the normative release-authority path when it belongs to the declared release run and is tied to the relevant run identity.
+A recorded `status.json` artifact can carry release-authority input when it belongs to the declared release run and is tied to the relevant run identity.
 
-A live or public `status.json` URL is a publication or access surface unless it is explicitly evaluated as the recorded artifact for a specific run.
+A public `status.json` URL is a reader / access carrier for release-state data.
 
-Ledger, Pages, badges, public URLs, and rendered views must be compared against the same recorded run identity:
+The Quality Ledger, Pages, badges, public URLs, and rendered views present recorded state through public reader or publication carriers.
+
+Publication and reader carriers are derived carriers.
+
+Authority review is tied to the recorded artifact source for a declared run and is compared through the same run identity:
 
 - `run_id`
 - `git_sha`
@@ -83,9 +87,9 @@ Ledger, Pages, badges, public URLs, and rendered views must be compared against 
 - artifact source
 - artifact hash when available
 
-A live surface must not be treated as release authority merely because it displays or links to release-state data.
+The public reader surface presents recorded state.
 
-The authority question is always tied to the recorded artifact source for a declared run.
+The PULSEmech path carries release authority.
 
 ## Field-surface map
 
@@ -93,18 +97,19 @@ The authority question is always tied to the recorded artifact source for a decl
 |---|---|---|---|
 | recorded release evidence | Evidence material available before release | Normative input | Already part of the release-authority path |
 | recorded `status.json` artifact | Machine-readable release-state artifact for a declared run | Normative source | Normative only as the recorded artifact bound to the selected run |
-| live/public `status.json` URL | Public access surface for release-state data | Publication / access surface | Not authority by itself; must be bound to run identity before authority review |
+| public `status.json` URL | Public reader / access carrier for release-state data | Reader / access carrier | Authority review uses the recorded artifact bound to run identity | 
 | declared gate policy | Defines the required gates for the selected lane | Normative input | Already part of the release-authority path |
 | materialized required gate set | Concrete gate set enforced by CI | Normative input | Already part of the release-authority path |
 | `check_gates.py` | Strict true-only gate evaluator | Normative enforcement | Already part of the release-authority path |
 | CI allow/block result | Final release permission result | Normative decision output | Already part of the release-authority path |
-| Quality Ledger | Human-readable rendering of release state | Audit / reader surface | Must remain parity-bound to recorded source artifacts |
+| Quality Ledger | Public reader carrier for recorded release state, reader-visible evidence state, traceability fields, and gate outcomes | Reader carrier | Non-authorizing carrier; parity-bound to recorded source artifacts |
 | release authority manifest | Reconstructs the decision trace | Audit / preservation surface | May support reconstruction; does not authorize independently |
 | audit bundle | Preserves evidence and decision artifacts | Preservation / review surface | May support replay and review; does not authorize independently |
 | external detector summaries | External evidence inputs | Conditional evidence surface | Becomes blocking only when declared policy requires a specific field or gate |
 | refusal-delta evidence | Stability signal across refusal behavior | Conditional evidence / stability surface | Becomes blocking only when declared policy requires a specific field or gate |
 | JUnit / SARIF exports | CI and security-tooling representation | Integration surface | Mirrors decision evidence; does not replace the decision path |
-| badges | Compact public state indicators | Publication surface | Must reflect source artifacts; cannot override them |
+| badges | Compact public state indicators derived from recorded artifacts | Publication carrier | Derived carrier only |
+| GitHub Pages | Public reader / publication carrier for rendered artifacts | Reader / publication carrier | Derived carrier only |
 | GitHub Pages | Public rendering surface | Publication / reader surface | Must remain derived from recorded artifacts |
 | Zenodo / DOI records | Preservation and citation surface | Publication / preservation surface | Preserves releases; does not decide releases |
 | Kaggle artifacts / notebooks | Reproducibility and public analysis surface | Research / publication surface | Supports review and reproduction; not release authority by default |

--- a/docs/quality_ledger.md
+++ b/docs/quality_ledger.md
@@ -1,6 +1,6 @@
 # PULSE Quality Ledger
 
-Human-readable view over one immutable `status.json` artefact.
+Public reader carrier for one recorded `status.json` artefact.
 
 This page documents the current renderer behavior, not an aspirational UI.
 If the renderer changes, this page should change in the same PR.
@@ -15,8 +15,18 @@ python PULSE_safe_pack_v0/tools/render_quality_ledger.py \
 
 It reads a single final `status.json` and writes a static HTML report.
 
-Optional publication surfaces such as GitHub Pages snapshots or PR comments remain opt-in presentation layers.
-They are not required parts of the normative gating path.
+Optional publication carriers such as GitHub Pages snapshots or PR comments publish reader artifacts derived from recorded run artifacts.
+
+Publication carriers are non-authorizing carriers unless a specific artifact field is folded into recorded release evidence and enforced as a required gate under declared policy.
+
+Authority carrier:
+
+```text
+status.json
+→ declared gate policy
+→ materialized required gate set
+→ strict fail-closed CI enforcement
+```
 
 ---
 
@@ -30,7 +40,7 @@ For release decisions, the authoritative inputs remain:
 - the active required gate set
 - `PULSE_safe_pack_v0/tools/check_gates.py`
 
-The ledger is a descriptive explanation layer over that same artefact.
+The ledger is the public reader carrier over that same recorded artefact.
 
 If the ledger and CI ever disagree, treat:
 
@@ -57,9 +67,13 @@ This section is inserted by:
 PULSE_safe_pack_v0/tools/insert_release_authority_manifest_ledger_section.py
 ```
 
-The section is a reader / renderer surface. It links or summarizes the release
-authority manifest for human review, but it does not compute, redefine, or
-override the release decision.
+The section is a reader / renderer carrier. It links or summarizes the release
+authority manifest for human review and traceability.
+
+Its carrier role is to present the recorded release-authority trace beside the
+Quality Ledger reader surface.
+
+Authority boundary: no independent decision function.
 
 The section may show:
 
@@ -79,13 +93,13 @@ The section may show:
 Authority rule:
 
 ```text
-status.json + declared gate policy + check_gates.py + primary CI workflow
-= release authority
+status.json → declared gate policy → materialized required gate set → strict fail-closed CI enforcement
+= authority carrier
 ```
 
 ```text
 Quality Ledger release-authority section
-= human-readable audit visibility
+= reader carrier for recorded release-authority trace
 ```
 
 If the manifest is missing, the Quality Ledger may show `MISSING/UNKNOWN`.
@@ -131,13 +145,13 @@ Purpose:
 Authority rule:
 
 ```text
-status.json + declared gate policy + check_gates.py + primary CI workflow
-= release authority
+status.json → declared gate policy → materialized required gate set → strict fail-closed CI enforcement
+= authority carrier
 ```
 
 ```text
 release-authority-audit-bundle
-= review / audit / traceability package
+= audit / preservation carrier for recorded release-authority artifacts
 ```
 
 The audit bundle is a publication and review surface. It does not compute,


### PR DESCRIPTION
## Summary

This PR declares public reader carrier boundaries in the repository documentation.

It updates legacy wording such as `Public release surfaces` and `Live release surfaces` so public URLs are described through professional mechanical carrier language.

## Updated boundary language

| Carrier | Boundary |
|---|---|
| Quality Ledger | Non-authorizing carrier |
| Release authority manifest | No independent decision function |
| Audit bundle | Non-authorizing carrier |
| Dashboards, badges, Pages | Derived carriers only |
| Diagnostic and shadow outputs | Authority participation requires recorded evidence inclusion and required-gate enforcement under declared policy |

## Authority carrier

Unchanged:

```text
status.json
→ declared gate policy
→ materialized required gate set
→ strict fail-closed CI enforcement
```

## Scope

Docs-only wording cleanup.

Expected files:

```text
README.md
docs/PULSE_FIELD_SURFACE_MAP_v0.md
docs/quality_ledger.md
```

## Zenodo / release boundary

This PR does not publish a release and does not touch the Zenodo path.

Preserved:

- Zenodo DOI references;
- current release DOI labels;
- concept DOI labels;
- release tags;
- CHANGELOG;
- generated artifacts;
- archive artifacts;
- GitHub release metadata.

## Preserved

This PR does not change:

- PULSEmech decision semantics;
- gate policy;
- `check_gates.py`;
- status schema;
- CI allow/block behavior;
- Quality Ledger renderer behavior;
- tests;
- cryptographic binding semantics.