### PR TITLE
docs(terminology): align governance wording with release authority

### DIFF
--- a/docs/EXTERNAL_DETECTORS.md
+++ b/docs/EXTERNAL_DETECTORS.md
@@ -237,7 +237,7 @@ That means:
 - pin tool versions or digests where possible,
 - keep enough provenance for later audit.
 
-External detectors should strengthen release governance, not create a new
+External detectors should strengthen release evidence review, not create a new
 untracked trust boundary.
 
 ---

--- a/docs/STATE_v0.md
+++ b/docs/STATE_v0.md
@@ -128,7 +128,7 @@ Important boundary:
 
 This means the repository now has:
 
-- a deterministic release-governance core,
+- a deterministic release-authority core,
 - plus a contract-disciplined shadow program around it.
 
 That is a meaningful architectural step beyond “optional diagnostics”.
@@ -146,7 +146,7 @@ The repository now includes a machine-readable shadow registry stack:
 - `tests/test_check_shadow_layer_registry.py`
 - `.github/workflows/shadow_layer_registry.yml`
 
-This registry is governance-facing and descriptive.
+This registry is review-facing and descriptive.
 
 It records:
 
@@ -268,10 +268,10 @@ For operational guidance, see:
 
 ---
 
-## 9. Drift and governance
+## 9. Drift and release-state review
 
 PULSE already exposes several artefacts that are useful for drift-aware
-governance:
+release-state review:
 
 - deterministic gate outcomes
 - `status.json`
@@ -301,8 +301,7 @@ A good mental model for the repository today is:
 - **core deterministic release gating** at the center,
 - **artifact-first reporting** around it,
 - **contract-disciplined shadow layers** on top,
-- and **governance / audit surfaces** growing around the same immutable
-  run artefacts.
+- and **review / audit surfaces** growing around the same immutable
 
 The repository is no longer best described as:
 
@@ -310,7 +309,7 @@ The repository is no longer best described as:
 
 It is better understood as:
 
-- a deterministic release-governance core,
+- a deterministic release-authority core,
 - plus additive diagnostic and review layers,
 - plus a machine-readable shadow registration and validation surface,
 - with explicit separation between normative and diagnostic meaning.


### PR DESCRIPTION
## Summary

This PR aligns PULSE-facing terminology in existing docs with the terminology risk register.

## Purpose

The Terminology Risk Register defines PULSEmech as an artifact-bound release-authority mechanism and marks `release governance` / governance-framed identity wording as a terminology risk for PULSE-facing text.

This PR updates older documentation passages that used governance wording near PULSE identity or release-core descriptions.

## Changes

Updated `docs/STATE_v0.md`:

- `deterministic release-governance core` → `deterministic release-authority core`
- `governance-facing and descriptive` → `review-facing and descriptive`
- `Drift and governance` → `Drift and release-state review`
- `drift-aware governance` → `drift-aware release-state review`
- `governance / audit surfaces` → `review / audit surfaces`

Updated `docs/EXTERNAL_DETECTORS.md`:

- `External detectors should strengthen release governance` → `External detectors should strengthen release evidence review`

## Boundary

This PR does not ban the term `governance`.

It only removes governance wording where it can be read as a PULSE identity descriptor.

Allowed uses for external AI-governance literature, repository stewardship, maintainer process, organizational adoption, or legacy context remain unchanged.

## Scope

Docs-only.

Changed files:

```text
docs/STATE_v0.md
docs/EXTERNAL_DETECTORS.md
```
Preserved

This PR does not change:

PULSEmech release authority;
gate policy;
required gate wiring;
schemas;
workflow mechanics;
CI allow/block behavior;
check_gates.py;
Quality Ledger renderer behavior;
Pages workflow behavior;
release tags;
DOI / Zenodo path.
Validation

```text
git diff --check -- docs/STATE_v0.md docs/EXTERNAL_DETECTORS.md
```
Optional identity smoke validation:

```text
python -m pytest tests/test_tools_release_authority_smoke.py tests/test_readme_release_authority_category_signal_v0.py
```