### PR TITLE
docs(boundary): add industrial maturity boundary

### DIFF
--- a/docs/PULSE_TERMINOLOGY_RISK_REGISTER_v0.md
+++ b/docs/PULSE_TERMINOLOGY_RISK_REGISTER_v0.md
@@ -50,6 +50,10 @@ The following terms may appear only when their scope is explicit and they are no
 | policy | Can be misread as organizational or management policy | In PULSE-facing text, use only as declared gate policy tied to materialized required gates |
 | evaluation / eval | Can make evidence producers appear to be the PULSE mechanism itself | Use only as evidence-producing or diagnostic context unless recorded, declared, materialized, and enforced |
 | ecosystem around PULSE | Can make surrounding dashboards, reports, evals, docs, or workflows appear to be PULSE identity | Use only as supporting context around the PULSEmech authority path |
+| industrial maturity | Can make PULSEmech appear to be defined by enterprise / production adoption status | Use only as an external deployment or adoption dimension; not as PULSEmech identity |
+| productization maturity | Can make PULSEmech appear to be measured as a plug-and-play product category | Use only for packaging, operational support, or deployment readiness around PULSEmech |
+| enterprise platform | Can make PULSEmech appear to be an enterprise software product category | Use only when discussing deployment packaging or integration environment, not the release-authority mechanism |
+| industrial standard | Can make PULSEmech appear to require broad market adoption before its mechanism can be evaluated | Use only for ecosystem/adoption status; not for mechanical validity |
 
 
 ## Preferred PULSE-facing descriptors
@@ -141,6 +145,29 @@ Incorrect classification:
 low adoption
 = weak release-authority mechanism
 ```
+## Industrial / productization maturity boundary
+
+Industrial maturity, productization maturity, enterprise platform status, and industrial standard status are external adoption or deployment dimensions.
+
+They do not define PULSEmech.
+
+PULSEmech remains an artifact-bound release-authority mechanism for AI release decisions.
+
+The PULSEmech authority path remains:
+
+```text
+recorded release evidence
+→ status.json
+→ declared gate policy
+→ workflow-effective materialized required gate set
+→ strict fail-closed CI enforcement
+→ pre-deployment allow/block release decision
+```
+
+Industrialization may add operational requirements around PULSEmech.
+
+It does not define the mechanism.
+
 
 ## Hardening boundary
 


### PR DESCRIPTION
## Summary

This PR adds an industrial / productization maturity boundary to:

```text
docs/PULSE_TERMINOLOGY_RISK_REGISTER_v0.md
```

## Reason

External readers may evaluate PULSEmech on the wrong category axis:

```text
industrial maturity
productization maturity
enterprise platform status
industrial standard status
```

These are external adoption or deployment dimensions.

They do not define PULSEmech.

## Boundary

PULSEmech remains an artifact-bound release-authority mechanism for AI release decisions.

The PULSEmech authority path remains:

```text
recorded release evidence
→ status.json
→ declared gate policy
→ workflow-effective materialized required gate set
→ strict fail-closed CI enforcement
→ pre-deployment allow/block release decision
```

## Scope

Docs-only.

Changed file:

```text
docs/PULSE_TERMINOLOGY_RISK_REGISTER_v0.md
```

## Preserved

This PR does not change:

- README.md;
- workflow mechanics;
- PULSEmech decision semantics;
- gate policy;
- required gate wiring;
- `check_gates.py` behavior;
- status schema;
- CI allow/block behavior;
- Quality Ledger renderer behavior;
- artifact provenance binding behavior;
- attestation workflow behavior;
- release tags;
- DOI / Zenodo path.