### PR TITLE
fix(security): confine binding verifier subject paths

### DIFF
--- a/PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py
+++ b/PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py
@@ -116,15 +116,14 @@ def reject_non_portable_subject_path(path_text: str, *, label: str) -> None:
 
     if "\\" in path_text:
         raise BindingMalformed(
-            f"{label} must be a POSIX-style repository-relative path"
+            f"{label} must be a POSIX-style path"
         )
 
     windows_path = PureWindowsPath(path_text)
     if windows_path.drive or windows_path.is_absolute():
-        raise BindingMalformed(f"{label} must be repository-relative")
-
-    if Path(path_text).is_absolute():
-        raise BindingMalformed(f"{label} must be repository-relative")
+        raise BindingMalformed(
+            f"{label} must not use Windows absolute path syntax"
+        )
 
 
 def resolve_bound_path(
@@ -135,13 +134,14 @@ def resolve_bound_path(
 ) -> Path:
     reject_non_portable_subject_path(path_text, label=label)
 
-    path = Path(path_text)
-
     if path_text.startswith("inline:"):
         raise BindingMalformed(f"{label} is inline but a file path is required")
 
+    path = Path(path_text)
+    candidate = path if path.is_absolute() else reviewed_root / path
+
     return ensure_inside_reviewed_root(
-        reviewed_root / path,
+        candidate,
         reviewed_root=reviewed_root,
         label=label,
     )

--- a/PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py
+++ b/PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py
@@ -7,8 +7,9 @@ import argparse
 import hashlib
 import json
 import sys
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Dict, List
+
 
 SCHEMA_ID = "pulse.artifact_provenance_binding.v0"
 
@@ -42,6 +43,7 @@ def sha256_canonical_json(value: Any) -> str:
 def sha256_file(path: Path) -> str:
     if not path.is_file():
         raise BindingMalformed(f"missing bound artifact: {path}")
+
     h = hashlib.sha256()
     with path.open("rb") as f:
         for chunk in iter(lambda: f.read(65536), b""):
@@ -52,9 +54,11 @@ def sha256_file(path: Path) -> str:
 def read_json(path: Path) -> Dict[str, Any]:
     if not path.is_file():
         raise BindingMalformed(f"missing binding: {path}")
+
     obj = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(obj, dict):
         raise BindingMalformed(f"expected top-level JSON object in {path}")
+
     return obj
 
 
@@ -66,21 +70,81 @@ def without_digest_field(value: Dict[str, Any], field_name: str) -> Dict[str, An
 
 def get_path(obj: Dict[str, Any], dotted: str) -> Any:
     current: Any = obj
+
     for part in dotted.split("."):
         if not isinstance(current, dict) or part not in current:
             raise BindingMalformed(f"missing binding field: {dotted}")
         current = current[part]
+
     return current
 
 
-def resolve_bound_path(path_text: str, *, binding_path: Path) -> Path:
-    p = Path(path_text)
-    if p.is_absolute():
-        return p
-    cwd_candidate = (Path.cwd() / p).resolve()
-    if cwd_candidate.exists():
-        return cwd_candidate
-    return (binding_path.parent / p).resolve()
+def ensure_inside_reviewed_root(
+    candidate: Path,
+    *,
+    reviewed_root: Path,
+    label: str,
+) -> Path:
+    resolved = candidate.resolve()
+
+    try:
+        resolved.relative_to(reviewed_root)
+    except ValueError as exc:
+        raise BindingMalformed(
+            f"{label} resolves outside reviewed repository root: {candidate}"
+        ) from exc
+
+    return resolved
+
+
+def resolve_binding_path(binding_arg: Path, *, reviewed_root: Path) -> Path:
+    candidate = binding_arg if binding_arg.is_absolute() else reviewed_root / binding_arg
+
+    return ensure_inside_reviewed_root(
+        candidate,
+        reviewed_root=reviewed_root,
+        label="binding path",
+    )
+
+
+def reject_non_portable_subject_path(path_text: str, *, label: str) -> None:
+    if not path_text.strip():
+        raise BindingMalformed(f"{label} is empty")
+
+    if path_text != path_text.strip():
+        raise BindingMalformed(f"{label} contains leading or trailing whitespace")
+
+    if "\\" in path_text:
+        raise BindingMalformed(
+            f"{label} must be a POSIX-style repository-relative path"
+        )
+
+    windows_path = PureWindowsPath(path_text)
+    if windows_path.drive or windows_path.is_absolute():
+        raise BindingMalformed(f"{label} must be repository-relative")
+
+    if Path(path_text).is_absolute():
+        raise BindingMalformed(f"{label} must be repository-relative")
+
+
+def resolve_bound_path(
+    path_text: str,
+    *,
+    reviewed_root: Path,
+    label: str,
+) -> Path:
+    reject_non_portable_subject_path(path_text, label=label)
+
+    path = Path(path_text)
+
+    if path_text.startswith("inline:"):
+        raise BindingMalformed(f"{label} is inline but a file path is required")
+
+    return ensure_inside_reviewed_root(
+        reviewed_root / path,
+        reviewed_root=reviewed_root,
+        label=label,
+    )
 
 
 def recompute_inline_hash(binding: Dict[str, Any], inline_path: str) -> str:
@@ -88,12 +152,16 @@ def recompute_inline_hash(binding: Dict[str, Any], inline_path: str) -> str:
         obj = get_path(binding, "authority_carrier.workflow_effective_required_gate_set")
         if not isinstance(obj, dict):
             raise BindingMalformed("workflow_effective_required_gate_set is not an object")
+
         return sha256_canonical_json(without_digest_field(obj, "sha256"))
+
     if inline_path == "inline:authority_carrier.strict_ci_gate_enforcement":
         obj = get_path(binding, "authority_carrier.strict_ci_gate_enforcement")
         if not isinstance(obj, dict):
             raise BindingMalformed("strict_ci_gate_enforcement is not an object")
+
         return sha256_canonical_json(without_digest_field(obj, "sha256"))
+
     raise BindingMalformed(f"unsupported inline binding subject: {inline_path}")
 
 
@@ -103,13 +171,26 @@ def assert_equal(label: str, expected: str, actual: str) -> None:
 
 
 def verify_file_field(
-    binding: Dict[str, Any], *, binding_path: Path, path_field: str, sha_field: str
+    binding: Dict[str, Any],
+    *,
+    reviewed_root: Path,
+    path_field: str,
+    sha_field: str,
 ) -> None:
     path_text = get_path(binding, path_field)
     expected = get_path(binding, sha_field)
+
     if not isinstance(path_text, str) or not isinstance(expected, str):
         raise BindingMalformed(f"invalid path/hash fields: {path_field}, {sha_field}")
-    actual = sha256_file(resolve_bound_path(path_text, binding_path=binding_path))
+
+    actual = sha256_file(
+        resolve_bound_path(
+            path_text,
+            reviewed_root=reviewed_root,
+            label=path_field,
+        )
+    )
+
     assert_equal(path_field, expected, actual)
 
 
@@ -117,6 +198,7 @@ def verify_binding_hash(binding: Dict[str, Any]) -> None:
     expected = binding.get("binding_hash")
     if not isinstance(expected, str) or not expected:
         raise BindingMalformed("missing binding_hash")
+
     actual = sha256_canonical_json(without_digest_field(binding, "binding_hash"))
     assert_equal("binding_hash", expected, actual)
 
@@ -125,6 +207,7 @@ def verify_inline_hashes(binding: Dict[str, Any]) -> None:
     gate_set = get_path(binding, "authority_carrier.workflow_effective_required_gate_set")
     if not isinstance(gate_set, dict):
         raise BindingMalformed("workflow_effective_required_gate_set is not an object")
+
     assert_equal(
         "workflow_effective_required_gate_set.sha256",
         str(gate_set.get("sha256")),
@@ -134,6 +217,7 @@ def verify_inline_hashes(binding: Dict[str, Any]) -> None:
     enforcement = get_path(binding, "authority_carrier.strict_ci_gate_enforcement")
     if not isinstance(enforcement, dict):
         raise BindingMalformed("strict_ci_gate_enforcement is not an object")
+
     assert_equal(
         "strict_ci_gate_enforcement.sha256",
         str(enforcement.get("sha256")),
@@ -141,80 +225,121 @@ def verify_inline_hashes(binding: Dict[str, Any]) -> None:
     )
 
 
-def verify_binding_subjects(binding: Dict[str, Any], *, binding_path: Path) -> None:
+def verify_binding_subjects(
+    binding: Dict[str, Any],
+    *,
+    reviewed_root: Path,
+) -> None:
     subjects = binding.get("binding_subjects")
+
     if not isinstance(subjects, list) or not subjects:
         raise BindingMalformed("binding_subjects must be a non-empty list")
 
     for idx, subject in enumerate(subjects):
         if not isinstance(subject, dict):
             raise BindingMalformed(f"binding_subjects[{idx}] is not an object")
+
         role = subject.get("role")
         path_text = subject.get("path")
         expected = subject.get("sha256")
-        if not isinstance(role, str) or not isinstance(path_text, str) or not isinstance(expected, str):
+
+        if not isinstance(role, str) or not isinstance(path_text, str):
+            raise BindingMalformed(f"binding_subjects[{idx}] has invalid fields")
+
+        if not isinstance(expected, str):
             raise BindingMalformed(f"binding_subjects[{idx}] has invalid fields")
 
         if path_text.startswith("inline:"):
             actual = recompute_inline_hash(binding, path_text)
         else:
-            actual = sha256_file(resolve_bound_path(path_text, binding_path=binding_path))
+            actual = sha256_file(
+                resolve_bound_path(
+                    path_text,
+                    reviewed_root=reviewed_root,
+                    label=f"binding_subjects[{idx}].path",
+                )
+            )
+
         assert_equal(f"binding_subjects[{idx}] {role}", expected, actual)
 
 
-def verify_binding(binding_path: Path) -> None:
-    binding = read_json(binding_path)
+def verify_binding(binding_path: Path, *, repo_root: Path | None = None) -> None:
+    reviewed_root = (repo_root or Path.cwd()).resolve()
+
+    if not reviewed_root.is_dir():
+        raise BindingMalformed(f"reviewed repository root is not a directory: {reviewed_root}")
+
+    resolved_binding_path = resolve_binding_path(
+        binding_path,
+        reviewed_root=reviewed_root,
+    )
+
+    binding = read_json(resolved_binding_path)
+
     if binding.get("schema_id") != SCHEMA_ID:
         raise BindingMalformed("unsupported schema_id")
 
     verify_file_field(
         binding,
-        binding_path=binding_path,
+        reviewed_root=reviewed_root,
         path_field="authority_carrier.status_json.path",
         sha_field="authority_carrier.status_json.sha256",
     )
     verify_file_field(
         binding,
-        binding_path=binding_path,
+        reviewed_root=reviewed_root,
         path_field="authority_carrier.declared_gate_policy.path",
         sha_field="authority_carrier.declared_gate_policy.sha256",
     )
     verify_file_field(
         binding,
-        binding_path=binding_path,
+        reviewed_root=reviewed_root,
         path_field="authority_carrier.release_decision.path",
         sha_field="authority_carrier.release_decision.sha256",
     )
     verify_file_field(
         binding,
-        binding_path=binding_path,
+        reviewed_root=reviewed_root,
         path_field="reader_carrier.quality_ledger.path",
         sha_field="reader_carrier.quality_ledger.sha256",
     )
     verify_file_field(
         binding,
-        binding_path=binding_path,
+        reviewed_root=reviewed_root,
         path_field="trace_carrier.release_authority_manifest.path",
         sha_field="trace_carrier.release_authority_manifest.sha256",
     )
+
     verify_inline_hashes(binding)
-    verify_binding_subjects(binding, binding_path=binding_path)
+    verify_binding_subjects(binding, reviewed_root=reviewed_root)
     verify_binding_hash(binding)
 
 
 def main(argv: List[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--binding", required=True)
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help=(
+            "Reviewed repository root used to resolve binding subject paths. "
+            "Defaults to the current working directory."
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
-        verify_binding(Path(args.binding))
+        verify_binding(
+            Path(args.binding),
+            repo_root=Path(args.repo_root),
+        )
     except BindingMismatch as exc:
         print(f"MISMATCH: {exc}", file=sys.stderr)
         return 1
     except (BindingMalformed, json.JSONDecodeError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
+
     return 0
 
 

--- a/tests/test_artifact_provenance_binding_v0.py
+++ b/tests/test_artifact_provenance_binding_v0.py
@@ -1,4 +1,5 @@
 import copy
+import hashlib
 import json
 import os
 import sys
@@ -51,6 +52,14 @@ def write_text(path: Path, text: str) -> None:
 
 def read_json(path: Path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
+
+def recompute_binding_hash(binding: dict) -> dict:
+    binding = copy.deepcopy(binding)
+    binding.pop("binding_hash", None)
+    binding["binding_hash"] = hashlib.sha256(
+        canonical_json_bytes(binding)
+    ).hexdigest()
+    return binding
 
 
 def write_policy(path: Path) -> None:
@@ -431,21 +440,57 @@ def test_verifier_fails_when_binding_hash_changes(tmp_path: Path) -> None:
     assert verify_binding(paths) != 0
 
 
-def test_verifier_rejects_absolute_authority_file_path(tmp_path: Path) -> None:
+def test_verifier_accepts_absolute_authority_file_path_inside_reviewed_root(
+    tmp_path: Path,
+) -> None:
     paths = write_fixtures(tmp_path)
     binding = build_binding(paths)
 
     binding["authority_carrier"]["status_json"]["path"] = str(paths["status"].resolve())
+    binding = recompute_binding_hash(binding)
+    write_json(paths["binding"], binding)
+
+    assert verify_binding(paths) == 0
+
+
+def test_verifier_accepts_absolute_binding_subject_path_inside_reviewed_root(
+    tmp_path: Path,
+) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    set_subject_path(binding, "status_json", str(paths["status"].resolve()))
+    binding = recompute_binding_hash(binding)
+    write_json(paths["binding"], binding)
+
+    assert verify_binding(paths) == 0
+
+
+def test_verifier_rejects_absolute_authority_file_path_outside_reviewed_root(
+    tmp_path: Path,
+) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    outside = paths["root"].parent / "outside_status.json"
+    write_json(outside, status_payload())
+
+    binding["authority_carrier"]["status_json"]["path"] = str(outside.resolve())
     write_json(paths["binding"], binding)
 
     assert verify_binding(paths) == 2
 
 
-def test_verifier_rejects_absolute_binding_subject_path(tmp_path: Path) -> None:
+def test_verifier_rejects_absolute_binding_subject_path_outside_reviewed_root(
+    tmp_path: Path,
+) -> None:
     paths = write_fixtures(tmp_path)
     binding = build_binding(paths)
 
-    set_subject_path(binding, "status_json", str(paths["status"].resolve()))
+    outside = paths["root"].parent / "outside_status.json"
+    write_json(outside, status_payload())
+
+    set_subject_path(binding, "status_json", str(outside.resolve()))
     write_json(paths["binding"], binding)
 
     assert verify_binding(paths) == 2
@@ -549,6 +594,40 @@ def test_verifier_keeps_inline_subject_behavior(tmp_path: Path) -> None:
     assert enforcement_subject["path"] == (
         "inline:authority_carrier.strict_ci_gate_enforcement"
     )
+    assert verify_binding(paths) == 0
+
+
+def test_verifier_accepts_absolute_paths_generated_by_builder_inside_reviewed_root(
+    tmp_path: Path,
+) -> None:
+    paths = write_fixtures(tmp_path)
+
+    with working_directory(paths["root"]):
+        assert build_main(
+            [
+                "--status",
+                str(paths["status"]),
+                "--policy",
+                str(paths["policy"]),
+                "--ledger",
+                str(paths["ledger"]),
+                "--release-decision",
+                str(paths["release_decision"]),
+                "--release-authority-manifest",
+                str(paths["manifest"]),
+                "--out",
+                str(paths["binding"]),
+                "--created-utc",
+                CREATED_UTC,
+            ]
+        ) == 0
+
+    binding = read_json(paths["binding"])
+
+    assert Path(binding["authority_carrier"]["status_json"]["path"]).is_absolute()
+    assert Path(binding["authority_carrier"]["declared_gate_policy"]["path"]).is_absolute()
+    assert Path(binding["reader_carrier"]["quality_ledger"]["path"]).is_absolute()
+
     assert verify_binding(paths) == 0
 
 

--- a/tests/test_artifact_provenance_binding_v0.py
+++ b/tests/test_artifact_provenance_binding_v0.py
@@ -1,12 +1,15 @@
 import copy
 import json
+import os
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 from jsonschema import ValidationError, validate
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
@@ -23,9 +26,22 @@ VALID_GIT_SHA = "a" * 40
 CREATED_UTC = "2026-02-17T12:34:56Z"
 
 
+@contextmanager
+def working_directory(path: Path):
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
 def write_json(path: Path, obj: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(obj, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(obj, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 
 
 def write_text(path: Path, text: str) -> None:
@@ -68,6 +84,7 @@ def status_payload(*, required_gates: list[str] | None = None) -> dict:
         "run_key": "GITHUB_RUN_ID=1|GITHUB_RUN_NUMBER=2|GITHUB_WORKFLOW=PULSE CI",
         "git_sha": VALID_GIT_SHA,
     }
+
     if required_gates is not None:
         metrics["required_gates"] = required_gates
 
@@ -86,14 +103,33 @@ def status_payload(*, required_gates: list[str] | None = None) -> dict:
 
 
 def fixture_paths(tmp_path: Path) -> dict[str, Path]:
+    reviewed_root = tmp_path / "reviewed_repo"
+
+    status_rel = Path("PULSE_safe_pack_v0/artifacts/status.json")
+    policy_rel = Path("pulse_gate_policy_v0.yml")
+    ledger_rel = Path("PULSE_safe_pack_v0/artifacts/report_card.html")
+    release_decision_rel = Path("PULSE_safe_pack_v0/artifacts/release_decision_v0.json")
+    manifest_rel = Path("PULSE_safe_pack_v0/artifacts/release_authority_v0.json")
+    binding_rel = Path("PULSE_safe_pack_v0/artifacts/artifact_provenance_binding_v0.json")
+
     return {
-        "status": tmp_path / "status.json",
-        "policy": tmp_path / "pulse_gate_policy_v0.yml",
-        "ledger": tmp_path / "report_card.html",
-        "release_decision": tmp_path / "release_decision_v0.json",
-        "manifest": tmp_path / "release_authority_v0.json",
-        "binding": tmp_path / "artifact_provenance_binding_v0.json",
-        "schema": REPO_ROOT / "schemas" / "provenance" / "artifact_provenance_binding_v0.schema.json",
+        "root": reviewed_root,
+        "status_rel": status_rel,
+        "policy_rel": policy_rel,
+        "ledger_rel": ledger_rel,
+        "release_decision_rel": release_decision_rel,
+        "manifest_rel": manifest_rel,
+        "binding_rel": binding_rel,
+        "status": reviewed_root / status_rel,
+        "policy": reviewed_root / policy_rel,
+        "ledger": reviewed_root / ledger_rel,
+        "release_decision": reviewed_root / release_decision_rel,
+        "manifest": reviewed_root / manifest_rel,
+        "binding": reviewed_root / binding_rel,
+        "schema": REPO_ROOT
+        / "schemas"
+        / "provenance"
+        / "artifact_provenance_binding_v0.schema.json",
     }
 
 
@@ -107,7 +143,7 @@ def write_fixtures(
 
     write_json(paths["status"], status_payload(required_gates=required_gates))
     write_policy(paths["policy"])
-    write_text(paths["ledger"], "<html><body>PULSE Quality Ledger</body></html>\n")
+    write_text(paths["ledger"], "PULSE Quality Ledger\n")
     write_json(
         paths["release_decision"],
         {
@@ -121,33 +157,55 @@ def write_fixtures(
     return paths
 
 
+def rel(paths: dict[str, Path], key: str) -> str:
+    return paths[f"{key}_rel"].as_posix()
+
+
 def build_args(paths: dict[str, Path], *extra_args: str) -> list[str]:
     return [
         "--status",
-        str(paths["status"]),
+        rel(paths, "status"),
         "--policy",
-        str(paths["policy"]),
+        rel(paths, "policy"),
         "--ledger",
-        str(paths["ledger"]),
+        rel(paths, "ledger"),
         "--release-decision",
-        str(paths["release_decision"]),
+        rel(paths, "release_decision"),
         "--release-authority-manifest",
-        str(paths["manifest"]),
+        rel(paths, "manifest"),
         "--out",
-        str(paths["binding"]),
+        rel(paths, "binding"),
         "--created-utc",
         CREATED_UTC,
         *extra_args,
     ]
 
 
+def run_build(paths: dict[str, Path], *extra_args: str) -> int:
+    with working_directory(paths["root"]):
+        return build_main(build_args(paths, *extra_args))
+
+
 def build_binding(paths: dict[str, Path], *extra_args: str) -> dict:
-    assert build_main(build_args(paths, *extra_args)) == 0
+    assert run_build(paths, *extra_args) == 0
     return read_json(paths["binding"])
 
 
+def verify_binding(paths: dict[str, Path]) -> int:
+    return verify_main(
+        [
+            "--binding",
+            str(paths["binding"]),
+            "--repo-root",
+            str(paths["root"]),
+        ]
+    )
+
+
 def schema() -> dict:
-    return read_json(REPO_ROOT / "schemas" / "provenance" / "artifact_provenance_binding_v0.schema.json")
+    return read_json(
+        REPO_ROOT / "schemas" / "provenance" / "artifact_provenance_binding_v0.schema.json"
+    )
 
 
 def assert_schema_valid(binding: dict) -> None:
@@ -157,6 +215,23 @@ def assert_schema_valid(binding: dict) -> None:
 def assert_schema_invalid(binding: dict) -> None:
     with pytest.raises(ValidationError):
         validate(instance=binding, schema=schema())
+
+
+def set_subject_path(binding: dict, role: str, path: str) -> None:
+    for subject in binding["binding_subjects"]:
+        if subject["role"] == role:
+            subject["path"] = path
+            return
+
+    raise AssertionError(f"missing binding subject role: {role}")
+
+
+def subject_by_role(binding: dict, role: str) -> dict:
+    for subject in binding["binding_subjects"]:
+        if subject["role"] == role:
+            return subject
+
+    raise AssertionError(f"missing binding subject role: {role}")
 
 
 def test_builder_creates_binding(tmp_path: Path) -> None:
@@ -179,7 +254,9 @@ def test_binding_schema_id_and_version(tmp_path: Path) -> None:
     assert_schema_valid(binding)
 
 
-def test_binding_records_status_policy_ledger_decision_manifest_hashes(tmp_path: Path) -> None:
+def test_binding_records_status_policy_ledger_decision_manifest_hashes(
+    tmp_path: Path,
+) -> None:
     paths = write_fixtures(tmp_path)
     binding = build_binding(paths)
 
@@ -191,9 +268,34 @@ def test_binding_records_status_policy_ledger_decision_manifest_hashes(tmp_path:
     assert_schema_valid(binding)
 
 
-def test_binding_records_workflow_effective_gate_set_from_policy_sets(tmp_path: Path) -> None:
+def test_binding_records_repository_relative_paths(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    assert binding["authority_carrier"]["status_json"]["path"] == rel(paths, "status")
+    assert binding["authority_carrier"]["declared_gate_policy"]["path"] == rel(
+        paths,
+        "policy",
+    )
+    assert binding["reader_carrier"]["quality_ledger"]["path"] == rel(paths, "ledger")
+    assert binding["authority_carrier"]["release_decision"]["path"] == rel(
+        paths,
+        "release_decision",
+    )
+    assert binding["trace_carrier"]["release_authority_manifest"]["path"] == rel(
+        paths,
+        "manifest",
+    )
+
+    assert_schema_valid(binding)
+
+
+def test_binding_records_workflow_effective_gate_set_from_policy_sets(
+    tmp_path: Path,
+) -> None:
     paths = write_fixtures(tmp_path)
     binding = build_binding(paths, "--policy-set", "required", "--policy-set", "release_required")
+
     gate_set = binding["authority_carrier"]["workflow_effective_required_gate_set"]
 
     assert gate_set["effective_source"] == "workflow-effective:required+release_required"
@@ -209,8 +311,12 @@ def test_binding_records_workflow_effective_gate_set_from_policy_sets(tmp_path: 
 
 
 def test_binding_records_metrics_required_gates_source(tmp_path: Path) -> None:
-    paths = write_fixtures(tmp_path, required_gates=["prod_gate_ok", "external_all_pass"])
+    paths = write_fixtures(
+        tmp_path,
+        required_gates=["prod_gate_ok", "external_all_pass"],
+    )
     binding = build_binding(paths)
+
     gate_set = binding["authority_carrier"]["workflow_effective_required_gate_set"]
 
     assert gate_set["effective_source"] == "metrics.required_gates"
@@ -219,7 +325,9 @@ def test_binding_records_metrics_required_gates_source(tmp_path: Path) -> None:
     assert_schema_valid(binding)
 
 
-def test_binding_separates_check_gates_result_from_release_decision_label(tmp_path: Path) -> None:
+def test_binding_separates_check_gates_result_from_release_decision_label(
+    tmp_path: Path,
+) -> None:
     paths = write_fixtures(tmp_path)
     binding = build_binding(paths)
 
@@ -238,69 +346,210 @@ def test_binding_separates_check_gates_result_from_release_decision_label(tmp_pa
 
 def test_binding_hash_is_canonical_and_stable(tmp_path: Path) -> None:
     paths = write_fixtures(tmp_path)
+
     first = build_binding(paths)
     first_hash = first["binding_hash"]
-
     second = build_binding(paths)
 
     assert second["binding_hash"] == first_hash
     assert_schema_valid(second)
 
 
-def test_verifier_passes_for_untouched_artifacts(tmp_path: Path) -> None:
+def test_verifier_passes_for_untouched_repository_relative_artifacts(
+    tmp_path: Path,
+) -> None:
     paths = write_fixtures(tmp_path)
     build_binding(paths)
 
-    assert verify_main(["--binding", str(paths["binding"])]) == 0
+    assert verify_binding(paths) == 0
+
+
+def test_verifier_passes_with_default_repo_root_when_run_from_reviewed_root(
+    tmp_path: Path,
+) -> None:
+    paths = write_fixtures(tmp_path)
+    build_binding(paths)
+
+    with working_directory(paths["root"]):
+        assert verify_main(["--binding", rel(paths, "binding")]) == 0
 
 
 def test_verifier_fails_when_status_changes(tmp_path: Path) -> None:
     paths = write_fixtures(tmp_path)
     build_binding(paths)
+
     write_json(paths["status"], {"changed": True})
 
-    assert verify_main(["--binding", str(paths["binding"])]) != 0
+    assert verify_binding(paths) != 0
 
 
 def test_verifier_fails_when_policy_changes(tmp_path: Path) -> None:
     paths = write_fixtures(tmp_path)
     build_binding(paths)
+
     write_text(paths["policy"], "gates:\n  required:\n    - changed_gate\n")
 
-    assert verify_main(["--binding", str(paths["binding"])]) != 0
+    assert verify_binding(paths) != 0
 
 
 def test_verifier_fails_when_ledger_changes(tmp_path: Path) -> None:
     paths = write_fixtures(tmp_path)
     build_binding(paths)
+
     write_text(paths["ledger"], "changed\n")
 
-    assert verify_main(["--binding", str(paths["binding"])]) != 0
+    assert verify_binding(paths) != 0
 
 
 def test_verifier_fails_when_release_decision_changes(tmp_path: Path) -> None:
     paths = write_fixtures(tmp_path)
     build_binding(paths)
+
     write_json(paths["release_decision"], {"release_level": "FAIL"})
 
-    assert verify_main(["--binding", str(paths["binding"])]) != 0
+    assert verify_binding(paths) != 0
 
 
-def test_verifier_fails_when_release_authority_manifest_changes(tmp_path: Path) -> None:
+def test_verifier_fails_when_release_authority_manifest_changes(
+    tmp_path: Path,
+) -> None:
     paths = write_fixtures(tmp_path)
     build_binding(paths)
+
     write_json(paths["manifest"], {"changed": True})
 
-    assert verify_main(["--binding", str(paths["binding"])]) != 0
+    assert verify_binding(paths) != 0
 
 
 def test_verifier_fails_when_binding_hash_changes(tmp_path: Path) -> None:
     paths = write_fixtures(tmp_path)
     binding = build_binding(paths)
+
     binding["binding_hash"] = "0" * 64
     write_json(paths["binding"], binding)
 
-    assert verify_main(["--binding", str(paths["binding"])]) != 0
+    assert verify_binding(paths) != 0
+
+
+def test_verifier_rejects_absolute_authority_file_path(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    binding["authority_carrier"]["status_json"]["path"] = str(paths["status"].resolve())
+    write_json(paths["binding"], binding)
+
+    assert verify_binding(paths) == 2
+
+
+def test_verifier_rejects_absolute_binding_subject_path(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    set_subject_path(binding, "status_json", str(paths["status"].resolve()))
+    write_json(paths["binding"], binding)
+
+    assert verify_binding(paths) == 2
+
+
+def test_verifier_rejects_parent_directory_escape_path(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    outside = paths["root"].parent / "outside_status.json"
+    write_json(outside, status_payload())
+
+    binding["authority_carrier"]["status_json"]["path"] = "../outside_status.json"
+    write_json(paths["binding"], binding)
+
+    assert verify_binding(paths) == 2
+
+
+def test_verifier_rejects_parent_directory_escape_binding_subject_path(
+    tmp_path: Path,
+) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    outside = paths["root"].parent / "outside_status.json"
+    write_json(outside, status_payload())
+
+    set_subject_path(binding, "status_json", "../outside_status.json")
+    write_json(paths["binding"], binding)
+
+    assert verify_binding(paths) == 2
+
+
+def test_verifier_rejects_symlink_escape_outside_reviewed_root(
+    tmp_path: Path,
+) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    outside = paths["root"].parent / "outside_status.json"
+    write_json(outside, status_payload())
+
+    link = paths["root"] / "PULSE_safe_pack_v0" / "artifacts" / "status_link.json"
+    link.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        link.symlink_to(outside)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is not available in this environment: {exc}")
+
+    binding["authority_carrier"]["status_json"]["path"] = (
+        link.relative_to(paths["root"]).as_posix()
+    )
+    write_json(paths["binding"], binding)
+
+    assert verify_binding(paths) == 2
+
+
+def test_verifier_rejects_windows_style_subject_path(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    binding["authority_carrier"]["status_json"]["path"] = (
+        "PULSE_safe_pack_v0\\artifacts\\status.json"
+    )
+    write_json(paths["binding"], binding)
+
+    assert verify_binding(paths) == 2
+
+
+def test_verifier_rejects_empty_subject_path(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    binding["authority_carrier"]["status_json"]["path"] = ""
+    write_json(paths["binding"], binding)
+
+    assert verify_binding(paths) == 2
+
+
+def test_verifier_rejects_whitespace_padded_subject_path(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    binding["authority_carrier"]["status_json"]["path"] = f" {rel(paths, 'status')} "
+    write_json(paths["binding"], binding)
+
+    assert verify_binding(paths) == 2
+
+
+def test_verifier_keeps_inline_subject_behavior(tmp_path: Path) -> None:
+    paths = write_fixtures(tmp_path)
+    binding = build_binding(paths)
+
+    gate_set_subject = subject_by_role(binding, "workflow_effective_required_gate_set")
+    enforcement_subject = subject_by_role(binding, "strict_ci_gate_enforcement")
+
+    assert gate_set_subject["path"] == (
+        "inline:authority_carrier.workflow_effective_required_gate_set"
+    )
+    assert enforcement_subject["path"] == (
+        "inline:authority_carrier.strict_ci_gate_enforcement"
+    )
+    assert verify_binding(paths) == 0
 
 
 def test_canonical_json_bytes_are_deterministic() -> None:
@@ -316,7 +565,7 @@ def test_builder_rejects_malformed_git_sha(tmp_path: Path) -> None:
     status["metrics"]["git_sha"] = "not-a-sha"
     write_json(paths["status"], status)
 
-    assert build_main(build_args(paths)) != 0
+    assert run_build(paths) != 0
 
 
 def test_builder_rejects_missing_run_identity(tmp_path: Path) -> None:
@@ -326,7 +575,7 @@ def test_builder_rejects_missing_run_identity(tmp_path: Path) -> None:
     status["metrics"]["run_key"] = ""
     write_json(paths["status"], status)
 
-    assert build_main(build_args(paths)) != 0
+    assert run_build(paths) != 0
 
 
 def test_builder_parses_run_id_from_run_key(tmp_path: Path) -> None:
@@ -352,13 +601,16 @@ def test_builder_rejects_unknown_release_decision_label(tmp_path: Path) -> None:
         },
     )
 
-    assert build_main(build_args(paths)) != 0
+    assert run_build(paths) != 0
 
 
 def test_workflow_effective_gate_set_deduplicates_gate_ids(tmp_path: Path) -> None:
     paths = write_fixtures(tmp_path)
     binding = build_binding(paths, "--policy-set", "required", "--policy-set", "release_required")
-    gate_ids = binding["authority_carrier"]["workflow_effective_required_gate_set"]["gate_ids"]
+
+    gate_ids = binding["authority_carrier"]["workflow_effective_required_gate_set"][
+        "gate_ids"
+    ]
 
     assert gate_ids == list(dict.fromkeys(gate_ids))
     assert_schema_valid(binding)
@@ -380,25 +632,39 @@ def test_schema_requires_non_empty_run_identifiers(tmp_path: Path) -> None:
 
     blank_run_id = copy.deepcopy(binding)
     blank_run_id["run"]["run_id"] = ""
+
     assert_schema_invalid(blank_run_id)
 
     blank_run_key = copy.deepcopy(binding)
     blank_run_key["run"]["run_key"] = ""
+
     assert_schema_invalid(blank_run_key)
 
 
-def test_schema_rejects_inconsistent_ci_enforcement_outcomes(tmp_path: Path) -> None:
+def test_schema_rejects_inconsistent_ci_enforcement_outcomes(
+    tmp_path: Path,
+) -> None:
     paths = write_fixtures(tmp_path)
     binding = build_binding(paths)
 
     allow_with_block_exit = copy.deepcopy(binding)
-    allow_with_block_exit["authority_carrier"]["strict_ci_gate_enforcement"]["result"] = "allow"
-    allow_with_block_exit["authority_carrier"]["strict_ci_gate_enforcement"]["exit_code"] = 1
+    allow_with_block_exit["authority_carrier"]["strict_ci_gate_enforcement"][
+        "result"
+    ] = "allow"
+    allow_with_block_exit["authority_carrier"]["strict_ci_gate_enforcement"][
+        "exit_code"
+    ] = 1
+
     assert_schema_invalid(allow_with_block_exit)
 
     block_with_allow_exit = copy.deepcopy(binding)
-    block_with_allow_exit["authority_carrier"]["strict_ci_gate_enforcement"]["result"] = "block"
-    block_with_allow_exit["authority_carrier"]["strict_ci_gate_enforcement"]["exit_code"] = 0
+    block_with_allow_exit["authority_carrier"]["strict_ci_gate_enforcement"][
+        "result"
+    ] = "block"
+    block_with_allow_exit["authority_carrier"]["strict_ci_gate_enforcement"][
+        "exit_code"
+    ] = 0
+
     assert_schema_invalid(block_with_allow_exit)
 
 
@@ -417,7 +683,9 @@ def test_schema_rejects_duplicate_effective_gate_ids(tmp_path: Path) -> None:
     binding = build_binding(paths)
 
     bad = copy.deepcopy(binding)
-    gate_ids = bad["authority_carrier"]["workflow_effective_required_gate_set"]["gate_ids"]
+    gate_ids = bad["authority_carrier"]["workflow_effective_required_gate_set"][
+        "gate_ids"
+    ]
     gate_ids.append(gate_ids[0])
 
     assert_schema_invalid(bad)


### PR DESCRIPTION
## Summary

This PR confines artifact provenance binding paths during verification.

The binding verifier now resolves binding file paths and binding subject file
paths against an explicit reviewed repository root and rejects paths that resolve
outside that reviewed root.

## Security boundary

The binding verifier may read a binding artifact from the reviewed repository.

Binding subject file paths must not resolve to arbitrary local files outside the
reviewed repository boundary.

The reviewed repository root is the boundary for file-based binding subjects.

Inline binding subjects remain handled through the existing inline verification
path.

## Fix

The verifier now accepts:

```text
--repo-root
```

This argument defines the reviewed repository root used for path resolution.

Repository-relative paths are resolved under the reviewed root.

Absolute paths are accepted only when they resolve inside the reviewed root.

The verifier rejects paths that are:

- empty;
- padded with leading or trailing whitespace;
- Windows-drive or backslash based;
- resolved outside the reviewed repository root.

This preserves compatibility with CI-produced bindings that record absolute
workspace paths while still rejecting external absolute paths, parent-directory
escapes, symlink escapes, and non-portable path syntax.

## Path resolution model

The verifier uses this model:

```text
binding path
→ resolve against reviewed repository root when relative
→ accept only if resolved path remains inside reviewed repository root
```

```text
file-based binding subject path
→ resolve against reviewed repository root when relative
→ accept absolute path only if it resolves inside reviewed repository root
→ reject if resolved path escapes reviewed repository root
```

```text
inline binding subject
→ verify through existing inline hash path
→ no filesystem path resolution
```

## CI compatibility

The GitHub workflow may generate bindings from absolute workspace paths.

This PR preserves that behavior when the generated absolute paths resolve inside
the reviewed repository root.

The verifier no longer treats an absolute path as invalid by definition.

It treats a path as invalid when the resolved target is outside the reviewed
repository root or uses unsupported path syntax.

## Tests

Regression tests verify:

- valid repository-relative subject paths pass;
- absolute subject paths inside the reviewed root pass;
- builder-generated absolute artifact paths inside the reviewed root pass;
- absolute subject paths outside the reviewed root are rejected;
- parent-directory escape paths are rejected;
- symlink escape outside the reviewed root is rejected;
- Windows-style / backslash paths are rejected;
- empty subject paths are rejected;
- whitespace-padded subject paths are rejected;
- inline subject behavior remains unchanged.

## Scope

Changed files:

```text
PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py
tests/test_artifact_provenance_binding_v0.py
```

## Preserved

This PR does not change:

- PULSEmech release authority;
- gate policy;
- required gate wiring;
- schemas;
- workflow mechanics;
- CI allow/block behavior;
- Quality Ledger renderer behavior;
- release tags;
- DOI / Zenodo path.

## Validation

Run before merge:

```bash
python -m py_compile \
  PULSE_safe_pack_v0/tools/verify_artifact_provenance_binding_v0.py \
  tests/test_artifact_provenance_binding_v0.py

python -m pytest -q tests/test_artifact_provenance_binding_v0.py
```

## Expected result

The verifier accepts binding paths and subject paths that resolve inside the
reviewed repository root.

The verifier rejects binding paths and subject paths that resolve outside the
reviewed repository root.

The binding verifier remains a verification tool only.

This PR does not create or modify release authority.