### PR TITLE
fix(ci): make attestation artifact download repository-explicit

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1885,6 +1885,7 @@ jobs:
           mkdir -p attestation-subject
 
           gh run download "${GITHUB_RUN_ID}" \
+            --repo "${GITHUB_REPOSITORY}" \
             --name "release-authority-artifact-binding-v0" \
             --dir "attestation-subject"
 

--- a/tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
+++ b/tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
@@ -88,6 +88,7 @@ def test_attestation_job_downloads_uploaded_binding_artifact() -> None:
     _pulse_block, attest_block, _blocks = workflow_blocks()
 
     assert 'gh run download "${GITHUB_RUN_ID}"' in attest_block
+    assert '--repo "${GITHUB_REPOSITORY}"' in attest_block
     assert '--name "release-authority-artifact-binding-v0"' in attest_block
     assert '--dir "attestation-subject"' in attest_block
     assert 'test -f "attestation-subject/artifact_provenance_binding_v0.json"' in attest_block
@@ -101,13 +102,21 @@ def test_download_step_runs_before_attestation_action() -> None:
         "- name: Download verified release authority artifact binding"
     )
     download_cmd_idx = attest_block.index('gh run download "${GITHUB_RUN_ID}"')
+    repo_arg_idx = attest_block.index('--repo "${GITHUB_REPOSITORY}"')
     file_check_idx = attest_block.index(
         'test -f "attestation-subject/artifact_provenance_binding_v0.json"'
     )
     attest_step_idx = attest_block.index("- name: Attest release authority artifact binding v0")
     attest_action_idx = attest_block.index(f"uses: actions/attest@{ATTEST_SHA}")
 
-    assert download_step_idx < download_cmd_idx < file_check_idx < attest_step_idx < attest_action_idx
+    assert (
+        download_step_idx
+        < download_cmd_idx
+        < repo_arg_idx
+        < file_check_idx
+        < attest_step_idx
+        < attest_action_idx
+    )
 
 
 def test_attestation_action_is_pinned_to_immutable_sha() -> None:


### PR DESCRIPTION
## Summary

This PR fixes the Release Authority Artifact Binding v0 attestation job.

The attestation job intentionally does not checkout the repository. Because there is no `.git` directory, `gh run download` cannot infer the repository and fails with:

```text
fatal: not a git repository
```

This PR makes the artifact download repository-explicit:

```bash
gh run download "${GITHUB_RUN_ID}" \
  --repo "${GITHUB_REPOSITORY}" \
  --name "release-authority-artifact-binding-v0" \
  --dir "attestation-subject"
```

## Test hardening

The attestation wiring smoke test now verifies:

- the exact `attest_release_authority_artifact_binding` job block;
- the exact combined job-level guard:
  `${{ github.event_name != 'pull_request' && needs.pulse.result == 'success' }}`;
- download-before-attest ordering;
- repository-explicit artifact download;
- SHA-pinned `actions/attest`;
- `artifact_provenance_binding_v0.json` as the attestation subject;
- no inline attestation step inside the `pulse` job.

## Validation

```bash
python -m py_compile tests/test_artifact_provenance_binding_attestation_wiring_smoke.py

python -m pytest -q tests/test_artifact_provenance_binding_attestation_wiring_smoke.py

python tests/test_artifact_provenance_binding_attestation_wiring_smoke.py

python tests/test_tools_tests_list_smoke.py
```

## Preserved

This PR does not change:

- PULSEmech decision semantics;
- gate policy;
- `check_gates.py`;
- status schema;
- Quality Ledger renderer;
- binding builder;
- binding verifier;
- release tags;
- DOI / Zenodo path.