### PR TITLE
docs(cleanup): remove stale refusal delta plan wording

### DIFF
--- a/docs/no_implicit_pass_release_grade_v1.md
+++ b/docs/no_implicit_pass_release_grade_v1.md
@@ -140,7 +140,7 @@ The release-reference fixture matrix reads this metadata and passes the extra ga
 --require-gate refusal_delta_evidence_present
 ```
 
-This allows the PULSE-REF fixture matrix to model release-grade evidence-presence requirements without immediately changing the global gate policy.
+This allows the PULSE-REF fixture matrix to model release-grade evidence-presence requirements while preserving the current declared release-grade policy path.
 
 The matrix test is:
 

--- a/docs/refusal_delta_evidence_presence_gate_v1.md
+++ b/docs/refusal_delta_evidence_presence_gate_v1.md
@@ -205,7 +205,7 @@ expected behavior.
 
 Run:
 
-The policy promotion PR should run:
+The current evidence-presence validation should run the following checks:
 
 ```bash
 python tests/test_no_implicit_pass_release_grade.py


### PR DESCRIPTION
## Summary

This PR removes two remaining stale planned-promotion phrases from the
refusal-delta evidence-presence documentation.

## Purpose

The previous cleanup reconciled `refusal_delta_evidence_present` documentation
against current policy, profile, fixture, and regression-test evidence.

The review found two remaining sentences that still implied future policy
promotion or an unchanged global policy state.

## Changes

Updated:

```text
docs/refusal_delta_evidence_presence_gate_v1.md
docs/no_implicit_pass_release_grade_v1.md
```

The wording now describes:

- current evidence-presence validation;
- the current declared release-grade policy path;
- current policy/profile/test-backed refusal-delta evidence behavior.

## Scope

Docs-only.

## Preserved

Preserved surfaces remain unchanged:

- PULSEmech release authority;
- gate policy semantics;
- required gate wiring;
- schemas;
- workflow mechanics;
- CI allow/block behavior;
- `check_gates.py`;
- Quality Ledger renderer behavior;
- Pages workflow behavior;
- release tags;
- DOI / Zenodo path.

## Validation

```bash
git diff --check -- docs/refusal_delta_evidence_presence_gate_v1.md docs/no_implicit_pass_release_grade_v1.md

python tests/test_no_implicit_pass_release_grade.py

python tests/test_release_reference_fixture_matrix_v1.py
```