### PR TITLE
ci(crypto): attest release authority artifact binding

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -42,6 +42,11 @@ jobs:
   pulse:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     env:
       PACK_DIR: ${{ github.workspace }}/PULSE_safe_pack_v0
 
@@ -1623,6 +1628,13 @@ jobs:
             echo "| Artifact | \`${OUT_PATH}\` |"
             echo "| Policy args | \`${POLICY_ARGS[*]}\` |"
           } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: "Release authority artifact binding v0: attest"
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/attest@v4.1.0
+        with:
+          subject-path: ${{ env.PACK_DIR }}/artifacts/artifact_provenance_binding_v0.json
+          show-summary: true
 
       - name: "Upload release authority artifact binding v0"
         if: always()

--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -44,9 +44,7 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
-      id-token: write
-      attestations: write
-      artifact-metadata: write
+    
     env:
       PACK_DIR: ${{ github.workspace }}/PULSE_safe_pack_v0
 
@@ -1629,13 +1627,6 @@ jobs:
             echo "| Policy args | \`${POLICY_ARGS[*]}\` |"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: "Release authority artifact binding v0: attest"
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/attest@v4.1.0
-        with:
-          subject-path: ${{ env.PACK_DIR }}/artifacts/artifact_provenance_binding_v0.json
-          show-summary: true
-
       - name: "Upload release authority artifact binding v0"
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
@@ -1870,6 +1861,42 @@ jobs:
             badges/*.svg
             reports/junit.xml
             reports/sarif.json
+
+  attest_release_authority_artifact_binding:
+    name: "Release authority artifact binding v0: attest"
+    needs: pulse
+    if: ${{ github.event_name != 'pull_request' && needs.pulse.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    steps:
+      - name: Download verified release authority artifact binding
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p attestation-subject
+
+          gh run download "${GITHUB_RUN_ID}" \
+            --name "release-authority-artifact-binding-v0" \
+            --dir "attestation-subject"
+
+          test -f "attestation-subject/artifact_provenance_binding_v0.json"
+
+          sha256sum "attestation-subject/artifact_provenance_binding_v0.json"
+
+      - name: Attest release authority artifact binding v0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+        with:
+          subject-path: attestation-subject/artifact_provenance_binding_v0.json
+          show-summary: true
 
   tools-tests:
     name: Tools smoke tests

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -73,6 +73,7 @@ tests/test_evidence_fold_in_admissibility_v0_contract.py
 tests/test_field_point_authority_map_v0_contract.py
 tests/test_build_field_point_authority_map_v0.py
 tests/test_artifact_provenance_binding_ci_wiring_smoke.py
+tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
 
 tools/operator_handoff_smoke.py
 

--- a/tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
+++ b/tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pulse_ci.yml"
+
+
+def read_workflow() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_pulse_ci_declares_attestation_permissions() -> None:
+    text = read_workflow()
+
+    assert "permissions:" in text
+    assert "id-token: write" in text
+    assert "attestations: write" in text
+    assert "artifact-metadata: write" in text
+    assert "contents: read" in text
+
+
+def test_pulse_ci_attests_release_authority_artifact_binding_subject() -> None:
+    text = read_workflow()
+
+    assert 'Release authority artifact binding v0: attest' in text
+    assert 'uses: actions/attest@v4.1.0' in text
+    assert 'subject-path: ${{ env.PACK_DIR }}/artifacts/artifact_provenance_binding_v0.json' in text
+    assert 'show-summary: true' in text
+
+
+def test_pulse_ci_attestation_skips_pull_request_runs() -> None:
+    text = read_workflow()
+
+    assert "if: ${{ github.event_name != 'pull_request' }}" in text
+
+
+def test_pulse_ci_attestation_step_order() -> None:
+    text = read_workflow()
+
+    materialize_idx = text.index(
+        'Release authority artifact binding v0: materialize and verify'
+    )
+    attest_idx = text.index('Release authority artifact binding v0: attest')
+    upload_idx = text.index('Upload release authority artifact binding v0')
+
+    assert materialize_idx < attest_idx < upload_idx
+
+
+def test_pulse_ci_attestation_step_is_standalone_workflow_step() -> None:
+    text = read_workflow()
+
+    for line in text.splitlines():
+        if 'name: "Release authority artifact binding v0: attest"' in line:
+            assert line.startswith("      - name:"), line
+            return
+
+    raise AssertionError("attestation step not found")


### PR DESCRIPTION
## Summary

This PR adds attestation wiring for Release Authority Artifact Binding v0.

The attestation subject is:

```text
artifact_provenance_binding_v0.json
```

The attestation step runs after the binding carrier is materialized and verified.

## Mechanical order

```text
artifact_provenance_binding_v0.json materialized
→ artifact_provenance_binding_v0.json verified
→ artifact_provenance_binding_v0.json attested
→ artifact_provenance_binding_v0.json uploaded
```

## Carrier roles

| Carrier | Artifact / path | Mechanical role |
|---|---|---|
| Authority carrier | `status.json` → declared gate policy → workflow-effective required gate set → strict CI enforcement | Carries release authority |
| Binding carrier | `artifact_provenance_binding_v0.json` | Carries digest-backed artifact relation |
| Verification carrier | `verify_artifact_provenance_binding_v0.py` | Recomputes and checks artifact relation |
| Attestation subject | `artifact_provenance_binding_v0.json` | Primary subject for cryptographic attestation |
| Attestation carrier | GitHub artifact attestation over the binding carrier | Attests the binding carrier |

## Changed files

```text
.github/workflows/pulse_ci.yml
tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
ci/tools-tests.list
```

## Permissions

This PR adds job-level permissions required by `actions/attest`:

```text
contents: read
id-token: write
attestations: write
artifact-metadata: write
```

The attestation step is skipped on `pull_request` events.

## Validation

```bash
python -m py_compile tests/test_artifact_provenance_binding_attestation_wiring_smoke.py

python -m pytest -q tests/test_artifact_provenance_binding_attestation_wiring_smoke.py

python -m pytest -q \
  tests/test_artifact_provenance_binding_ci_wiring_smoke.py \
  tests/test_artifact_provenance_binding_attestation_wiring_smoke.py

python tests/test_tools_tests_list_smoke.py
```

## Preserved

This PR does not change:

- PULSEmech decision semantics;
- gate policy;
- `check_gates.py` behavior;
- status schema;
- Quality Ledger renderer behavior;
- Artifact Provenance Binding schema;
- binding builder;
- binding verifier;
- release tags;
- DOI / Zenodo path.