### PR TITLE
docs(boundary): clarify ledger policy and safety terminology

### DIFF
--- a/docs/GLOSSARY_v0.md
+++ b/docs/GLOSSARY_v0.md
@@ -251,6 +251,33 @@ The radius (or scale parameter) at which the protocol’s decodability criterion
 
 ## D
 
+### declared gate policy
+
+**What it means**
+
+The machine-readable gate policy used to determine which gate IDs are required for a given PULSE release path.
+
+It is part of the PULSEmech authority path only when it is used to materialize the workflow-effective required gate set.
+
+Typical authority path:
+
+```text
+declared gate policy
+→ workflow-effective materialized required gate set
+→ strict fail-closed CI enforcement
+```
+
+**What it is not**
+
+- Not organizational policy.
+- Not management policy.
+- Not compliance policy.
+- Not a human approval preference.
+- Not a general governance framework.
+
+A declared gate policy becomes release-relevant through materialized required gates and fail-closed enforcement, not through prose.
+
+ 
 ### Decision Engine
 
 **What it means**
@@ -597,20 +624,49 @@ they may allow more tuning than I-gates.
 
 **What it means**
 
-A human-oriented, usually HTML or markdown report that:
+A human-readable reader carrier over a recorded `status.json` artifact.
 
-- summarises a PULSE run or a set of runs,
-- lists gate outcomes, RDSI, EPF bands, key overlays,
-- acts as an audit-friendly reader surface.
+It may be rendered as HTML, Markdown, or another reader surface.
+
+It may display:
+
+- gate outcomes,
+- run metadata,
+- diagnostic overlays,
+- release-decision summaries,
+- public surface state,
+- traceability fields.
 
 Typically generated alongside `status.json`.
 
 **What it is not**
 
-- Not the formal source of truth for machine tools. That is `status.json`.
-- Not a substitute for detailed logs when debugging.
-- Not the release-authority path.
+- Not release authority.
+- Not a quality-assurance dashboard that decides release.
+- Not a substitute for `status.json`.
+- Not a substitute for declared gate policy.
+- Not a substitute for the workflow-effective materialized required gate set.
+- Not a substitute for strict fail-closed CI enforcement.
 
+The PULSEmech authority path remains:
+
+- Not release authority.
+- Not a quality-assurance dashboard that decides release.
+- Not a substitute for `status.json`.
+- Not a substitute for declared gate policy.
+- Not a substitute for the workflow-effective materialized required gate set.
+- Not a substitute for strict fail-closed CI enforcement.
+
+The PULSEmech authority path remains:
+
+```text
+recorded release evidence
+→ status.json
+→ declared gate policy
+→ workflow-effective materialized required gate set
+→ strict fail-closed CI enforcement
+→ pre-deployment allow/block release decision
+```
 ---
 
 ## R
@@ -677,6 +733,26 @@ surface, while still remaining non-promoted as a broader line.
 ---
 
 ## S
+
+### Safe & Useful AI
+
+**What it means**
+
+A release-domain phrase used to describe the kind of AI release decisions PULSE is intended to support.
+
+In PULSE-facing text, it means that recorded safety, utility, and SLO evidence may be evaluated through declared gates.
+
+**What it is not**
+
+- Not a general definition of safety.
+- Not a general definition of usefulness.
+- Not an AI-governance framework.
+- Not a compliance framework.
+- Not a claim that PULSE replaces model evaluation, human review, or domain-specific safety work.
+
+PULSE does not define safety or usefulness in the abstract.
+
+PULSEmech determines whether recorded release evidence satisfies declared gates under strict fail-closed enforcement.
 
 ### safe-pack
 

--- a/docs/PULSE_TERMINOLOGY_RISK_REGISTER_v0.md
+++ b/docs/PULSE_TERMINOLOGY_RISK_REGISTER_v0.md
@@ -45,6 +45,12 @@ The following terms may appear only when their scope is explicit and they are no
 | runtime guardrail | Can move PULSE away from pre-deployment release authority | Use only as contrast or external category |
 | compliance | Can make PULSE appear to be a legal compliance system | Use only as external adoption context |
 | adoption metrics | Can be misread as mechanical validity metrics | Use only as ecosystem visibility / uptake signals |
+| Quality Ledger | Can make PULSE appear to be a quality-assurance dashboard or evaluation report | Use only as a reader carrier over recorded `status.json`; never as release authority |
+| Safe & Useful AI | Can make PULSE appear to define safety or usefulness as a broad governance framework | Use only as release-domain wording; PULSE checks recorded release evidence, not general safety meaning |
+| policy | Can be misread as organizational or management policy | In PULSE-facing text, use only as declared gate policy tied to materialized required gates |
+| evaluation / eval | Can make evidence producers appear to be the PULSE mechanism itself | Use only as evidence-producing or diagnostic context unless recorded, declared, materialized, and enforced |
+| ecosystem around PULSE | Can make surrounding dashboards, reports, evals, docs, or workflows appear to be PULSE identity | Use only as supporting context around the PULSEmech authority path |
+
 
 ## Preferred PULSE-facing descriptors
 
@@ -198,6 +204,112 @@ rendered report
 ```
 
 Reader carriers must not be described as the source of release authority.
+
+## Quality Ledger boundary
+
+The Quality Ledger is a reader carrier.
+
+It displays or summarizes recorded release-state artifacts.
+
+It does not create release authority.
+
+It does not replace:
+
+```text
+status.json
+declared gate policy
+workflow-effective materialized required gate set
+strict fail-closed CI enforcement
+```
+
+Correct use:
+
+```text
+Quality Ledger reader surface over recorded status.json
+```
+
+Incorrect use:
+
+```text
+Quality Ledger as the release authority
+Quality Ledger as the source of release permission
+Quality Ledger as a quality-assurance dashboard that decides release
+```
+
+## Safe & Useful AI boundary
+
+The phrase `Safe & Useful AI` names the release domain in which PULSE is applied.
+
+It does not mean that PULSE defines safety, usefulness, or general AI-governance policy.
+
+PULSE checks whether recorded release evidence satisfies declared gates.
+
+Correct use:
+
+```text
+PULSE applies artifact-bound release authority to Safe & Useful AI release decisions.
+```
+
+Incorrect use:
+
+```text
+PULSE is a general Safe & Useful AI governance framework.
+```
+
+The PULSEmech authority path remains:
+
+```text
+recorded release evidence
+→ status.json
+→ declared gate policy
+→ workflow-effective materialized required gate set
+→ strict fail-closed CI enforcement
+→ pre-deployment allow/block release decision
+```
+
+## Declared gate policy boundary
+
+In PULSE-facing text, `policy` means declared gate policy.
+
+It does not mean organizational policy, management policy, compliance policy, or institutional governance.
+
+A declared gate policy is release-relevant only when it is used to materialize the required gate set enforced by strict fail-closed CI.
+
+Correct use:
+
+```text
+declared gate policy
+→ workflow-effective materialized required gate set
+```
+
+Incorrect use:
+
+```text
+policy as broad organizational governance
+policy as a management framework
+policy as human approval preference
+```
+
+## Ecosystem boundary
+
+Dashboards, reports, evals, external detectors, reader surfaces, docs, and review artifacts may exist around PULSE.
+
+They are not PULSE identity.
+
+They become release-relevant only through the PULSEmech authority path:
+
+```text
+recorded as release evidence
+referenced by declared gate policy
+materialized as a required gate
+enforced through strict fail-closed CI
+```
+
+Existence around PULSE is not authority.
+
+Repository presence is not release authority.
+
+Reader visibility is not release authority.
 
 ## Trace and audit carrier boundary
 


### PR DESCRIPTION
## Summary

This PR clarifies terminology boundaries that can cause PULSE to be misread outside the PULSEmech category boundary.

## Changes

- Define Quality Ledger as a reader carrier, not release authority.
- Define `declared gate policy` as machine-readable gate policy, not organizational / management policy.
- Define `Safe & Useful AI` as release-domain wording, not a general AI-governance framework.
- Add an ecosystem boundary for dashboards, reports, evals, docs, and review artifacts around PULSE.

## Reason

External readers can confuse the PULSEmech mechanism with surrounding ecosystem terms:

```text
Quality Ledger → QA dashboard
Safe & Useful AI → general AI-governance framework
policy → organizational policy
```

This PR records the correct boundaries.

## PULSEmech authority path

Unchanged:

```text
recorded release evidence
→ status.json
→ declared gate policy
→ workflow-effective materialized required gate set
→ strict fail-closed CI enforcement
→ pre-deployment allow/block release decision
```

## Scope

Docs-only.

Changed files:

```text
docs/PULSE_TERMINOLOGY_RISK_REGISTER_v0.md
docs/GLOSSARY_v0.md
```

## Preserved

This PR does not change:

- README.md;
- workflow mechanics;
- PULSEmech decision semantics;
- gate policy;
- required gate wiring;
- `check_gates.py` behavior;
- status schema;
- CI allow/block behavior;
- Quality Ledger renderer behavior;
- artifact provenance binding behavior;
- attestation workflow behavior;
- release tags;
- DOI / Zenodo path.