### PR TITLE
docs(cleanup): reconcile refusal delta evidence language

### DIFF
--- a/docs/evidence_presence_policy_v1.md
+++ b/docs/evidence_presence_policy_v1.md
@@ -230,31 +230,35 @@ external_all_pass = false
 
 and therefore release-grade FAIL.
 
-## Refusal-delta hardening target
+## Refusal-delta  evidence-presence state
 
-The next evidence-presence hardening target is refusal-delta evidence.
+Refusal-delta evidence presence is a current release-grade evidence-presence
+hardening surface.
 
-Current hardening objective:
-
-```text
-release-grade paths must not allow missing refusal-delta evidence to become implicit PASS
-```
-
-Recommended release-grade behavior:
+Refusal-delta evidence presence is a current release-grade evidence-presence
+hardening surface.
 
 ```text
 refusal_delta_evidence_present = false
--> release-grade FAIL
+→ release-grade FAIL
+refusal_delta_evidence_present = true
+refusal_delta_pass = true
+→ release-grade PASS
 ```
 
-Recommended policy addition:
+The current repository state includes:
 
 ```text
-release_required:
-  - refusal_delta_evidence_present
+pulse_gate_policy_v0.yml
+PULSE_safe_pack_v0/profiles/release_grade_reference_v1.yml
+tests/fixtures/release_reference_v1/missing_refusal_delta/
+tests/fixtures/release_reference_v1/refusal_delta_evidence_present/
+tests/test_no_implicit_pass_release_grade.py
+tests/test_release_reference_fixture_matrix_v1.py
 ```
 
-or equivalent declared policy promotion when refusal-delta is release-relevant.
+Missing refusal-delta evidence must not be converted into PASS by legacy fallback
+behavior.
 
 ## Non-interference
 
@@ -291,29 +295,34 @@ release_reference_v1/false_gate
 release_reference_v1/implicit_fallback_attempt
 release_reference_v1/malformed_summary
 release_reference_v1/unsigned_summary
+release_reference_v1/missing_refusal_delta
+release_reference_v1/refusal_delta_evidence_present
 ```
 
-The `implicit_fallback_attempt` fixture already validates non-materialized detector evidence:
+The `implicit_fallback_attempt` fixture validates non-materialized detector
+evidence:
 
 ```text
 detectors_materialized_ok = false
--> FAIL
+→ FAIL
 ```
 
-The next recommended fixture category is:
-
-```text
-release_reference_v1/missing_refusal_delta
-```
-
-Expected target behavior:
+The `missing_refusal_delta` fixture validates missing refusal-delta evidence
 
 ```text
 refusal_delta_evidence_present = false
--> FAIL
+→ FAIL
 ```
 
-## Test expectations
+The `refusal_delta_evidence_present` fixture validates materialized
+refusal-delta evidence:
+
+```text
+refusal_delta_evidence_present = true
+refusal_delta_pass = true
+→ PASS
+```
+
 
 Evidence presence tests should verify:
 
@@ -323,8 +332,11 @@ Evidence presence tests should verify:
 - malformed external summaries fail closed;
 - unsigned release-grade summaries fail closed;
 - missing refusal-delta evidence fails closed when release-required;
+- materialized refusal-delta evidence can satisfy the release-grade evidence
+  presence requirement when the refusal-delta result gate also passes;
 - diagnostic-only retained evidence does not become release authority;
-- advisory-only evidence does not become release authority unless promoted by policy.
+- advisory-only evidence does not become release authority unless promoted by
+  policy.
 
 ## How to run current related tests
 
@@ -352,26 +364,22 @@ External summary envelope fixture matrix:
 python tests/test_external_summary_envelope_fixture_matrix_v1.py
 ```
 
-## Future implementation work
+## Remaining implementation surface
 
-Future commits should add:
+Current policy, profile, fixture, and regression-test evidence already covers
+the refusal-delta evidence-presence behavior.
 
-- `refusal_delta_evidence_present` gate;
-- release-grade refusal-delta evidence presence fixture;
-- no-implicit-PASS release-grade tests;
+Remaining future work should be limited to items that are still absent or
+intentionally separate from this current proof layer.
+
+Possible remaining future items may include:
+
 - evidence presence policy schema;
-- release-reference fixture for missing refusal-delta evidence;
-- release-grade path wiring so missing refusal-delta evidence cannot pass silently.
+- additional refusal-delta evidence envelope tests;
+- additional signed or subject-bound refusal-delta evidence fixtures;
+- additional release-reference package evidence-packet coverage.
 
-Potential future files:
-
-```text
-schemas/evidence_presence_policy_v1.json
-tests/test_no_implicit_pass_release_grade.py
-tests/test_refusal_delta_presence_policy.py
-tests/fixtures/release_reference_v1/missing_refusal_delta/status.json
-tests/fixtures/release_reference_v1/missing_refusal_delta/expected_outcome.json
-```
+These items should be opened only when a current mechanical gap is identified.
 
 ## Summary
 

--- a/docs/no_implicit_pass_release_grade_v1.md
+++ b/docs/no_implicit_pass_release_grade_v1.md
@@ -241,25 +241,51 @@ refusal_delta_evidence_present=false
 
 This demonstrates zero implicit PASS behavior for missing refusal-delta evidence.
 
-## Future work
+## Current policy / profile state
 
-Future implementation work may promote `refusal_delta_evidence_present` into the global release-grade policy when appropriate.
+The no-implicit-PASS refusal-delta behavior is represented by current repository
+evidence.
 
-Potential future changes:
+Current state includes:
 
 ```text
 pulse_gate_policy_v0.yml
-release_required:
-  - refusal_delta_evidence_present
+PULSE_safe_pack_v0/profiles/release_grade_reference_v1.yml
+tests/fixtures/release_reference_v1/missing_refusal_delta/
+tests/fixtures/release_reference_v1/refusal_delta_evidence_present/
+tests/test_no_implicit_pass_release_grade.py
+tests/test_release_reference_fixture_matrix_v1.py
 ```
 
-or an equivalent declared policy promotion for release-grade paths.
+The policy path includes `refusal_delta_evidence_present` in the release-grade
+required gate set.
 
-Any such promotion should be done in a separate PR with explicit policy-change review.
+The release-grade reference profile records that refusal-delta evidence is
+required when release-required.
+
+The negative fixture proves:
+
+```text
+refusal_delta_pass = true
+refusal_delta_evidence_present = false
+→ FAIL
+```
+
+The positive fixture proves:
+
+```text
+refusal_delta_pass = true
+refusal_delta_evidence_present = true
+→ PASS
+```
+
+Future work should only describe remaining absent coverage or deliberately
+separate implementation tracks.
 
 ## Summary
 
-The no-implicit-PASS release-grade test proves that a passing result gate cannot substitute for missing materialized evidence.
+The no-implicit-PASS release-grade test proves that a passing result gate cannot
+substitute for missing materialized evidence.
 
 For PULSE-REF release-grade validation:
 
@@ -268,6 +294,18 @@ required evidence must be present
 required evidence must be materialized
 required evidence must be explicit
 missing evidence must fail closed
+```
+
+The refusal-delta proof now has both negative and positive fixture coverage:
+
+```text
+refusal_delta_pass = true
+refusal_delta_evidence_present = false
+→ FAIL
+
+refusal_delta_pass = true
+refusal_delta_evidence_present = true
+→ PASS
 ```
 
 This strengthens PULSE without creating a second release-decision engine.

--- a/docs/refusal_delta_evidence_presence_gate_v1.md
+++ b/docs/refusal_delta_evidence_presence_gate_v1.md
@@ -2,7 +2,8 @@
 
 ## Purpose
 
-This document defines the PULSE-REF plan for promoting `refusal_delta_evidence_present` into release-grade evidence-presence enforcement.
+This document records the current PULSE-REF release-grade evidence-presence
+behavior for `refusal_delta_evidence_present`.
 
 The purpose is to prevent this state from passing release-grade validation:
 
@@ -11,33 +12,35 @@ refusal_delta_pass = true
 refusal_delta_evidence_present = false
 ```
 
-A passing refusal-delta gate result must not substitute for missing materialized refusal-delta evidence.
+A passing refusal-delta result gate does not substitute for missing materialized
+refusal-delta evidence.
 
-This document prepares the policy change.
-
-It does not modify release authority by itself.
+The current repository state includes policy, profile, fixture, and regression
+evidence for this behavior.
 
 ## Current status
 
-The current PULSE-REF fixture and regression layer already demonstrates the target behavior through:
+`refusal_delta_evidence_present` is now represented in the release-grade
+evidence path through current repository evidence.
+
+Current evidence includes:
 
 ```text
+pulse_gate_policy_v0.yml
+PULSE_safe_pack_v0/profiles/release_grade_reference_v1.yml
 tests/fixtures/release_reference_v1/missing_refusal_delta/status.json
 tests/fixtures/release_reference_v1/missing_refusal_delta/expected_outcome.json
+tests/fixtures/release_reference_v1/refusal_delta_evidence_present/status.json
+tests/fixtures/release_reference_v1/refusal_delta_evidence_present/expected_outcome.json
 tests/test_no_implicit_pass_release_grade.py
+tests/test_release_reference_fixture_matrix_v1.py
 ```
 
-The fixture sets:
+The current negative fixture sets:
 
 ```text
 refusal_delta_pass = true
 refusal_delta_evidence_present = false
-```
-
-and the dedicated regression test runs the PULSE-REF guard with:
-
-```bash
---require-gate refusal_delta_evidence_present
 ```
 
 Expected result:
@@ -46,28 +49,51 @@ Expected result:
 FAIL
 ```
 
-This proves the desired release-grade behavior without changing the global gate policy yet.
+The current positive fixture sets:
+
+```text
+refusal_delta_pass = true
+refusal_delta_evidence_present = true
+```
+
+Expected result:
+
+```text
+PASS
+```
+
+The fixture matrix passes fixture-specific extra required gates through:
+
+```json
+"expected_extra_required_gates": [
+  "refusal_delta_evidence_present"
+]
+```
+
+The release-grade reference profile records that refusal-delta evidence is
+required when release-required.
 
 ## Authority boundary
 
-This document does not define release authority.
+The current behavior remains declared-policy based.
 
-The normative release decision remains produced by the declared-policy gate-enforcement path and recorded through the CI outcome.
-
-The normative path remains:
+Release permission is produced by:
 
 ```text
-recorded evidence
--> status.json
--> declared gate policy
--> materialized required gate set
--> strict gate checking
--> CI outcome
+recorded release evidence
+→ status.json
+→ declared gate policy
+→ materialized required gate set
+→ strict gate checking
+→ CI outcome
 ```
 
-This document describes a planned evidence-presence gate promotion.
+`refusal_delta_evidence_present` participates in release-grade validation
+through declared policy, profile requirements, fixture evidence, and guard tests.
 
-It does not authorize release, block release, replace `check_gates.py`, or make documentation, fixtures, ledgers, manifests, audit bundles, dashboards, summaries, or publication surfaces normative.
+Documentation, fixtures, ledgers, manifests, audit bundles, dashboards,
+summaries, and publication surfaces preserve or explain evidence state; they do
+not independently authorize release.
 
 ## Core rule
 
@@ -141,87 +167,43 @@ The matrix passes this to the PULSE-REF guard as:
 --require-gate refusal_delta_evidence_present
 ```
 
-This allows PULSE-REF to test the desired release-grade behavior before global policy promotion.
+This allows PULSE-REF to preserve the current release-grade evidence-presence behavior through fixture-matrix coverage.
 
-## Proposed policy promotion
+## Current policy and fixture state
 
-The planned policy promotion is to include:
-
-```text
-refusal_delta_evidence_present
-```
-
-in the release-grade required gate set when refusal-delta is release-relevant.
-
-Potential policy shape:
-
-```yaml
-gates:
-  release_required:
-    - detectors_materialized_ok
-    - external_summaries_present
-    - external_all_pass
-    - refusal_delta_evidence_present
-```
-
-or an equivalent declared release-grade policy section.
-
-## Promotion prerequisites
-
-Before adding `refusal_delta_evidence_present` globally to release-grade policy, the following must be true:
-
-- `missing_refusal_delta` fixture exists and passes matrix validation.
-- `tests/test_no_implicit_pass_release_grade.py` passes.
-- Release-reference fixture matrix supports extra required gates.
-- Existing release-reference fixtures still pass or fail for their intended isolated reasons.
-- External summary and envelope fixture matrices still pass.
-- The change is documented as a release-grade evidence-presence hardening step.
-- The policy change PR explicitly states that release-authority semantics remain declared-policy based.
-
-## Expected behavior after promotion
-
-After policy promotion, release-grade validation should fail whenever:
+The release-grade policy path includes:
 
 ```text
-refusal_delta_evidence_present != true
+release_required:
+  - refusal_delta_evidence_present
 ```
 
-This includes:
-
-- missing gate;
-- false gate;
-- null value;
-- string `"true"`;
-- numeric `1`;
-- malformed evidence;
-- diagnostic-only evidence;
-- advisory-only evidence not promoted by declared policy.
-
-PASS requires literal boolean:
+The release-grade reference profile records:
 
 ```text
+require_refusal_delta_evidence_when_release_required: true
+```
+
+The negative fixture proves the fail-closed missing-evidence case:
+
+```text
+refusal_delta_pass = true
+refusal_delta_evidence_present = false
+→ FAIL
+```
+
+The positive fixture proves the materialized-evidence case:
+
+```text
+refusal_delta_pass = true
 refusal_delta_evidence_present = true
+→ PASS
 ```
 
-## Non-release-grade behavior
+The fixture matrix and dedicated no-implicit-PASS regression test preserve the
+expected behavior.
 
-Legacy, demo, advisory, or diagnostic paths may retain non-release-grade behavior if explicitly labeled.
-
-Such paths must not be confused with release-grade validation.
-
-Permissive behavior must be marked as:
-
-```text
-legacy
-advisory
-diagnostic
-non-authoritative
-not release-grade
-```
-
-Release-grade paths must not inherit permissive fallback semantics.
-
-## Required tests for policy promotion
+Run:
 
 The policy promotion PR should run:
 
@@ -233,7 +215,7 @@ python tests/test_external_summary_schema_v1.py
 python tests/test_external_summary_fixture_matrix_v1.py
 ```
 
-It should also run a direct guard check:
+Direct negative guard check:
 
 ```bash
 python ci/check_release_reference_complete_v1.py \
@@ -242,6 +224,7 @@ python ci/check_release_reference_complete_v1.py \
   --required-sets required,release_required \
   --allowed-run-modes prod \
   --require-nonstubbed \
+  --require-nonscaffolded \
   --require-detectors-materialized \
   --require-external-summaries \
   --require-gate refusal_delta_evidence_present
@@ -259,40 +242,19 @@ Expected failure target:
 refusal_delta_evidence_present
 ```
 
-## Required negative fixture
+Direct positive guard check:
 
-The required negative fixture is:
-
-```text
-tests/fixtures/release_reference_v1/missing_refusal_delta/
-```
-
-It must contain:
-
-```text
-status.json
-expected_outcome.json
-```
-
-The expected failure must remain isolated to:
-
-```text
-refusal_delta_evidence_present
-```
-
-## Required positive fixture target
-
-A future positive fixture may be added:
-
-```text
-tests/fixtures/release_reference_v1/refusal_delta_evidence_present/
-```
-
-Expected state:
-
-```text
-refusal_delta_pass = true
-refusal_delta_evidence_present = true
+```bash
+python ci/check_release_reference_complete_v1.py \
+  --status tests/fixtures/release_reference_v1/refusal_delta_evidence_present/status.json \
+  --policy pulse_gate_policy_v0.yml \
+  --required-sets required,release_required \
+  --allowed-run-modes prod \
+  --require-nonstubbed \
+  --require-nonscaffolded \
+  --require-detectors-materialized \
+  --require-external-summaries \
+  --require-gate refusal_delta_evidence_present
 ```
 
 Expected result:
@@ -301,46 +263,17 @@ Expected result:
 PASS
 ```
 
-This positive fixture is useful before or alongside global policy promotion.
+Remaining cleanup surface
 
-## Rollout plan
+Future edits to this document should distinguish current implemented evidence
+from future work.
 
-Recommended rollout:
-
-1. Keep `refusal_delta_evidence_present` as fixture-specific extra required gate.
-2. Add this promotion plan document.
-3. Add a positive fixture where refusal-delta evidence is present.
-4. Update `pulse_gate_policy_v0.yml` to include `refusal_delta_evidence_present` in release-grade required gates.
-5. Re-run all release-reference and external evidence fixture matrices.
-6. Confirm no fixture fails for an unrelated reason.
-7. Merge only if the authority boundary remains unchanged.
-
-## Risk
-
-Policy promotion risk is moderate because it changes release-grade required-gate behavior.
-
-The risk is acceptable if the change is:
-
-- explicit;
-- documented;
-- covered by fixtures;
-- covered by direct guard tests;
-- limited to release-grade semantics;
-- not applied silently to legacy / diagnostic paths.
-
-## Rollback
-
-If policy promotion causes unintended release-grade failures, rollback should remove `refusal_delta_evidence_present` from the global release-required gate set while keeping:
-
-- the `missing_refusal_delta` fixture;
-- `tests/test_no_implicit_pass_release_grade.py`;
-- this policy promotion document.
-
-This preserves the hardening target while allowing policy rollout to be retried safely.
+Open future work should be limited to items that are still absent or explicitly
+kept as a separate implementation track.
 
 ## Non-goals
 
-This plan does not:
+This document does not:
 
 - replace `check_gates.py`;
 - make fixture metadata normative;
@@ -351,7 +284,8 @@ This plan does not:
 
 ## Summary
 
-`refusal_delta_evidence_present` is the release-grade evidence-presence gate for refusal-delta evidence.
+`refusal_delta_evidence_present` is the release-grade evidence-presence gate for
+refusal-delta evidence.
 
 It prevents this unsafe release-grade state:
 
@@ -362,6 +296,9 @@ refusal_delta_evidence_present = false
 
 from becoming PASS.
 
-The gate should be promoted only through declared policy, with explicit fixture coverage and regression tests.
+Current repository evidence includes declared policy, release-grade profile
+requirements, negative and positive fixtures, fixture-matrix integration, and a
+dedicated no-implicit-PASS regression test.
 
-This strengthens PULSE-REF without creating a second release-decision engine.
+This strengthens the PULSE-REF evidence-presence boundary without creating a
+second release-decision engine.


### PR DESCRIPTION
## Summary

This PR reconciles stale refusal-delta evidence-presence plan language against
current repository evidence.

## Purpose

Several docs still described `refusal_delta_evidence_present` as planned future
promotion / future implementation work.

Current repository evidence now includes:

- `refusal_delta_evidence_present` in the release-grade required gate set;
- release-grade profile requirements for refusal-delta evidence when
  release-required;
- negative fixture coverage for missing refusal-delta evidence;
- positive fixture coverage for materialized refusal-delta evidence;
- no-implicit-PASS regression coverage;
- release-reference fixture matrix coverage.

## Updated files

```text
docs/refusal_delta_evidence_presence_gate_v1.md
docs/no_implicit_pass_release_grade_v1.md
docs/evidence_presence_policy_v1.md
```

## Cleanup performed

The update replaces stale language such as:

```text
planned promotion
future implementation
future commits should add
positive fixture may be added
before global policy promotion
```

with current-state language:

```text
current policy/profile/test-backed release-grade evidence-presence behavior
negative fixture proves fail-closed missing-evidence case
positive fixture proves materialized-evidence pass case
remaining future work is limited to actually absent or deliberately separate items
```

## Scope

Docs-only.

## Preserved

Preserved surfaces remain unchanged:

- PULSEmech release authority;
- gate policy semantics;
- schemas;
- workflow mechanics;
- CI allow/block behavior;
- `check_gates.py`;
- Quality Ledger renderer behavior;
- Pages workflow behavior;
- release tags;
- DOI / Zenodo path.

## Validation

```bash
git diff --check -- \
  docs/refusal_delta_evidence_presence_gate_v1.md \
  docs/no_implicit_pass_release_grade_v1.md \
  docs/evidence_presence_policy_v1.md

python tests/test_no_implicit_pass_release_grade.py
python tests/test_release_reference_fixture_matrix_v1.py
```