### PR TITLE
chore(boundary): remove active governance identity surfaces

### DIFF
--- a/docs/GLOSSARY_v0.md
+++ b/docs/GLOSSARY_v0.md
@@ -1,7 +1,7 @@
 # PULSE GLOSSARY_v0
 
 > Working glossary for the main terms used in the PULSE safe-pack, Core
-> profile and Governance Pack.
+> profile, PULSEmech release-authority path, and Instrument Review Pack.
 
 This glossary is descriptive and versioned (`_v0`): it captures how we
 currently use these terms. As the pack evolves, we may update or extend
@@ -21,7 +21,7 @@ They are **decision-relative** and **evidence-first**: they describe a structure
 
 An explicit reference frame used to compute deltas, classify drift, and orient the Paradox field. Examples:
 
-- a baseline `status.json` used as the release-governance reference,
+- a baseline `status.json` used as the release-authority reference,
 - a policy cut / threshold set (e.g. θ),
 - a specific run context (commit + runner image + seed + profile_id).
 
@@ -111,6 +111,7 @@ The Core exists to make reviewer output readable while preserving auditability.
 Field-first overlays are audit-compatible only if they are stable under reruns.
 
 **Minimum determinism requirements (v0):**
+
 1. **Pinned context**: runner image + dependency versions + (CPU/GPU mode if relevant) are part of run context.
 2. **Explicit seed**: any sampling/permutation is seeded and recorded.
 3. **Canonical ordering**: lists (atoms/edges/events) are sorted using a documented rule.
@@ -160,7 +161,7 @@ In PULSE Core:
 **What it is not**
 
 - Not a “best-effort” run – there is no silent downgrade on gate failure.
-- Not a recommendation to fail prod deploys automatically on all governance signals.
+- Not a recommendation to fail prod deploys automatically on all diagnostic or review signals.
 
 ---
 
@@ -203,7 +204,7 @@ Defined in:
 
 **What it is not**
 
-- Not a full Governance Pack – it focuses on concrete PASS/FAIL gates.
+- Not the full Instrument Review Pack – it focuses on concrete PASS/FAIL gates.
 - Not tied to any single CI system; GitHub Actions is the first reference.
 
 ---
@@ -230,18 +231,22 @@ Typical use:
 **What it is not**
 
 - Not the same as promoting the whole shadow line.
-- Not a normative release surface.
+- Not a release-authority surface.
 - Not a claim that the broader workflow family is already `shadow-contracted`.
 
 ---
 
 ### critical radius (r_c)
+
 #### What it means
+
 The radius (or scale parameter) at which the protocol’s decodability criterion reaches the required threshold (e.g. C(r_c)=h_req). Serves as a compact, reviewable summary of where the boundary sits for a given run/context.
 
 #### What it is not
+
 - Not a universal constant; it is context- and protocol-dependent.
 - Not a guarantee of stability outside the recorded conditions.
+
 ---
 
 ## D
@@ -250,29 +255,62 @@ The radius (or scale parameter) at which the protocol’s decodability criterion
 
 **What it means**
 
-A Governance Pack component that:
+A shadow-mode instrument-review artifact in the PULSE Instrument Review Pack v0.
 
-- reads `status.json`, `stability_map_v0.json` and overlays (EPF, paradox, etc.),
-- emits a structured decision object, e.g. `decision_engine_v0.json`, with:
+It may:
 
-  - `release_state` ∈ {`fail`, `stage_only`, `prod_ok`},
-  - `stability_type` (e.g. `stable_good`, `high_tension`),
-  - `decision_trace[]` – small, auditable rule hits.
+- read `status.json`, `stability_map_v0.json`, and overlays such as EPF or paradox artifacts,
+- emit a structured review object, for example `decision_engine_v0.json`,
+- record small, auditable rule hits in `decision_trace[]`,
+- support human review or release triage.
 
-Runs in **shadow mode** by default (does not change PASS/FAIL).
+Canonical JSON `release_state` values use implementation / schema labels such as:
+
+```text
+BLOCK
+STAGE_ONLY
+PROD_OK
+```
+
+Reader-facing displays may render these as:
+
+```text
+BLOCK
+STAGE-ONLY
+PROD-OK
+```
+
+The hyphenated forms are display labels, not canonical JSON values.
+
+Runs in **shadow mode** by default.
 
 **What it is not**
 
-- Not a replacement for human governance.
-- Not a magic “AI judge” – it is a rule-based policy surface.
+- Not release authority by default.
+- Not a replacement for `status.json`.
+- Not a replacement for declared gate policy.
+- Not a replacement for the workflow-effective materialized required gate set.
+- Not a replacement for strict fail-closed CI enforcement.
+- Not a replacement for human review.
+- Not a magic “AI judge” — it is a traceable review artifact.
+
+Legacy note:
+
+```text
+Earlier documents may describe this as part of the Governance Pack.
+The canonical technical role is now PULSE Instrument Review Pack v0.
+```
 
 ---
 
 ### Decodability Wall (Gravity Record Protocol)
+
 #### What it means
+
 An operational measurement boundary defined from recorded signals: the point (often expressed via a critical radius r_c) where the decodability criterion crosses a required threshold (h_req). Used to make “decodable vs not-decodable (under this protocol)” auditable and repeatable.
 
 #### What it is not
+
 - Not a physical “wall” or a causal barrier in the system.
 - Not a security guarantee by itself.
 - Not a substitute for recording inputs/contexts; it only makes the boundary explicit given those records.
@@ -344,26 +382,34 @@ Usually recorded in artefacts like `g_field_v0.json`.
 
 ### Governance Pack
 
-**What it means**
+Legacy alias for:
 
-An optional layer on top of PULSE Core that focuses on:
+```text
+PULSE Instrument Review Pack v0
+```
 
-- long-term stability,
-- paradox and trade-off visibility,
-- governance-ready decision fields.
+Legacy filename / workshop alias:
 
-Typical components:
+```text
+docs/GOVERNANCE_PACK_v0.md
+```
 
-- Stability Map,
-- Decision Engine (shadow),
-- EPF & Paradox Playbook,
-- G-field & GPT overlays,
-- history & drift tools.
+Do not use `Governance Pack` as the active PULSE-facing identity descriptor.
+
+Use:
+
+```text
+PULSE Instrument Review Pack v0
+```
+
+for the optional diagnostic / instrument-review layer around PULSEmech.
 
 **What it is not**
 
-- Not required to run the Core gates.
-- Not a replacement for Core fail-closed behaviour.
+- Not the canonical component name.
+- Not PULSE identity.
+- Not release authority.
+- Not a second release-decision engine.
 
 ---
 
@@ -404,7 +450,7 @@ tooling and validation.
 **What it is not**
 
 - Not automatic promotion.
-- Not normative authority.
+- Not release authority.
 - Not equivalent to being release-required.
 - Not the same as merely being mentioned in a docs inventory table.
 
@@ -416,7 +462,7 @@ tooling and validation.
 
 **What it means**  
 A shadow-layer property stating that, under the same required gate set
-and the same normative enforcement path, adding, folding, or removing
+and the same release-authority enforcement path, adding, folding, or removing
 the shadow layer does not change the release outcome.
 
 Typical proof shape:
@@ -462,6 +508,69 @@ Overlays:
 
 ---
 
+## P
+
+### PULSE Instrument Review Pack v0
+
+**What it means**
+
+An optional diagnostic and instrument-review layer around PULSEmech.
+
+Legacy filename / workshop alias:
+
+```text
+docs/GOVERNANCE_PACK_v0.md
+Governance Pack
+```
+
+The pack may include review artifacts such as:
+
+- `stability_map_v0.json`
+- `decision_engine_v0.json`
+- EPF / paradox review notes
+- G-field / GPT overlay review summaries
+- history and drift review artifacts
+
+These artifacts may support:
+
+- human review,
+- release triage,
+- diagnostic interpretation,
+- stability review,
+- field / topology inspection.
+
+They are non-authorizing by default.
+
+A signal from this pack becomes release-relevant only if it is:
+
+```text
+recorded as release evidence
+referenced by declared policy
+materialized as a required gate
+enforced through the strict fail-closed CI path
+```
+
+The PULSEmech authority path remains:
+
+```text
+recorded release evidence
+→ status.json
+→ declared gate policy
+→ workflow-effective materialized required gate set
+→ strict fail-closed CI enforcement
+→ pre-deployment allow/block release decision
+```
+
+**What it is not**
+
+- Not PULSE identity.
+- Not release authority.
+- Not a second release-decision engine.
+- Not required to run Core gates.
+- Not a replacement for Core fail-closed behaviour.
+
+---
+
 ## Q
 
 ### Q-gate (quality gate)
@@ -490,16 +599,17 @@ they may allow more tuning than I-gates.
 
 A human-oriented, usually HTML or markdown report that:
 
-- summarises a PULSE run (or a set of runs),
+- summarises a PULSE run or a set of runs,
 - lists gate outcomes, RDSI, EPF bands, key overlays,
-- acts as an audit-friendly “release card”.
+- acts as an audit-friendly reader surface.
 
 Typically generated alongside `status.json`.
 
 **What it is not**
 
-- Not the formal source of truth for machine tools (that’s `status.json`).
+- Not the formal source of truth for machine tools. That is `status.json`.
 - Not a substitute for detailed logs when debugging.
+- Not the release-authority path.
 
 ---
 
@@ -544,6 +654,8 @@ Used to detect whether safety interventions are actually changing outcomes.
 - Not a raw refusal rate.
 - Not always a gate by itself – in v0 it can be a CI-neutral stability signal.
 
+---
+
 ### research diagnostic
 
 **What it means**  
@@ -557,7 +669,7 @@ surface, while still remaining non-promoted as a broader line.
 
 **What it is not**
 
-- Not a normative release surface.
+- Not a release-authority surface.
 - Not the same as `shadow-contracted`.
 - Not a synonym for “unimportant”.
 - Not evidence that the layer may change release authority.
@@ -601,7 +713,7 @@ surface, including at minimum:
 - a canonical fixture matrix (including valid and invalid fixtures where applicable),
 - and regression tests.
 
-A `shadow-contracted` layer is still non-normative by default, but it is
+A `shadow-contracted` layer is still non-authorizing by default, but it is
 no longer just an informal research note or ad hoc shadow experiment.
 
 **What it is not**
@@ -609,7 +721,7 @@ no longer just an informal research note or ad hoc shadow experiment.
 - Not advisory or policy-bound by default.
 - Not release-required.
 - Not permission to write under `gates.*`.
-- Not equivalent to promotion into the normative decision path.
+- Not equivalent to promotion into the release-authority decision path.
 
 ---
 
@@ -617,7 +729,7 @@ no longer just an informal research note or ad hoc shadow experiment.
 
 **What it means**
 
-An aggregate view (usually JSON) that:
+An aggregate view, usually JSON, that:
 
 - combines gate outcomes, RDSI, EPF and overlays,
 - produces an **instability score** and a **stability type** label,
@@ -625,7 +737,7 @@ An aggregate view (usually JSON) that:
 
 Example fields:
 
-- `stability_type` (e.g. `stable_good`, `unstably_good`, `high_tension`),
+- `stability_type` such as `stable_good`, `unstably_good`, `stable_bad`, `unstably_bad`, or another schema-defined label,
 - `instability_score`,
 - `components[]`.
 
@@ -633,6 +745,7 @@ Example fields:
 
 - Not a raw log of test cases.
 - Not meant to hide which gate actually failed.
+- Not release authority by default.
 
 ---
 
@@ -721,5 +834,4 @@ Example: `.github/workflows/pulse_core_ci.yml`.
 **What it is not**
 
 - Not the only way to run PULSE – local runs and other CI systems are also valid.
-- Not a full Governance Pack runner; it focuses on Core behaviour.
-
+- Not a full Instrument Review Pack runner; it focuses on Core behaviour.

--- a/docs/GOVERNANCE_PACK_v0.md
+++ b/docs/GOVERNANCE_PACK_v0.md
@@ -1,7 +1,50 @@
-# PULSE Governance Pack (v0)
+# PULSE Instrument Review Pack v0
 
-> From PASS/FAIL gates to governance-ready decision fields.  
-> The Governance Pack is an *optional* layer on top of PULSE Core.
+Legacy filename / workshop alias:
+
+```text
+docs/GOVERNANCE_PACK_v0.md
+```
+
+Canonical technical name:
+
+```text
+PULSE Instrument Review Pack v0
+```
+
+## Boundary
+
+This document describes optional instrument-review and diagnostic surfaces around PULSEmech.
+
+It does not define PULSE.
+
+It does not define release authority.
+
+It does not create a second release-decision engine.
+
+The PULSEmech authority path remains:
+
+```text
+recorded release evidence
+→ status.json
+→ declared gate policy
+→ workflow-effective materialized required gate set
+→ strict fail-closed CI enforcement
+→ pre-deployment allow/block release decision
+```
+
+The Instrument Review Pack may support human review, release triage, diagnostic interpretation, stability review, or optional field-level inspection.
+
+It is non-authorizing by default.
+
+A signal from this pack becomes release-relevant only if it is:
+
+```text
+recorded as release evidence
+referenced by declared policy
+materialized as a required gate
+enforced through the strict fail-closed CI path
+```
 
 ---
 
@@ -9,19 +52,31 @@
 
 PULSE Core answers:
 
-- “Is this model / release safe enough and within basic SLOs to ship?”
+```text
+Does the recorded release state satisfy the declared required gate set under strict fail-closed enforcement?
+```
 
-The Governance Pack answers:
+The Instrument Review Pack supports review questions such as:
 
-- “*How* safe and stable is it over time?”
-- “Where are the tensions and paradoxes between safety and utility?”
-- “What decision should we record: **BLOCK**, **STAGE-ONLY**, or **PROD-OK**, and why?”
+```text
+How stable is the release field over time?
+Where are the tensions between safety, utility, stability, and operational constraints?
+Which diagnostic patterns should reviewers inspect before a release decision?
+Which review recommendation should be recorded for human interpretation: BLOCK, STAGE-ONLY, or PROD-OK?
+Why was that recommendation produced?
+```
 
 All components in this pack are **CI-neutral by default**:
 
-- they read existing PULSE artefacts (status.json, overlays, history),
-- they emit additional JSON/markdown/HTML views,
-- they do *not* change PASS/FAIL unless you explicitly wire them into CD.
+```text
+they read existing PULSE artifacts
+they emit additional JSON / Markdown / HTML views
+they do not change PASS / FAIL
+they do not change release authority
+they do not change PULSEmech semantics
+```
+
+They affect release outcome only if explicitly promoted through the PULSEmech authority path.
 
 ---
 
@@ -29,164 +84,509 @@ All components in this pack are **CI-neutral by default**:
 
 ### 1.1 Stability Map
 
-**Goal:** aggregate PULSE runs into a single “stability field” for a model line.
+**Goal:** aggregate PULSE runs into a single stability field for a model line, release line, or evaluated system surface.
 
-- **Inputs**
-  - historical `status.json` artefacts (per run),
-  - optional EPF / paradox overlays.
-- **Output**
-  - `stability_map_v0.json` with e.g.:
-    - per-gate stability categories (`stable_good`, `unstably_good`, `high_tension`),
-    - instability score and contributing components,
-    - drift notes and timestamps.
-- **Primary users**
-  - ML leads, safety engineers, governance boards.
+Inputs:
 
-The Stability Map does *not* change CI status; it is a diagnostic view.
+```text
+historical status.json artifacts
+optional EPF overlays
+optional paradox overlays
+optional field / topology overlays
+```
+
+Output:
+
+```text
+stability_map_v0.json
+```
+
+Possible contents:
+
+```text
+per-gate stability categories
+stable_good / unstably_good / stably_bad / unstably_bad classifications
+instability score
+contributing components
+drift notes
+timestamps
+artifact references
+```
+
+Primary users:
+
+```text
+ML leads
+safety engineers
+release reviewers
+field / topology reviewers
+audit reviewers
+```
+
+The Stability Map does not change CI status.
+
+It is a diagnostic view.
+
+It is not release authority.
 
 ---
 
-### 1.2 Decision Engine (shadow)
+### 1.2 Decision Engine — shadow mode
 
-**Goal:** turn the Stability Map + current run into a structured decision object.
+**Goal:** turn the Stability Map and the current run into a structured review object.
 
-- **Inputs**
-  - latest `status.json`,
-  - `stability_map_v0.json`,
-  - paradox / EPF overlays (if available).
-- **Output**
-  - `decision_engine_v0.json`, containing at minimum:
-    - `release_state` ∈ {`fail`, `stage_only`, `prod_ok`},
-    - `stability_type` (e.g. `stable_good`, `high_tension`),
-    - `decision_trace[]` (rule hits, gate IDs, paradox links, short explanations).
-- **Behaviour**
-  - runs in **shadow mode** by default (no change to PASS/FAIL),
-  - can later be used to gate prod deploys or drive human approvals.
+Inputs:
 
-The Decision Engine is a **policy surface**: rules should be small, explicit and auditable.
+```text
+latest status.json
+stability_map_v0.json
+paradox overlays when available
+EPF overlays when available
+field / topology overlays when available
+```
+
+Output:
+
+```text
+decision_engine_v0.json
+```
+
+Minimum fields may include:
+
+```text
+release_state
+stability_type
+decision_trace[]
+rule hits
+gate IDs
+paradox links
+short explanations
+review recommendation
+```
+
+Recommended release-state vocabulary for this review artifact:
+
+```text
+fail
+stage_only
+prod_ok
+```
+
+or, when aligned to public reader labels:
+
+```text
+BLOCK
+STAGE-ONLY
+PROD-OK
+```
+
+Behavior:
+
+```text
+runs in shadow mode by default
+does not change PASS / FAIL
+does not replace check_gates.py
+does not replace status.json
+does not replace declared gate policy
+does not replace materialized required gate enforcement
+```
+
+A later PR may promote a specific output field into release authority only by declaring it in policy and enforcing it as a required gate.
+
+The Decision Engine is a **review surface**.
+
+Its rules should be:
+
+```text
+small
+explicit
+auditable
+deterministic where possible
+traceable to recorded artifacts
+```
+
+It is not an independent release-decision engine by default.
 
 ---
 
 ### 1.3 EPF & Paradox Playbook
 
-**Goal:** make EPF and paradox signals actionable for humans.
+**Goal:** make EPF and paradox signals actionable for human review.
 
-- **Artefact**
-  - `docs/PULSE_EPF_PARADOX_PLAYBOOK_v0.md`, answering questions like:
-    - when is a gate considered “paradox-heavy”,
-    - what it means if EPF is consistently better/worse than the baseline,
-    - what to do in typical trade-off cases:
-      - fairness vs SLO,
-      - refusal policy vs utility,
-      - hallucination vs productivity.
-- **Usage**
-  - referenced from the Quality Ledger and decision traces,
-  - used in release reviews, post-mortems, and governance meetings.
+Artifact:
 
-The Playbook turns abstract metrics into concrete “if X, consider doing Y” patterns.
+```text
+docs/PULSE_EPF_PARADOX_PLAYBOOK_v0.md
+```
+
+The playbook may answer questions such as:
+
+```text
+when a gate is considered paradox-heavy
+what it means if EPF is consistently better or worse than baseline
+what to inspect in fairness vs SLO trade-off cases
+what to inspect in refusal policy vs utility cases
+what to inspect in hallucination vs productivity cases
+which diagnostic pattern is present
+which review action should be considered
+```
+
+Usage:
+
+```text
+referenced from Quality Ledger
+referenced from decision traces
+used in release reviews
+used in post-mortems
+used in diagnostic review
+used in field / topology review
+```
+
+The Playbook turns abstract metrics into concrete review patterns.
+
+It does not authorize a release.
+
+It does not change gate enforcement.
 
 ---
 
 ### 1.4 G-field & GPT overlays
 
-**Goal:** give governance a compact view of dependency on internal vs external models and providers.
+**Goal:** provide a compact diagnostic view of dependency on internal and external model providers.
 
-- **Inputs**
-  - `g_field_v0.json` (G-field snapshot),
-  - optional `g_field_stability_v0.json`,
-  - `g_epf_overlay_v0.json` (bridge from EPF to G-field),
-  - `gpt_external_detection_v0.json` (usage stats from `logs/model_invocations.jsonl`).
-- **Output**
-  - `g_snapshot_report_v0.md` or HTML:
-    - key KPIs (external GPT call ratio, vendor mix, high-risk provider usage),
-    - present / missing overlays,
-    - short narrative for risk / governance boards.
+Inputs:
 
-The G-field is intended to answer questions like:
+```text
+g_field_v0.json
+g_field_stability_v0.json
+g_epf_overlay_v0.json
+gpt_external_detection_v0.json
+logs/model_invocations.jsonl
+```
 
-- “How much do we depend on external GPTs?”
-- “Where are we using more models than the risk board is aware of?”
+Output:
+
+```text
+g_snapshot_report_v0.md
+```
+
+or:
+
+```text
+g_snapshot_report_v0.html
+```
+
+Possible contents:
+
+```text
+external GPT call ratio
+vendor mix
+high-risk provider usage
+present overlays
+missing overlays
+short diagnostic narrative
+risk-review notes
+release-review notes
+```
+
+This layer may answer questions such as:
+
+```text
+How much does this release candidate depend on external GPT calls?
+Which providers are involved?
+Where are additional models used?
+Which provider-related surfaces should reviewers inspect?
+Which dependencies are missing from the recorded evidence surface?
+```
+
+The G-field / GPT overlay layer is diagnostic by default.
+
+It does not define release authority.
+
+It becomes release-relevant only through explicit recorded evidence inclusion, declared policy reference, required-gate materialization, and strict fail-closed enforcement.
 
 ---
 
 ### 1.5 History & Drift tools
 
-**Goal:** create a minimal history trail that higher-level tools can build on.
+**Goal:** create a minimal history trail that higher-level review tools can build on.
 
 Candidate scripts:
 
-- `scripts/append_status_history.py`
-  - appends each run’s `status.json` to `logs/status_history.jsonl`,
-  - can be called at the end of the PULSE CI job.
-- `scripts/diff_runs_minimal.py`
-  - compares two runs gate-by-gate,
-  - emits a small JSON or markdown diff summary.
+```text
+scripts/append_status_history.py
+scripts/diff_runs_minimal.py
+```
 
-These scripts are deliberately small; they are foundations for future dashboards.
+`append_status_history.py` may:
+
+```text
+append each run's status.json to logs/status_history.jsonl
+be called at the end of a PULSE CI job
+preserve a minimal run history
+support later stability and drift review
+```
+
+`diff_runs_minimal.py` may:
+
+```text
+compare two runs gate-by-gate
+emit a small JSON diff summary
+emit a small Markdown diff summary
+identify changed gates
+identify changed metrics
+identify changed diagnostic overlays
+```
+
+These scripts are deliberately small.
+
+They are foundations for later review views.
+
+They are not release authority by default.
 
 ---
 
 ## 2. Integration patterns
 
-The Governance Pack is designed to run **after** PULSE Core.
+The Instrument Review Pack is designed to run **after** PULSE Core.
 
 Typical pattern:
 
-1. Core CI job runs and enforces the minimal gate set (fail-closed).
-2. Governance jobs (separate workflows or jobs) consume:
-   - `status.json`,
-   - historical logs,
-   - overlays (EPF, paradox, G-field).
-3. Governance artefacts are published as:
-   - markdown or HTML snapshots,
-   - dashboards,
-   - attachments to risk / release review tickets.
+```text
+1. Core CI job runs.
+2. Core CI enforces the selected required gate set fail-closed.
+3. Instrument-review jobs consume recorded artifacts.
+4. Instrument-review jobs produce diagnostic artifacts.
+5. Human reviewers inspect those diagnostic artifacts.
+6. Shipping authority remains anchored to the PULSEmech path unless a signal is explicitly promoted into required-gate enforcement.
+```
+
+Typical inputs:
+
+```text
+status.json
+status_history.jsonl
+EPF overlays
+paradox overlays
+G-field overlays
+GPT external detection summaries
+stability maps
+decision traces
+```
+
+Typical outputs:
+
+```text
+Markdown snapshots
+HTML snapshots
+diagnostic JSON artifacts
+release-review attachments
+risk-review attachments
+post-mortem attachments
+field-review artifacts
+```
 
 Examples:
 
-- A nightly job that builds `stability_map_v0.json` from the latest history.
-- A per-release job that generates `decision_engine_v0.json` in shadow mode.
-- An on-demand job that produces the `g_snapshot_report_v0` for a specific branch or environment.
+```text
+a nightly job that builds stability_map_v0.json from the latest history
+a per-release job that generates decision_engine_v0.json in shadow mode
+an on-demand job that produces g_snapshot_report_v0 for a branch or environment
+a diagnostic review job that compares current field state with historical baseline
+```
 
-In all cases, CI for shipping code remains **fail-closed** on Core gates.
-
----
-
-## 3. Roadmap (suggested)
-
-This document only describes v0. A suggested evolution:
-
-- **v0.1 — layout & schemas**
-  - finalise JSON Schemas for `stability_map_v0` and `decision_engine_v0`,
-  - provide at least one concrete example for each artefact.
-- **v0.2 — minimal implementation**
-  - first Stability Map builder over `logs/status_history.jsonl`,
-  - first Decision Engine ruleset (small, explainable rules).
-- **v0.3 — dashboards & UX**
-  - lightweight Decision-Field dashboard (HTML/markdown),
-  - links from Quality Ledger and G snapshot reports.
-- **v1.0 — production governance profile**
-  - documented decision policies for `BLOCK` / `STAGE-ONLY` / `PROD-OK`,
-  - at least one real-world case study using the full Governance Pack.
+In all cases, shipping CI remains **fail-closed** on the PULSEmech required gate path.
 
 ---
 
-## 4. Ownership
+## 3. Promotion boundary
+
+A component in this pack may be promoted from diagnostic review into release authority only through a scoped PR that declares:
+
+```text
+the recorded evidence field
+the policy reference
+the required gate ID
+the registry entry
+the materialized required gate behavior
+the fail-closed enforcement path
+the tests that prove missing / false / malformed evidence fails closed
+```
+
+Promotion must not be implicit.
+
+Promotion must not occur through reader wording, dashboard presentation, report display, or review recommendation alone.
+
+Correct promotion path:
+
+```text
+diagnostic signal
+→ recorded release evidence field
+→ gate registry entry
+→ declared gate policy
+→ workflow-effective materialized required gate set
+→ strict fail-closed CI enforcement
+```
+
+Incorrect promotion path:
+
+```text
+diagnostic signal
+→ dashboard display
+→ human confidence
+→ implicit release authority
+```
+
+---
+
+## 4. Roadmap — suggested
+
+This document describes v0.
+
+Suggested evolution:
+
+### v0.1 — layout and schemas
+
+```text
+finalize JSON Schemas for stability_map_v0
+finalize JSON Schemas for decision_engine_v0
+provide at least one concrete example for each artifact
+document carrier boundaries for each artifact
+```
+
+### v0.2 — minimal implementation
+
+```text
+first Stability Map builder over logs/status_history.jsonl
+first Decision Engine ruleset
+small explicit review rules
+traceable review recommendations
+```
+
+### v0.3 — review surfaces
+
+```text
+lightweight Decision-Field HTML / Markdown view
+links from Quality Ledger
+links from G snapshot reports
+review-facing summary sections
+```
+
+### v1.0 — release-review profile
+
+```text
+documented review recommendation policies for BLOCK / STAGE-ONLY / PROD-OK
+at least one case study using the full Instrument Review Pack
+clear distinction between review recommendation and release authority
+explicit promotion procedure for any release-relevant signal
+```
+
+The roadmap is advisory.
+
+It does not change PULSEmech release authority.
+
+---
+
+## 5. Ownership
 
 Suggested roles:
 
-- **Field / topology owner**
-  - Stability Map & Decision Engine design,
-  - field definitions and stability types.
-- **Governance lead**
-  - EPF & Paradox Playbook,
-  - decision policies and escalation paths.
-- **Runtime / infra owner**
-  - history logging, drift tooling, artefact storage,
-  - simple dashboards and publishing.
-- **Docs owner**
-  - governance docs,
-  - snapshot copy and examples kept up to date.
+### Field / topology owner
 
-The Governance Pack is intentionally modular: teams can adopt it piece by piece,  
-without touching the Core fail-closed gates.
+Responsibilities:
+
+```text
+Stability Map design
+Decision Engine design
+field definitions
+stability types
+topology labels
+diagnostic field interpretation
+```
+
+### Instrument review owner
+
+Responsibilities:
+
+```text
+EPF & Paradox Playbook
+review recommendation rules
+diagnostic interpretation patterns
+release-triage support
+review escalation notes
+```
+
+### Runtime / infrastructure owner
+
+Responsibilities:
+
+```text
+history logging
+drift tooling
+artifact storage
+diagnostic report generation
+simple review-surface publishing
+```
+
+### Docs owner
+
+Responsibilities:
+
+```text
+instrument-review documentation
+snapshot copy
+examples
+boundary statements
+artifact role descriptions
+```
+
+The Instrument Review Pack is intentionally modular.
+
+Teams can adopt it piece by piece without touching the Core fail-closed gates.
+
+---
+
+## 6. Boundary held by this document
+
+This document does not change:
+
+```text
+PULSEmech decision semantics
+gate policy
+required gate wiring
+check_gates.py behavior
+status schema
+CI allow/block behavior
+Quality Ledger renderer behavior
+artifact provenance binding behavior
+attestation workflow behavior
+release tags
+DOI / Zenodo path
+```
+
+The PULSEmech authority path remains:
+
+```text
+recorded release evidence
+→ status.json
+→ declared gate policy
+→ workflow-effective materialized required gate set
+→ strict fail-closed CI enforcement
+→ pre-deployment allow/block release decision
+```
+
+## Final definition
+
+PULSE Instrument Review Pack v0 is:
+
+```text
+an optional diagnostic and instrument-review layer around PULSEmech
+that reads recorded PULSE artifacts, emits review artifacts,
+and supports human interpretation without changing release authority by default.
+```
+
+It is not PULSE identity.
+
+It is not release authority.
+
+It is not a second release-decision engine.

--- a/docs/GOVERNANCE_PACK_v0.md
+++ b/docs/GOVERNANCE_PACK_v0.md
@@ -6,6 +6,12 @@ Legacy filename / workshop alias:
 docs/GOVERNANCE_PACK_v0.md
 ```
 
+Legacy document name:
+
+```text
+PULSE Governance Pack v0
+```
+
 Canonical technical name:
 
 ```text
@@ -22,6 +28,8 @@ It does not define release authority.
 
 It does not create a second release-decision engine.
 
+It does not change the PULSEmech authority path.
+
 The PULSEmech authority path remains:
 
 ```text
@@ -33,7 +41,16 @@ recorded release evidence
 → pre-deployment allow/block release decision
 ```
 
-The Instrument Review Pack may support human review, release triage, diagnostic interpretation, stability review, or optional field-level inspection.
+The Instrument Review Pack may support:
+
+```text
+human review
+release triage
+diagnostic interpretation
+stability review
+field / topology inspection
+post-release analysis
+```
 
 It is non-authorizing by default.
 
@@ -44,6 +61,16 @@ recorded as release evidence
 referenced by declared policy
 materialized as a required gate
 enforced through the strict fail-closed CI path
+```
+
+The legacy term `Governance Pack` is retained only as a filename / workshop alias.
+
+Do not use `Governance Pack` as the active PULSE-facing identity descriptor.
+
+Use:
+
+```text
+PULSE Instrument Review Pack v0
 ```
 
 ---
@@ -62,11 +89,11 @@ The Instrument Review Pack supports review questions such as:
 How stable is the release field over time?
 Where are the tensions between safety, utility, stability, and operational constraints?
 Which diagnostic patterns should reviewers inspect before a release decision?
-Which review recommendation should be recorded for human interpretation: BLOCK, STAGE-ONLY, or PROD-OK?
+Which review recommendation should be recorded for human interpretation?
 Why was that recommendation produced?
 ```
 
-All components in this pack are **CI-neutral by default**:
+All components in this pack are CI-neutral by default:
 
 ```text
 they read existing PULSE artifacts
@@ -105,12 +132,29 @@ Possible contents:
 
 ```text
 per-gate stability categories
-stable_good / unstably_good / stably_bad / unstably_bad classifications
+stable_good / unstably_good / stable_bad / unstably_bad classifications
 instability score
 contributing components
 drift notes
 timestamps
 artifact references
+```
+
+Canonical stability labels must use existing implementation / documentation values.
+
+Use:
+
+```text
+stable_good
+unstably_good
+stable_bad
+unstably_bad
+```
+
+Do not emit:
+
+```text
+stably_bad
 ```
 
 Primary users:
@@ -164,21 +208,27 @@ short explanations
 review recommendation
 ```
 
-Recommended release-state vocabulary for this review artifact:
+Canonical `release_state` values for JSON artifacts must use the existing implementation / schema labels.
+
+Use underscore labels in artifacts:
 
 ```text
-fail
-stage_only
-prod_ok
+BLOCK
+STAGE_ONLY
+PROD_OK
 ```
 
-or, when aligned to public reader labels:
+Reader-facing displays may render these values as:
 
 ```text
 BLOCK
 STAGE-ONLY
 PROD-OK
 ```
+
+The hyphenated forms are display labels only.
+
+They must not be emitted as canonical JSON `release_state` values.
 
 Behavior:
 
@@ -188,12 +238,13 @@ does not change PASS / FAIL
 does not replace check_gates.py
 does not replace status.json
 does not replace declared gate policy
-does not replace materialized required gate enforcement
+does not replace workflow-effective materialized required gate enforcement
+does not create a second release-decision engine
 ```
 
 A later PR may promote a specific output field into release authority only by declaring it in policy and enforcing it as a required gate.
 
-The Decision Engine is a **review surface**.
+The Decision Engine is a review surface.
 
 Its rules should be:
 
@@ -203,6 +254,7 @@ explicit
 auditable
 deterministic where possible
 traceable to recorded artifacts
+schema-compatible
 ```
 
 It is not an independent release-decision engine by default.
@@ -348,7 +400,7 @@ They are not release authority by default.
 
 ## 2. Integration patterns
 
-The Instrument Review Pack is designed to run **after** PULSE Core.
+The Instrument Review Pack is designed to run after PULSE Core.
 
 Typical pattern:
 
@@ -395,7 +447,7 @@ an on-demand job that produces g_snapshot_report_v0 for a branch or environment
 a diagnostic review job that compares current field state with historical baseline
 ```
 
-In all cases, shipping CI remains **fail-closed** on the PULSEmech required gate path.
+In all cases, shipping CI remains fail-closed on the PULSEmech required gate path.
 
 ---
 
@@ -408,7 +460,7 @@ the recorded evidence field
 the policy reference
 the required gate ID
 the registry entry
-the materialized required gate behavior
+the workflow-effective materialized required gate behavior
 the fail-closed enforcement path
 the tests that prove missing / false / malformed evidence fails closed
 ```
@@ -439,7 +491,56 @@ diagnostic signal
 
 ---
 
-## 4. Roadmap — suggested
+## 4. Artifact label compatibility
+
+The Instrument Review Pack must not introduce new labels that conflict with existing implementation or schema values.
+
+Canonical JSON labels must remain schema-compatible.
+
+### 4.1 Canonical release_state labels
+
+Use these values in JSON artifacts:
+
+```text
+BLOCK
+STAGE_ONLY
+PROD_OK
+```
+
+Display layers may show:
+
+```text
+BLOCK
+STAGE-ONLY
+PROD-OK
+```
+
+The display labels are reader-facing only.
+
+### 4.2 Canonical stability labels
+
+Use these values for stability classifications:
+
+```text
+stable_good
+unstably_good
+stable_bad
+unstably_bad
+```
+
+Do not introduce alternate spellings.
+
+In particular:
+
+```text
+stably_bad
+```
+
+is not a canonical label.
+
+---
+
+## 5. Roadmap — suggested
 
 This document describes v0.
 
@@ -475,7 +576,7 @@ review-facing summary sections
 ### v1.0 — release-review profile
 
 ```text
-documented review recommendation policies for BLOCK / STAGE-ONLY / PROD-OK
+documented review recommendation policies using canonical artifact labels
 at least one case study using the full Instrument Review Pack
 clear distinction between review recommendation and release authority
 explicit promotion procedure for any release-relevant signal
@@ -487,7 +588,7 @@ It does not change PULSEmech release authority.
 
 ---
 
-## 5. Ownership
+## 6. Ownership
 
 Suggested roles:
 
@@ -546,7 +647,7 @@ Teams can adopt it piece by piece without touching the Core fail-closed gates.
 
 ---
 
-## 6. Boundary held by this document
+## 7. Boundary held by this document
 
 This document does not change:
 


### PR DESCRIPTION
## Summary

This PR removes active governance-first identity surfaces while preserving controlled legacy and risk-register usage.

## Reason

The Terminology Risk Register now controls terms that can cause PULSE to be misread outside the PULSEmech category boundary.

The remaining active surfaces should use release-authority / instrument-review wording instead of governance-first wording.

## Changes

- Rename tools smoke test wording from governance smoke to release-authority smoke.
- Update `ci/tools-tests.list`.
- Update the PULSE CI tools-smoke step label / success message.
- Reframe `docs/GOVERNANCE_PACK_v0.md` as `PULSE Instrument Review Pack v0` while keeping the file path as a legacy alias.
- Reframe `docs/PULSE_topology_v0_governance_patterns.md` as topology instrument-review patterns while keeping the file path as a legacy alias.

## Boundary

The word `governance` is not banned.

It remains allowed in:

- `docs/PULSE_TERMINOLOGY_RISK_REGISTER_v0.md`;
- legacy alias notes;
- historical changelog entries;
- external AI-governance context.

It must not function as the active PULSE identity descriptor.

## PULSEmech identity

```text
recorded release evidence
→ status.json
→ declared gate policy
→ workflow-effective materialized required gate set
→ strict fail-closed CI enforcement
→ pre-deployment allow/block release decision
```

## Preserved

This PR does not change:

- README.md;
- workflow mechanics;
- PULSEmech decision semantics;
- gate policy;
- required gate wiring;
- `check_gates.py` behavior;
- status schema;
- CI allow/block behavior;
- Quality Ledger renderer behavior;
- artifact provenance binding behavior;
- attestation workflow behavior;
- release tags;
- DOI / Zenodo path.