### PR TITLE
fix(authority): classify remaining normative shadow workflow drift

### DIFF
--- a/scripts/build_normative_shadow_inventory_v0.py
+++ b/scripts/build_normative_shadow_inventory_v0.py
@@ -119,15 +119,38 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
                 "materializes, enforces, binds, and may attest authority artifacts."
             ),
         )
-
     if any(
         token in identity_l
         for token in (
-            "core_baseline",
-            "core baseline",
-            "pulse_core",
-            "pulse-core",
-            "core ci",
+            "theory_overlay",
+            "theory overlay",
+            "overlay",
+        )
+    ):
+        return entry(
+            name=name,
+            path=rel,
+            surface_type="workflow",
+            primary_role="diagnostic / overlay workflow",
+            carrier_class="diagnostic_shadow",
+            authority_impacting="conditional",
+            authority_boundary=(
+                "Authority participation requires recorded evidence inclusion and "
+                "required-gate enforcement under declared policy."
+            ),
+            notes="Diagnostic / overlay carrier.",
+        )
+    if any(
+        token in identity_l
+        for token in (
+            "pages",
+            "publish",
+            "publication",
+            "badges",
+            "seo",
+            "make_org",
+            "deployment",
+            "report_pages",
         )
     ):
         return entry(
@@ -328,6 +351,11 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
             "shadow_layer_registry",
             "pulse-paradox-gate",
             "pulse paradox gate",
+            "pulse_pd",
+            "pulse-pd",
+            "pulse pd",
+            "pd_smoke",
+            "pd smoke",
             "shadow",
             "experiment",
             "demo",

--- a/scripts/build_normative_shadow_inventory_v0.py
+++ b/scripts/build_normative_shadow_inventory_v0.py
@@ -145,7 +145,23 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
             notes="Core baseline verification carrier; not a second release path.",
         )
 
-    if "release_check" in rel_l or "release check" in name_l:
+    if "validate-status" in rel_l or "validate_status" in rel_l or "status validation" in name_l:
+        return entry(
+            name=name,
+            path=rel,
+            surface_type="workflow",
+            primary_role="status validation workflow",
+            carrier_class="status_contract",
+            authority_impacting="conditional",
+            authority_boundary=(
+                "Status-contract guard carrier. Authority participation requires "
+                "explicit release-authority path wiring."
+            ),
+            reads_artifacts=["status.json", "schemas/status/*"],
+            notes="Status validation carrier; not an independent release decision engine.",
+        )
+
+    if "release_check" in rel_l or "release-check" in rel_l or "release check" in name_l:
         return entry(
             name=name,
             path=rel,
@@ -160,24 +176,17 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
             notes="Release-check carrier; not a second release-decision engine.",
         )
 
-    if (
-        "theory_overlay" in rel_l
-        or "theory overlay" in name_l
-        or "overlay" in rel_l
-        or "overlay" in name_l
-    ):
+    if "public_surface_audit" in rel_l or "public surface audit" in name_l:
         return entry(
             name=name,
             path=rel,
             surface_type="workflow",
-            primary_role="diagnostic / overlay workflow",
-            carrier_class="diagnostic_shadow",
-            authority_impacting="conditional",
-            authority_boundary=(
-                "Authority participation requires recorded evidence inclusion and "
-                "required-gate enforcement under declared policy."
-            ),
-            notes="Diagnostic / overlay carrier.",
+            primary_role="public surface audit workflow",
+            carrier_class="audit_preservation",
+            authority_impacting="no",
+            authority_boundary="Audit / reader-boundary review carrier",
+            reads_artifacts=["Quality Ledger", "public reader surfaces"],
+            notes="Public-surface audit carrier; non-authorizing.",
         )
 
     if any(
@@ -187,6 +196,10 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
             "publish",
             "publication",
             "badges",
+            "seo",
+            "make_org",
+            "deployment",
+            "report_pages",
         )
     ):
         return entry(
@@ -204,23 +217,23 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
     if any(
         token in identity_l
         for token in (
-            "shadow",
-            "paradox",
-            "experiment",
+            "secret",
+            "gitleaks",
+            "sarif",
+            "security",
+            "scan",
         )
     ):
         return entry(
             name=name,
             path=rel,
             surface_type="workflow",
-            primary_role="shadow / diagnostic workflow",
-            carrier_class="diagnostic_shadow",
-            authority_impacting="conditional",
-            authority_boundary=(
-                "Authority participation requires recorded evidence inclusion and "
-                "required-gate enforcement under declared policy."
-            ),
-            notes="Diagnostic / shadow carrier.",
+            primary_role="security / code scanning workflow",
+            carrier_class="advisory",
+            authority_impacting="no",
+            authority_boundary="Non-authorizing security / repository hygiene carrier",
+            publishes_artifacts=["security signals", "SARIF"],
+            notes="Security / code scanning carrier.",
         )
 
     if any(
@@ -228,8 +241,13 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
         for token in (
             "hygiene",
             "lint",
-            "security",
-            "scan",
+            "link-check",
+            "link_check",
+            "docs_link",
+            "semantic_pr",
+            "semantic pr",
+            "changelog",
+            "dco",
         )
     ):
         return entry(
@@ -240,7 +258,93 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
             carrier_class="advisory",
             authority_impacting="no",
             authority_boundary="Non-authorizing guard carrier",
-            notes="Repository hygiene / security signal carrier.",
+            notes="Repository hygiene / review signal carrier.",
+        )
+
+    if any(
+        token in identity_l
+        for token in (
+            "reproduce",
+            "reproduction",
+        )
+    ):
+        return entry(
+            name=name,
+            path=rel,
+            surface_type="workflow",
+            primary_role="reproducibility workflow",
+            carrier_class="audit_preservation",
+            authority_impacting="conditional",
+            authority_boundary=(
+                "Reproduction / review carrier. Authority participation requires "
+                "explicit required-gate wiring under declared policy."
+            ),
+            notes="Reproducibility carrier; does not create release authority.",
+        )
+
+    if any(
+        token in identity_l
+        for token in (
+            "bundle",
+            "reviewer bundle",
+            "evidence packet",
+            "package verifier",
+        )
+    ):
+        return entry(
+            name=name,
+            path=rel,
+            surface_type="workflow",
+            primary_role="audit / preservation workflow",
+            carrier_class="audit_preservation",
+            authority_impacting="no",
+            authority_boundary="Audit / preservation carrier; non-authorizing",
+            publishes_artifacts=["review bundles", "evidence packets"],
+            notes="Review package / preservation carrier.",
+        )
+
+    if any(
+        token in identity_l
+        for token in (
+            "theory_overlay",
+            "theory overlay",
+            "overlay",
+            "stability",
+            "separation_phase",
+            "separation phase",
+            "topology",
+            "epf",
+            "field",
+            "snapshot",
+            "history_drift",
+            "drift",
+            "relational_gain",
+            "openai_evals",
+            "refusal",
+            "parameter_golf",
+            "paradox",
+            "gpt_external",
+            "gravity_record",
+            "shadow_layer_registry",
+            "pulse-paradox-gate",
+            "pulse paradox gate",
+            "shadow",
+            "experiment",
+            "demo",
+        )
+    ):
+        return entry(
+            name=name,
+            path=rel,
+            surface_type="workflow",
+            primary_role="diagnostic / shadow workflow",
+            carrier_class="diagnostic_shadow",
+            authority_impacting="conditional",
+            authority_boundary=(
+                "Authority participation requires recorded evidence inclusion and "
+                "required-gate enforcement under declared policy."
+            ),
+            notes="Diagnostic / shadow carrier.",
         )
 
     return entry(

--- a/scripts/build_normative_shadow_inventory_v0.py
+++ b/scripts/build_normative_shadow_inventory_v0.py
@@ -83,8 +83,10 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
     name = workflow_name(path, text)
 
     rel_l = rel.lower()
+    file_l = path.name.lower()
+    stem_l = path.stem.lower()
     name_l = name.lower()
-    identity_l = f"{rel_l}\n{name_l}"
+    identity_l = f"{rel_l}\n{file_l}\n{stem_l}\n{name_l}"
 
     if rel == ".github/workflows/pulse_ci.yml":
         return entry(
@@ -119,38 +121,21 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
                 "materializes, enforces, binds, and may attest authority artifacts."
             ),
         )
-    if any(
+
+    if file_l in {
+        "core_baseline_capture.yml",
+        "core_baseline_check.yml",
+        "pulse_core_ci.yml",
+    } or any(
         token in identity_l
         for token in (
-            "theory_overlay",
-            "theory overlay",
-            "overlay",
-        )
-    ):
-        return entry(
-            name=name,
-            path=rel,
-            surface_type="workflow",
-            primary_role="diagnostic / overlay workflow",
-            carrier_class="diagnostic_shadow",
-            authority_impacting="conditional",
-            authority_boundary=(
-                "Authority participation requires recorded evidence inclusion and "
-                "required-gate enforcement under declared policy."
-            ),
-            notes="Diagnostic / overlay carrier.",
-        )
-    if any(
-        token in identity_l
-        for token in (
-            "pages",
-            "publish",
-            "publication",
-            "badges",
-            "seo",
-            "make_org",
-            "deployment",
-            "report_pages",
+            "core_baseline",
+            "core-baseline",
+            "core baseline",
+            "pulse_core",
+            "pulse-core",
+            "pulse core",
+            "core ci",
         )
     ):
         return entry(
@@ -168,7 +153,10 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
             notes="Core baseline verification carrier; not a second release path.",
         )
 
-    if "validate-status" in rel_l or "validate_status" in rel_l or "status validation" in name_l:
+    if file_l in {
+        "validate-status.yml",
+        "validate_status.yml",
+    } or "validate-status" in rel_l or "validate_status" in rel_l or "status validation" in name_l:
         return entry(
             name=name,
             path=rel,
@@ -184,7 +172,10 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
             notes="Status validation carrier; not an independent release decision engine.",
         )
 
-    if "release_check" in rel_l or "release-check" in rel_l or "release check" in name_l:
+    if file_l in {
+        "release_check.yml",
+        "release-check.yml",
+    } or "release_check" in rel_l or "release-check" in rel_l or "release check" in name_l:
         return entry(
             name=name,
             path=rel,
@@ -199,7 +190,10 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
             notes="Release-check carrier; not a second release-decision engine.",
         )
 
-    if "public_surface_audit" in rel_l or "public surface audit" in name_l:
+    if file_l in {
+        "public_surface_audit.yml",
+        "public-surface-audit.yml",
+    } or "public_surface_audit" in rel_l or "public surface audit" in name_l:
         return entry(
             name=name,
             path=rel,
@@ -215,14 +209,48 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
     if any(
         token in identity_l
         for token in (
+            "theory_overlay",
+            "theory-overlay",
+            "theory overlay",
+            "overlay_schema",
+            "overlay-schema",
+            "overlay schema",
+            "overlay",
+        )
+    ):
+        return entry(
+            name=name,
+            path=rel,
+            surface_type="workflow",
+            primary_role="diagnostic / overlay workflow",
+            carrier_class="diagnostic_shadow",
+            authority_impacting="conditional",
+            authority_boundary=(
+                "Authority participation requires recorded evidence inclusion and "
+                "required-gate enforcement under declared policy."
+            ),
+            notes="Diagnostic / overlay carrier.",
+        )
+
+    if file_l in {
+        "publish_report_pages.yml",
+        "cancel_pages_deployment.yml",
+        "pages_paradox_core_publish_shadow.yml",
+        "pages_paradox_core_publish_case_study_shadow.yml",
+        "paradox_core_pages_preview_shadow.yml",
+    } or any(
+        token in identity_l
+        for token in (
             "pages",
-            "publish",
+            "publish_report",
+            "publish-report",
             "publication",
             "badges",
             "seo",
             "make_org",
             "deployment",
             "report_pages",
+            "report-pages",
         )
     ):
         return entry(
@@ -267,7 +295,9 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
             "link-check",
             "link_check",
             "docs_link",
+            "docs-link",
             "semantic_pr",
+            "semantic-pr",
             "semantic pr",
             "changelog",
             "dco",
@@ -329,32 +359,38 @@ def classify_workflow(path: Path, *, repo_root: Path) -> dict[str, Any]:
     if any(
         token in identity_l
         for token in (
-            "theory_overlay",
-            "theory overlay",
-            "overlay",
             "stability",
             "separation_phase",
+            "separation-phase",
             "separation phase",
             "topology",
             "epf",
             "field",
             "snapshot",
             "history_drift",
+            "history-drift",
             "drift",
             "relational_gain",
+            "relational-gain",
             "openai_evals",
+            "openai-evals",
             "refusal",
             "parameter_golf",
+            "parameter-golf",
             "paradox",
             "gpt_external",
+            "gpt-external",
             "gravity_record",
+            "gravity-record",
             "shadow_layer_registry",
+            "shadow-layer-registry",
             "pulse-paradox-gate",
             "pulse paradox gate",
             "pulse_pd",
             "pulse-pd",
             "pulse pd",
             "pd_smoke",
+            "pd-smoke",
             "pd smoke",
             "shadow",
             "experiment",

--- a/tests/test_build_normative_shadow_inventory_v0.py
+++ b/tests/test_build_normative_shadow_inventory_v0.py
@@ -350,3 +350,22 @@ def test_inventory_classifies_shadow_and_overlay_workflows_without_drift(
     assert parameter_golf["carrier_class"] == "diagnostic_shadow"
     assert topology["carrier_class"] == "diagnostic_shadow"
     assert inventory["drift_findings"] == []
+
+
+def test_inventory_classifies_pulse_pd_smoke_without_drift(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    write_workflow(
+        repo / ".github" / "workflows" / "pulse_pd_smoke.yml",
+        name="PULSE PD Smoke",
+    )
+
+    inventory = run_builder_for_repo(repo, tmp_path)
+
+    pulse_pd = entry_by_path(inventory, ".github/workflows/pulse_pd_smoke.yml")
+
+    assert pulse_pd["carrier_class"] == "diagnostic_shadow"
+    assert pulse_pd["primary_role"] == "diagnostic / shadow workflow"
+    assert pulse_pd["authority_impacting"] == "conditional"
+    assert inventory["drift_findings"] == []

--- a/tests/test_build_normative_shadow_inventory_v0.py
+++ b/tests/test_build_normative_shadow_inventory_v0.py
@@ -217,3 +217,136 @@ def test_inventory_includes_release_decision_materializer_when_present(
     assert materializer["carrier_class"] == "authority"
     assert materializer["authority_impacting"] == "yes"
     assert "release-decision labels" in materializer["authority_boundary"]
+
+def test_inventory_has_no_unclassified_workflow_drift_for_current_repo(
+    tmp_path: Path,
+) -> None:
+    inventory, _markdown = run_builder(tmp_path)
+
+    unclassified = [
+        finding
+        for finding in inventory["drift_findings"]
+        if finding["finding"] == "workflow requires explicit carrier-role classification"
+    ]
+
+    assert unclassified == []
+
+
+def test_inventory_classifies_validate_status_as_status_contract_carrier(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    write_workflow(
+        repo / ".github" / "workflows" / "validate-status.yml",
+        name="Validate Status",
+    )
+
+    inventory = run_builder_for_repo(repo, tmp_path)
+
+    validate_status = entry_by_path(inventory, ".github/workflows/validate-status.yml")
+
+    assert validate_status["primary_role"] == "status validation workflow"
+    assert validate_status["carrier_class"] == "status_contract"
+    assert validate_status["authority_impacting"] == "conditional"
+    assert inventory["drift_findings"] == []
+
+
+def test_inventory_classifies_public_surface_audit_as_audit_carrier(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    write_workflow(
+        repo / ".github" / "workflows" / "public_surface_audit.yml",
+        name="Public Surface Audit",
+    )
+
+    inventory = run_builder_for_repo(repo, tmp_path)
+
+    audit = entry_by_path(inventory, ".github/workflows/public_surface_audit.yml")
+
+    assert audit["primary_role"] == "public surface audit workflow"
+    assert audit["carrier_class"] == "audit_preservation"
+    assert audit["authority_impacting"] == "no"
+    assert inventory["drift_findings"] == []
+
+
+def test_inventory_classifies_security_and_hygiene_workflows_without_drift(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    write_workflow(repo / ".github" / "workflows" / "dco.yml", name="DCO Check")
+    write_workflow(
+        repo / ".github" / "workflows" / "workflow_lint.yml",
+        name="workflow-lint",
+    )
+    write_workflow(repo / ".github" / "workflows" / "gitleaks.yml", name="Gitleaks")
+    write_workflow(
+        repo / ".github" / "workflows" / "upload_sarif.yml",
+        name="Upload SARIF",
+    )
+
+    inventory = run_builder_for_repo(repo, tmp_path)
+
+    assert entry_by_path(inventory, ".github/workflows/dco.yml")["carrier_class"] == "advisory"
+    assert entry_by_path(inventory, ".github/workflows/workflow_lint.yml")["carrier_class"] == "advisory"
+    assert entry_by_path(inventory, ".github/workflows/gitleaks.yml")["carrier_class"] == "advisory"
+    assert entry_by_path(inventory, ".github/workflows/upload_sarif.yml")["carrier_class"] == "advisory"
+    assert inventory["drift_findings"] == []
+
+
+def test_inventory_classifies_publication_workflows_without_body_publish_false_positive(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    write_workflow(
+        repo / ".github" / "workflows" / "publish_report_pages.yml",
+        name="Publish Report Pages",
+    )
+    write_workflow(
+        repo / ".github" / "workflows" / "cancel_pages_deployment.yml",
+        name="Cancel Pages Deployment",
+    )
+
+    inventory = run_builder_for_repo(repo, tmp_path)
+
+    publish = entry_by_path(inventory, ".github/workflows/publish_report_pages.yml")
+    cancel = entry_by_path(inventory, ".github/workflows/cancel_pages_deployment.yml")
+
+    assert publish["carrier_class"] == "publication"
+    assert publish["authority_impacting"] == "no"
+    assert cancel["carrier_class"] == "publication"
+    assert cancel["authority_impacting"] == "no"
+    assert inventory["drift_findings"] == []
+
+
+def test_inventory_classifies_shadow_and_overlay_workflows_without_drift(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    write_workflow(
+        repo / ".github" / "workflows" / "theory_overlay_v0.yml",
+        name="Theory Overlay v0",
+        body="          echo 'nothing to publish for this overlay'",
+    )
+    write_workflow(
+        repo / ".github" / "workflows" / "parameter_golf_shadow.yml",
+        name="Parameter Golf Shadow",
+    )
+    write_workflow(
+        repo / ".github" / "workflows" / "pulse_topology_demo.yml",
+        name="Pulse Topology Demo",
+    )
+
+    inventory = run_builder_for_repo(repo, tmp_path)
+
+    overlay = entry_by_path(inventory, ".github/workflows/theory_overlay_v0.yml")
+    parameter_golf = entry_by_path(
+        inventory,
+        ".github/workflows/parameter_golf_shadow.yml",
+    )
+    topology = entry_by_path(inventory, ".github/workflows/pulse_topology_demo.yml")
+
+    assert overlay["carrier_class"] == "diagnostic_shadow"
+    assert parameter_golf["carrier_class"] == "diagnostic_shadow"
+    assert topology["carrier_class"] == "diagnostic_shadow"
+    assert inventory["drift_findings"] == []


### PR DESCRIPTION
## Summary

This PR refines Normative vs Shadow Inventory workflow classification.

The previous inventory builder could still emit unclassified workflow drift findings for existing first-party workflows. This PR classifies the remaining workflow families so the machine report does not produce false drift for known repository surfaces.

## Classification updates

This PR classifies:

- `validate-status` workflows as `status_contract` guard carriers;
- `public_surface_audit` workflows as audit / preservation carriers;
- security / SARIF / secret-scan workflows as advisory guard carriers;
- hygiene / DCO / semantic / link / lint / changelog workflows as advisory guard carriers;
- publication / Pages / deployment workflows as publication carriers;
- bundle / reviewer / evidence-packet workflows as audit / preservation carriers;
- topology / EPF / overlay / drift / paradox / experiment / demo / shadow workflows as diagnostic / shadow carriers.

## Validation

```bash
python -m py_compile scripts/build_normative_shadow_inventory_v0.py
```

```bash
python -m pytest -q tests/test_build_normative_shadow_inventory_v0.py
```

## Preserved

This PR does not change:

- workflow files;
- PULSEmech decision semantics;
- gate policy;
- required gate wiring;
- `check_gates.py` behavior;
- status schema;
- CI allow/block behavior;
- Quality Ledger renderer behavior;
- artifact provenance binding behavior;
- attestation workflow behavior;
- release tags;
- DOI / Zenodo path.