### PR TITLE
ci(crypto): materialize and verify release authority artifact binding

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1573,6 +1573,65 @@ jobs:
             printf -- '- output: `%s`\n' "${OUT_PATH}"
           } >> "${GITHUB_STEP_SUMMARY}"
       
+           - name: "Release authority artifact binding v0: materialize and verify"
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PACK_DIR="${{ env.PACK_DIR }}"
+          STATUS_PATH="${PACK_DIR}/artifacts/status.json"
+          POLICY_PATH="pulse_gate_policy_v0.yml"
+          LEDGER_PATH="${PACK_DIR}/artifacts/report_card.html"
+          RELEASE_DECISION_PATH="${PACK_DIR}/artifacts/release_decision_v0.json"
+          RELEASE_AUTHORITY_MANIFEST_PATH="${PACK_DIR}/artifacts/release_authority_v0.json"
+          OUT_PATH="${PACK_DIR}/artifacts/artifact_provenance_binding_v0.json"
+
+          POLICY_ARGS=(--policy-set "${PULSE_POLICY_SET:-core_required}")
+          if [[ "${PULSE_IS_RELEASE:-0}" == "1" ]]; then
+            POLICY_ARGS+=(--policy-set release_required)
+          fi
+
+          echo "artifact_provenance_binding_v0 status=${STATUS_PATH}"
+          echo "artifact_provenance_binding_v0 policy=${POLICY_PATH}"
+          echo "artifact_provenance_binding_v0 ledger=${LEDGER_PATH}"
+          echo "artifact_provenance_binding_v0 release_decision=${RELEASE_DECISION_PATH}"
+          echo "artifact_provenance_binding_v0 release_authority_manifest=${RELEASE_AUTHORITY_MANIFEST_PATH}"
+          echo "artifact_provenance_binding_v0 out=${OUT_PATH}"
+          echo "artifact_provenance_binding_v0 policy_args=${POLICY_ARGS[*]}"
+
+          python "${PACK_DIR}/tools/build_artifact_provenance_binding_v0.py" \
+            --status "${STATUS_PATH}" \
+            --policy "${POLICY_PATH}" \
+            --ledger "${LEDGER_PATH}" \
+            --release-decision "${RELEASE_DECISION_PATH}" \
+            --release-authority-manifest "${RELEASE_AUTHORITY_MANIFEST_PATH}" \
+            --out "${OUT_PATH}" \
+            "${POLICY_ARGS[@]}"
+
+          python "${PACK_DIR}/tools/verify_artifact_provenance_binding_v0.py" \
+            --binding "${OUT_PATH}"
+
+          {
+            echo "### Release authority artifact binding v0"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Binding carrier | \`artifact_provenance_binding_v0.json\` |"
+            echo "| Status | Materialized and verified |"
+            echo "| Artifact | \`${OUT_PATH}\` |"
+            echo "| Policy args | \`${POLICY_ARGS[*]}\` |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: "Upload release authority artifact binding v0"
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        with:
+          name: release-authority-artifact-binding-v0
+          if-no-files-found: warn
+          path: ${{ env.PACK_DIR }}/artifacts/artifact_provenance_binding_v0.json
+          retention-days: 30
+      
       - name: "Upload release decision v0 artifact bundle"
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned

--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1518,6 +1518,7 @@ jobs:
             printf -- '- output: `%s`\n' "${OUT_PATH}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
+  
       - name: "Release decision v0: compose report card"
         if: always()
         shell: bash
@@ -1573,7 +1574,7 @@ jobs:
             printf -- '- output: `%s`\n' "${OUT_PATH}"
           } >> "${GITHUB_STEP_SUMMARY}"
       
-           - name: "Release authority artifact binding v0: materialize and verify"
+      - name: "Release authority artifact binding v0: materialize and verify"
         if: always()
         shell: bash
         run: |

--- a/ci/pytest-tests.list
+++ b/ci/pytest-tests.list
@@ -12,3 +12,4 @@ tests/test_render_quality_ledger_diagnostic_sections.py
 tests/test_render_quality_ledger_check_gates_parity.py
 tests/test_parameter_golf_submission_evidence_v0.py
 tests/test_core_baseline_v0.py
+tests/test_artifact_provenance_binding_ci_wiring_smoke.py

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -72,6 +72,7 @@ tests/test_hpc_evidence_bundle_v0_contract.py
 tests/test_evidence_fold_in_admissibility_v0_contract.py
 tests/test_field_point_authority_map_v0_contract.py
 tests/test_build_field_point_authority_map_v0.py
+tests/test_artifact_provenance_binding_ci_wiring_smoke.py
 
 tools/operator_handoff_smoke.py
 

--- a/tests/test_artifact_provenance_binding_ci_wiring_smoke.py
+++ b/tests/test_artifact_provenance_binding_ci_wiring_smoke.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pulse_ci.yml"
+
+
+def read_workflow() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_pulse_ci_materializes_and_verifies_artifact_provenance_binding() -> None:
+    text = read_workflow()
+
+    assert "Release authority artifact binding v0: materialize and verify" in text
+    assert "build_artifact_provenance_binding_v0.py" in text
+    assert "verify_artifact_provenance_binding_v0.py" in text
+    assert "artifact_provenance_binding_v0.json" in text
+
+
+def test_pulse_ci_binding_uses_workflow_effective_policy_sets() -> None:
+    text = read_workflow()
+
+    assert 'POLICY_ARGS=(--policy-set "${PULSE_POLICY_SET:-core_required}")' in text
+    assert 'POLICY_ARGS+=(--policy-set release_required)' in text
+    assert 'if [[ "${PULSE_IS_RELEASE:-0}" == "1" ]]; then' in text
+
+
+def test_pulse_ci_uploads_artifact_provenance_binding() -> None:
+    text = read_workflow()
+
+    assert "Upload release authority artifact binding v0" in text
+    assert "release-authority-artifact-binding-v0" in text
+    assert "${{ env.PACK_DIR }}/artifacts/artifact_provenance_binding_v0.json" in text
+
+
+def test_pulse_ci_binding_step_is_after_release_decision_materialization() -> None:
+    text = read_workflow()
+
+    release_decision_idx = text.index('Release decision v0: materialize artifact')
+    binding_idx = text.index('Release authority artifact binding v0: materialize and verify')
+
+    assert release_decision_idx < binding_idx


### PR DESCRIPTION
## Summary

This PR wires Release Authority Artifact Binding v0 into PULSE CI.

The workflow now materializes and verifies:

```text
PULSE_safe_pack_v0/artifacts/artifact_provenance_binding_v0.json
```

after `release_decision_v0.json` exists.

## Mechanical role

Binding carrier:

```text
artifact_provenance_binding_v0.json
```

Verification carrier:

```text
verify_artifact_provenance_binding_v0.py
```

Authority carrier remains:

```text
status.json
→ declared gate policy
→ workflow-effective materialized required gate set
→ strict fail-closed CI enforcement
```

## Workflow-effective gate set

The CI binding step passes the same effective policy-set structure used by the gate-enforcement path:

```text
PULSE_POLICY_SET
+ release_required when PULSE_IS_RELEASE=1
```

This keeps the binding aligned with the materialized required gate set enforced by CI.

## Added / changed

```text
.github/workflows/pulse_ci.yml
tests/test_artifact_provenance_binding_ci_wiring_smoke.py
ci/pytest-tests.list
```

## Validation

```bash
python -m pytest -q tests/test_artifact_provenance_binding_ci_wiring_smoke.py
```

```bash
python -m py_compile \
  PULSE_safe_pack_v0/tools/build_artifact_provenance_binding_v0.py \
  PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py

python -m pytest -q \
  tests/test_artifact_provenance_binding_v0.py \
  tests/test_artifact_provenance_binding_ci_wiring_smoke.py
```

## Preserved

This PR does not change:

- PULSEmech decision semantics;
- gate policy;
- `check_gates.py` behavior;
- status schema;
- Quality Ledger renderer behavior;
- release tags;
- DOI / Zenodo path.

## Not included

This PR does not add cryptographic attestation yet.

Attestation remains a later layer over the verified binding carrier.