### PR TITLE
docs(review): keep low adoption example in adoption category

### DIFF
--- a/docs/PULSE_NATIVE_REVIEW_FRAME_v0.md
+++ b/docs/PULSE_NATIVE_REVIEW_FRAME_v0.md
@@ -851,7 +851,7 @@ Low visible GitHub adoption.
 Category:
 Adoption / ecosystem gap.
 
-Affected signal:
+Affected carrier:
 Adoption / ecosystem signal.
 
 Authority impact:
@@ -861,10 +861,10 @@ Evidence:
 Low visible stars / forks / external PRs / integrations.
 
 Current mitigation:
-Documentation, citation records, public reference surfaces.
+Documentation, citation metadata, public reader surfaces.
 
 Remaining work:
-Reference integrations, external usage examples, adoption outreach.
+Ecosystem integrations, external usage examples, adoption outreach.
 
 Status:
 Adoption / ecosystem gap.

--- a/docs/PULSE_NATIVE_REVIEW_FRAME_v0.md
+++ b/docs/PULSE_NATIVE_REVIEW_FRAME_v0.md
@@ -841,6 +841,7 @@ external validation maturity
 
 They should not be replaced by adoption metrics.
 
+
 ## Review example: low adoption
 
 ```text
@@ -850,8 +851,8 @@ Low visible GitHub adoption.
 Category:
 Adoption / ecosystem gap.
 
-Affected carrier:
-External ecosystem signal.
+Affected signal:
+Adoption / ecosystem signal.
 
 Authority impact:
 No direct PULSEmech authority-path impact.
@@ -860,13 +861,13 @@ Evidence:
 Low visible stars / forks / external PRs / integrations.
 
 Current mitigation:
-Documentation, DOI records, external verification path.
+Documentation, citation records, public reference surfaces.
 
 Remaining work:
-Third-party reproduction, external reviewer report, reference integration, adoption outreach.
+Reference integrations, external usage examples, adoption outreach.
 
 Status:
-External maturity gap.
+Adoption / ecosystem gap.
 ```
 
 ## Review example: missing independent audit


### PR DESCRIPTION
Addressed.

The low-adoption example now stays within the adoption / ecosystem category.

Changed:

- `Status: External maturity gap`

to:

- `Status: Adoption / ecosystem gap`

The example now treats low stars / forks / external PRs / integrations as adoption / ecosystem signals.

External validation remains reserved for independent reproduction, independent audit, third-party reference integration, external reviewer reports, or consumer-side verification.

Docs-only. No workflow, schema, builder, verifier, renderer, policy, release tag, DOI, or Zenodo path changed.
```