### PR TITLE
docs(cleanup): refine PULSE-REF baseline reconciliation

### DIFF
--- a/docs/PULSE_REF_RELEASE_REFERENCE_EVIDENCE_PACKET_BASELINE_v0.md
+++ b/docs/PULSE_REF_RELEASE_REFERENCE_EVIDENCE_PACKET_BASELINE_v0.md
@@ -1,15 +1,16 @@
 # PULSE-REF Release-Reference Evidence Packet Baseline v0
 
-Status: planning baseline  
+Status: planning baseline / current baseline relation  
 Authority status: non-normative  
 Scope: PULSE-REF / release-reference fixture matrix / evidence packet baseline  
 Release-grade status: not release-grade evidence  
 Verifier status: not a verifier  
-Decision status: does not authorize, block, override, or create release authority
+Decision status: does not authorize, block, override, or create release authority  
 
 ## Purpose
 
-This document defines the first PULSE-REF release-reference evidence packet baseline.
+This document defines the first PULSE-REF release-reference evidence packet
+baseline.
 
 It connects three already-established PULSE-REF surfaces:
 
@@ -17,7 +18,12 @@ It connects three already-established PULSE-REF surfaces:
 - the evidence packet layout;
 - the minimum content contract.
 
-The purpose is to define what the first release-reference evidence packet baseline must preserve before PULSE moves toward a concrete release-grade reference evidence packet.
+The baseline now also records the current relation to the schema-aligned
+pass-fixture packet-builder path.
+
+The purpose is to define what the release-reference evidence packet baseline
+preserves as PULSE moves from controlled fixture cases toward a concrete,
+digest-backed, reconstructable release-reference evidence packet.
 
 This document does not create release authority.
 
@@ -25,32 +31,53 @@ This document does not validate release-grade evidence.
 
 This document does not run RA1.
 
-This document does not replace the evidence packet layout, the minimum content contract, or the release-reference fixture matrix.
+This document does not replace the evidence packet layout, the minimum content
+contract, the release-reference fixture matrix, or the schema-aligned packet
+builder checkpoint.
 
-It defines the baseline relation between them.
+It defines the baseline relation between those surfaces.
 
 ## Core statement
 
 A PULSE-REF release-grade reference is not merely a run.
 
-A release-grade reference is a recorded, artifact-bound, digest-backed, reconstructable evidence packet.
+A release-grade reference is a recorded, artifact-bound, digest-backed,
+reconstructable evidence packet.
 
 The fixture matrix tests fail-closed evidence-to-decision behavior.
 
-The evidence packet baseline preserves the artifact field required to reconstruct that behavior.
+The evidence packet baseline preserves the artifact field required to
+reconstruct that behavior.
 
-The baseline exists so the next release-reference state can move from isolated fixture cases toward a packet-shaped reconstruction target.
+The current baseline relation is no longer only a planning target.
+
+It now connects:
+
+```text
+guarded positive release-reference fixture
+→ release-reference completeness guard
+→ policy-derived materialized required gates
+→ schema-aligned packet builder
+→ canonical packet artifacts
+→ schema-aligned packet validator
+→ reconstructable packet-shaped baseline candidate
+```
+
+The remaining baseline work concerns packet-completeness surfaces, generated
+packet fixtures, and later RA1 / HPC follow-on work.
 
 ## Normative release path
 
 The normative PULSE release decision remains:
 
-recorded release evidence  
-→ recorded `status.json` artifact  
-→ declared gate policy  
-→ materialized required gate set  
-→ strict fail-closed CI gate enforcement  
+```text
+recorded release evidence
+→ recorded status.json artifact
+→ declared gate policy
+→ materialized required gate set
+→ strict fail-closed CI gate enforcement
 → declared-policy CI allow/block release decision
+```
 
 A release-reference evidence packet preserves and reconstructs this path.
 
@@ -58,7 +85,9 @@ It does not replace it.
 
 The packet does not authorize release by existing.
 
-The packet is release-relevant only as a recorded artifact field that preserves the evidence, declared policy, materialized gates, CI outcome, and reconstruction surfaces needed to inspect the declared-policy decision path.
+The packet is release-relevant only as a recorded artifact field that preserves
+the evidence, declared policy, materialized gates, CI outcome, and reconstruction
+surfaces needed to inspect the declared-policy decision path.
 
 ## Relation to existing PULSE-REF surfaces
 
@@ -68,19 +97,24 @@ The packet is release-relevant only as a recorded artifact field that preserves 
 
 This baseline does not change that layout.
 
-The baseline uses the existing canonical packet structure as the packet target for future release-reference evidence.
+The baseline uses the existing canonical packet structure as the packet target
+for release-reference evidence.
 
 ### Minimum content contract
 
-`docs/PULSE_REF_EVIDENCE_PACKET_MINIMUM_CONTENT_CONTRACT_v0.md` defines the minimum content classes a future packet must carry.
+`docs/PULSE_REF_EVIDENCE_PACKET_MINIMUM_CONTENT_CONTRACT_v0.md` defines the
+minimum content classes a packet must carry.
 
 This baseline does not replace that contract.
 
-The baseline identifies which minimum content classes are needed first for release-reference baseline closure.
+The baseline identifies which minimum content classes are needed for
+release-reference baseline closure and which content classes remain reserved for
+the next packet-completeness layer.
 
 ### Minimal content packet builder
 
-`scripts/build_pulse_ref_minimal_content_packet_v0.py` builds a minimal content-bearing packet.
+`scripts/build_pulse_ref_minimal_content_packet_v0.py` builds a minimal
+content-bearing packet.
 
 That generated packet is useful as a bridge fixture.
 
@@ -92,24 +126,53 @@ It is not release authority.
 
 ### Release-reference fixture matrix
 
-`tests/fixtures/release_reference_v1/` and `tests/test_release_reference_fixture_matrix_v1.py` exercise positive and negative release-reference behavior.
+`tests/fixtures/release_reference_v1/` and
+`tests/test_release_reference_fixture_matrix_v1.py` exercise positive and
+negative release-reference behavior.
 
 The fixture matrix is not a packet.
 
 The matrix proves fail-closed behavior across controlled candidate states.
 
-The packet baseline defines the artifact field that should preserve a selected candidate state and its reconstruction trail.
+The packet baseline defines the artifact field that preserves a selected
+candidate state and its reconstruction trail.
+
+### Schema-aligned packet-builder checkpoint
+
+`docs/PULSE_REF_SCHEMA_ALIGNED_PACKET_BUILDER_CHECKPOINT_v0.md` records the
+current schema-aligned packet-builder state.
+
+The checkpoint records that the builder path is no longer only conceptual.
+
+It includes:
+
+- guarded source fixture;
+- baseline evidence-packet principle;
+- handoff plan;
+- schema-aligned builder contract;
+- contract guard;
+- schema-aligned packet validator;
+- schema-aligned pass-fixture packet builder;
+- publication snapshot manifest-reference hardening.
+
+The current builder emits a reconstructable v0 packet candidate.
+
+The field-point authority map and evidence fold-in admissibility artifacts remain
+reserved for the next packet-completeness layer.
 
 ## Baseline objective
 
-The first release-reference evidence packet baseline must be able to preserve:
+The release-reference evidence packet baseline preserves the packet field needed
+to reconstruct a controlled release-reference candidate state.
+
+The complete baseline target includes:
 
 - packet identity;
 - run identity;
 - recorded `status.json`;
 - declared gate policy;
 - gate registry;
-- materialized required and release_required gate sets;
+- materialized required and `release_required` gate sets;
 - effective required gate set;
 - declared-policy CI outcome;
 - release authority manifest;
@@ -124,71 +187,123 @@ The first release-reference evidence packet baseline must be able to preserve:
 - optional HPC evidence references;
 - optional recognition-surface diagnostic references.
 
+The current schema-aligned pass-fixture packet builder covers the current v0
+packet candidate subset:
+
+- packet overview;
+- package manifest;
+- recorded status;
+- source expected-outcome metadata;
+- declared policy;
+- gate registry;
+- policy-derived materialized gate sets;
+- CI outcome;
+- release authority manifest;
+- operator handoff report;
+- package digests;
+- audit bundle;
+- external summary note;
+- reconstruction instructions.
+
+The reserved next-layer surfaces are:
+
+```text
+field/field_point_authority_map_v0.json
+admissibility/evidence_fold_in_admissibility_v0.json
+publication/publication_snapshot.json when canonical publication surface exists
+```
+
 The baseline succeeds when the packet is reconstructable and authority-safe.
 
-The baseline does not require that the packet already be release-grade.
+Baseline completeness is separate from release authorization.
 
 ## Baseline source candidate
 
-The first baseline source candidate should be a controlled release-reference fixture state.
+The current baseline source candidate is the controlled positive
+release-reference fixture state.
 
 Preferred baseline candidate:
 
-`tests/fixtures/release_reference_v1/pass/`
+```text
+tests/fixtures/release_reference_v1/pass/
+```
 
 Reason:
 
 - it is a positive release-grade reference fixture candidate;
 - required gates are literal boolean `true`;
-- release_required gates are literal boolean `true`;
+- `release_required` gates are literal boolean `true`;
 - detector evidence is materialized;
 - external summaries are present;
 - external aggregate is passing;
 - diagnostics are non-stubbed;
 - diagnostics are non-scaffolded.
 
-Negative fixtures remain essential for fail-closed testing, but the first evidence packet baseline should start from a positive candidate so reconstruction can focus on packet completeness rather than intentional failure.
+The schema-aligned packet-builder path currently uses this guarded positive
+fixture as the source fixture.
+
+Negative fixtures remain essential for fail-closed testing, but the first
+evidence packet baseline starts from a positive candidate so reconstruction can
+focus on packet completeness rather than intentional failure.
 
 ## Negative fixture relation
 
 Negative release-reference fixtures remain part of the baseline field.
 
-They validate that the release-reference guard fails closed when evidence is incomplete, stubbed, scaffolded, false, missing, malformed, or non-materialized.
+They validate that the release-reference guard fails closed when evidence is:
 
-The packet baseline should preserve the existence of these negative cases as regression evidence, but it should not combine all negative fixtures into the first packet.
+- incomplete;
+- stubbed;
+- scaffolded;
+- false;
+- missing;
+- malformed;
+- non-materialized.
+
+The packet baseline preserves the existence of these negative cases as
+regression evidence.
+
+The first packet baseline preserves one selected positive candidate state and
+references the matrix as supporting regression coverage.
 
 Each negative fixture remains isolated.
 
-A packet baseline may later include a fixture matrix summary, but the first packet baseline should preserve one selected candidate state and reference the matrix as supporting regression coverage.
+A later packet-completeness layer may include a fixture matrix summary.
 
 ## Minimum baseline packet content
 
-The first release-reference evidence packet baseline should include at minimum:
+The complete release-reference evidence packet baseline target includes the
+following content classes.
 
-| Packet path | Baseline requirement | Role | Authority status |
-|---|---:|---|---|
-| `README.md` | required | packet overview and authority boundary | non-normative |
-| `package_manifest.json` | required | packet inventory and artifact references | audit / reconstruction |
-| `status/status.json` | required | recorded release-state artifact | normative input for inspected path |
-| `policy/pulse_gate_policy_v0.yml` | required | declared gate policy | normative input |
-| `policy/pulse_gate_registry_v0.yml` | required | gate semantic registry | normative support |
-| `gates/materialized_gate_sets.json` | required | materialized required gate sets | normative input |
-| `ci/ci_outcome.json` | required | declared-policy gate-enforcement outcome | normative enforcement output |
-| `release_authority/release_authority_manifest.json` | required | audit / trace manifest | non-normative trace |
-| `audit/release_authority_audit_bundle/` | required | evidence preservation bundle | non-normative audit |
-| `digests/package_digests.json` | required | digest coverage | audit / reconstruction |
-| `handoff/operator_handoff_report.json` | required | operator reconstruction surface | non-normative |
-| `publication/publication_snapshot.json` | required when public surfaces are included | publication identity | non-normative |
-| `field/field_point_authority_map_v0.json` | required | field-point authority classification | non-normative diagnostic |
-| `admissibility/evidence_fold_in_admissibility_v0.json` | required | fold-in admissibility state | non-normative diagnostic |
-| `external/summaries/` | conditional | external evidence references | policy-routed candidate evidence |
-| `hpc/hpc_evidence_bundle_v0.json` | optional for baseline | compute-scale validation reference | non-normative diagnostic |
-| `recognition/recognition_surface_drift_v0.json` | optional for baseline | recognition drift diagnostic | non-normative |
-| `reconstruction/reconstruction_instructions.md` | required | reconstruction guide | non-normative operator surface |
+The current schema-aligned builder already emits the current v0 packet candidate
+subset.
+
+| Packet path | Baseline requirement | Current v0 builder state | Role | Authority status |
+|---|---:|---|---|---|
+| `README.md` | required | emitted | packet overview and authority boundary | non-normative |
+| `package_manifest.json` | required | emitted | packet inventory and artifact references | audit / reconstruction |
+| `status/status.json` | required | emitted | recorded release-state artifact | normative input for inspected path |
+| `reconstruction/source_expected_outcome.json` | required for fixture-derived packet | emitted | source fixture expected-outcome metadata | non-normative reconstruction |
+| `policy/pulse_gate_policy_v0.yml` | required | emitted | declared gate policy | normative input |
+| `policy/pulse_gate_registry_v0.yml` | required | emitted | gate semantic registry | normative support |
+| `gates/materialized_gate_sets.json` | required | emitted | materialized required gate sets | normative input |
+| `ci/ci_outcome.json` | required | emitted | declared-policy gate-enforcement outcome | normative enforcement output |
+| `release_authority/release_authority_manifest.json` | required | emitted | audit / trace manifest | non-normative trace |
+| `audit/release_authority_audit_bundle/` | required | emitted | evidence preservation bundle | non-normative audit |
+| `digests/package_digests.json` | required | emitted | digest coverage | audit / reconstruction |
+| `handoff/operator_handoff_report.json` | required | emitted | operator reconstruction surface | non-normative |
+| `external/summaries/README.md` | required for current v0 external note | emitted | external summary note | non-normative evidence note |
+| `reconstruction/reconstruction_instructions.md` | required | emitted | reconstruction guide | non-normative operator surface |
+| `publication/publication_snapshot.json` | required when public surfaces are included | reserved until canonical publication surface exists | publication identity | non-normative |
+| `field/field_point_authority_map_v0.json` | required for next packet-completeness layer | reserved | field-point authority classification | non-normative diagnostic |
+| `admissibility/evidence_fold_in_admissibility_v0.json` | required for next packet-completeness layer | reserved | fold-in admissibility state | non-normative diagnostic |
+| `external/summaries/` | conditional | external note emitted; summary payloads remain policy-routed | external evidence references | policy-routed candidate evidence |
+| `hpc/hpc_evidence_bundle_v0.json` | optional for baseline | reserved | compute-scale validation reference | non-normative diagnostic |
+| `recognition/recognition_surface_drift_v0.json` | optional for baseline | reserved | recognition drift diagnostic | non-normative |
 
 ## Packet identity requirements
 
-The baseline packet must preserve stable packet identity.
+The baseline packet preserves stable packet identity.
 
 Required identity fields:
 
@@ -203,13 +318,11 @@ Required identity fields:
 - package manifest path;
 - package digest manifest path.
 
-Packet identity is not release authority.
-
 Packet identity supports reconstruction and digest binding.
 
 ## Run identity requirements
 
-The baseline packet must preserve run identity.
+The baseline packet preserves run identity.
 
 Required run identity fields:
 
@@ -223,15 +336,20 @@ Required run identity fields:
 - event type;
 - run URL or archived run reference when available.
 
-Run identity must bind to the recorded `status.json`, materialized gate set, CI outcome, and release authority manifest.
+Run identity must bind to the recorded `status.json`, materialized gate set, CI
+outcome, and release authority manifest.
 
-A packet is not baseline-complete if its run identity cannot be tied to its recorded artifacts.
+A packet is not baseline-complete if its run identity cannot be tied to its
+recorded artifacts.
+
+For fixture-derived packet candidates, the source fixture identity also supports
+reconstruction.
 
 ## Recorded status requirements
 
-The baseline packet must include a recorded `status/status.json`.
+The baseline packet includes a recorded `status/status.json`.
 
-For the first positive baseline candidate, the status artifact should preserve:
+For the positive baseline candidate, the status artifact preserves:
 
 - `metrics.run_mode = "prod"`;
 - selected fixture or candidate identity;
@@ -239,7 +357,7 @@ For the first positive baseline candidate, the status artifact should preserve:
 - `diagnostics.gates_stubbed = false`;
 - `diagnostics.scaffold = false`;
 - required gates as literal boolean `true`;
-- release_required gates as literal boolean `true`;
+- `release_required` gates as literal boolean `true`;
 - detector materialization state;
 - external summary presence state;
 - external aggregate pass state;
@@ -249,14 +367,15 @@ A live or public `status.json` URL is not a substitute for the recorded artifact
 
 ## Policy and registry requirements
 
-The baseline packet must include the declared policy and registry used for the inspected candidate.
+The baseline packet includes the declared policy and registry used for the
+inspected candidate.
 
 Required policy and registry content:
 
 - policy artifact path;
 - policy artifact SHA-256 digest;
 - selected policy set;
-- release_required set where used;
+- `release_required` set where used;
 - gate registry artifact path;
 - gate registry SHA-256 digest;
 - evidence that required gates are registry-backed.
@@ -265,12 +384,12 @@ The materialized gate set must be reconstructable from the declared policy.
 
 ## Materialized gate-set requirements
 
-The baseline packet must include `gates/materialized_gate_sets.json`.
+The baseline packet includes `gates/materialized_gate_sets.json`.
 
-The artifact should record:
+The artifact records:
 
 - required gate set;
-- release_required gate set;
+- `release_required` gate set;
 - effective required gate set;
 - selected lane or policy scope;
 - policy source path;
@@ -279,13 +398,15 @@ The artifact should record:
 - ordering rule;
 - materialization command or reference when available.
 
+The materialized gate set preserves declared policy materialization.
+
 The materialized gate set must not be hand-edited to satisfy release evidence.
 
 ## CI outcome requirements
 
-The baseline packet must include `ci/ci_outcome.json`.
+The baseline packet includes `ci/ci_outcome.json`.
 
-The CI outcome should record:
+The CI outcome records:
 
 - CI provider;
 - workflow name;
@@ -301,15 +422,18 @@ The CI outcome should record:
 - run URL or archived run reference when available;
 - authority-boundary statement.
 
-The CI outcome is release-relevant only as the declared-policy gate-enforcement result.
+The CI outcome is release-relevant as the declared-policy gate-enforcement
+result.
 
-A generic green workflow is not equivalent to a declared-policy release decision.
+A generic green workflow is not equivalent to a declared-policy release
+decision.
 
 ## Release authority manifest requirements
 
-The baseline packet must include `release_authority/release_authority_manifest.json`.
+The baseline packet includes
+`release_authority/release_authority_manifest.json`.
 
-The manifest should preserve:
+The manifest preserves:
 
 - run identity;
 - status artifact reference;
@@ -329,7 +453,7 @@ It is not a second decision engine.
 
 ## Audit bundle requirements
 
-The baseline packet must include an audit bundle or audit-bundle reference.
+The baseline packet includes an audit bundle or audit-bundle reference.
 
 Minimum audit bundle content:
 
@@ -346,25 +470,32 @@ It does not authorize release.
 
 ## Digest requirements
 
-The baseline packet must include `digests/package_digests.json`.
+The baseline packet includes `digests/package_digests.json`.
 
-Digest coverage should include all required packet payload artifacts.
+Digest coverage includes all required current packet payload artifacts.
 
-Minimum digest coverage:
+Minimum current v0 digest coverage:
 
 - `README.md`;
 - `package_manifest.json`;
 - `status/status.json`;
+- `reconstruction/source_expected_outcome.json`;
 - `policy/pulse_gate_policy_v0.yml`;
 - `policy/pulse_gate_registry_v0.yml`;
 - `gates/materialized_gate_sets.json`;
 - `ci/ci_outcome.json`;
 - `release_authority/release_authority_manifest.json`;
 - `handoff/operator_handoff_report.json`;
-- `publication/publication_snapshot.json` when present;
+- `digests/package_digests.json`;
+- `audit/release_authority_audit_bundle/`;
+- `external/summaries/README.md`;
+- `reconstruction/reconstruction_instructions.md`.
+
+Next-layer digest coverage will include, when present:
+
+- `publication/publication_snapshot.json`;
 - `field/field_point_authority_map_v0.json`;
 - `admissibility/evidence_fold_in_admissibility_v0.json`;
-- `reconstruction/reconstruction_instructions.md`;
 - any included external summary;
 - any included HPC evidence bundle;
 - any included recognition-surface diagnostic.
@@ -373,9 +504,9 @@ A packet without digest coverage is not baseline-complete.
 
 ## Operator handoff requirements
 
-The baseline packet must include `handoff/operator_handoff_report.json`.
+The baseline packet includes `handoff/operator_handoff_report.json`.
 
-The operator handoff report should preserve:
+The operator handoff report preserves:
 
 - gate mode;
 - status source;
@@ -394,9 +525,10 @@ It does not create release authority.
 
 ## Publication snapshot requirements
 
-If the packet references public surfaces, it must include `publication/publication_snapshot.json`.
+If the packet references public surfaces, it includes
+`publication/publication_snapshot.json`.
 
-The publication snapshot should preserve:
+The publication snapshot preserves:
 
 - public URL or archived reference;
 - status URL or archived status reference;
@@ -411,11 +543,15 @@ Publication surfaces are reader surfaces.
 
 They do not create release authority.
 
+The current schema-aligned builder omits the publication snapshot until a
+canonical publication surface exists.
+
 ## Field-point authority map requirements
 
-The baseline packet must include `field/field_point_authority_map_v0.json`.
+The complete baseline target includes
+`field/field_point_authority_map_v0.json`.
 
-The field-point map should classify each included surface as one of:
+The field-point map classifies each included surface as one of:
 
 - normative input;
 - normative enforcement output;
@@ -427,15 +563,19 @@ The field-point map should classify each included surface as one of:
 - optional analysis surface;
 - non-normative surface.
 
-Any field point that claims release-authority relevance must state its policy route.
+Any field point that claims release-authority relevance must state its policy
+route.
 
 No unclassified packet surface may be treated as release-authoritative.
 
+The field-point authority map is reserved for the next packet-completeness layer.
+
 ## Evidence fold-in admissibility requirements
 
-The baseline packet must include `admissibility/evidence_fold_in_admissibility_v0.json`.
+The complete baseline target includes
+`admissibility/evidence_fold_in_admissibility_v0.json`.
 
-The admissibility artifact should record:
+The admissibility artifact records:
 
 - candidate evidence ID;
 - source surface type;
@@ -451,13 +591,18 @@ The admissibility artifact should record:
 
 Admissibility is not release permission.
 
-Admissibility only states whether candidate evidence can enter a future policy-routed fold-in path.
+Admissibility states whether candidate evidence can enter a policy-routed fold-in
+path.
+
+The evidence fold-in admissibility artifact is reserved for the next
+packet-completeness layer.
 
 ## External evidence baseline relation
 
 External evidence remains conditional.
 
-If declared policy requires external evidence, the packet must preserve external summary artifacts or verified summary references.
+If declared policy requires external evidence, the packet preserves external
+summary artifacts or verified summary references.
 
 Minimum external evidence references:
 
@@ -477,11 +622,18 @@ Presence alone is not enough.
 
 Aggregate pass alone is not enough.
 
+The current schema-aligned builder emits an external summary note as part of the
+current v0 packet candidate.
+
+Policy-routed external summary payload inclusion remains a next-layer
+packet-completeness surface.
+
 ## HPC evidence baseline relation
 
 HPC evidence is optional for the first baseline.
 
-If included, it must be non-normative unless future declared policy promotes a specific evidence field or gate.
+If included, it remains non-normative unless future declared policy promotes a
+specific evidence field or gate.
 
 Minimum HPC reference content:
 
@@ -496,13 +648,14 @@ Minimum HPC reference content:
 
 HPC scale does not create release authority.
 
-HPC output is useful only when materialized, recorded, digest-backed, reconstructable, role-classified, and verified.
+HPC output is useful when materialized, recorded, digest-backed,
+reconstructable, role-classified, and verified.
 
 ## Recognition-surface baseline relation
 
 Recognition-surface diagnostics are optional for the first baseline.
 
-If included, they must remain non-normative.
+If included, they remain non-normative.
 
 Recognition-surface content may include:
 
@@ -519,13 +672,14 @@ They do not authorize release.
 
 ## Reconstruction baseline
 
-The packet must include `reconstruction/reconstruction_instructions.md`.
+The packet includes `reconstruction/reconstruction_instructions.md`.
 
-The instructions should explain how to reconstruct:
+The instructions explain how to reconstruct:
 
 - packet identity;
 - run identity;
 - recorded status artifact;
+- source fixture expected-outcome metadata;
 - declared policy;
 - gate registry;
 - materialized required gate set;
@@ -533,11 +687,14 @@ The instructions should explain how to reconstruct:
 - release authority manifest;
 - audit bundle;
 - digest manifest;
-- field-point authority map;
-- evidence fold-in admissibility state;
+- operator handoff report;
+- external summary note;
+- optional publication snapshot;
+- optional field-point authority map;
+- optional evidence fold-in admissibility state;
 - optional external / HPC / recognition evidence.
 
-The reconstruction instructions must distinguish:
+The reconstruction instructions distinguish:
 
 - normative inputs;
 - normative enforcement outputs;
@@ -548,25 +705,33 @@ The reconstruction instructions must distinguish:
 
 ## Baseline acceptance conditions
 
-A release-reference evidence packet baseline may be accepted as baseline-complete when:
+A release-reference evidence packet baseline may be accepted as baseline-complete
+when:
 
 1. packet identity is present;
 2. run identity is present;
 3. recorded `status.json` is present;
-4. declared policy is present;
-5. gate registry is present;
-6. materialized required gate set is present;
-7. CI outcome is present;
-8. release authority manifest is present;
-9. audit bundle or audit references are present;
-10. package digests are present;
-11. operator handoff report is present;
-12. reconstruction instructions are present;
-13. field-point authority classification is present;
+4. source expected-outcome metadata is present for fixture-derived candidates;
+5. declared policy is present;
+6. gate registry is present;
+7. materialized required gate set is present;
+8. CI outcome is present;
+9. release authority manifest is present;
+10. audit bundle or audit references are present;
+11. package digests are present;
+12. operator handoff report is present;
+13. reconstruction instructions are present;
 14. authority-boundary statements are present;
-15. all required artifacts are digest-backed;
-16. all required references bind to the same packet/run identity;
+15. all required current packet artifacts are digest-backed;
+16. all required references bind to the same packet, fixture, or run identity;
 17. no non-normative surface claims independent release authority.
+
+The current v0 schema-aligned builder candidate satisfies the current
+reconstructable packet-candidate subset when it passes the schema-aligned packet
+validator.
+
+The field-point authority map and evidence fold-in admissibility artifacts are
+reserved next-layer acceptance surfaces.
 
 Baseline completeness is not release authorization.
 
@@ -577,38 +742,84 @@ A baseline packet must fail packet-completeness review when:
 - packet identity is missing;
 - run identity is missing;
 - recorded `status.json` is missing;
+- source expected-outcome metadata is missing for fixture-derived candidates;
 - declared policy is missing;
 - gate registry is missing;
 - materialized gate set is missing;
 - CI outcome is missing;
 - package digests are missing;
+- operator handoff report is missing;
 - reconstruction instructions are missing;
 - required artifacts are not digest-backed;
-- packet references do not bind to the same run identity;
+- packet references do not bind to the same packet, fixture, or run identity;
 - reader, audit, publication, diagnostic, or HPC surfaces claim release authority;
-- advisory or diagnostic evidence is treated as required evidence without declared policy routing;
+- advisory or diagnostic evidence is treated as required evidence without
+  declared policy routing;
 - missing required evidence is interpreted as PASS.
 
 All negative conditions must fail closed.
 
+## Relation to current schema-aligned builder
+
+The current schema-aligned builder path is the implementation bridge from a
+guarded positive fixture to a packet-shaped baseline candidate.
+
+Current chain:
+
+```text
+tests/fixtures/release_reference_v1/pass/status.json
+→ release-reference completeness guard
+→ policy-derived materialized required gates
+→ schema-aligned packet builder
+→ canonical packet artifacts
+→ schema-aligned packet validator
+→ reconstructable packet-shaped baseline candidate
+```
+
+The current builder path prepares the baseline candidate from:
+
+```text
+tests/fixtures/release_reference_v1/pass/
+```
+
+The current validator checks the packet artifact shape, canonical JSON artifact
+schemas, release authority manifest shape, policy-derived materialized gate
+sets, package manifest references, package digest references, optional
+publication snapshot schema when present, and package-relative path safety for
+manifest artifact references.
+
+This relation supersedes the older purely planning-baseline wording.
+
 ## Relation to future implementation
 
-This baseline prepares future implementation work.
+The first schema-aligned implementation layer is partially realized.
 
-Possible next implementation steps:
+Current implemented bridge:
 
-1. build a `pass` release-reference fixture into a packet-shaped baseline;
-2. add a baseline packet fixture under `tests/fixtures/pulse_ref/`;
-3. bind packet paths to package digests;
-4. add a baseline checker that verifies packet completeness only;
-5. keep the checker non-authoritative;
-6. later connect baseline packet verification to RA1-style package verification.
+1. guarded positive release-reference fixture;
+2. release-reference completeness guard before packet generation;
+3. schema-aligned pass-fixture packet builder;
+4. canonical packet artifacts;
+5. package manifest and digest coverage;
+6. schema-aligned packet validator;
+7. publication snapshot manifest-reference hardening.
 
-The first implementation should remain conservative.
+Remaining possible next implementation steps:
 
-It should verify packet completeness and authority boundaries.
+1. add a generated packet fixture from the schema-aligned builder;
+2. add a golden generated-packet regression test;
+3. add packet diff / drift detection between generated candidate packets;
+4. add field-point authority map artifact generation;
+5. add evidence fold-in admissibility artifact generation;
+6. add builder-to-validator-to-RA1 bridge testing;
+7. add HPC candidate batch planning over schema-aligned packet candidates;
+8. add relational evidence-field references into the packet manifest or field map.
 
-It should not authorize release.
+The next step preserves the current chain.
+
+The checker remains packet-completeness and authority-boundary oriented.
+
+It does not authorize release.
 
 ## Relation to RA1
 
@@ -620,15 +831,25 @@ This baseline does not replace RA1.
 
 This baseline does not relax RA1.
 
-This baseline defines the packet-preparation field before concrete RA1 verification.
+This baseline defines the packet-preparation field before concrete RA1
+verification.
 
 RA1 may later consume or verify a concrete packet instance.
 
+Current boundary:
+
+```text
+schema-aligned packet preparation
+→ packet artifact validation
+→ future RA1 verification path
+```
+
 ## Relation to fellowship / HPC validation
 
-The release-reference evidence packet baseline is the anchor for later fellowship/HPC validation.
+The release-reference evidence packet baseline is the anchor for later
+fellowship / HPC validation.
 
-HPC validation should not start from an undefined release state.
+HPC validation starts from a defined release state.
 
 HPC candidate-state validation should start from:
 
@@ -654,6 +875,8 @@ This document does not change:
 - `check_gates.py`;
 - release-reference fixture behavior;
 - release-reference guard behavior;
+- schema-aligned packet builder behavior;
+- schema-aligned packet validator behavior;
 - CI workflow behavior;
 - RA1 verifier behavior;
 - README front-door positioning;
@@ -669,11 +892,15 @@ The evidence packet layout defines canonical packet shape.
 
 The minimum content contract defines required content classes.
 
-This baseline connects those surfaces into the next release-reference evidence field.
+The schema-aligned packet builder now produces a reconstructable v0 packet
+candidate from the guarded positive pass fixture.
+
+This baseline connects those surfaces into the release-reference evidence field.
 
 The next proof state is not merely a passing run.
 
-The next proof state is a recorded, digest-backed, reconstructable release-reference evidence packet.
+The next proof state is a recorded, digest-backed, reconstructable
+release-reference evidence packet.
 
 It preserves the declared PULSEmech path.
 

--- a/docs/PULSE_REF_RELEASE_REFERENCE_EVIDENCE_PACKET_BASELINE_v0.md
+++ b/docs/PULSE_REF_RELEASE_REFERENCE_EVIDENCE_PACKET_BASELINE_v0.md
@@ -1,16 +1,15 @@
 # PULSE-REF Release-Reference Evidence Packet Baseline v0
 
-Status: planning baseline / current baseline relation  
-Authority status: non-normative  
-Scope: PULSE-REF / release-reference fixture matrix / evidence packet baseline  
-Release-grade status: not release-grade evidence  
-Verifier status: not a verifier  
-Decision status: does not authorize, block, override, or create release authority  
+Status: planning baseline / current baseline relation
+Authority status: non-normative
+Scope: PULSE-REF / release-reference fixture matrix / evidence packet baseline
+Release-grade status: not release-grade evidence
+Verifier status: not a verifier
+Decision status: does not authorize, block, override, or create release authority
 
 ## Purpose
 
-This document defines the first PULSE-REF release-reference evidence packet
-baseline.
+This document defines the first PULSE-REF release-reference evidence packet baseline.
 
 It connects three already-established PULSE-REF surfaces:
 
@@ -41,8 +40,7 @@ It defines the baseline relation between those surfaces.
 
 A PULSE-REF release-grade reference is not merely a run.
 
-A release-grade reference is a recorded, artifact-bound, digest-backed,
-reconstructable evidence packet.
+A release-grade reference is a recorded, artifact-bound, digest-backed, reconstructable evidence packet.
 
 The fixture matrix tests fail-closed evidence-to-decision behavior.
 
@@ -72,12 +70,14 @@ The normative PULSE release decision remains:
 
 ```text
 recorded release evidence
-→ recorded status.json artifact
+→ recorded `status.json` artifact
 → declared gate policy
 → materialized required gate set
 → strict fail-closed CI gate enforcement
 → declared-policy CI allow/block release decision
 ```
+
+The baseline packet preserves the recorded `status.json` artifact.
 
 A release-reference evidence packet preserves and reconstructs this path.
 
@@ -290,7 +290,7 @@ subset.
 | `ci/ci_outcome.json` | required | emitted | declared-policy gate-enforcement outcome | normative enforcement output |
 | `release_authority/release_authority_manifest.json` | required | emitted | audit / trace manifest | non-normative trace |
 | `audit/release_authority_audit_bundle/` | required | emitted | evidence preservation bundle | non-normative audit |
-| `digests/package_digests.json` | required | emitted | digest coverage | audit / reconstruction |
+| `digests/package_digests.json` | required | emitted | digest manifest | audit / reconstruction |
 | `handoff/operator_handoff_report.json` | required | emitted | operator reconstruction surface | non-normative |
 | `external/summaries/README.md` | required for current v0 external note | emitted | external summary note | non-normative evidence note |
 | `reconstruction/reconstruction_instructions.md` | required | emitted | reconstruction guide | non-normative operator surface |
@@ -472,12 +472,12 @@ It does not authorize release.
 
 The baseline packet includes `digests/package_digests.json`.
 
-Digest coverage includes all required current packet payload artifacts.
+Digest coverage includes the regular payload files that the current builder
+records in the digest map.
 
-Minimum current v0 digest coverage:
+Minimum current v0 digest coverage includes regular payload files such as:
 
 - `README.md`;
-- `package_manifest.json`;
 - `status/status.json`;
 - `reconstruction/source_expected_outcome.json`;
 - `policy/pulse_gate_policy_v0.yml`;
@@ -486,10 +486,17 @@ Minimum current v0 digest coverage:
 - `ci/ci_outcome.json`;
 - `release_authority/release_authority_manifest.json`;
 - `handoff/operator_handoff_report.json`;
-- `digests/package_digests.json`;
-- `audit/release_authority_audit_bundle/`;
+- `audit/release_authority_audit_bundle/README.md`;
+- `audit/release_authority_audit_bundle/status.json`;
+- `audit/release_authority_audit_bundle/release_authority_manifest.json`;
 - `external/summaries/README.md`;
 - `reconstruction/reconstruction_instructions.md`.
+
+The current builder treats `package_manifest.json` and
+`digests/package_digests.json` as structural manifest / digest-manifest surfaces.
+
+They are generated and validated as packet artifacts, but they are not entries in
+the current `package_digests.json` artifact map.
 
 Next-layer digest coverage will include, when present:
 
@@ -718,13 +725,14 @@ when:
 8. CI outcome is present;
 9. release authority manifest is present;
 10. audit bundle or audit references are present;
-11. package digests are present;
+11. package digest manifest is present;
 12. operator handoff report is present;
 13. reconstruction instructions are present;
 14. authority-boundary statements are present;
-15. all required current packet artifacts are digest-backed;
-16. all required references bind to the same packet, fixture, or run identity;
-17. no non-normative surface claims independent release authority.
+15. all required current digest-map payload files are digest-backed;
+16. structural manifest / digest-manifest surfaces are present and valid;
+17. all required references bind to the same packet, fixture, or run identity;
+18. no non-normative surface claims independent release authority.
 
 The current v0 schema-aligned builder candidate satisfies the current
 reconstructable packet-candidate subset when it passes the schema-aligned packet
@@ -747,10 +755,11 @@ A baseline packet must fail packet-completeness review when:
 - gate registry is missing;
 - materialized gate set is missing;
 - CI outcome is missing;
-- package digests are missing;
+- package digest manifest is missing;
 - operator handoff report is missing;
 - reconstruction instructions are missing;
-- required artifacts are not digest-backed;
+- required digest-map payload files are not digest-backed;
+- structural manifest / digest-manifest surfaces are missing or invalid;
 - packet references do not bind to the same packet, fixture, or run identity;
 - reader, audit, publication, diagnostic, or HPC surfaces claim release authority;
 - advisory or diagnostic evidence is treated as required evidence without

--- a/docs/PULSE_REF_SCHEMA_ALIGNED_PACKET_BUILDER_CHECKPOINT_v0.md
+++ b/docs/PULSE_REF_SCHEMA_ALIGNED_PACKET_BUILDER_CHECKPOINT_v0.md
@@ -1,31 +1,38 @@
 # PULSE-REF Schema-Aligned Packet Builder Checkpoint v0
 
-Status: checkpoint  
-Authority status: non-normative checkpoint  
-Scope: PULSE-REF / schema-aligned packet builder / validator / pass-fixture packet baseline  
-Checkpoint date: 2026-05-28  
+Status: checkpoint / current builder state
+Authority status: non-normative checkpoint
+Scope: PULSE-REF / schema-aligned packet builder / validator / pass-fixture packet baseline
+Checkpoint date: 2026-05-28
 Decision status: preserves the declared PULSEmech release-authority path
 
 ## Purpose
 
-This checkpoint records the current PULSE-REF schema-aligned packet builder state.
+This checkpoint records the current PULSE-REF schema-aligned packet builder
+state.
 
-It closes the development segment that moved from:
+It preserves the current working relation between:
 
-release-reference pass fixture  
-→ evidence packet baseline planning  
-→ handoff plan  
-→ schema-aligned builder contract  
-→ contract guard  
-→ schema-aligned packet validator  
-→ schema-aligned pass-fixture packet builder  
-→ publication snapshot manifest-reference hardening
+- the guarded positive release-reference fixture;
+- the release-reference evidence packet baseline;
+- the pass-fixture-to-evidence-packet handoff plan;
+- the schema-aligned builder contract;
+- the schema-aligned packet validator;
+- the schema-aligned pass-fixture packet builder;
+- publication snapshot manifest-reference hardening.
 
-The purpose is to preserve the working state before the next implementation layer begins.
+The checkpoint records the current builder path before the next
+packet-completeness implementation layer begins.
+
+The current state is not only conceptual.
+
+It is a working schema-aligned bridge from a guarded positive fixture to a
+reconstructable packet-shaped baseline candidate.
 
 ## Core checkpoint statement
 
-PULSE-REF now has a schema-aligned packet-builder path for the guarded positive pass fixture.
+PULSE-REF now has a schema-aligned packet-builder path for the guarded positive
+pass fixture.
 
 The path is no longer only conceptual.
 
@@ -37,27 +44,77 @@ It now contains:
 - a schema-aligned builder contract;
 - a guard for that contract;
 - a schema-aligned packet validator;
-- a pass-fixture packet builder;
-- validator hardening for optional publication snapshot manifest references.
+- a schema-aligned pass-fixture packet builder;
+- publication snapshot manifest-reference hardening.
 
-This checkpoint records the current artifact field so later work does not regress into fixture-specific canonical-path payloads.
+The current builder emits a reconstructable v0 packet candidate.
+
+The field-point authority map and evidence fold-in admissibility artifacts remain
+reserved for the next packet-completeness layer.
+
+This checkpoint records the current artifact field so later work does not
+regress into fixture-specific payloads written into canonical packet paths.
+
+## Current packet-builder chain
+
+The current chain is:
+
+```text
+tests/fixtures/release_reference_v1/pass/status.json
+→ release-reference completeness guard
+→ policy-derived materialized required gates
+→ schema-aligned packet builder
+→ canonical packet artifacts
+→ schema-aligned packet validator
+→ reconstructable packet-shaped baseline candidate
+```
+
+This chain is the current implementation bridge from a guarded positive fixture
+to a schema-aligned packet baseline.
 
 ## PULSEmech path preserved
 
 The declared PULSEmech release-authority path remains:
 
-recorded release evidence  
-→ recorded `status.json` artifact  
-→ declared gate policy  
-→ materialized required gate set  
-→ strict fail-closed CI gate enforcement  
+```text
+recorded release evidence
+→ recorded `status.json` artifact
+→ declared gate policy
+→ materialized required gate set
+→ strict fail-closed CI gate enforcement
 → declared-policy CI allow/block release decision
+```
 
-The schema-aligned packet builder prepares artifact packets that preserve this path for reconstruction.
+The schema-aligned packet builder prepares artifact packets that preserve this
+path for reconstruction.
 
 The builder path is an artifact-preparation surface.
 
 The PULSEmech path remains the release-authority materialization path.
+
+## Relation to release-reference evidence packet baseline
+
+`docs/PULSE_REF_RELEASE_REFERENCE_EVIDENCE_PACKET_BASELINE_v0.md` records the
+baseline as:
+
+```text
+planning baseline / current baseline relation
+```
+
+This checkpoint preserves the current builder side of that relation.
+
+The baseline document connects:
+
+- release-reference fixture matrix;
+- evidence packet layout;
+- minimum content contract;
+- schema-aligned pass-fixture packet-builder relation.
+
+This checkpoint records the current schema-aligned builder / validator state
+that supports the current v0 builder-covered subset.
+
+The complete baseline target, current v0 builder subset, and reserved next-layer
+packet-completeness surfaces remain separate.
 
 ## Relational evidence-field principle
 
@@ -67,25 +124,32 @@ The packet is not only a PASS / FAIL label carrier.
 
 The packet preserves the field relation behind the terminal decision:
 
-candidate evidence  
-↔ declared policy  
-↔ materialized required gates  
-↔ boundary pressure  
-↔ stability signals  
-↔ release-authority state  
+```text
+candidate evidence
+↔ declared policy
+↔ materialized required gates
+↔ boundary pressure
+↔ stability signals
+↔ release-authority state
 → recorded terminal enforcement result
+```
 
-The generated packet is valuable because it preserves the generation relation behind the result.
+The generated packet is valuable because it preserves the generation relation
+behind the result.
 
 ## Source fixture state
 
 The source fixture for the current builder path is:
 
-`tests/fixtures/release_reference_v1/pass/`
+```text
+tests/fixtures/release_reference_v1/pass/
+```
 
 The source fixture is protected by:
 
-`tests/test_pulse_ref_pass_fixture_packet_baseline_candidate_v0.py`
+```text
+tests/test_pulse_ref_pass_fixture_packet_baseline_candidate_v0.py
+```
 
 The fixture must remain:
 
@@ -104,36 +168,55 @@ The fixture must remain:
 
 ## Baseline and handoff surfaces
 
-The following planning and guard surfaces now define the path into packet form:
+The following planning, baseline, and guard surfaces define the path into packet
+form:
 
-- `docs/PULSE_REF_RELEASE_REFERENCE_EVIDENCE_PACKET_BASELINE_v0.md`
-- `tests/test_pulse_ref_release_reference_evidence_packet_baseline_v0.py`
-- `docs/PULSE_REF_PASS_FIXTURE_TO_EVIDENCE_PACKET_HANDOFF_PLAN_v0.md`
-- `tests/test_pulse_ref_pass_fixture_to_evidence_packet_handoff_plan_v0.py`
+```text
+docs/PULSE_REF_RELEASE_REFERENCE_EVIDENCE_PACKET_BASELINE_v0.md
+tests/test_pulse_ref_release_reference_evidence_packet_baseline_v0.py
+docs/PULSE_REF_PASS_FIXTURE_TO_EVIDENCE_PACKET_HANDOFF_PLAN_v0.md
+tests/test_pulse_ref_pass_fixture_to_evidence_packet_handoff_plan_v0.py
+```
 
-These surfaces define the transition from a guarded fixture to a packet-shaped baseline candidate.
+These surfaces define the transition from a guarded fixture to a packet-shaped
+baseline candidate.
+
+The current checkpoint preserves that transition and records the builder /
+validator state attached to it.
 
 ## Schema-aligned builder contract
 
 The schema-aligned builder contract is:
 
-`docs/PULSE_REF_SCHEMA_ALIGNED_PASS_FIXTURE_PACKET_BUILDER_CONTRACT_v0.md`
+```text
+docs/PULSE_REF_SCHEMA_ALIGNED_PASS_FIXTURE_PACKET_BUILDER_CONTRACT_v0.md
+```
 
 The contract states the mechanical rule:
 
+```text
 A canonical packet path carries a canonical artifact contract.
+```
 
 The contract protects packet artifact fidelity.
 
 It preserves PULSE as an artifact-bound release-authority system.
 
-Schema alignment is used to preserve reconstructability, artifact identity, verifier compatibility, digest integrity, and authority-role classification.
+Schema alignment is used to preserve:
+
+- reconstructability;
+- artifact identity;
+- verifier compatibility;
+- digest integrity;
+- authority-role classification.
 
 ## Contract guard
 
 The schema-aligned builder contract is protected by:
 
-`tests/test_pulse_ref_schema_aligned_packet_builder_contract_v0.py`
+```text
+tests/test_pulse_ref_schema_aligned_packet_builder_contract_v0.py
+```
 
 This guard preserves the contract anchors for:
 
@@ -157,11 +240,15 @@ This guard preserves the contract anchors for:
 
 The schema-aligned packet validator is:
 
-`scripts/check_pulse_ref_schema_aligned_packet_v0.py`
+```text
+scripts/check_pulse_ref_schema_aligned_packet_v0.py
+```
 
 Its smoke tests are:
 
-`tests/test_check_pulse_ref_schema_aligned_packet_v0.py`
+```text
+tests/test_check_pulse_ref_schema_aligned_packet_v0.py
+```
 
 The validator checks:
 
@@ -181,15 +268,21 @@ This validator is the checker that the schema-aligned builder must pass.
 
 The schema-aligned builder is:
 
-`scripts/build_pulse_ref_schema_aligned_pass_fixture_packet_v0.py`
+```text
+scripts/build_pulse_ref_schema_aligned_pass_fixture_packet_v0.py
+```
 
 Its smoke tests are:
 
-`tests/test_build_pulse_ref_schema_aligned_pass_fixture_packet_v0.py`
+```text
+tests/test_build_pulse_ref_schema_aligned_pass_fixture_packet_v0.py
+```
 
 The builder produces a canonical packet-shaped baseline candidate under:
 
-`pulse_ref_evidence_packet_v0/`
+```text
+pulse_ref_evidence_packet_v0/
+```
 
 The generated packet includes:
 
@@ -202,67 +295,97 @@ The generated packet includes:
 - `gates/materialized_gate_sets.json`;
 - `ci/ci_outcome.json`;
 - `release_authority/release_authority_manifest.json`;
-- `handoff/operator_handoff_report.json`;
+- `audit/release_authority_audit_bundle/README.md`;
+- `audit/release_authority_audit_bundle/status.json`;
+- `audit/release_authority_audit_bundle/release_authority_manifest.json`;
 - `digests/package_digests.json`;
-- `audit/release_authority_audit_bundle/`;
+- `handoff/operator_handoff_report.json`;
 - `external/summaries/README.md`;
 - `reconstruction/reconstruction_instructions.md`.
 
-The publication snapshot surface is omitted by the builder until a canonical publication surface exists.
+The publication snapshot surface is omitted by the builder until a canonical
+publication surface exists.
 
 ## Current v0 packet-completeness boundary
 
-The current schema-aligned pass-fixture packet builder emits a reconstructable v0 packet candidate.
+The current schema-aligned pass-fixture packet builder emits a reconstructable
+v0 packet candidate.
 
-The current v0 output contract covers recorded status, source expected-outcome metadata, declared policy, gate registry, policy-derived materialized gate sets, CI outcome, release-authority manifest, operator handoff report, package digests, audit bundle, external summary note, and reconstruction instructions.
+The current v0 output contract covers:
 
-Field-point authority-map and evidence-fold-in admissibility artifacts are reserved for the next packet-completeness layer.
+- packet overview;
+- package manifest;
+- recorded status;
+- source expected-outcome metadata;
+- declared policy;
+- gate registry;
+- policy-derived materialized gate sets;
+- CI outcome;
+- release-authority manifest;
+- operator handoff report;
+- digest manifest;
+- audit bundle files;
+- external summary note;
+- reconstruction instructions.
 
-The reserved next-layer surfaces are:
+The current builder emits the digest manifest as:
 
-- `field/field_point_authority_map_v0.json`
-- `admissibility/evidence_fold_in_admissibility_v0.json`
+```text
+digests/package_digests.json
+```
 
-This boundary preserves the earlier packet-baseline and handoff direction while keeping the current v0 builder contract mechanically accurate.
+The digest manifest records regular payload files.
+
+The structural manifest and digest-manifest surfaces are generated packet
+artifacts and validator inputs.
+
+Reserved next-layer packet-completeness surfaces:
+
+```text
+field/field_point_authority_map_v0.json
+admissibility/evidence_fold_in_admissibility_v0.json
+publication/publication_snapshot.json when canonical publication surface exists
+```
+
+This boundary preserves the packet-baseline and handoff direction while keeping
+the current v0 builder contract mechanically accurate.
 
 ## Builder hardening now included
 
-The builder now protects the reviewed failure modes:
+The builder protects the reviewed failure modes:
 
 - false policy-required gates in the pass fixture are rejected;
 - the release-reference completeness guard is run before packet generation;
-- stubbed, scaffolded, non-prod, missing-detector, missing-external, and non-literal-true required-gate states fail before packet generation;
+- stubbed states fail before packet generation;
+- scaffolded states fail before packet generation;
+- non-prod states fail before packet generation;
+- missing-detector states fail before packet generation;
+- missing-external states fail before packet generation;
+- non-literal-true required-gate states fail before packet generation;
 - handoff commands are recorded with replayable tool and packet artifact paths;
-- relative `--out-dir` values work when the builder is launched outside the repository root;
+- relative `--out-dir` values work when the builder is launched outside the
+  repository root;
 - the generated packet is validated by the schema-aligned packet validator.
 
 ## Publication snapshot manifest reference hardening
 
-The validator now checks optional `publication_snapshot` manifest references when present.
+The validator checks optional `publication_snapshot` manifest references when
+present.
 
 The optional manifest reference must:
 
 - use a safe package-relative path;
 - stay inside the packet root;
-- reference the canonical artifact path `publication/publication_snapshot.json`;
+- reference the canonical artifact path
+  `publication/publication_snapshot.json`;
 - point to an existing file;
 - match the actual SHA-256 digest.
 
-This closes the remaining optional publication-reference gap.
+This closes the optional publication-reference gap for the current
+schema-aligned validator.
 
-## Current packet-builder chain
-
-The current chain is:
-
-`tests/fixtures/release_reference_v1/pass/status.json`  
-→ release-reference completeness guard  
-→ policy-derived materialized required gates  
-→ schema-aligned packet builder  
-→ canonical packet artifacts  
-→ schema-aligned packet validator  
-→ reconstructable packet-shaped baseline candidate
-
-This chain is the current implementation bridge from a guarded positive fixture to a schema-aligned packet baseline.
+The builder still omits `publication/publication_snapshot.json` until a
+canonical publication surface exists.
 
 ## Preserved artifact contracts
 
@@ -275,21 +398,26 @@ The generated packet aligns with the following canonical artifact contracts:
 - `pulse_ref_operator_handoff_report_v0`;
 - `release_authority_v0`.
 
-The release-authority manifest is checked with the existing release authority manifest checker.
+The release-authority manifest is checked with the existing release authority
+manifest checker.
 
 ## Resolved earlier builder issue
 
-The earlier builder attempt was stopped because it wrote fixture-specific payloads into canonical packet paths.
+The earlier builder attempt was stopped because it wrote fixture-specific
+payloads into canonical packet paths.
 
-That earlier pattern is now replaced by the schema-aligned path:
+That earlier pattern is replaced by the schema-aligned path:
 
-fixture source  
-→ declared policy materialization  
-→ canonical artifact payloads  
-→ manifest and digest cross-checks  
+```text
+fixture source
+→ declared policy materialization
+→ canonical artifact payloads
+→ manifest and digest cross-checks
 → schema-aligned packet validation
+```
 
-This checkpoint records that the old fixture-specific canonical-path pattern is no longer the accepted builder path.
+This checkpoint records that fixture-specific payloads in canonical packet paths
+are no longer the accepted builder pattern.
 
 ## Checkpoint acceptance state
 
@@ -305,7 +433,8 @@ python tests/test_build_pulse_ref_schema_aligned_pass_fixture_packet_v0.py
 python tests/test_tools_tests_list_smoke.py
 ```
 
-These checks preserve the current bridge from source fixture to schema-aligned packet candidate.
+These checks preserve the current bridge from source fixture to schema-aligned
+packet candidate.
 
 ## Relation to RA1
 
@@ -315,17 +444,21 @@ The current builder prepares schema-aligned packet candidates.
 
 The validator checks artifact shape and reconstruction readiness.
 
-A later step may connect generated packet candidates more directly to RA1-style package verification.
+A later step may connect generated packet candidates more directly to RA1-style
+package verification.
 
-This checkpoint preserves the boundary:
+Current boundary:
 
-schema-aligned packet preparation  
-→ packet artifact validation  
+```text
+schema-aligned packet preparation
+→ packet artifact validation
 → future RA1 verification path
+```
 
 ## Relation to HPC validation
 
-This checkpoint prepares the packet shape needed for future HPC candidate-state validation.
+This checkpoint prepares the packet shape needed for future HPC candidate-state
+validation.
 
 HPC validation should operate on packet candidates that preserve:
 
@@ -351,16 +484,28 @@ Possible next implementation steps:
 - add a golden generated-packet regression test;
 - add a builder-to-validator-to-RA1 bridge test;
 - add packet diff / drift detection between generated candidate packets;
+- add field-point authority map artifact generation;
+- add evidence fold-in admissibility artifact generation;
 - add HPC candidate batch planning over schema-aligned packet candidates;
 - add relational evidence-field references into the packet manifest or field map.
 
-The next step should preserve the current chain.
+The next step preserves the current chain.
+
+The checkpoint remains packet-preparation and artifact-validation oriented.
 
 ## Closing statement
 
-The current PULSE-REF packet-builder line now has a guarded source, a declared contract, a contract guard, a schema-aligned validator, a schema-aligned builder, and publication-reference hardening.
+The current PULSE-REF packet-builder line has:
 
-The packet-builder path is now strong enough to serve as the next baseline for generated packet fixtures and future RA1 / HPC validation work.
+- a guarded source;
+- a declared contract;
+- a contract guard;
+- a schema-aligned validator;
+- a schema-aligned builder;
+- publication-reference hardening.
+
+The packet-builder path is strong enough to serve as the current baseline for
+generated packet fixtures and future RA1 / HPC validation work.
 
 PULSE remains defined by the release-authority materialization path.
 

--- a/tests/test_pulse_ref_release_reference_evidence_packet_baseline_v0.py
+++ b/tests/test_pulse_ref_release_reference_evidence_packet_baseline_v0.py
@@ -2,12 +2,11 @@
 """Smoke guard for the PULSE-REF release-reference evidence packet baseline.
 
 This test protects the non-normative baseline document from losing its
-release-authority boundary anchors and packet-baseline relation anchors.
+release-authority boundary anchors, packet-baseline relation anchors, current
+schema-aligned builder relation anchors, and current digest-coverage wording.
 
 It does not validate release-grade evidence.
-
 It does not run RA1.
-
 It does not authorize, block, override, or create release authority.
 """
 
@@ -25,7 +24,7 @@ BASELINE = (
 
 
 REQUIRED_ANCHORS = [
-    "Status: planning baseline",
+    "Status: planning baseline / current baseline relation",
     "Authority status: non-normative",
     "Release-grade status: not release-grade evidence",
     "Verifier status: not a verifier",
@@ -34,14 +33,25 @@ REQUIRED_ANCHORS = [
     "the release-reference fixture matrix",
     "the evidence packet layout",
     "the minimum content contract",
+    "The baseline now also records the current relation to the schema-aligned",
+    "pass-fixture packet-builder path.",
     "A PULSE-REF release-grade reference is not merely a run.",
     "A release-grade reference is a recorded, artifact-bound, digest-backed, reconstructable evidence packet.",
+    "The current baseline relation is no longer only a planning target.",
+    "guarded positive release-reference fixture",
+    "release-reference completeness guard",
+    "policy-derived materialized required gates",
+    "schema-aligned packet builder",
+    "canonical packet artifacts",
+    "schema-aligned packet validator",
+    "reconstructable packet-shaped baseline candidate",
     "recorded release evidence",
     "recorded `status.json` artifact",
     "declared gate policy",
     "materialized required gate set",
     "strict fail-closed CI gate enforcement",
     "declared-policy CI allow/block release decision",
+    "The baseline packet preserves the recorded `status.json` artifact.",
     "A release-reference evidence packet preserves and reconstructs this path.",
     "It does not replace it.",
     "The packet does not authorize release by existing.",
@@ -49,11 +59,21 @@ REQUIRED_ANCHORS = [
     "Minimum content contract",
     "Minimal content packet builder",
     "Release-reference fixture matrix",
+    "Schema-aligned packet-builder checkpoint",
     "Baseline objective",
+    "complete baseline target",
+    "current v0",
+    "reserved next-layer surfaces",
+    "field/field_point_authority_map_v0.json",
+    "admissibility/evidence_fold_in_admissibility_v0.json",
+    "publication/publication_snapshot.json when canonical publication surface exists",
     "Baseline source candidate",
     "tests/fixtures/release_reference_v1/pass/",
     "Negative fixture relation",
     "Minimum baseline packet content",
+    "Current v0 builder state",
+    "reconstruction/source_expected_outcome.json",
+    "external/summaries/README.md",
     "Packet identity requirements",
     "Run identity requirements",
     "Recorded status requirements",
@@ -63,6 +83,16 @@ REQUIRED_ANCHORS = [
     "Release authority manifest requirements",
     "Audit bundle requirements",
     "Digest requirements",
+    "Digest coverage includes the regular payload files that the current builder",
+    "records in the digest map.",
+    "Minimum current v0 digest coverage includes regular payload files such as:",
+    "audit/release_authority_audit_bundle/README.md",
+    "audit/release_authority_audit_bundle/status.json",
+    "audit/release_authority_audit_bundle/release_authority_manifest.json",
+    "The current builder treats `package_manifest.json` and",
+    "`digests/package_digests.json` as structural manifest / digest-manifest surfaces.",
+    "They are generated and validated as packet artifacts, but they are not entries in",
+    "the current `package_digests.json` artifact map.",
     "Operator handoff requirements",
     "Publication snapshot requirements",
     "Field-point authority map requirements",
@@ -72,14 +102,27 @@ REQUIRED_ANCHORS = [
     "Recognition-surface baseline relation",
     "Reconstruction baseline",
     "Baseline acceptance conditions",
+    "package digest manifest is present",
+    "all required current digest-map payload files are digest-backed",
+    "structural manifest / digest-manifest surfaces are present and valid",
     "Baseline rejection conditions",
+    "package digest manifest is missing",
+    "required digest-map payload files are not digest-backed",
+    "structural manifest / digest-manifest surfaces are missing or invalid",
+    "Relation to current schema-aligned builder",
+    "This relation supersedes the older purely planning-baseline wording.",
     "Relation to future implementation",
+    "The first schema-aligned implementation layer is partially realized.",
+    "Current implemented bridge:",
+    "Remaining possible next implementation steps:",
     "Relation to RA1",
     "Relation to fellowship / HPC validation",
     "Scope exclusions",
     "This document does not change:",
     "HPC validates the decision field.",
     "PULSEmech remains the release-authority mechanism.",
+    "The schema-aligned packet builder now produces a reconstructable v0 packet",
+    "candidate from the guarded positive pass fixture.",
 ]
 
 
@@ -95,6 +138,28 @@ FORBIDDEN_CLAIMS = [
     "The packet authorizes release by existing.",
     "The baseline authorizes release.",
     "HPC creates release authority.",
+]
+
+
+FORBIDDEN_STALE_OR_INACCURATE_ANCHORS = [
+    "Status: planning baseline  ",
+    "Authority status: non-normative  ",
+    "Scope: PULSE-REF / release-reference fixture matrix / evidence packet baseline  ",
+    "Release-grade status: not release-grade evidence  ",
+    "Verifier status: not a verifier  ",
+    "Decision status: does not authorize, block, override, or create release authority  ",
+    "This document defines the first PULSE-REF release-reference evidence packet\nbaseline.",
+    "A release-grade reference is a recorded, artifact-bound, digest-backed,\nreconstructable evidence packet.",
+    "recorded status.json artifact",
+    "Digest coverage includes all required current packet payload artifacts.",
+    "Minimum current v0 digest coverage:\n\n- `README.md`;",
+    "- `package_manifest.json`;\n- `status/status.json`;",
+    "- `handoff/operator_handoff_report.json`;\n- `digests/package_digests.json`;",
+    "- `digests/package_digests.json`;\n- `audit/release_authority_audit_bundle/`;",
+    "package digests are present",
+    "all required current packet artifacts are digest-backed",
+    "package digests are missing",
+    "required artifacts are not digest-backed",
 ]
 
 
@@ -120,11 +185,37 @@ def test_baseline_does_not_claim_release_authority() -> None:
         assert claim not in text, claim
 
 
+def test_baseline_has_no_stale_or_inaccurate_anchors() -> None:
+    text = _read_baseline()
+
+    for anchor in FORBIDDEN_STALE_OR_INACCURATE_ANCHORS:
+        assert anchor not in text, anchor
+
+
+def test_baseline_status_block_has_no_trailing_whitespace() -> None:
+    lines = _read_baseline().splitlines()
+
+    protected_prefixes = (
+        "Status:",
+        "Authority status:",
+        "Scope:",
+        "Release-grade status:",
+        "Verifier status:",
+        "Decision status:",
+    )
+
+    for line in lines:
+        if line.startswith(protected_prefixes):
+            assert line == line.rstrip(), line
+
+
 def main() -> int:
     try:
         test_baseline_file_exists()
         test_baseline_required_anchors_present()
         test_baseline_does_not_claim_release_authority()
+        test_baseline_has_no_stale_or_inaccurate_anchors()
+        test_baseline_status_block_has_no_trailing_whitespace()
     except AssertionError as exc:
         print(f"ERROR: {exc}")
         return 1


### PR DESCRIPTION
## Summary

This PR refines the PULSE-REF release-reference evidence packet baseline reconciliation.

## Purpose

The unrealized documentation plans audit identified the PULSE-REF packet baseline as a partial / stale-plan review target.

This update keeps the baseline in the correct middle state:

```text
planning baseline / current baseline relation
```

The document remains a baseline relation between the fixture matrix, evidence packet layout, and minimum content contract, while now recording the current schema-aligned pass-fixture packet-builder relation.

## Current chain recorded

The baseline now records the current chain explicitly:

```text
guarded positive release-reference fixture
→ release-reference completeness guard
→ policy-derived materialized required gates
→ schema-aligned packet builder
→ canonical packet artifacts
→ schema-aligned packet validator
→ reconstructable packet-shaped baseline candidate
```

## Cleanup performed

The update distinguishes:

- complete baseline target;
- current v0 builder-covered subset;
- reserved next-layer packet-completeness surfaces;
- future RA1 / HPC follow-on work.

The schema-aligned packet-builder checkpoint is kept in planning/current-state balance rather than being rewritten as completed packet-completeness work.

The baseline smoke guard anchors are updated to match the refined wording.

## Changed files

```text
docs/PULSE_REF_RELEASE_REFERENCE_EVIDENCE_PACKET_BASELINE_v0.md
docs/PULSE_REF_SCHEMA_ALIGNED_PACKET_BUILDER_CHECKPOINT_v0.md
tests/test_pulse_ref_release_reference_evidence_packet_baseline_v0.py
```

## Preserved

Preserved surfaces remain unchanged:

- PULSEmech release authority;
- gate policy semantics;
- required gate wiring;
- schemas;
- workflow mechanics;
- CI allow/block behavior;
- `check_gates.py`;
- Quality Ledger renderer behavior;
- Pages workflow behavior;
- release tags;
- DOI / Zenodo path.

## Validation

```bash
python tests/test_pulse_ref_release_reference_evidence_packet_baseline_v0.py

python tests/test_pulse_ref_pass_fixture_packet_baseline_candidate_v0.py

python tests/test_pulse_ref_pass_fixture_to_evidence_packet_handoff_plan_v0.py

python tests/test_pulse_ref_schema_aligned_packet_builder_contract_v0.py

python tests/test_check_pulse_ref_schema_aligned_packet_v0.py

python tests/test_build_pulse_ref_schema_aligned_pass_fixture_packet_v0.py

python tests/test_tools_tests_list_smoke.py

git diff --check
```