### PR TITLE
fix(crypto): repair release decision label extraction indentation

### DIFF
--- a/PULSE_safe_pack_v0/tools/build_artifact_provenance_binding_v0.py
+++ b/PULSE_safe_pack_v0/tools/build_artifact_provenance_binding_v0.py
@@ -228,6 +228,7 @@ def extract_release_decision_label(release_decision: Dict[str, Any]) -> str:
         ("decision", "label"),
         ("release", "label"),
     ]
+
     for path in candidate_paths:
         current: Any = release_decision
         for part in path:
@@ -235,11 +236,13 @@ def extract_release_decision_label(release_decision: Dict[str, Any]) -> str:
                 current = None
                 break
             current = current[part]
-     if isinstance(current, str) and current.strip():
+
+        if isinstance(current, str) and current.strip():
             label = current.strip()
             if label not in VALID_RELEASE_DECISION_LABELS:
                 raise BindingBuildError(f"unsupported release decision label: {label}")
             return label
+
     raise BindingBuildError("release decision label cannot be read")
 
 


### PR DESCRIPTION
## Summary

This PR repairs an indentation error in the Artifact Provenance Binding v0 builder.

The previous commit introduced malformed indentation inside:

```text
extract_release_decision_label(...)
```

which caused the builder module to fail before import:

```text
IndentationError: unindent does not match any outer indentation level
```

This blocked both syntax validation and provenance binding test collection:

```bash
python -m py_compile \
  PULSE_safe_pack_v0/tools/build_artifact_provenance_binding_v0.py \
  PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py

python -m pytest -q tests/test_artifact_provenance_binding_v0.py
```

## Fix

The release-decision label extraction loop is restored with the correct indentation boundary.

The function now checks each candidate release-decision label path, validates the extracted label, and fails closed when the label is missing or unsupported.

Accepted release-decision labels remain:

```text
FAIL
STAGE-PASS
PROD-PASS
```

Unsupported release-decision labels continue to fail closed.

## Mechanical boundary

This PR keeps the Artifact Provenance Binding v0 carrier split unchanged.

```text
check_gates.py
= strict CI gate-enforcement carrier

release_decision_v0.json / materialize_release_decision.py
= release-decision materialization carrier
```

The builder still records release-level labels from release-decision materialization, not from `check_gates.py`.

## Scope

This is a narrow syntax and builder-import repair.

Expected changed file:

```text
PULSE_safe_pack_v0/tools/build_artifact_provenance_binding_v0.py
```

## Preserved

This PR does not change:

- PULSEmech decision semantics;
- gate policy;
- `check_gates.py` behavior;
- status schema;
- workflow / CI wiring;
- Quality Ledger renderer behavior;
- Artifact Provenance Binding schema semantics;
- release tags;
- DOI / Zenodo path.

## Validation

Run:

```bash
python -m py_compile \
  PULSE_safe_pack_v0/tools/build_artifact_provenance_binding_v0.py \
  PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py
```

Run:

```bash
python -m pytest -q tests/test_artifact_provenance_binding_v0.py
```

## Expected result

The builder imports cleanly.

The provenance binding tests collect and pass.

The release-decision label boundary remains:

```text
FAIL
STAGE-PASS
PROD-PASS
```

Unsupported release-decision labels fail closed.