### PR TITLE
docs(state): restore immutable run artefacts wording

### DIFF
--- a/docs/STATE_v0.md
+++ b/docs/STATE_v0.md
@@ -301,7 +301,7 @@ A good mental model for the repository today is:
 - **core deterministic release gating** at the center,
 - **artifact-first reporting** around it,
 - **contract-disciplined shadow layers** on top,
-- and **review / audit surfaces** growing around the same immutable
+- and **review / audit surfaces** growing around the same immutable run artefacts.
 
 The repository is no longer best described as:
 


### PR DESCRIPTION
## Summary

This PR fixes an incomplete bullet in `docs/STATE_v0.md`.

## Fix

The previous terminology alignment left one bullet without its object:

```text
- and review / audit surfaces growing around the same immutable
```

This PR restores the intended wording:

```text
- and review / audit surfaces growing around the same immutable run artefacts.
```

## Scope

Docs-only.

Changed file:

```text
docs/STATE_v0.md
```

## Preserved

This PR does not change:

- PULSEmech release authority;
- gate policy;
- required gate wiring;
- schemas;
- workflow mechanics;
- CI allow/block behavior;
- `check_gates.py`;
- Quality Ledger renderer behavior;
- Pages workflow behavior;
- release tags;
- DOI / Zenodo path.

## Validation

```bash
git diff --check -- docs/STATE_v0.md
```

Optional identity smoke validation:

```bash
python -m pytest tests/test_tools_release_authority_smoke.py tests/test_readme_release_authority_category_signal_v0.py
```

## Squash merge title

```text
docs(state): restore immutable run artefacts wording
```