### PR TITLE
fix(validation): harden external verification packet builder  Harden …

### DIFF
--- a/docs/EXTERNAL_VERIFICATION_PACKET_v0.md
+++ b/docs/EXTERNAL_VERIFICATION_PACKET_v0.md
@@ -133,12 +133,15 @@ generated_utc
 repository
 commit
 run_identity
+verification_profile
 authority_carrier
 artifact_records
 verification_commands
 carrier_boundary_summary
 reviewer_checklist
 known_missing_artifacts
+binding_verification
+packet_status
 packet_boundary
 ```
 
@@ -165,12 +168,15 @@ packet_boundary
     "run_mode": "...",
     "created_utc": "..."
   },
+ "verification_profile": "authority-path",
   "authority_carrier": "status.json -> declared gate policy -> workflow-effective materialized required gate set -> strict fail-closed CI enforcement",
   "artifact_records": [],
   "verification_commands": [],
   "carrier_boundary_summary": [],
   "reviewer_checklist": [],
   "known_missing_artifacts": [],
+  "binding_verification": {},
+  "packet_status": "partially_verified",
   "packet_boundary": "external verification carrier; not release authority"
 }
 ```
@@ -278,6 +284,14 @@ python -m pytest -q tests/test_artifact_provenance_binding_v0.py
 python -m pytest -q \
   tests/test_artifact_provenance_binding_ci_wiring_smoke.py \
   tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
+```
+
+```bash
+python -m pytest -q tests/test_check_gates_fail_closed.py
+python -m pytest -q \
+  tests/test_render_quality_ledger.py \
+  tests/test_render_quality_ledger_decision_logic.py \
+  tests/test_render_quality_ledger_check_gates_parity.py
 ```
 
 If the artifact provenance binding exists:
@@ -458,12 +472,15 @@ PULSE_NATIVE_REVIEW_FRAME_v0.md
 
 This document defines the packet contract.
 
-It does not implement the packet builder.
-
-A later PR may add:
+The current v0 builder implementation is:
 
 ```text
 scripts/build_external_verification_packet_v0.py
+```
+
+The builder test for this contract is:
+
+```text
 tests/test_build_external_verification_packet_v0.py
 ```
 

--- a/scripts/build_external_verification_packet_v0.py
+++ b/scripts/build_external_verification_packet_v0.py
@@ -1,3 +1,4 @@
+cat > scripts/build_external_verification_packet_v0.py <<'PY'
 #!/usr/bin/env python3
 """Build External Verification Packet v0.
 
@@ -68,10 +69,11 @@ def sha256_file(path: Path) -> str | None:
 
 def read_json_object_status(path: Path) -> tuple[dict[str, Any], bool, str | None]:
     if not path.is_file():
-        return {}, False, "missing"   
+        return {}, False, "missing"
+
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-        except Exception as exc:
+    except Exception as exc:
         return {}, False, f"invalid JSON: {exc}"
 
     if not isinstance(payload, dict):
@@ -87,7 +89,6 @@ def read_json_if_exists(path: Path) -> dict[str, Any]:
 
 def as_dict(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
-
 
 
 def parse_run_key_value(run_key: Any, key: str) -> str | None:
@@ -243,8 +244,6 @@ def status_run_identity(repo_root: Path) -> dict[str, Any]:
         or parse_run_key_value(run_key, "GITHUB_RUN_ID")
     )
 
-    metrics = as_dict(status.get("metrics"))
-
     return {
         "run_id": run_id,
         "run_key": run_key,
@@ -263,7 +262,7 @@ def repository_identity(repo_root: Path, repository_name: str | None) -> dict[st
         "name": repository_name or "unknown",
         "root": repo_root.as_posix(),
         "remote": remote,
-   }
+    }
 
 
 def commit_identity(repo_root: Path) -> dict[str, Any]:
@@ -291,7 +290,7 @@ def verification_commands() -> list[dict[str, str]]:
                 "PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py"
             ),
         },
-         {
+        {
             "name": "fail-closed gate enforcement tests",
             "purpose": (
                 "Verify literal true-only and missing-required-gate "
@@ -313,7 +312,7 @@ def verification_commands() -> list[dict[str, str]]:
                 "tests/test_artifact_provenance_binding_attestation_wiring_smoke.py"
             ),
         },
-         {
+        {
             "name": "Quality Ledger reader-surface tests",
             "purpose": "Verify reader-surface boundary and check-gates parity semantics.",
             "command": (
@@ -493,15 +492,15 @@ def packet_status(
     if not commit.get("git_sha"):
         return "inconclusive"
 
-   binding = next(
-       (record for record in records if record["role"] == "artifact provenance binding"),
+    binding = next(
+        (record for record in records if record["role"] == "artifact provenance binding"),
         None,
     )
-  
-   if binding is not None and not binding["exists"]:
+
+    if binding is not None and not binding["exists"]:
         return "partially_verified"
 
-        if binding is not None and binding["exists"]:
+    if binding is not None and binding["exists"]:
         if binding_verification.get("verified") is True:
             return "verified"
         if binding_verification.get("verified") is False:
@@ -517,8 +516,8 @@ def build_packet(repo_root: Path, repository_name: str | None = None) -> dict[st
     missing = [record for record in records if not record["exists"]]
     commit = commit_identity(repo_root)
     binding_verification = verify_binding_carrier(repo_root, records)
- 
-  return {
+
+    return {
         "schema_id": SCHEMA_ID,
         "schema_version": SCHEMA_VERSION,
         "generated_utc": utc_now(),
@@ -645,7 +644,7 @@ def markdown_report(packet: dict[str, Any]) -> str:
 
     lines.extend(
         [
-                      "",
+            "",
             "## Binding verification",
             "",
             "```json",
@@ -654,7 +653,7 @@ def markdown_report(packet: dict[str, Any]) -> str:
                 indent=2,
                 sort_keys=True,
             ),
-            "```", 
+            "```",
             "",
             "## Boundary",
             "",
@@ -704,3 +703,4 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+PY

--- a/scripts/build_external_verification_packet_v0.py
+++ b/scripts/build_external_verification_packet_v0.py
@@ -18,6 +18,7 @@ import datetime as dt
 import hashlib
 import json
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +30,8 @@ AUTHORITY_CARRIER = (
     "status.json -> declared gate policy -> workflow-effective materialized "
     "required gate set -> strict fail-closed CI enforcement"
 )
+
+PACKET_BOUNDARY = "external verification carrier; not release authority"
 
 
 def utc_now() -> str:
@@ -63,18 +66,43 @@ def sha256_file(path: Path) -> str | None:
     return h.hexdigest()
 
 
-def read_json_if_exists(path: Path) -> dict[str, Any]:
+def read_json_object_status(path: Path) -> tuple[dict[str, Any], bool, str | None]:
     if not path.is_file():
-        return {}
+        return {}, False, "missing"   
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
-        return {}
-    return payload if isinstance(payload, dict) else {}
+        except Exception as exc:
+        return {}, False, f"invalid JSON: {exc}"
+
+    if not isinstance(payload, dict):
+        return {}, False, "top-level JSON value is not an object"
+
+    return payload, True, None
+
+
+def read_json_if_exists(path: Path) -> dict[str, Any]:
+    payload, _ok, _error = read_json_object_status(path)
+    return payload
 
 
 def as_dict(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
+
+
+
+def parse_run_key_value(run_key: Any, key: str) -> str | None:
+    if not isinstance(run_key, str):
+        return None
+
+    for part in run_key.split("|"):
+        if "=" not in part:
+            continue
+        left, right = part.split("=", 1)
+        if left.strip() == key:
+            value = right.strip()
+            return value or None
+
+    return None
 
 
 def artifact_record(
@@ -86,9 +114,16 @@ def artifact_record(
     carrier_class: str,
     boundary: str,
     notes: str = "",
+    json_object_required: bool = False,
 ) -> dict[str, Any]:
     artifact_path = repo_root / path
     exists = artifact_path.is_file()
+
+    parseable_json: bool | None = None
+    parse_error: str | None = None
+
+    if json_object_required:
+        _payload, parseable_json, parse_error = read_json_object_status(artifact_path)
 
     return {
         "role": role,
@@ -99,6 +134,9 @@ def artifact_record(
         "carrier_class": carrier_class,
         "boundary": boundary,
         "notes": notes,
+        "json_object_required": json_object_required,
+        "parseable_json": parseable_json,
+        "parse_error": parse_error,
     }
 
 
@@ -111,6 +149,7 @@ def collect_artifact_records(repo_root: Path) -> list[dict[str, Any]]:
             required=True,
             carrier_class="authority",
             boundary="recorded release-state artifact",
+            json_object_required=True,
         ),
         artifact_record(
             repo_root=repo_root,
@@ -193,17 +232,28 @@ def collect_artifact_records(repo_root: Path) -> list[dict[str, Any]]:
 
 def status_run_identity(repo_root: Path) -> dict[str, Any]:
     status_path = repo_root / "PULSE_safe_pack_v0" / "artifacts" / "status.json"
-    status = read_json_if_exists(status_path)
+    status, parse_ok, parse_error = read_json_object_status(status_path)
+
+    metrics = as_dict(status.get("metrics"))
+    run_key = metrics.get("run_key") or status.get("run_key")
+
+    run_id = (
+        metrics.get("run_id")
+        or status.get("run_id")
+        or parse_run_key_value(run_key, "GITHUB_RUN_ID")
+    )
 
     metrics = as_dict(status.get("metrics"))
 
     return {
-        "run_id": metrics.get("run_id") or status.get("run_id"),
-        "run_key": metrics.get("run_key") or status.get("run_key"),
+        "run_id": run_id,
+        "run_key": run_key,
         "run_mode": metrics.get("run_mode") or status.get("run_mode"),
         "created_utc": status.get("created_utc"),
         "status_version": status.get("version"),
         "status_git_sha": metrics.get("git_sha") or status.get("git_sha"),
+        "status_parse_ok": parse_ok,
+        "status_parse_error": parse_error,
     }
 
 
@@ -213,7 +263,7 @@ def repository_identity(repo_root: Path, repository_name: str | None) -> dict[st
         "name": repository_name or "unknown",
         "root": repo_root.as_posix(),
         "remote": remote,
-    }
+   }
 
 
 def commit_identity(repo_root: Path) -> dict[str, Any]:
@@ -241,6 +291,14 @@ def verification_commands() -> list[dict[str, str]]:
                 "PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py"
             ),
         },
+         {
+            "name": "fail-closed gate enforcement tests",
+            "purpose": (
+                "Verify literal true-only and missing-required-gate "
+                "fail-closed semantics."
+            ),
+            "command": "python -m pytest -q tests/test_check_gates_fail_closed.py",
+        },
         {
             "name": "artifact provenance binding tests",
             "purpose": "Verify binding builder / verifier behavior.",
@@ -255,6 +313,16 @@ def verification_commands() -> list[dict[str, str]]:
                 "tests/test_artifact_provenance_binding_attestation_wiring_smoke.py"
             ),
         },
+         {
+            "name": "Quality Ledger reader-surface tests",
+            "purpose": "Verify reader-surface boundary and check-gates parity semantics.",
+            "command": (
+                "python -m pytest -q "
+                "tests/test_render_quality_ledger.py "
+                "tests/test_render_quality_ledger_decision_logic.py "
+                "tests/test_render_quality_ledger_check_gates_parity.py"
+            ),
+        },
         {
             "name": "verify artifact provenance binding",
             "purpose": "Recompute and verify the binding carrier if present.",
@@ -265,7 +333,10 @@ def verification_commands() -> list[dict[str, str]]:
         },
         {
             "name": "generate normative/shadow inventory report",
-            "purpose": "Review workflow carrier classification without committing generated output.",
+            "purpose": (
+                "Review workflow carrier classification without committing "
+                "generated output."
+            ),
             "command": (
                 "TMPDIR=\"$(mktemp -d)\" && "
                 "python scripts/build_normative_shadow_inventory_v0.py "
@@ -324,41 +395,150 @@ def reviewer_checklist() -> list[str]:
     ]
 
 
-def packet_status(records: list[dict[str, Any]]) -> str:
-    missing_required = [r for r in records if r["required"] and not r["exists"]]
+def verify_binding_carrier(
+    repo_root: Path,
+    records: list[dict[str, Any]],
+) -> dict[str, Any]:
+    binding = next(
+        (record for record in records if record["role"] == "artifact provenance binding"),
+        None,
+    )
+
+    if binding is None:
+        return {
+            "requested": False,
+            "available": False,
+            "verified": None,
+            "exit_code": None,
+            "reason": "binding record missing",
+        }
+
+    if not binding["exists"]:
+        return {
+            "requested": True,
+            "available": False,
+            "verified": None,
+            "exit_code": None,
+            "reason": "binding artifact missing",
+        }
+
+    verifier = (
+        repo_root
+        / "PULSE_safe_pack_v0"
+        / "tools"
+        / "verify_artifact_provenance_binding_v0.py"
+    )
+    binding_path = repo_root / binding["path"]
+
+    if not verifier.is_file():
+        return {
+            "requested": True,
+            "available": True,
+            "verified": None,
+            "exit_code": None,
+            "reason": "binding verifier missing",
+        }
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            verifier.as_posix(),
+            "--binding",
+            binding_path.as_posix(),
+        ],
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+    return {
+        "requested": True,
+        "available": True,
+        "verified": proc.returncode == 0,
+        "exit_code": proc.returncode,
+        "reason": (
+            "binding verifier passed"
+            if proc.returncode == 0
+            else "binding verifier failed"
+        ),
+        "stdout": proc.stdout.strip(),
+        "stderr": proc.stderr.strip(),
+    }
+
+
+def packet_status(
+    records: list[dict[str, Any]],
+    *,
+    commit: dict[str, Any],
+    binding_verification: dict[str, Any],
+) -> str:
+    missing_required = [
+        record for record in records if record["required"] and not record["exists"]
+    ]
     if missing_required:
         return "authority_artifact_missing"
 
-    binding = next(
-        (r for r in records if r["role"] == "artifact provenance binding"),
+    malformed_required = [
+        record
+        for record in records
+        if record["required"]
+        and record.get("json_object_required") is True
+        and record.get("parseable_json") is not True
+    ]
+    if malformed_required:
+        return "verification_failed"
+
+    if not commit.get("git_sha"):
+        return "inconclusive"
+
+   binding = next(
+       (record for record in records if record["role"] == "artifact provenance binding"),
         None,
     )
-    if binding is not None and not binding["exists"]:
+  
+   if binding is not None and not binding["exists"]:
         return "partially_verified"
 
-    return "verified"
+        if binding is not None and binding["exists"]:
+        if binding_verification.get("verified") is True:
+            return "verified"
+        if binding_verification.get("verified") is False:
+            return "verification_failed"
+        return "inconclusive"
+
+    return "partially_verified"
 
 
 def build_packet(repo_root: Path, repository_name: str | None = None) -> dict[str, Any]:
     repo_root = repo_root.resolve()
     records = collect_artifact_records(repo_root)
     missing = [record for record in records if not record["exists"]]
-
-    return {
+    commit = commit_identity(repo_root)
+    binding_verification = verify_binding_carrier(repo_root, records)
+ 
+  return {
         "schema_id": SCHEMA_ID,
         "schema_version": SCHEMA_VERSION,
         "generated_utc": utc_now(),
         "repository": repository_identity(repo_root, repository_name),
-        "commit": commit_identity(repo_root),
+        "commit": commit,
         "run_identity": status_run_identity(repo_root),
+        "verification_profile": "authority-path",
         "authority_carrier": AUTHORITY_CARRIER,
         "artifact_records": records,
         "verification_commands": verification_commands(),
         "carrier_boundary_summary": carrier_boundary_summary(),
         "reviewer_checklist": reviewer_checklist(),
         "known_missing_artifacts": missing,
-        "packet_status": packet_status(records),
-        "packet_boundary": "external verification carrier; not release authority",
+        "binding_verification": binding_verification,
+        "packet_status": packet_status(
+            records,
+            commit=commit,
+            binding_verification=binding_verification,
+        ),
+        "packet_boundary": PACKET_BOUNDARY,
     }
 
 
@@ -374,6 +554,7 @@ def markdown_report(packet: dict[str, Any]) -> str:
         f"- schema_id: `{packet['schema_id']}`",
         f"- schema_version: `{packet['schema_version']}`",
         f"- generated_utc: `{packet['generated_utc']}`",
+        f"- verification_profile: `{packet['verification_profile']}`",
         f"- packet_status: `{packet['packet_status']}`",
         f"- repository: `{repository.get('name')}`",
         f"- git_sha: `{commit.get('git_sha')}`",
@@ -464,6 +645,16 @@ def markdown_report(packet: dict[str, Any]) -> str:
 
     lines.extend(
         [
+                      "",
+            "## Binding verification",
+            "",
+            "```json",
+            json.dumps(
+                packet.get("binding_verification") or {},
+                indent=2,
+                sort_keys=True,
+            ),
+            "```", 
             "",
             "## Boundary",
             "",

--- a/tests/test_build_external_verification_packet_v0.py
+++ b/tests/test_build_external_verification_packet_v0.py
@@ -1,0 +1,293 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "build_external_verification_packet_v0.py"
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def git_commit_all(repo: Path, message: str) -> None:
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", message],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def valid_status() -> dict:
+    return {
+        "version": "1.0.0-core",
+        "created_utc": "2026-06-03T00:00:00Z",
+        "metrics": {
+            "run_mode": "core",
+            "git_sha": "0" * 40,
+            "run_key": (
+                "GITHUB_RUN_ID=12345|GITHUB_RUN_NUMBER=7|"
+                "GITHUB_WORKFLOW=PULSE CI"
+            ),
+        },
+        "gates": {"core_gate": True},
+    }
+
+
+def make_repo(
+    base: Path,
+    *,
+    git: bool = True,
+    status_text: str | None = None,
+    binding: bool = False,
+    verifier_exit: int | None = None,
+) -> Path:
+    repo = base / "repo"
+
+    if status_text is None:
+        status_text = json.dumps(valid_status(), indent=2, sort_keys=True) + "\n"
+
+    write(repo / "PULSE_safe_pack_v0" / "artifacts" / "status.json", status_text)
+    write(
+        repo / "pulse_gate_policy_v0.yml",
+        "gates:\n  core_required:\n    - core_gate\n",
+    )
+    write(
+        repo / "pulse_gate_registry_v0.yml",
+        "gates:\n  core_gate:\n    intent: test\n",
+    )
+
+    if binding:
+        write(
+            repo
+            / "PULSE_safe_pack_v0"
+            / "artifacts"
+            / "artifact_provenance_binding_v0.json",
+            "{}\n",
+        )
+
+    if verifier_exit is not None:
+        write(
+            repo
+            / "PULSE_safe_pack_v0"
+            / "tools"
+            / "verify_artifact_provenance_binding_v0.py",
+            f"import sys\nsys.exit({verifier_exit})\n",
+        )
+
+    if git:
+        subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.PIPE)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo,
+            check=True,
+        )
+        git_commit_all(repo, "fixture")
+
+    return repo
+
+
+def run_builder(repo: Path, tmp_path: Path) -> tuple[dict, str]:
+    out_json = tmp_path / "external_verification_packet_v0.json"
+    out_md = tmp_path / "external_verification_packet_v0.md"
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo-root",
+            str(repo),
+            "--out-json",
+            str(out_json),
+            "--out-md",
+            str(out_md),
+            "--repository-name",
+            "HKati/pulse-release-gates-0.1",
+        ],
+        check=True,
+    )
+
+    return json.loads(out_json.read_text(encoding="utf-8")), out_md.read_text(
+        encoding="utf-8"
+    )
+
+
+def record_by_role(packet: dict, role: str) -> dict:
+    for record in packet["artifact_records"]:
+        if record["role"] == role:
+            return record
+    raise AssertionError(f"missing artifact record for role: {role}")
+
+
+def command_names(packet: dict) -> set[str]:
+    return {item["name"] for item in packet["verification_commands"]}
+
+
+def test_builder_outputs_minimum_packet_fields_and_boundaries(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    packet, markdown = run_builder(repo, tmp_path)
+
+    assert packet["schema_id"] == "pulse.external_verification_packet.v0"
+    assert packet["schema_version"] == "0.1.0"
+    assert packet["verification_profile"] == "authority-path"
+    assert packet["packet_status"] == "partially_verified"
+    assert packet["packet_boundary"] == (
+        "external verification carrier; not release authority"
+    )
+    assert packet["authority_carrier"] == (
+        "status.json -> declared gate policy -> workflow-effective materialized "
+        "required gate set -> strict fail-closed CI enforcement"
+    )
+
+    status_record = record_by_role(packet, "status")
+    assert status_record["required"] is True
+    assert status_record["exists"] is True
+    assert status_record["json_object_required"] is True
+    assert status_record["parseable_json"] is True
+    assert status_record["parse_error"] is None
+
+    assert "External Verification Packet v0" in markdown
+    assert "verification_profile" in markdown
+    assert "Binding verification" in markdown
+
+
+def test_malformed_required_status_json_blocks_verified_packet(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path, status_text="{not json\n")
+    packet, _markdown = run_builder(repo, tmp_path)
+
+    status_record = record_by_role(packet, "status")
+    assert status_record["exists"] is True
+    assert status_record["json_object_required"] is True
+    assert status_record["parseable_json"] is False
+    assert status_record["parse_error"]
+
+    assert packet["run_identity"]["status_parse_ok"] is False
+    assert packet["run_identity"]["status_parse_error"]
+    assert packet["packet_status"] == "verification_failed"
+
+
+def test_non_object_status_json_blocks_verified_packet(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path, status_text="[]\n")
+    packet, _markdown = run_builder(repo, tmp_path)
+
+    status_record = record_by_role(packet, "status")
+    assert status_record["parseable_json"] is False
+    assert status_record["parse_error"] == "top-level JSON value is not an object"
+    assert packet["packet_status"] == "verification_failed"
+
+
+def test_run_id_is_extracted_from_github_run_id_inside_run_key(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    packet, _markdown = run_builder(repo, tmp_path)
+
+    assert packet["run_identity"]["run_id"] == "12345"
+    assert packet["run_identity"]["run_key"] == (
+        "GITHUB_RUN_ID=12345|GITHUB_RUN_NUMBER=7|GITHUB_WORKFLOW=PULSE CI"
+    )
+
+
+def test_explicit_run_id_is_preferred_over_run_key_value(tmp_path: Path) -> None:
+    status = valid_status()
+    status["metrics"]["run_id"] = "explicit-run-id"
+
+    repo = make_repo(
+        tmp_path,
+        status_text=json.dumps(status, indent=2, sort_keys=True) + "\n",
+    )
+    packet, _markdown = run_builder(repo, tmp_path)
+
+    assert packet["run_identity"]["run_id"] == "explicit-run-id"
+
+
+def test_missing_git_commit_identity_is_inconclusive(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path, git=False)
+    packet, _markdown = run_builder(repo, tmp_path)
+
+    assert packet["commit"]["git_sha"] is None
+    assert packet["packet_status"] == "inconclusive"
+
+
+def test_existing_binding_must_verify_before_packet_can_be_verified(
+    tmp_path: Path,
+) -> None:
+    fail_repo = make_repo(
+        tmp_path / "fail",
+        binding=True,
+        verifier_exit=1,
+    )
+    fail_packet, _markdown = run_builder(fail_repo, tmp_path / "fail_out")
+
+    assert fail_packet["binding_verification"]["requested"] is True
+    assert fail_packet["binding_verification"]["available"] is True
+    assert fail_packet["binding_verification"]["verified"] is False
+    assert fail_packet["binding_verification"]["exit_code"] == 1
+    assert fail_packet["packet_status"] == "verification_failed"
+
+    pass_repo = make_repo(
+        tmp_path / "pass",
+        binding=True,
+        verifier_exit=0,
+    )
+    pass_packet, _markdown = run_builder(pass_repo, tmp_path / "pass_out")
+
+    assert pass_packet["binding_verification"]["requested"] is True
+    assert pass_packet["binding_verification"]["available"] is True
+    assert pass_packet["binding_verification"]["verified"] is True
+    assert pass_packet["binding_verification"]["exit_code"] == 0
+    assert pass_packet["packet_status"] == "verified"
+
+
+def test_existing_binding_without_verifier_is_inconclusive(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path, binding=True, verifier_exit=None)
+    packet, _markdown = run_builder(repo, tmp_path)
+
+    assert packet["binding_verification"]["requested"] is True
+    assert packet["binding_verification"]["available"] is True
+    assert packet["binding_verification"]["verified"] is None
+    assert packet["binding_verification"]["reason"] == "binding verifier missing"
+    assert packet["packet_status"] == "inconclusive"
+
+
+def test_semantic_review_commands_are_present(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    packet, _markdown = run_builder(repo, tmp_path)
+
+    names = command_names(packet)
+    assert "fail-closed gate enforcement tests" in names
+    assert "Quality Ledger reader-surface tests" in names
+
+    commands = {item["name"]: item["command"] for item in packet["verification_commands"]}
+    assert "tests/test_check_gates_fail_closed.py" in commands[
+        "fail-closed gate enforcement tests"
+    ]
+    assert "tests/test_render_quality_ledger.py" in commands[
+        "Quality Ledger reader-surface tests"
+    ]
+    assert "tests/test_render_quality_ledger_decision_logic.py" in commands[
+        "Quality Ledger reader-surface tests"
+    ]
+    assert "tests/test_render_quality_ledger_check_gates_parity.py" in commands[
+        "Quality Ledger reader-surface tests"
+    ]
+
+
+def test_builder_does_not_write_inside_repo_by_default(tmp_path: Path) -> None:
+    repo = make_repo(tmp_path)
+    run_builder(repo, tmp_path)
+
+    assert not (repo / "external_verification_packet_v0.json").exists()
+    assert not (repo / "external_verification_packet_v0.md").exists()
+    assert not (repo / "out" / "external_verification_packet_v0.json").exists()
+    assert not (repo / "out" / "external_verification_packet_v0.md").exists()


### PR DESCRIPTION
## Summary

This PR hardens the External Verification Packet v0 builder as a clean builder-only unit.

The packet remains an external verification carrier. It does not become release authority, a required gate input, a verifier engine, or CI manifest wiring.

## What changed

### Builder hardening

`scripts/build_external_verification_packet_v0.py` now:

- records required JSON artifact parseability and parse errors;
- requires `status.json` to be a JSON object for authority-path packet review;
- extracts `run_identity.run_id` from `GITHUB_RUN_ID` inside `run_key` when no explicit run ID is present;
- records `verification_profile`;
- records `binding_verification`;
- uses a shared packet boundary string:

```text
external verification carrier; not release authority
```

- marks malformed required authority artifacts as `verification_failed`;
- marks missing git commit identity as `inconclusive`, never `verified`;
- invokes the artifact provenance binding verifier when `artifact_provenance_binding_v0.json` exists;
- requires a passing binding verifier before `packet_status=verified`;
- surfaces binding verification details in Markdown output;
- expands reviewer commands with fail-closed gate enforcement and Quality Ledger reader-surface checks.

### Contract docs

`docs/EXTERNAL_VERIFICATION_PACKET_v0.md` now documents:

- `verification_profile`;
- `binding_verification`;
- `packet_status`;
- additional semantic reviewer commands;
- the current builder implementation path;
- the current builder test path.

### Tests

Adds focused builder tests in:

```text
tests/test_build_external_verification_packet_v0.py
```

The tests cover:

- minimum packet fields and boundary output;
- malformed required `status.json`;
- non-object `status.json`;
- `GITHUB_RUN_ID` extraction from `run_key`;
- explicit `run_id` preference;
- missing git identity producing `inconclusive`;
- binding verifier failure;
- binding verifier success;
- binding present but verifier missing;
- semantic review command presence;
- clean temp-output behavior.

## Scope

This PR intentionally touches only:

```text
docs/EXTERNAL_VERIFICATION_PACKET_v0.md
scripts/build_external_verification_packet_v0.py
tests/test_build_external_verification_packet_v0.py
```

## Explicitly not changed

This PR does not create or modify:

```text
scripts/verify_external_verification_packet_v0.py
tests/test_verify_external_verification_packet_v0.py
ci/pytest-tests.list
ci/tools-tests.list
.github/workflows/*
schemas/*
policy files
release / DOI / Zenodo paths
generated out/... files
PULSE_safe_pack_v0/artifacts/*
```

## Validation

```bash
python -m py_compile scripts/build_external_verification_packet_v0.py tests/test_build_external_verification_packet_v0.py
python -m pytest -q tests/test_build_external_verification_packet_v0.py
python -m pytest -q
git diff --check
```

Temporary packet generation was also checked with output written outside the repository tree, and the working tree remained clean.

## Boundary

This is builder hardening only.

Verifier v0 remains a separate future clean unit.