### PR TITLE
feat(crypto): add release authority artifact binding v0

### DIFF
--- a/PULSE_safe_pack_v0/tools/build_artifact_provenance_binding_v0.py
+++ b/PULSE_safe_pack_v0/tools/build_artifact_provenance_binding_v0.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Build PULSE Artifact Provenance Binding v0."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+import yaml
+
+SCHEMA_ID = "pulse.artifact_provenance_binding.v0"
+SCHEMA_VERSION = "0.1.0"
+PRODUCER_NAME = "build_artifact_provenance_binding_v0.py"
+PRODUCER_VERSION = "0.1.0"
+
+
+class BindingBuildError(RuntimeError):
+    """Raised when the binding cannot be built from the supplied artifacts."""
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    if not path.is_file():
+        raise BindingBuildError(f"missing required artifact: {path}")
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def sha256_canonical_json(value: Any) -> str:
+    return sha256_bytes(canonical_json_bytes(value))
+
+
+def read_json(path: Path) -> Dict[str, Any]:
+    if not path.is_file():
+        raise BindingBuildError(f"missing required JSON artifact: {path}")
+    obj = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(obj, dict):
+        raise BindingBuildError(f"expected top-level JSON object in {path}")
+    return obj
+
+
+def read_yaml(path: Path) -> Dict[str, Any]:
+    if not path.is_file():
+        raise BindingBuildError(f"missing required YAML artifact: {path}")
+    obj = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(obj, dict):
+        raise BindingBuildError(f"expected top-level YAML object in {path}")
+    return obj
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def as_dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def as_str_list(value: Any) -> List[str]:
+    if not isinstance(value, list):
+        return []
+    out: List[str] = []
+    for item in value:
+        text = str(item).strip()
+        if text:
+            out.append(text)
+    return out
+
+
+def path_record(path: Path) -> str:
+    return path.as_posix() if not path.is_absolute() else str(path)
+
+
+def get_policy_gate_sets(policy: Dict[str, Any]) -> Dict[str, Any]:
+    top_level = as_dict(policy.get("gates"))
+    if top_level:
+        return top_level
+    nested = as_dict(as_dict(policy.get("policy")).get("gates"))
+    if nested:
+        return nested
+    return {}
+
+
+def dedupe_preserve_order(items: Iterable[str]) -> List[str]:
+    seen: set[str] = set()
+    out: List[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
+def required_gate_set_from_policy_sets(
+    gate_sets: Dict[str, Any], policy_sets: List[str]
+) -> List[str]:
+    gate_ids: List[str] = []
+    for set_name in policy_sets:
+        selected = as_str_list(gate_sets.get(set_name))
+        if not selected:
+            raise BindingBuildError(f"policy gate set is missing or empty: {set_name}")
+        gate_ids.extend(selected)
+    return dedupe_preserve_order(gate_ids)
+
+
+def resolve_workflow_effective_gate_set(
+    status: Dict[str, Any], policy: Dict[str, Any], cli_policy_sets: List[str]
+) -> Dict[str, Any]:
+    metrics = as_dict(status.get("metrics"))
+    gate_sets = get_policy_gate_sets(policy)
+
+    if cli_policy_sets:
+        policy_sets = list(cli_policy_sets)
+        gate_ids = required_gate_set_from_policy_sets(gate_sets, policy_sets)
+        effective_source = "workflow-effective:" + "+".join(policy_sets)
+    else:
+        explicit = as_str_list(metrics.get("required_gates"))
+        if explicit:
+            policy_sets = []
+            gate_ids = dedupe_preserve_order(explicit)
+            effective_source = "metrics.required_gates"
+        else:
+            required_gate_set = metrics.get("required_gate_set")
+            if isinstance(required_gate_set, str) and required_gate_set.strip():
+                set_name = required_gate_set.strip()
+                effective_source = f"metrics.required_gate_set:{set_name}"
+            else:
+                run_mode = str(metrics.get("run_mode", "")).strip().lower()
+                set_name = "core_required" if run_mode in {"demo", "core"} else "required"
+                effective_source = f"workflow-effective:{set_name}"
+            policy_sets = [set_name]
+            gate_ids = required_gate_set_from_policy_sets(gate_sets, policy_sets)
+
+    if not gate_ids:
+        raise BindingBuildError("workflow-effective required gate set is empty")
+
+    gate_set = {
+        "effective_source": effective_source,
+        "policy_sets": policy_sets,
+        "gate_ids": gate_ids,
+    }
+    gate_set["sha256"] = sha256_canonical_json(gate_set)
+    return gate_set
+
+
+def build_strict_ci_gate_enforcement(
+    status: Dict[str, Any], gate_ids: List[str]
+) -> Dict[str, Any]:
+    gates = as_dict(status.get("gates"))
+    allow = all(gates.get(gate_id) is True for gate_id in gate_ids)
+    obj = {
+        "source": "check_gates.py",
+        "result": "allow" if allow else "block",
+        "exit_code": 0 if allow else 1,
+    }
+    obj["sha256"] = sha256_canonical_json(obj)
+    return obj
+
+
+def extract_release_decision_label(release_decision: Dict[str, Any]) -> str:
+    candidate_paths = [
+        ("label",),
+        ("release_level",),
+        ("verdict",),
+        ("decision",),
+        ("release_decision", "label"),
+        ("decision", "label"),
+        ("release", "label"),
+    ]
+    for path in candidate_paths:
+        current: Any = release_decision
+        for part in path:
+            if not isinstance(current, dict) or part not in current:
+                current = None
+                break
+            current = current[part]
+        if isinstance(current, str) and current.strip():
+            return current.strip()
+    raise BindingBuildError("release decision label cannot be read")
+
+
+def build_binding(
+    *,
+    status_path: Path,
+    policy_path: Path,
+    ledger_path: Path,
+    release_decision_path: Path,
+    release_authority_manifest_path: Path,
+    out_path: Path,
+    policy_sets: List[str],
+    created_utc: str | None = None,
+) -> Dict[str, Any]:
+    status = read_json(status_path)
+    policy = read_yaml(policy_path)
+    release_decision_json = read_json(release_decision_path)
+
+    status_sha = sha256_file(status_path)
+    policy_sha = sha256_file(policy_path)
+    ledger_sha = sha256_file(ledger_path)
+    release_decision_sha = sha256_file(release_decision_path)
+    release_authority_manifest_sha = sha256_file(release_authority_manifest_path)
+
+    required_gate_set = resolve_workflow_effective_gate_set(status, policy, policy_sets)
+    strict_enforcement = build_strict_ci_gate_enforcement(
+        status, as_str_list(required_gate_set.get("gate_ids"))
+    )
+    release_label = extract_release_decision_label(release_decision_json)
+
+    metrics = as_dict(status.get("metrics"))
+    run = {
+        "run_id": str(metrics.get("run_id") or status.get("run_id") or ""),
+        "run_key": str(metrics.get("run_key") or status.get("run_key") or ""),
+        "git_sha": str(metrics.get("git_sha") or status.get("git_sha") or ""),
+        "run_mode": str(metrics.get("run_mode") or ""),
+    }
+
+    binding = {
+        "schema_id": SCHEMA_ID,
+        "schema_version": SCHEMA_VERSION,
+        "producer": {"name": PRODUCER_NAME, "version": PRODUCER_VERSION},
+        "created_utc": created_utc or utc_now(),
+        "run": run,
+        "authority_carrier": {
+            "status_json": {"path": path_record(status_path), "sha256": status_sha},
+            "declared_gate_policy": {
+                "path": path_record(policy_path),
+                "sha256": policy_sha,
+            },
+            "workflow_effective_required_gate_set": required_gate_set,
+            "strict_ci_gate_enforcement": strict_enforcement,
+            "release_decision": {
+                "path": path_record(release_decision_path),
+                "producer": "materialize_release_decision.py",
+                "label": release_label,
+                "sha256": release_decision_sha,
+            },
+        },
+        "reader_carrier": {
+            "quality_ledger": {"path": path_record(ledger_path), "sha256": ledger_sha}
+        },
+        "trace_carrier": {
+            "release_authority_manifest": {
+                "path": path_record(release_authority_manifest_path),
+                "sha256": release_authority_manifest_sha,
+            }
+        },
+        "binding_subjects": [
+            {"role": "status_json", "path": path_record(status_path), "sha256": status_sha},
+            {
+                "role": "declared_gate_policy",
+                "path": path_record(policy_path),
+                "sha256": policy_sha,
+            },
+            {
+                "role": "workflow_effective_required_gate_set",
+                "path": "inline:authority_carrier.workflow_effective_required_gate_set",
+                "sha256": required_gate_set["sha256"],
+            },
+            {
+                "role": "strict_ci_gate_enforcement",
+                "path": "inline:authority_carrier.strict_ci_gate_enforcement",
+                "sha256": strict_enforcement["sha256"],
+            },
+            {
+                "role": "release_decision",
+                "path": path_record(release_decision_path),
+                "sha256": release_decision_sha,
+            },
+            {
+                "role": "quality_ledger",
+                "path": path_record(ledger_path),
+                "sha256": ledger_sha,
+            },
+            {
+                "role": "release_authority_manifest",
+                "path": path_record(release_authority_manifest_path),
+                "sha256": release_authority_manifest_sha,
+            },
+        ],
+    }
+    binding["binding_hash"] = sha256_canonical_json(binding)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(binding, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return binding
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--status", required=True)
+    parser.add_argument("--policy", required=True)
+    parser.add_argument("--ledger", required=True)
+    parser.add_argument("--release-decision", required=True)
+    parser.add_argument("--release-authority-manifest", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--policy-set", action="append", default=[])
+    parser.add_argument("--created-utc", default=None)
+    args = parser.parse_args(argv)
+
+    try:
+        build_binding(
+            status_path=Path(args.status),
+            policy_path=Path(args.policy),
+            ledger_path=Path(args.ledger),
+            release_decision_path=Path(args.release_decision),
+            release_authority_manifest_path=Path(args.release_authority_manifest),
+            out_path=Path(args.out),
+            policy_sets=list(args.policy_set or []),
+            created_utc=args.created_utc,
+        )
+    except BindingBuildError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/PULSE_safe_pack_v0/tools/build_artifact_provenance_binding_v0.py
+++ b/PULSE_safe_pack_v0/tools/build_artifact_provenance_binding_v0.py
@@ -7,6 +7,7 @@ import argparse
 import datetime as dt
 import hashlib
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
@@ -18,6 +19,9 @@ SCHEMA_VERSION = "0.1.0"
 PRODUCER_NAME = "build_artifact_provenance_binding_v0.py"
 PRODUCER_VERSION = "0.1.0"
 
+GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+VALID_RUN_MODES = {"demo", "core", "prod"}
+VALID_RELEASE_DECISION_LABELS = {"FAIL", "STAGE-PASS", "PROD-PASS"}
 
 class BindingBuildError(RuntimeError):
     """Raised when the binding cannot be built from the supplied artifacts."""
@@ -86,6 +90,42 @@ def as_str_list(value: Any) -> List[str]:
         if text:
             out.append(text)
     return out
+
+
+def parse_run_id_from_run_key(run_key: str) -> str:
+    for part in run_key.split("|"):
+        key, sep, value = part.partition("=")
+        if sep and key == "GITHUB_RUN_ID" and value.strip():
+            return value.strip()
+    return ""
+
+
+def extract_run_identity(status: Dict[str, Any]) -> Dict[str, str]:
+    metrics = as_dict(status.get("metrics"))
+
+    run_key = str(metrics.get("run_key") or status.get("run_key") or "").strip()
+    run_id = str(metrics.get("run_id") or status.get("run_id") or "").strip()
+    if not run_id and run_key:
+        run_id = parse_run_id_from_run_key(run_key)
+
+    git_sha = str(metrics.get("git_sha") or status.get("git_sha") or "").strip()
+    run_mode = str(metrics.get("run_mode") or status.get("run_mode") or "").strip().lower()
+
+    if not run_id:
+        raise BindingBuildError("run_id is required")
+    if not run_key:
+        raise BindingBuildError("run_key is required")
+    if not GIT_SHA_RE.fullmatch(git_sha):
+        raise BindingBuildError("git_sha must be a 40-character lowercase hex commit SHA")
+    if run_mode not in VALID_RUN_MODES:
+        raise BindingBuildError("run_mode must be one of: demo, core, prod")
+
+    return {
+        "run_id": run_id,
+        "run_key": run_key,
+        "git_sha": git_sha,
+        "run_mode": run_mode,
+    }
 
 
 def path_record(path: Path) -> str:
@@ -195,8 +235,11 @@ def extract_release_decision_label(release_decision: Dict[str, Any]) -> str:
                 current = None
                 break
             current = current[part]
-        if isinstance(current, str) and current.strip():
-            return current.strip()
+     if isinstance(current, str) and current.strip():
+            label = current.strip()
+            if label not in VALID_RELEASE_DECISION_LABELS:
+                raise BindingBuildError(f"unsupported release decision label: {label}")
+            return label
     raise BindingBuildError("release decision label cannot be read")
 
 
@@ -227,14 +270,8 @@ def build_binding(
     )
     release_label = extract_release_decision_label(release_decision_json)
 
-    metrics = as_dict(status.get("metrics"))
-    run = {
-        "run_id": str(metrics.get("run_id") or status.get("run_id") or ""),
-        "run_key": str(metrics.get("run_key") or status.get("run_key") or ""),
-        "git_sha": str(metrics.get("git_sha") or status.get("git_sha") or ""),
-        "run_mode": str(metrics.get("run_mode") or ""),
-    }
-
+    run = extract_run_identity(status)
+    
     binding = {
         "schema_id": SCHEMA_ID,
         "schema_version": SCHEMA_VERSION,

--- a/PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py
+++ b/PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Verify PULSE Artifact Provenance Binding v0."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+SCHEMA_ID = "pulse.artifact_provenance_binding.v0"
+
+
+class BindingMismatch(RuntimeError):
+    """Raised when an artifact relation does not match the binding."""
+
+
+class BindingMalformed(RuntimeError):
+    """Raised when a binding or artifact cannot be read as required."""
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_canonical_json(value: Any) -> str:
+    return sha256_bytes(canonical_json_bytes(value))
+
+
+def sha256_file(path: Path) -> str:
+    if not path.is_file():
+        raise BindingMalformed(f"missing bound artifact: {path}")
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def read_json(path: Path) -> Dict[str, Any]:
+    if not path.is_file():
+        raise BindingMalformed(f"missing binding: {path}")
+    obj = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(obj, dict):
+        raise BindingMalformed(f"expected top-level JSON object in {path}")
+    return obj
+
+
+def without_digest_field(value: Dict[str, Any], field_name: str) -> Dict[str, Any]:
+    out = dict(value)
+    out.pop(field_name, None)
+    return out
+
+
+def get_path(obj: Dict[str, Any], dotted: str) -> Any:
+    current: Any = obj
+    for part in dotted.split("."):
+        if not isinstance(current, dict) or part not in current:
+            raise BindingMalformed(f"missing binding field: {dotted}")
+        current = current[part]
+    return current
+
+
+def resolve_bound_path(path_text: str, *, binding_path: Path) -> Path:
+    p = Path(path_text)
+    if p.is_absolute():
+        return p
+    cwd_candidate = (Path.cwd() / p).resolve()
+    if cwd_candidate.exists():
+        return cwd_candidate
+    return (binding_path.parent / p).resolve()
+
+
+def recompute_inline_hash(binding: Dict[str, Any], inline_path: str) -> str:
+    if inline_path == "inline:authority_carrier.workflow_effective_required_gate_set":
+        obj = get_path(binding, "authority_carrier.workflow_effective_required_gate_set")
+        if not isinstance(obj, dict):
+            raise BindingMalformed("workflow_effective_required_gate_set is not an object")
+        return sha256_canonical_json(without_digest_field(obj, "sha256"))
+    if inline_path == "inline:authority_carrier.strict_ci_gate_enforcement":
+        obj = get_path(binding, "authority_carrier.strict_ci_gate_enforcement")
+        if not isinstance(obj, dict):
+            raise BindingMalformed("strict_ci_gate_enforcement is not an object")
+        return sha256_canonical_json(without_digest_field(obj, "sha256"))
+    raise BindingMalformed(f"unsupported inline binding subject: {inline_path}")
+
+
+def assert_equal(label: str, expected: str, actual: str) -> None:
+    if expected != actual:
+        raise BindingMismatch(f"{label} mismatch: expected {expected}, got {actual}")
+
+
+def verify_file_field(
+    binding: Dict[str, Any], *, binding_path: Path, path_field: str, sha_field: str
+) -> None:
+    path_text = get_path(binding, path_field)
+    expected = get_path(binding, sha_field)
+    if not isinstance(path_text, str) or not isinstance(expected, str):
+        raise BindingMalformed(f"invalid path/hash fields: {path_field}, {sha_field}")
+    actual = sha256_file(resolve_bound_path(path_text, binding_path=binding_path))
+    assert_equal(path_field, expected, actual)
+
+
+def verify_binding_hash(binding: Dict[str, Any]) -> None:
+    expected = binding.get("binding_hash")
+    if not isinstance(expected, str) or not expected:
+        raise BindingMalformed("missing binding_hash")
+    actual = sha256_canonical_json(without_digest_field(binding, "binding_hash"))
+    assert_equal("binding_hash", expected, actual)
+
+
+def verify_inline_hashes(binding: Dict[str, Any]) -> None:
+    gate_set = get_path(binding, "authority_carrier.workflow_effective_required_gate_set")
+    if not isinstance(gate_set, dict):
+        raise BindingMalformed("workflow_effective_required_gate_set is not an object")
+    assert_equal(
+        "workflow_effective_required_gate_set.sha256",
+        str(gate_set.get("sha256")),
+        sha256_canonical_json(without_digest_field(gate_set, "sha256")),
+    )
+
+    enforcement = get_path(binding, "authority_carrier.strict_ci_gate_enforcement")
+    if not isinstance(enforcement, dict):
+        raise BindingMalformed("strict_ci_gate_enforcement is not an object")
+    assert_equal(
+        "strict_ci_gate_enforcement.sha256",
+        str(enforcement.get("sha256")),
+        sha256_canonical_json(without_digest_field(enforcement, "sha256")),
+    )
+
+
+def verify_binding_subjects(binding: Dict[str, Any], *, binding_path: Path) -> None:
+    subjects = binding.get("binding_subjects")
+    if not isinstance(subjects, list) or not subjects:
+        raise BindingMalformed("binding_subjects must be a non-empty list")
+
+    for idx, subject in enumerate(subjects):
+        if not isinstance(subject, dict):
+            raise BindingMalformed(f"binding_subjects[{idx}] is not an object")
+        role = subject.get("role")
+        path_text = subject.get("path")
+        expected = subject.get("sha256")
+        if not isinstance(role, str) or not isinstance(path_text, str) or not isinstance(expected, str):
+            raise BindingMalformed(f"binding_subjects[{idx}] has invalid fields")
+
+        if path_text.startswith("inline:"):
+            actual = recompute_inline_hash(binding, path_text)
+        else:
+            actual = sha256_file(resolve_bound_path(path_text, binding_path=binding_path))
+        assert_equal(f"binding_subjects[{idx}] {role}", expected, actual)
+
+
+def verify_binding(binding_path: Path) -> None:
+    binding = read_json(binding_path)
+    if binding.get("schema_id") != SCHEMA_ID:
+        raise BindingMalformed("unsupported schema_id")
+
+    verify_file_field(
+        binding,
+        binding_path=binding_path,
+        path_field="authority_carrier.status_json.path",
+        sha_field="authority_carrier.status_json.sha256",
+    )
+    verify_file_field(
+        binding,
+        binding_path=binding_path,
+        path_field="authority_carrier.declared_gate_policy.path",
+        sha_field="authority_carrier.declared_gate_policy.sha256",
+    )
+    verify_file_field(
+        binding,
+        binding_path=binding_path,
+        path_field="authority_carrier.release_decision.path",
+        sha_field="authority_carrier.release_decision.sha256",
+    )
+    verify_file_field(
+        binding,
+        binding_path=binding_path,
+        path_field="reader_carrier.quality_ledger.path",
+        sha_field="reader_carrier.quality_ledger.sha256",
+    )
+    verify_file_field(
+        binding,
+        binding_path=binding_path,
+        path_field="trace_carrier.release_authority_manifest.path",
+        sha_field="trace_carrier.release_authority_manifest.sha256",
+    )
+    verify_inline_hashes(binding)
+    verify_binding_subjects(binding, binding_path=binding_path)
+    verify_binding_hash(binding)
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binding", required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        verify_binding(Path(args.binding))
+    except BindingMismatch as exc:
+        print(f"MISMATCH: {exc}", file=sys.stderr)
+        return 1
+    except (BindingMalformed, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/ARTIFACT_PROVENANCE_BINDING_v0.md
+++ b/docs/ARTIFACT_PROVENANCE_BINDING_v0.md
@@ -1,0 +1,183 @@
+# Artifact Provenance Binding v0
+
+Artifact Provenance Binding v0 is the machine-readable provenance carrier for the PULSEmech authority path.
+
+## Mechanical role
+
+The binding records the digest-backed artifact relationship around a recorded PULSE release-authority run.
+
+It connects:
+
+- recorded run identity,
+- source commit identity,
+- `status.json`,
+- declared gate policy,
+- workflow-effective required gate set,
+- strict CI gate-enforcement result,
+- release-decision materialization record,
+- Quality Ledger reader artifact,
+- release authority manifest / trace artifact,
+- binding subjects,
+- binding hash.
+
+## Carrier roles
+
+| Carrier | Artifact | Mechanical role |
+|---|---|---|
+| Authority carrier | `status.json` + declared policy + workflow-effective required gate set + strict CI enforcement | Carries release authority |
+| Binding carrier | `artifact_provenance_binding_v0.json` | Carries digest-backed artifact relation |
+| Verification carrier | `verify_artifact_provenance_binding_v0.py` | Recomputes and checks artifact relation |
+| Reader carrier | Quality Ledger | Presents recorded state |
+| Trace carrier | release authority manifest / release decision artifact | Preserves reconstruction and decision trace |
+| Attestation carrier | later cryptographic attestation | Attests the binding carrier |
+
+## Binding artifact
+
+The binding artifact is:
+
+```text
+PULSE_safe_pack_v0/artifacts/artifact_provenance_binding_v0.json
+```
+
+The binding records:
+
+```text
+recorded_run_identity
++ git_sha
++ status_json_digest
++ declared_gate_policy_digest
++ workflow_effective_required_gate_set_digest
++ strict_ci_gate_enforcement_result
++ release_decision_materialization_record
++ quality_ledger_digest
++ release_authority_manifest_digest
++ binding_subjects
++ binding_hash
+```
+
+## Workflow-effective gate-set rule
+
+The binding records the workflow-effective required gate set, not a static policy placeholder.
+
+Resolution order:
+
+```text
+1. explicit CLI policy sets
+2. status.metrics.required_gates
+3. status.metrics.required_gate_set
+4. run_mode fallback:
+   demo/core -> core_required
+   prod -> required
+```
+
+Gate order is preserved from the effective source.
+
+Duplicate gate IDs are de-duplicated by first occurrence.
+
+## Strict CI gate-enforcement and release-decision materialization
+
+`check_gates.py` is the strict CI gate-enforcement carrier.
+
+It records:
+
+```text
+allow / block
+exit_code
+```
+
+Release-level labels are carried by release-decision materialization.
+
+The split is:
+
+```text
+check_gates.py
+= strict CI gate-enforcement carrier
+
+release_decision_v0.json / materialize_release_decision.py
+= release-decision materialization carrier
+```
+
+## Canonical JSON byte rule
+
+Structured-object digests use canonical JSON bytes:
+
+```python
+json.dumps(
+    value,
+    sort_keys=True,
+    separators=(",", ":"),
+    ensure_ascii=False,
+    allow_nan=False,
+).encode("utf-8")
+```
+
+Rules:
+
+```text
+- object keys sorted
+- no insignificant whitespace
+- UTF-8 bytes
+- no trailing newline
+- NaN / Infinity rejected
+- digest field omitted from the object being digested
+```
+
+## Binding hash
+
+The binding carries:
+
+```text
+binding_hash
+```
+
+Rule:
+
+```text
+binding_hash = sha256(canonical_json_bytes(binding_without_binding_hash))
+```
+
+The binding hash is the compact digest of the recorded artifact relationship.
+
+## Verification carrier
+
+The verification carrier is:
+
+```text
+PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py
+```
+
+The verifier recomputes:
+
+- file digests,
+- inline object digests,
+- workflow-effective required gate-set digest,
+- strict CI gate-enforcement digest,
+- binding subject digests,
+- binding hash.
+
+Verification accepts the binding when the recorded artifact relationship matches the current artifact set.
+
+Verification reports mismatch when a bound artifact changes, disappears, or no longer matches its recorded digest.
+
+## Later attestation subject
+
+The primary future attestation subject is:
+
+```text
+artifact_provenance_binding_v0.json
+```
+
+The binding carrier lets the attestation layer bind one compact artifact relation record instead of scattering the authority artifact set across unrelated file signatures.
+
+## Boundary
+
+The PULSEmech authority carrier remains:
+
+```text
+status.json
+→ declared gate policy
+→ workflow-effective materialized required gate set
+→ strict fail-closed CI enforcement
+```
+
+Artifact Provenance Binding v0 carries the digest-backed artifact relationship around that authority path.

--- a/schemas/provenance/artifact_provenance_binding_v0.schema.json
+++ b/schemas/provenance/artifact_provenance_binding_v0.schema.json
@@ -47,16 +47,20 @@
       "required": ["run_id", "run_key", "git_sha", "run_mode"],
       "properties": {
         "run_id": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "run_key": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "git_sha": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
         },
         "run_mode": {
-          "type": "string"
+          "type": "string",
+          "enum": ["demo", "core", "prod"]
         }
       }
     },
@@ -88,13 +92,16 @@
             },
             "policy_sets": {
               "type": "array",
+              "uniqueItems": true,
               "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               }
             },
             "gate_ids": {
               "type": "array",
               "minItems": 1,
+              "uniqueItems": true,
               "items": {
                 "type": "string",
                 "minLength": 1
@@ -117,12 +124,27 @@
               "enum": ["allow", "block"]
             },
             "exit_code": {
-              "type": "integer"
+              "type": "integer",
+              "enum": [0, 1, 2]
             },
             "sha256": {
               "$ref": "#/$defs/sha256"
             }
-          }
+          },
+          "oneOf": [
+            {
+              "properties": {
+                "result": { "const": "allow" },
+                "exit_code": { "const": 0 }
+              }
+            },
+            {
+              "properties": {
+                "result": { "const": "block" },
+                "exit_code": { "enum": [1, 2] }
+              }
+            }
+          ]
         },
         "release_decision": {
           "type": "object",
@@ -138,7 +160,7 @@
             },
             "label": {
               "type": "string",
-              "minLength": 1
+              "enum": ["FAIL", "STAGE-PASS", "PROD-PASS"]
             },
             "sha256": {
               "$ref": "#/$defs/sha256"

--- a/schemas/provenance/artifact_provenance_binding_v0.schema.json
+++ b/schemas/provenance/artifact_provenance_binding_v0.schema.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "pulse.artifact_provenance_binding.v0",
+  "title": "PULSE Artifact Provenance Binding v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_id",
+    "schema_version",
+    "producer",
+    "created_utc",
+    "run",
+    "authority_carrier",
+    "reader_carrier",
+    "trace_carrier",
+    "binding_subjects",
+    "binding_hash"
+  ],
+  "properties": {
+    "schema_id": {
+      "const": "pulse.artifact_provenance_binding.v0"
+    },
+    "schema_version": {
+      "const": "0.1.0"
+    },
+    "producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": {
+          "const": "build_artifact_provenance_binding_v0.py"
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "created_utc": {
+      "type": "string",
+      "minLength": 1
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["run_id", "run_key", "git_sha", "run_mode"],
+      "properties": {
+        "run_id": {
+          "type": "string"
+        },
+        "run_key": {
+          "type": "string"
+        },
+        "git_sha": {
+          "type": "string"
+        },
+        "run_mode": {
+          "type": "string"
+        }
+      }
+    },
+    "authority_carrier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status_json",
+        "declared_gate_policy",
+        "workflow_effective_required_gate_set",
+        "strict_ci_gate_enforcement",
+        "release_decision"
+      ],
+      "properties": {
+        "status_json": {
+          "$ref": "#/$defs/file_subject"
+        },
+        "declared_gate_policy": {
+          "$ref": "#/$defs/file_subject"
+        },
+        "workflow_effective_required_gate_set": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["effective_source", "policy_sets", "gate_ids", "sha256"],
+          "properties": {
+            "effective_source": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy_sets": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "gate_ids": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "sha256": {
+              "$ref": "#/$defs/sha256"
+            }
+          }
+        },
+        "strict_ci_gate_enforcement": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source", "result", "exit_code", "sha256"],
+          "properties": {
+            "source": {
+              "const": "check_gates.py"
+            },
+            "result": {
+              "enum": ["allow", "block"]
+            },
+            "exit_code": {
+              "type": "integer"
+            },
+            "sha256": {
+              "$ref": "#/$defs/sha256"
+            }
+          }
+        },
+        "release_decision": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["path", "producer", "label", "sha256"],
+          "properties": {
+            "path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "producer": {
+              "const": "materialize_release_decision.py"
+            },
+            "label": {
+              "type": "string",
+              "minLength": 1
+            },
+            "sha256": {
+              "$ref": "#/$defs/sha256"
+            }
+          }
+        }
+      }
+    },
+    "reader_carrier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["quality_ledger"],
+      "properties": {
+        "quality_ledger": {
+          "$ref": "#/$defs/file_subject"
+        }
+      }
+    },
+    "trace_carrier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["release_authority_manifest"],
+      "properties": {
+        "release_authority_manifest": {
+          "$ref": "#/$defs/file_subject"
+        }
+      }
+    },
+    "binding_subjects": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["role", "path", "sha256"],
+        "properties": {
+          "role": {
+            "type": "string",
+            "minLength": 1
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sha256": {
+            "$ref": "#/$defs/sha256"
+          }
+        }
+      }
+    },
+    "binding_hash": {
+      "$ref": "#/$defs/sha256"
+    }
+  },
+  "$defs": {
+    "file_subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  }
+}

--- a/tests/test_artifact_provenance_binding_v0.py
+++ b/tests/test_artifact_provenance_binding_v0.py
@@ -1,0 +1,423 @@
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import ValidationError, validate
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from PULSE_safe_pack_v0.tools.build_artifact_provenance_binding_v0 import (  # noqa: E402
+    canonical_json_bytes,
+    main as build_main,
+)
+from PULSE_safe_pack_v0.tools.verify_artifact_provenance_binding_v0 import (  # noqa: E402
+    main as verify_main,
+)
+
+
+VALID_GIT_SHA = "a" * 40
+CREATED_UTC = "2026-02-17T12:34:56Z"
+
+
+def write_json(path: Path, obj: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_policy(path: Path) -> None:
+    write_text(
+        path,
+        "\n".join(
+            [
+                "id: pulse-gate-policy-v0",
+                'version: "0.1.1"',
+                "gates:",
+                "  required:",
+                "    - prod_gate_ok",
+                "    - shared_gate_ok",
+                "  release_required:",
+                "    - detectors_materialized_ok",
+                "    - external_all_pass",
+                "    - prod_gate_ok",
+                "  core_required:",
+                "    - core_gate_ok",
+                "  advisory: []",
+                "",
+            ]
+        ),
+    )
+
+
+def status_payload(*, required_gates: list[str] | None = None) -> dict:
+    metrics: dict = {
+        "run_mode": "prod",
+        "run_id": "1",
+        "run_key": "GITHUB_RUN_ID=1|GITHUB_RUN_NUMBER=2|GITHUB_WORKFLOW=PULSE CI",
+        "git_sha": VALID_GIT_SHA,
+    }
+    if required_gates is not None:
+        metrics["required_gates"] = required_gates
+
+    return {
+        "version": "1.0.0-prod",
+        "created_utc": CREATED_UTC,
+        "metrics": metrics,
+        "gates": {
+            "prod_gate_ok": True,
+            "shared_gate_ok": True,
+            "detectors_materialized_ok": True,
+            "external_all_pass": True,
+            "core_gate_ok": True,
+        },
+    }
+
+
+def fixture_paths(tmp_path: Path) -> dict[str, Path]:
+    return {
+        "status": tmp_path / "status.json",
+        "policy": tmp_path / "pulse_gate_policy_v0.yml",
+        "ledger": tmp_path / "report_card.html",
+        "release_decision": tmp_path / "release_decision_v0.json",
+        "manifest": tmp_path / "release_authority_v0.json",
+        "binding": tmp_path / "artifact_provenance_binding_v0.json",
+        "schema": REPO_ROOT / "schemas" / "provenance" / "artifact_provenance_binding_v0.schema.json",
+    }
+
+
+def write_fixtures(
+    tmp_path: Path,
+    *,
+    required_gates: list[str] | None = None,
+    release_level: str = "PROD-PASS",
+) -> dict[str, Path]:
+    paths = fixture_paths(tmp_path)
+
+    write_json(paths["status"], status_payload(required_gates=required_gates))
+    write_policy(paths["policy"])
+    write_text(paths["ledger"], "<html><body>PULSE Quality Ledger</body></html>\n")
+    write_json(
+        paths["release_decision"],
+        {
+            "schema_id": "pulse_release_decision_v0",
+            "producer": "materialize_release_decision.py",
+            "release_level": release_level,
+        },
+    )
+    write_json(paths["manifest"], {"schema_id": "release_authority_v0", "ok": True})
+
+    return paths
+
+
+def build_args(paths: dict[str, Path], *extra_args: str) -> list[str]:
+    return [
+        "--status",
+        str(paths["status"]),
+        "--policy",
+        str(paths["policy"]),
+        "--ledger",
+        str(paths["ledger"]),
+        "--release-decision",
+        str(paths["release_decision"]),
+        "--release-authority-manifest",
+        str(paths["manifest"]),
+        "--out",
+        str(paths["binding"]),
+        "--created-utc",
+        CREATED_UTC,
+        *extra_args,
+    ]
+
+
+def build_binding(paths: dict[str, Path], *extra_args: str) -> dict:
+    assert build_main(build_args(paths, *extra_args)) == 0
+    return read_json(paths["binding"])
+
+
+def schema() -> dict:
+    return read_json(REPO_ROOT / "schemas" / "provenance" / "artifact_provenance_binding_v0.schema.json")
+
+
+def assert_schema_valid(binding: dict) -> None:
+    validate(instance=binding, schema=schema())
+
+
+def assert_schema_invalid(binding: dict) -> None:
+    with pytest.raises(ValidationError):
+        validate(instance=binding, schema=schema())
+
+
+def test_builder_creates_binding(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths, "--policy-set", "required", "--policy-set", "release_required")
+
+    assert paths["binding"].exists()
+    assert binding["schema_id"] == "pulse.artifact_provenance_binding.v0"
+    assert binding["binding_hash"]
+    assert_schema_valid(binding)
+
+
+def test_binding_schema_id_and_version(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    assert binding["schema_id"] == "pulse.artifact_provenance_binding.v0"
+    assert binding["schema_version"] == "0.1.0"
+    assert binding["producer"]["name"] == "build_artifact_provenance_binding_v0.py"
+    assert_schema_valid(binding)
+
+
+def test_binding_records_status_policy_ledger_decision_manifest_hashes(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    assert binding["authority_carrier"]["status_json"]["sha256"]
+    assert binding["authority_carrier"]["declared_gate_policy"]["sha256"]
+    assert binding["reader_carrier"]["quality_ledger"]["sha256"]
+    assert binding["authority_carrier"]["release_decision"]["sha256"]
+    assert binding["trace_carrier"]["release_authority_manifest"]["sha256"]
+    assert_schema_valid(binding)
+
+
+def test_binding_records_workflow_effective_gate_set_from_policy_sets(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths, "--policy-set", "required", "--policy-set", "release_required")
+    gate_set = binding["authority_carrier"]["workflow_effective_required_gate_set"]
+
+    assert gate_set["effective_source"] == "workflow-effective:required+release_required"
+    assert gate_set["policy_sets"] == ["required", "release_required"]
+    assert gate_set["gate_ids"] == [
+        "prod_gate_ok",
+        "shared_gate_ok",
+        "detectors_materialized_ok",
+        "external_all_pass",
+    ]
+    assert gate_set["sha256"]
+    assert_schema_valid(binding)
+
+
+def test_binding_records_metrics_required_gates_source(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path, required_gates=["prod_gate_ok", "external_all_pass"])
+    binding = build_binding(paths)
+    gate_set = binding["authority_carrier"]["workflow_effective_required_gate_set"]
+
+    assert gate_set["effective_source"] == "metrics.required_gates"
+    assert gate_set["policy_sets"] == []
+    assert gate_set["gate_ids"] == ["prod_gate_ok", "external_all_pass"]
+    assert_schema_valid(binding)
+
+
+def test_binding_separates_check_gates_result_from_release_decision_label(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    enforcement = binding["authority_carrier"]["strict_ci_gate_enforcement"]
+    release_decision = binding["authority_carrier"]["release_decision"]
+
+    assert enforcement["source"] == "check_gates.py"
+    assert enforcement["result"] == "allow"
+    assert enforcement["exit_code"] == 0
+    assert "label" not in enforcement
+
+    assert release_decision["producer"] == "materialize_release_decision.py"
+    assert release_decision["label"] == "PROD-PASS"
+    assert_schema_valid(binding)
+
+
+def test_binding_hash_is_canonical_and_stable(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    first = build_binding(paths)
+    first_hash = first["binding_hash"]
+
+    second = build_binding(paths)
+
+    assert second["binding_hash"] == first_hash
+    assert_schema_valid(second)
+
+
+def test_verifier_passes_for_untouched_artifacts(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    build_binding(paths)
+
+    assert verify_main(["--binding", str(paths["binding"])]) == 0
+
+
+def test_verifier_fails_when_status_changes(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    build_binding(paths)
+    write_json(paths["status"], {"changed": True})
+
+    assert verify_main(["--binding", str(paths["binding"])]) != 0
+
+
+def test_verifier_fails_when_policy_changes(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    build_binding(paths)
+    write_text(paths["policy"], "gates:\n  required:\n    - changed_gate\n")
+
+    assert verify_main(["--binding", str(paths["binding"])]) != 0
+
+
+def test_verifier_fails_when_ledger_changes(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    build_binding(paths)
+    write_text(paths["ledger"], "changed\n")
+
+    assert verify_main(["--binding", str(paths["binding"])]) != 0
+
+
+def test_verifier_fails_when_release_decision_changes(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    build_binding(paths)
+    write_json(paths["release_decision"], {"release_level": "FAIL"})
+
+    assert verify_main(["--binding", str(paths["binding"])]) != 0
+
+
+def test_verifier_fails_when_release_authority_manifest_changes(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    build_binding(paths)
+    write_json(paths["manifest"], {"changed": True})
+
+    assert verify_main(["--binding", str(paths["binding"])]) != 0
+
+
+def test_verifier_fails_when_binding_hash_changes(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+    binding["binding_hash"] = "0" * 64
+    write_json(paths["binding"], binding)
+
+    assert verify_main(["--binding", str(paths["binding"])]) != 0
+
+
+def test_canonical_json_bytes_are_deterministic() -> None:
+    left = {"b": 2, "a": {"d": 4, "c": 3}}
+    right = {"a": {"c": 3, "d": 4}, "b": 2}
+
+    assert canonical_json_bytes(left) == canonical_json_bytes(right)
+
+
+def test_builder_rejects_malformed_git_sha(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    status = status_payload()
+    status["metrics"]["git_sha"] = "not-a-sha"
+    write_json(paths["status"], status)
+
+    assert build_main(build_args(paths)) != 0
+
+
+def test_builder_rejects_missing_run_identity(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    status = status_payload()
+    status["metrics"].pop("run_id", None)
+    status["metrics"]["run_key"] = ""
+    write_json(paths["status"], status)
+
+    assert build_main(build_args(paths)) != 0
+
+
+def test_builder_parses_run_id_from_run_key(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    status = status_payload()
+    status["metrics"].pop("run_id", None)
+    write_json(paths["status"], status)
+
+    binding = build_binding(paths)
+
+    assert binding["run"]["run_id"] == "1"
+    assert_schema_valid(binding)
+
+
+def test_builder_rejects_unknown_release_decision_label(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    write_json(
+        paths["release_decision"],
+        {
+            "schema_id": "pulse_release_decision_v0",
+            "producer": "materialize_release_decision.py",
+            "release_level": "NOT-A-DECISION",
+        },
+    )
+
+    assert build_main(build_args(paths)) != 0
+
+
+def test_workflow_effective_gate_set_deduplicates_gate_ids(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths, "--policy-set", "required", "--policy-set", "release_required")
+    gate_ids = binding["authority_carrier"]["workflow_effective_required_gate_set"]["gate_ids"]
+
+    assert gate_ids == list(dict.fromkeys(gate_ids))
+    assert_schema_valid(binding)
+
+
+def test_schema_requires_real_git_sha(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    bad = copy.deepcopy(binding)
+    bad["run"]["git_sha"] = "not-a-sha"
+
+    assert_schema_invalid(bad)
+
+
+def test_schema_requires_non_empty_run_identifiers(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    blank_run_id = copy.deepcopy(binding)
+    blank_run_id["run"]["run_id"] = ""
+    assert_schema_invalid(blank_run_id)
+
+    blank_run_key = copy.deepcopy(binding)
+    blank_run_key["run"]["run_key"] = ""
+    assert_schema_invalid(blank_run_key)
+
+
+def test_schema_rejects_inconsistent_ci_enforcement_outcomes(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    allow_with_block_exit = copy.deepcopy(binding)
+    allow_with_block_exit["authority_carrier"]["strict_ci_gate_enforcement"]["result"] = "allow"
+    allow_with_block_exit["authority_carrier"]["strict_ci_gate_enforcement"]["exit_code"] = 1
+    assert_schema_invalid(allow_with_block_exit)
+
+    block_with_allow_exit = copy.deepcopy(binding)
+    block_with_allow_exit["authority_carrier"]["strict_ci_gate_enforcement"]["result"] = "block"
+    block_with_allow_exit["authority_carrier"]["strict_ci_gate_enforcement"]["exit_code"] = 0
+    assert_schema_invalid(block_with_allow_exit)
+
+
+def test_schema_constrains_release_decision_labels(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    bad = copy.deepcopy(binding)
+    bad["authority_carrier"]["release_decision"]["label"] = "NOT-A-DECISION"
+
+    assert_schema_invalid(bad)
+
+
+def test_schema_rejects_duplicate_effective_gate_ids(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    bad = copy.deepcopy(binding)
+    gate_ids = bad["authority_carrier"]["workflow_effective_required_gate_set"]["gate_ids"]
+    gate_ids.append(gate_ids[0])
+
+    assert_schema_invalid(bad)


### PR DESCRIPTION
## Summary

This PR adds Release Authority Artifact Binding v0.

It introduces `artifact_provenance_binding_v0.json` as the machine-readable provenance carrier for the PULSEmech authority path.

The binding records a digest-backed artifact relationship around a recorded PULSE release-authority run.

## Carrier roles

| Carrier | Artifact / path | Mechanical role |
|---|---|---|
| Authority carrier | `status.json` → declared gate policy → workflow-effective required gate set → strict CI enforcement | Carries release authority |
| Binding carrier | `artifact_provenance_binding_v0.json` | Carries digest-backed artifact relation |
| Verification carrier | `verify_artifact_provenance_binding_v0.py` | Recomputes and checks artifact relation |
| Reader carrier | Quality Ledger | Presents recorded state |
| Trace carrier | release authority manifest / release decision artifact | Preserves reconstruction and decision trace |
| Attestation carrier | later cryptographic attestation | Attests the binding carrier |

## Added

```text
schemas/provenance/artifact_provenance_binding_v0.schema.json
PULSE_safe_pack_v0/tools/build_artifact_provenance_binding_v0.py
PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py
tests/test_artifact_provenance_binding_v0.py
docs/ARTIFACT_PROVENANCE_BINDING_v0.md
```

## Binding records

The binding records:

- recorded run identity;
- git SHA;
- `status.json` digest;
- declared gate policy digest;
- workflow-effective required gate set digest;
- strict CI gate-enforcement result;
- release-decision materialization record;
- Quality Ledger reader artifact digest;
- release authority manifest digest;
- binding subjects;
- `binding_hash`.

## Mechanical boundary

The PULSEmech authority carrier remains:

```text
status.json
→ declared gate policy
→ workflow-effective materialized required gate set
→ strict fail-closed CI enforcement
```

The binding carrier records the artifact relationship around that path.

## Gate-set boundary

The binding records the workflow-effective required gate set, not a static `policy:required` placeholder.

Supported sources include:

- explicit CLI policy sets;
- `status.metrics.required_gates`;
- `status.metrics.required_gate_set`;
- run-mode fallback: `demo/core → core_required`, `prod → required`.

## Enforcement / decision split

`check_gates.py` is recorded as the strict CI gate-enforcement carrier.

Release-level labels are recorded through release-decision materialization.

```text
check_gates.py
= strict CI gate-enforcement carrier

release_decision_v0.json / materialize_release_decision.py
= release-decision materialization carrier
```

## Canonical hash rule

Structured-object digests use canonical JSON bytes:

```python
json.dumps(
    value,
    sort_keys=True,
    separators=(",", ":"),
    ensure_ascii=False,
    allow_nan=False,
).encode("utf-8")
```

## Validation

```bash
python -m py_compile \
  PULSE_safe_pack_v0/tools/build_artifact_provenance_binding_v0.py \
  PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py

python -m pytest -q tests/test_artifact_provenance_binding_v0.py
```

## Scope

This PR adds the binding carrier, verifier, schema, tests, and role doc.

It does not wire the binding into CI yet.

## Preserved

This PR does not change:

- PULSEmech decision semantics;
- gate policy;
- `check_gates.py` behavior;
- status schema;
- CI allow/block behavior;
- Quality Ledger renderer behavior;
- README wording;
- workflow wiring;
- release tags;
- DOI / Zenodo path.