### PR TITLE
docs(cleanup): reconcile PULSE-REF handoff plan

### DIFF
--- a/docs/PULSE_REF_PASS_FIXTURE_TO_EVIDENCE_PACKET_HANDOFF_PLAN_v0.md
+++ b/docs/PULSE_REF_PASS_FIXTURE_TO_EVIDENCE_PACKET_HANDOFF_PLAN_v0.md
@@ -1,29 +1,34 @@
 # PULSE-REF Pass Fixture to Evidence Packet Handoff Plan v0
 
-Status: planning handoff  
-Authority status: non-normative  
-Scope: PULSE-REF / release-reference pass fixture / evidence packet baseline handoff  
-Release-grade status: not release-grade evidence  
-Verifier status: not a verifier  
+Status: planning handoff / current builder relation
+Authority status: non-normative handoff record
+Scope: PULSE-REF / release-reference pass fixture / evidence packet baseline handoff
+Release-grade status: not release-grade evidence
+Verifier status: not a verifier
 Decision status: does not authorize, block, override, or create release authority
 
 ## Purpose
 
-This document defines the handoff plan from the positive `release_reference_v1/pass` fixture to the first PULSE-REF evidence packet baseline candidate.
+This document defines the handoff relation from the positive `release_reference_v1/pass` fixture to the first PULSE-REF evidence packet baseline candidate.
 
-The release-reference evidence packet baseline identifies the positive pass fixture as the preferred first source candidate for a packet-shaped baseline.
+It connects:
 
-This document defines how that source candidate should be mapped into the canonical evidence packet layout before any builder implementation changes are made.
+- the guarded positive release-reference fixture;
+- the release-reference evidence packet baseline;
+- the canonical evidence packet layout;
+- the schema-aligned pass-fixture packet builder;
+- the schema-aligned packet validator;
+- the reserved next-layer packet-completeness surfaces.
 
-This document does not build an evidence packet.
+The release-reference evidence packet baseline identifies the positive pass
+fixture as the preferred first source candidate for a packet-shaped baseline.
 
-This document does not validate release-grade evidence.
+This document records how that source candidate maps into the canonical evidence
+packet layout and how the current schema-aligned builder covers the current v0
+packet subset.
 
-This document does not run RA1.
-
-This document does not authorize release.
-
-It defines the artifact mapping and handoff boundary for the next implementation step.
+The handoff relation preserves the artifact mapping between the guarded fixture
+and the reconstructable packet-shaped baseline candidate.
 
 ## Core statement
 
@@ -31,327 +36,354 @@ The next proof state is not merely a passing fixture.
 
 The next proof state is a packet-shaped, digest-backed, reconstructable baseline candidate derived from a controlled positive release-reference fixture.
 
-The `release_reference_v1/pass` fixture proves that a controlled candidate can satisfy the release-reference completeness guard.
+The `release_reference_v1/pass` fixture proves that a controlled candidate can
+satisfy the release-reference completeness guard.
 
-The evidence packet handoff must preserve that candidate as recorded artifact state.
+The evidence packet handoff preserves that candidate as recorded artifact state.
 
-The handoff must not reinterpret the fixture as release authority.
+The current handoff relation is no longer only a future implementation plan.
+
+It now connects:
+
+```text
+tests/fixtures/release_reference_v1/pass/status.json
+→ release-reference completeness guard
+→ policy-derived materialized required gates
+→ schema-aligned packet builder
+→ canonical packet artifacts
+→ schema-aligned packet validator
+→ reconstructable packet-shaped baseline candidate
+```
 
 ## Normative release path
 
 The normative PULSE release decision remains:
 
-recorded release evidence  
-→ recorded `status.json` artifact  
-→ declared gate policy  
-→ materialized required gate set  
-→ strict fail-closed CI gate enforcement  
+```text
+recorded release evidence
+→ recorded `status.json` artifact
+→ declared gate policy
+→ materialized required gate set
+→ strict fail-closed CI gate enforcement
 → declared-policy CI allow/block release decision
+```
 
-The handoff plan preserves and prepares this path for packet reconstruction.
+The handoff relation preserves and prepares this path for packet reconstruction.
 
-It does not replace the path.
+A packet-shaped baseline candidate preserves release-state evidence as an
+artifact field.
 
-A packet-shaped baseline candidate does not authorize release by existing.
+Release permission remains produced by the declared PULSEmech path.
 
 ## Source candidate
 
 The source candidate for the first handoff is:
 
-`tests/fixtures/release_reference_v1/pass/`
+```text
+tests/fixtures/release_reference_v1/pass/
+```
 
 Required source files:
 
-- `status.json`
-- `expected_outcome.json`
+- `status.json`;
+- `expected_outcome.json`.
 
-The source candidate is selected because it is the controlled positive release-reference fixture.
+The source candidate is selected because it is the controlled positive
+release-reference fixture.
 
 It must remain:
 
-- `metrics.run_mode = "prod"`
-- `metrics.fixture_id = "release_reference_v1/pass"`
-- `metrics.fixture_kind = "positive_release_reference"`
-- `diagnostics.gates_stubbed = false`
-- `diagnostics.scaffold = false`
-- required gates literal boolean `true`
-- release_required gates literal boolean `true`
-- detector evidence materialized
-- external summaries present
-- external aggregate passing
-- expected outcome `PASS`
-- free of release-authority claims
+- `metrics.run_mode = "prod"`;
+- `metrics.fixture_id = "release_reference_v1/pass"`;
+- `metrics.fixture_kind = "positive_release_reference"`;
+- `diagnostics.gates_stubbed = false`;
+- `diagnostics.scaffold = false`;
+- required gates literal boolean `true`;
+- release_required gates literal boolean `true`;
+- detector evidence materialized;
+- external summaries present;
+- external aggregate passing;
+- expected outcome `PASS`;
+- free of release-authority claims.
 
-The source candidate is protected by the pass fixture packet-baseline candidate guard.
+The source candidate is protected by the pass fixture packet-baseline candidate
+guard.
 
 ## Target packet shape
 
 The target packet shape follows:
 
-`docs/PULSE_REF_EVIDENCE_PACKET_LAYOUT_v0.md`
+```text
+docs/PULSE_REF_EVIDENCE_PACKET_LAYOUT_v0.md
+```
 
 Canonical packet root:
 
-`pulse_ref_evidence_packet_v0/`
+```text
+pulse_ref_evidence_packet_v0/
+```
 
-The first packet-shaped baseline candidate should use the canonical layout rather than inventing a new top-level structure.
+The packet-shaped baseline candidate uses the canonical layout.
 
-The handoff should preserve the distinction between:
+The handoff preserves the distinction between:
 
-- source fixture
-- generated packet candidate
-- packet manifest
-- digest manifest
-- reconstruction surface
-- release-authority manifest
-- audit bundle
-- optional external/HPC/recognition surfaces
+- source fixture;
+- generated packet candidate;
+- packet manifest;
+- digest manifest;
+- reconstruction surface;
+- release-authority manifest;
+- audit bundle;
+- current v0 builder-covered packet subset;
+- reserved next-layer packet-completeness surfaces.
 
 ## Handoff objective
 
-The handoff objective is to map the positive release-reference fixture into a packet-shaped baseline candidate.
+The handoff objective is to map the positive release-reference fixture into a
+packet-shaped baseline candidate.
 
-The handoff succeeds when a future implementation can produce a packet directory that contains:
+The current schema-aligned builder emits the current v0 packet subset.
 
-- recorded `status.json` copied or generated from the pass fixture source
-- declared policy snapshot
-- gate registry snapshot
-- materialized gate-set artifact
-- declared-policy CI outcome artifact
-- release authority manifest
-- audit bundle
-- package manifest
-- digest manifest
-- operator handoff report
-- field-point authority map
-- evidence fold-in admissibility state
-- reconstruction instructions
+Current v0 builder-covered subset:
 
-The handoff is not successful merely because the fixture passes.
+- recorded `status.json`;
+- source expected-outcome metadata;
+- declared policy snapshot;
+- gate registry snapshot;
+- policy-derived materialized gate-set artifact;
+- declared-policy CI outcome artifact;
+- release authority manifest;
+- audit bundle files;
+- package manifest;
+- digest manifest;
+- operator handoff report;
+- external summary note;
+- reconstruction instructions.
 
-The handoff is successful when the fixture state can be preserved as a reconstructable artifact field.
+Reserved next-layer packet-completeness surfaces:
 
-## Non-goals
+```text
+field/field_point_authority_map_v0.json
+admissibility/evidence_fold_in_admissibility_v0.json
+publication/publication_snapshot.json when canonical publication surface exists
+```
 
-This handoff plan does not:
-
-- change the pass fixture
-- change expected outcome semantics
-- change the release-reference guard
-- change declared gate policy
-- change the gate registry
-- change status schema
-- change CI workflow behavior
-- build the evidence packet
-- run RA1
-- validate release-grade evidence
-- create release authority
-- promote optional diagnostic surfaces into release authority
-- treat a publication surface as release authority
-- treat a generic green CI run as a declared-policy release decision
+The handoff is successful when the fixture state is preserved as a
+reconstructable artifact field and the generated packet candidate passes the
+schema-aligned packet validator.
 
 ## Source-to-packet mapping
 
-| Source / derived input | Target packet path | Role | Authority status |
-|---|---|---|---|
-| `tests/fixtures/release_reference_v1/pass/status.json` | `status/status.json` | recorded release-state artifact for packet candidate | normative input for inspected path |
-| `tests/fixtures/release_reference_v1/pass/expected_outcome.json` | `reconstruction/source_expected_outcome.json` or manifest reference | fixture expectation metadata | non-normative reconstruction |
-| `pulse_gate_policy_v0.yml` | `policy/pulse_gate_policy_v0.yml` | declared gate policy | normative input |
-| `pulse_gate_registry_v0.yml` | `policy/pulse_gate_registry_v0.yml` | gate semantic registry | normative support |
-| derived required/release_required sets | `gates/materialized_gate_sets.json` | materialized gate set | normative input |
-| gate check result | `ci/ci_outcome.json` | declared-policy gate-enforcement outcome | normative enforcement output |
-| evidence-policy-evaluator trace | `release_authority/release_authority_manifest.json` | audit / trace surface | non-normative reconstruction |
-| preserved status + manifest + report card | `audit/release_authority_audit_bundle/` | audit bundle | non-normative preservation |
-| packet inventory | `package_manifest.json` | inventory / references | audit / reconstruction |
-| artifact digests | `digests/package_digests.json` | digest coverage | audit / reconstruction |
-| operator commands and reconstruction route | `handoff/operator_handoff_report.json` | operator reconstruction surface | non-normative |
-| public state references if present | `publication/publication_snapshot.json` | publication identity snapshot | non-normative reader surface |
-| authority classification | `field/field_point_authority_map_v0.json` | field role map | non-normative diagnostic |
-| fold-in status | `admissibility/evidence_fold_in_admissibility_v0.json` | candidate evidence admissibility | non-normative diagnostic |
-| external summary references if included | `external/summaries/` | external evidence references | conditional / policy-routed evidence |
-| HPC bundle if included | `hpc/hpc_evidence_bundle_v0.json` | compute-scale validation reference | non-normative diagnostic |
-| recognition diagnostic if included | `recognition/recognition_surface_drift_v0.json` | recognition drift diagnostic | non-normative |
-| reconstruction guide | `reconstruction/reconstruction_instructions.md` | reconstruction instructions | non-normative operator surface |
+| Source / derived input | Target packet path | Current v0 builder state | Role | Authority status |
+|---|---|---|---|---|
+| `tests/fixtures/release_reference_v1/pass/status.json` | `status/status.json` | emitted | recorded release-state artifact for packet candidate | normative input for inspected path |
+| `tests/fixtures/release_reference_v1/pass/expected_outcome.json` | `reconstruction/source_expected_outcome.json` | emitted | fixture expectation metadata | non-normative reconstruction |
+| `pulse_gate_policy_v0.yml` | `policy/pulse_gate_policy_v0.yml` | emitted | declared gate policy | normative input |
+| `pulse_gate_registry_v0.yml` | `policy/pulse_gate_registry_v0.yml` | emitted | gate semantic registry | normative support |
+| derived required/release_required sets | `gates/materialized_gate_sets.json` | emitted | materialized gate set | normative input |
+| gate check result | `ci/ci_outcome.json` | emitted | declared-policy gate-enforcement outcome | normative enforcement output |
+| evidence-policy-evaluator trace | `release_authority/release_authority_manifest.json` | emitted | audit / trace surface | non-normative reconstruction |
+| preserved status + manifest + report card | `audit/release_authority_audit_bundle/` | emitted as regular files | audit bundle | non-normative preservation |
+| packet inventory | `package_manifest.json` | emitted | inventory / references | audit / reconstruction |
+| artifact digests | `digests/package_digests.json` | emitted | digest manifest | audit / reconstruction |
+| operator commands and reconstruction route | `handoff/operator_handoff_report.json` | emitted | operator reconstruction surface | non-normative |
+| public state references if present | `publication/publication_snapshot.json` | reserved until canonical publication surface exists | publication identity snapshot | non-normative reader surface |
+| authority classification | `field/field_point_authority_map_v0.json` | reserved for next packet-completeness layer | field role map | non-normative diagnostic |
+| fold-in status | `admissibility/evidence_fold_in_admissibility_v0.json` | reserved for next packet-completeness layer | candidate evidence admissibility | non-normative diagnostic |
+| external summary note | `external/summaries/README.md` | emitted | external summary note | non-normative evidence note |
+| external summary payloads if included | `external/summaries/` | policy-routed next-layer surface | external evidence references | conditional / policy-routed evidence |
+| HPC bundle if included | `hpc/hpc_evidence_bundle_v0.json` | reserved | compute-scale validation reference | non-normative diagnostic |
+| recognition diagnostic if included | `recognition/recognition_surface_drift_v0.json` | reserved | recognition drift diagnostic | non-normative |
+| reconstruction guide | `reconstruction/reconstruction_instructions.md` | emitted | reconstruction instructions | non-normative operator surface |
 
 ## Status artifact handoff
 
-The source fixture `status.json` should become the packet candidate’s recorded status artifact.
+The source fixture `status.json` becomes the packet candidate’s recorded status
+artifact.
 
 Target:
 
-`status/status.json`
+```text
+status/status.json
+```
 
-The handoff must preserve:
+The handoff preserves:
 
-- version
-- created UTC
-- metrics object
-- run mode
-- fixture identity
-- fixture kind
-- diagnostics object
-- `diagnostics.gates_stubbed = false`
-- `diagnostics.scaffold = false`
-- gates object
-- all recorded gate values
-- evidence object
-- detector materialization state
-- external summary state
-- authority-boundary statement where available
+- version;
+- created UTC;
+- metrics object;
+- run mode;
+- fixture identity;
+- fixture kind;
+- diagnostics object;
+- `diagnostics.gates_stubbed = false`;
+- `diagnostics.scaffold = false`;
+- gates object;
+- all recorded gate values;
+- evidence object;
+- detector materialization state;
+- external summary state;
+- authority-boundary statement where available.
 
-The status artifact must be packet-bound by digest.
+The status artifact is packet-bound by digest.
 
-A live or public `status.json` URL must not be used as a substitute for the recorded artifact.
+A live or public `status.json` URL is not a substitute for the recorded artifact.
 
 ## Expected outcome handoff
 
-The source fixture `expected_outcome.json` should be preserved as fixture expectation metadata.
+The source fixture `expected_outcome.json` is preserved as fixture expectation
+metadata.
 
-It may be copied into:
+Target:
 
-`reconstruction/source_expected_outcome.json`
-
-or referenced in:
-
-`package_manifest.json`
+```text
+reconstruction/source_expected_outcome.json
+```
 
 The expected outcome is not a decision engine.
 
 It records what the fixture matrix expects.
 
-For the pass fixture, it must preserve:
+For the pass fixture, it preserves:
 
-- fixture ID
-- expected result `PASS`
-- expected guard
-- expected checks
-- authority-boundary statement
+- fixture ID;
+- expected result `PASS`;
+- expected guard;
+- expected checks;
+- authority-boundary statement.
 
-Expected outcome metadata must not override the declared-policy CI outcome.
+Expected outcome metadata does not override the declared-policy CI outcome.
 
 ## Policy handoff
 
-The packet candidate must include the declared policy used to evaluate the candidate.
+The packet candidate includes the declared policy used to evaluate the candidate.
 
 Target:
 
-`policy/pulse_gate_policy_v0.yml`
+```text
+policy/pulse_gate_policy_v0.yml
+```
 
-The policy artifact must be digest-backed.
+The policy artifact is digest-backed.
 
-The materialized gate set must be derived from this policy.
+The materialized gate set is derived from this policy.
 
-The policy copy does not create release authority by document presence.
-
-It is a normative input only when bound to the recorded evidence and enforced through the declared PULSEmech path.
+The policy copy is a normative input when bound to the recorded evidence and
+enforced through the declared PULSEmech path.
 
 ## Registry handoff
 
-The packet candidate must include the gate registry used to stabilize gate meaning.
+The packet candidate includes the gate registry used to stabilize gate meaning.
 
 Target:
 
-`policy/pulse_gate_registry_v0.yml`
+```text
+policy/pulse_gate_registry_v0.yml
+```
 
-The registry artifact must be digest-backed.
+The registry artifact is digest-backed.
 
 The registry supports semantic stability of gate IDs.
 
-It does not create release authority by itself.
-
 ## Materialized gate-set handoff
 
-The packet candidate must include the materialized required gate set.
+The packet candidate includes the materialized required gate set.
 
 Target:
 
-`gates/materialized_gate_sets.json`
+```text
+gates/materialized_gate_sets.json
+```
 
-The materialized gate-set artifact should include:
+The materialized gate-set artifact includes:
 
-- required gate set
-- release_required gate set
-- effective required gate set
-- selected lane or policy scope
-- policy source path
-- policy digest
-- duplicate-handling rule
-- ordering rule
-- materialization command or reference when available
+- required gate set;
+- release_required gate set;
+- effective required gate set;
+- selected lane or policy scope;
+- policy source path;
+- policy digest;
+- duplicate-handling rule;
+- ordering rule;
+- materialization command or reference when available.
 
-The materialized gate set must be consistent with the declared policy.
+The materialized gate set is consistent with the declared policy.
 
-It must not be hand-edited to satisfy the fixture.
+The materialized gate set is not hand-edited to satisfy the fixture.
 
 ## CI outcome handoff
 
-The packet candidate must include a declared-policy CI outcome artifact.
+The packet candidate includes a declared-policy CI outcome artifact.
 
 Target:
 
-`ci/ci_outcome.json`
+```text
+ci/ci_outcome.json
+```
 
-The artifact should preserve:
+The artifact preserves:
 
-- CI provider or execution environment
-- workflow name
-- workflow path or reference
-- run ID or local execution identity
-- run attempt when available
-- commit SHA or source revision
-- gate-check command
-- effective required gate set
-- gate-check conclusion
-- expected allow/block outcome
-- fail-closed indicator
-- authority-boundary statement
+- CI provider or execution environment;
+- workflow name;
+- workflow path or reference;
+- run ID or local execution identity;
+- run attempt when available;
+- commit SHA or source revision;
+- gate-check command;
+- effective required gate set;
+- gate-check conclusion;
+- expected allow/block outcome;
+- fail-closed indicator;
+- authority-boundary statement.
 
-A generic green workflow is not enough.
+The CI outcome represents the declared-policy gate-enforcement result for the
+packet candidate.
 
-The CI outcome must represent the declared-policy gate-enforcement result for the packet candidate.
+A generic green workflow is not equivalent to a declared-policy release
+decision.
 
 ## Release authority manifest handoff
 
-The packet candidate must include a release authority manifest as an audit and trace surface.
+The packet candidate includes a release authority manifest as an audit and trace
+surface.
 
 Target:
 
-`release_authority/release_authority_manifest.json`
+```text
+release_authority/release_authority_manifest.json
+```
 
-The manifest should preserve:
+The manifest preserves:
 
-- run identity
-- status artifact reference
-- policy artifact reference
-- registry artifact reference
-- materialized gate-set reference
-- effective required gates
-- gate evaluation summary
-- declared decision state
-- fail-closed indicator
-- authority-boundary statement
-- non-normative diagnostic statement where applicable
+- run identity;
+- status artifact reference;
+- policy artifact reference;
+- registry artifact reference;
+- materialized gate-set reference;
+- effective required gates;
+- gate evaluation summary;
+- declared decision state;
+- fail-closed indicator;
+- authority-boundary statement;
+- non-normative diagnostic statement where applicable.
 
-The manifest is not a second decision engine.
-
-It reconstructs the declared-policy path.
+The manifest reconstructs the declared-policy path.
 
 ## Audit bundle handoff
 
-The packet candidate must include an audit bundle.
+The packet candidate includes an audit bundle.
 
 Target:
 
-`audit/release_authority_audit_bundle/`
+```text
+audit/release_authority_audit_bundle/
+```
 
-Minimum audit bundle content:
+Current v0 audit bundle files:
 
-- status artifact copy or reference
-- release authority manifest copy or reference
-- CI outcome reference
-- package digest reference
-- reconstruction instruction reference
-- report card or reader surface when available
+- `audit/release_authority_audit_bundle/README.md`;
+- `audit/release_authority_audit_bundle/status.json`;
+- `audit/release_authority_audit_bundle/release_authority_manifest.json`.
 
 The audit bundle preserves evidence.
 
@@ -359,123 +391,138 @@ It does not authorize release.
 
 ## Digest handoff
 
-The packet candidate must include a digest manifest.
+The packet candidate includes a digest manifest.
 
 Target:
 
-`digests/package_digests.json`
+```text
+digests/package_digests.json
+```
 
-Digest coverage should include all required packet artifacts:
+The digest manifest records regular payload files.
 
-- `README.md`
-- `package_manifest.json`
-- `status/status.json`
-- `policy/pulse_gate_policy_v0.yml`
-- `policy/pulse_gate_registry_v0.yml`
-- `gates/materialized_gate_sets.json`
-- `ci/ci_outcome.json`
-- `release_authority/release_authority_manifest.json`
-- `handoff/operator_handoff_report.json`
-- `field/field_point_authority_map_v0.json`
-- `admissibility/evidence_fold_in_admissibility_v0.json`
-- `reconstruction/reconstruction_instructions.md`
-- included publication, external, HPC, or recognition artifacts when present
+Current v0 digest-map payload coverage includes files such as:
+
+- `README.md`;
+- `status/status.json`;
+- `reconstruction/source_expected_outcome.json`;
+- `policy/pulse_gate_policy_v0.yml`;
+- `policy/pulse_gate_registry_v0.yml`;
+- `gates/materialized_gate_sets.json`;
+- `ci/ci_outcome.json`;
+- `release_authority/release_authority_manifest.json`;
+- `handoff/operator_handoff_report.json`;
+- `audit/release_authority_audit_bundle/README.md`;
+- `audit/release_authority_audit_bundle/status.json`;
+- `audit/release_authority_audit_bundle/release_authority_manifest.json`;
+- `external/summaries/README.md`;
+- `reconstruction/reconstruction_instructions.md`.
+
+The structural packet manifest and digest manifest are generated packet
+artifacts.
+
+They are validated as packet artifacts and are distinct from entries inside the
+current digest map.
 
 A packet candidate without digest coverage is not baseline-complete.
 
 ## Operator handoff report
 
-The packet candidate must include an operator handoff report.
+The packet candidate includes an operator handoff report.
 
 Target:
 
-`handoff/operator_handoff_report.json`
+```text
+handoff/operator_handoff_report.json
+```
 
-The report should preserve:
+The report preserves:
 
-- source fixture path
-- status source
-- status digest
-- policy source
-- registry source
-- materialized gate sets
-- effective required gates
-- command list or command references
-- tool paths and tool digests when available
-- errors and warnings
-- authority-boundary statement
+- source fixture path;
+- status source;
+- status digest;
+- policy source;
+- registry source;
+- materialized gate sets;
+- effective required gates;
+- command list or command references;
+- tool paths and tool digests when available;
+- errors and warnings;
+- authority-boundary statement.
 
 Operator handoff supports reconstruction.
 
-It does not create release authority.
-
 ## Publication snapshot
 
-Publication snapshot is optional unless public surfaces are included.
+Publication snapshot is optional until a canonical publication surface exists.
 
 Target:
 
-`publication/publication_snapshot.json`
+```text
+publication/publication_snapshot.json
+```
 
-If included, it should preserve:
+If included, it preserves:
 
-- public status reference
-- Quality Ledger reference when available
-- release authority manifest reference
-- audit bundle reference
-- publication timestamp when available
-- run identity binding
-- authority-boundary statement
+- public status reference;
+- Quality Ledger reference when available;
+- release authority manifest reference;
+- audit bundle reference;
+- publication timestamp when available;
+- run identity binding;
+- authority-boundary statement.
 
 Publication surfaces are reader surfaces.
 
-They do not create release authority.
-
 ## Field-point authority map
 
-The packet candidate must include a field-point authority map.
+Field-point authority classification is reserved for the next packet-completeness
+layer.
 
-Target:
+Reserved target:
 
-`field/field_point_authority_map_v0.json`
+```text
+field/field_point_authority_map_v0.json
+```
 
-The map should classify packet surfaces as:
+The map classifies packet surfaces as:
 
-- normative input
-- normative enforcement output
-- audit / reconstruction surface
-- preservation surface
-- publication / reader surface
-- diagnostic / shadow surface
-- candidate evidence surface
-- optional analysis surface
-- non-normative surface
+- normative input;
+- normative enforcement output;
+- audit / reconstruction surface;
+- preservation surface;
+- publication / reader surface;
+- diagnostic / shadow surface;
+- candidate evidence surface;
+- optional analysis surface;
+- non-normative surface.
 
 No unclassified surface may be treated as release-authoritative.
 
 ## Evidence fold-in admissibility
 
-The packet candidate must include evidence fold-in admissibility state.
+Evidence fold-in admissibility state is reserved for the next
+packet-completeness layer.
 
-Target:
+Reserved target:
 
-`admissibility/evidence_fold_in_admissibility_v0.json`
+```text
+admissibility/evidence_fold_in_admissibility_v0.json
+```
 
-For the first pass-fixture handoff, admissibility may be simple and conservative.
+The admissibility artifact records:
 
-It should record:
-
-- candidate evidence ID
-- source surface type
-- source artifact path
-- source artifact digest
-- schema-valid status where available
-- digest-valid status
-- verification status
-- fold-in requested status
-- policy route when fold-in is requested
-- gate ID when fold-in is requested
-- admissibility result
+- candidate evidence ID;
+- source surface type;
+- source artifact path;
+- source artifact digest;
+- schema-valid status where available;
+- digest-valid status;
+- verification status;
+- fold-in requested status;
+- policy route when fold-in is requested;
+- gate ID when fold-in is requested;
+- admissibility result.
 
 Admissibility is not release permission.
 
@@ -483,13 +530,16 @@ Admissibility is not release permission.
 
 The pass fixture includes external summary state as fixture evidence.
 
-For the first packet candidate, external evidence may be represented as:
+For the current v0 packet candidate, external evidence is represented by:
 
-- fixture-level external summary state
-- external summary references
-- an `external/summaries/README.md` explaining fixture mode
+```text
+external/summaries/README.md
+```
 
-If later external summary artifacts are included, they must be digest-backed and role-classified.
+Later packet-completeness layers may include external summary payloads.
+
+If external summary artifacts are included, they must be digest-backed and
+role-classified.
 
 Presence alone is not enough.
 
@@ -499,11 +549,13 @@ Aggregate pass alone is not enough.
 
 HPC evidence is optional for this handoff.
 
-If included, it must remain non-normative unless future declared policy promotes a specific evidence field or gate.
+If included, it remains non-normative unless future declared policy promotes a
+specific evidence field or gate.
 
-The first pass-fixture handoff should not depend on HPC evidence.
+The first pass-fixture handoff does not depend on HPC evidence.
 
-HPC becomes relevant after the packet baseline exists and candidate-state batches can be scaled.
+HPC becomes relevant after the packet baseline exists and candidate-state batches
+can be scaled.
 
 ## Recognition-surface relation
 
@@ -511,47 +563,50 @@ Recognition-surface diagnostics are optional for this handoff.
 
 They may later help preserve how public surfaces classify the packet.
 
-They must remain non-normative.
-
-They do not authorize release.
+They remain non-normative.
 
 ## Reconstruction instructions
 
-The packet candidate must include reconstruction instructions.
+The packet candidate includes reconstruction instructions.
 
 Target:
 
-`reconstruction/reconstruction_instructions.md`
+```text
+reconstruction/reconstruction_instructions.md
+```
 
-The instructions should explain how to verify:
+The instructions explain how to verify:
 
-- packet identity
-- run identity
-- status artifact
-- policy artifact
-- registry artifact
-- materialized gate set
-- CI outcome
-- release authority manifest
-- audit bundle
-- digest manifest
-- operator handoff report
-- field-point authority map
-- admissibility state
-- optional external/HPC/recognition evidence
+- packet identity;
+- run identity;
+- status artifact;
+- expected-outcome metadata;
+- policy artifact;
+- registry artifact;
+- materialized gate set;
+- CI outcome;
+- release authority manifest;
+- audit bundle;
+- digest manifest;
+- operator handoff report;
+- current external summary note;
+- reserved field-point authority map when present;
+- reserved admissibility state when present;
+- optional external / HPC / recognition evidence.
 
-The instructions must clearly distinguish:
+The instructions distinguish:
 
-- normative inputs
-- normative enforcement outputs
-- audit surfaces
-- diagnostic surfaces
-- publication surfaces
-- candidate evidence surfaces
+- normative inputs;
+- normative enforcement outputs;
+- audit surfaces;
+- diagnostic surfaces;
+- publication surfaces;
+- candidate evidence surfaces.
 
 ## Acceptance conditions
 
-The pass fixture to evidence packet handoff may be accepted as a planning baseline when:
+The pass fixture to evidence packet handoff may be accepted as a current
+baseline relation when:
 
 1. the pass fixture remains guarded as packet-baseline source candidate;
 2. the target packet layout is canonical;
@@ -562,18 +617,18 @@ The pass fixture to evidence packet handoff may be accepted as a planning baseli
 7. materialized gate-set mapping is defined;
 8. CI outcome mapping is defined;
 9. release authority manifest mapping is defined;
-10. audit bundle mapping is defined;
-11. digest coverage is defined;
+10. current v0 audit bundle file mapping is defined;
+11. digest-manifest mapping is defined;
 12. operator handoff mapping is defined;
 13. reconstruction instructions are defined;
-14. field-point authority classification is defined;
+14. current builder-covered subset is separated from reserved next-layer surfaces;
 15. no non-normative surface claims independent release authority.
 
-Acceptance of this plan is not acceptance of a release-grade packet.
+Acceptance of this handoff relation is not acceptance of a release-grade packet.
 
 ## Rejection conditions
 
-A future implementation should reject a packet candidate when:
+A packet candidate fails handoff review when:
 
 - source fixture identity is missing or inconsistent;
 - source status is missing;
@@ -593,63 +648,58 @@ A future implementation should reject a packet candidate when:
 - CI outcome is missing;
 - digest manifest is missing;
 - reconstruction instructions are missing;
-- audit, diagnostic, publication, HPC, recognition, or handoff surfaces claim independent release authority;
+- audit, diagnostic, publication, HPC, recognition, or handoff surfaces claim
+  independent release authority;
 - missing evidence is interpreted as PASS.
 
-All negative conditions should fail closed.
+All negative conditions fail closed.
 
-## Implementation sequence
+## Current implemented bridge
 
-The next implementation should proceed conservatively.
+The current implemented bridge contains:
 
-Suggested sequence:
+1. guarded positive release-reference fixture;
+2. release-reference completeness guard before packet generation;
+3. schema-aligned pass-fixture packet builder;
+4. canonical packet artifacts;
+5. package manifest and digest-manifest coverage;
+6. schema-aligned packet validator;
+7. publication snapshot manifest-reference hardening.
 
-1. create a packet builder mode for the pass fixture source;
-2. generate canonical packet paths;
-3. copy or render `status/status.json`;
-4. copy declared policy and registry;
-5. materialize gate sets;
-6. write `ci/ci_outcome.json`;
-7. write release authority manifest;
-8. write audit bundle;
-9. write package manifest;
-10. write package digests;
-11. write operator handoff report;
-12. write reconstruction instructions;
-13. add a packet-baseline fixture;
-14. add a packet-completeness checker;
-15. keep the checker non-authoritative;
-16. only later connect the packet candidate to RA1-style verification.
-
-The first implementation should verify packet completeness and authority boundaries.
-
-It should not authorize release.
+This bridge transforms the guarded pass fixture into a packet-shaped baseline
+candidate without changing release authority.
 
 ## Relation to minimal content packet builder
 
 The existing minimal content packet builder is useful as a structural bridge.
 
-The pass-fixture handoff is stricter because it starts from a concrete positive release-reference fixture.
+The pass-fixture handoff is stricter because it starts from a concrete positive
+release-reference fixture.
 
-The builder implementation may reuse layout-generation patterns from the minimal content packet builder.
+The builder implementation may reuse layout-generation patterns from the
+minimal content packet builder.
 
-It must not reuse non-release-grade placeholders as if they were release-grade evidence.
+It must not reuse non-release-grade placeholders as if they were release-grade
+evidence.
 
 ## Relation to RA1
 
 RA1 remains the stricter concrete package-verification path.
 
-This handoff plan does not run RA1.
-
-This handoff plan does not replace RA1.
-
-This handoff plan does not relax RA1.
-
 A future packet candidate may later be checked by RA1-style verification.
+
+Current boundary:
+
+```text
+schema-aligned packet preparation
+→ packet artifact validation
+→ future RA1 verification path
+```
 
 ## Relation to fellowship / HPC validation
 
-The pass-fixture evidence packet handoff prepares the first positive packet-shaped baseline candidate.
+The pass-fixture evidence packet handoff prepares the first positive
+packet-shaped baseline candidate.
 
 HPC validation should later start from:
 
@@ -677,6 +727,8 @@ This document does not change:
 - status schema;
 - `check_gates.py`;
 - release-reference guard behavior;
+- schema-aligned packet builder behavior;
+- schema-aligned packet validator behavior;
 - CI workflow behavior;
 - RA1 verifier behavior;
 - release-authority semantics.
@@ -685,12 +737,13 @@ This document does not change:
 
 The pass fixture proves a controlled positive release-reference candidate.
 
-The evidence packet baseline defines the packet field that must preserve such a candidate.
+The evidence packet baseline defines the packet field that must preserve such a
+candidate.
 
-This handoff plan connects them.
+This handoff plan connects them through the current schema-aligned builder
+relation.
 
-The next implementation should transform the guarded pass fixture into a packet-shaped baseline candidate without changing release authority.
+The current bridge transforms the guarded pass fixture into a packet-shaped
+baseline candidate while preserving release authority.
 
 The packet preserves the PULSEmech path.
-
-It does not replace it.

--- a/docs/PULSE_REF_PASS_FIXTURE_TO_EVIDENCE_PACKET_HANDOFF_PLAN_v0.md
+++ b/docs/PULSE_REF_PASS_FIXTURE_TO_EVIDENCE_PACKET_HANDOFF_PLAN_v0.md
@@ -181,9 +181,9 @@ schema-aligned packet validator.
 | `pulse_gate_policy_v0.yml` | `policy/pulse_gate_policy_v0.yml` | emitted | declared gate policy | normative input |
 | `pulse_gate_registry_v0.yml` | `policy/pulse_gate_registry_v0.yml` | emitted | gate semantic registry | normative support |
 | derived required/release_required sets | `gates/materialized_gate_sets.json` | emitted | materialized gate set | normative input |
-| gate check result | `ci/ci_outcome.json` | emitted | declared-policy gate-enforcement outcome | normative enforcement output |
-| evidence-policy-evaluator trace | `release_authority/release_authority_manifest.json` | emitted | audit / trace surface | non-normative reconstruction |
-| preserved status + manifest + report card | `audit/release_authority_audit_bundle/` | emitted as regular files | audit bundle | non-normative preservation |
+| gate-check conclusion | `ci/ci_outcome.json` | emitted | workflow/run identity and gate-check conclusion | normative enforcement output |
+| release-authority trace | `release_authority/release_authority_manifest.json` | emitted | audit / trace surface | non-normative reconstruction |
+| preserved audit README + status + manifest | `audit/release_authority_audit_bundle/` | emitted as regular files | audit bundle | non-normative preservation |
 | packet inventory | `package_manifest.json` | emitted | inventory / references | audit / reconstruction |
 | artifact digests | `digests/package_digests.json` | emitted | digest manifest | audit / reconstruction |
 | operator commands and reconstruction route | `handoff/operator_handoff_report.json` | emitted | operator reconstruction surface | non-normative |
@@ -295,21 +295,20 @@ Target:
 gates/materialized_gate_sets.json
 ```
 
-The materialized gate-set artifact includes:
+The materialized gate-set artifact records the current schema-aligned v0 fields:
 
-- required gate set;
-- release_required gate set;
-- effective required gate set;
-- selected lane or policy scope;
-- policy source path;
-- policy digest;
-- duplicate-handling rule;
-- ordering rule;
-- materialization command or reference when available.
+- `schema`;
+- `policy_path`;
+- `policy_sha256`;
+- `sets`;
+- `effective_required_gates`;
+- `authority_boundary`.
 
 The materialized gate set is consistent with the declared policy.
 
-The materialized gate set is not hand-edited to satisfy the fixture.
+Additional lane, ordering, duplicate-handling, or command metadata belongs in
+reconstruction / handoff surfaces unless a future schema revision declares those
+fields.
 
 ## CI outcome handoff
 
@@ -321,23 +320,22 @@ Target:
 ci/ci_outcome.json
 ```
 
-The artifact preserves:
+The artifact preserves the current schema-aligned v0 fields:
 
-- CI provider or execution environment;
-- workflow name;
-- workflow path or reference;
-- run ID or local execution identity;
-- run attempt when available;
-- commit SHA or source revision;
-- gate-check command;
-- effective required gate set;
-- gate-check conclusion;
-- expected allow/block outcome;
-- fail-closed indicator;
-- authority-boundary statement.
+- workflow / run metadata;
+- `gate_check_job`;
+- `gate_check_conclusion`;
+- `authority_boundary`.
 
-The CI outcome represents the declared-policy gate-enforcement result for the
+The CI outcome records workflow/run identity and gate-check conclusion for the
 packet candidate.
+
+Effective required gates are recorded in `gates/materialized_gate_sets.json`.
+
+Detailed command replay is recorded in `handoff/operator_handoff_report.json`.
+
+Declared decision reconstruction is recorded in
+`release_authority/release_authority_manifest.json`.
 
 A generic green workflow is not equivalent to a declared-policy release
 decision.

--- a/docs/PULSE_REF_PASS_FIXTURE_TO_EVIDENCE_PACKET_HANDOFF_PLAN_v0.md
+++ b/docs/PULSE_REF_PASS_FIXTURE_TO_EVIDENCE_PACKET_HANDOFF_PLAN_v0.md
@@ -322,9 +322,19 @@ ci/ci_outcome.json
 
 The artifact preserves the current schema-aligned v0 fields:
 
-- workflow / run metadata;
+- `schema`;
+- `provider`;
+- `workflow`;
+- `run_id`;
+- `run_attempt`;
+- `run_url`;
+- `repository`;
+- `commit_sha`;
 - `gate_check_job`;
 - `gate_check_conclusion`;
+- `created_utc`;
+- `started_utc`;
+- `completed_utc`;
 - `authority_boundary`.
 
 The CI outcome records workflow/run identity and gate-check conclusion for the

--- a/tests/test_pulse_ref_pass_fixture_to_evidence_packet_handoff_plan_v0.py
+++ b/tests/test_pulse_ref_pass_fixture_to_evidence_packet_handoff_plan_v0.py
@@ -179,15 +179,24 @@ FORBIDDEN_STALE_OR_INACCURATE_ANCHORS = [
     "selected lane or policy scope",
     "duplicate-handling rule",
     "ordering rule",
+]
+
+FORBIDDEN_CI_OUTCOME_SECTION_ANCHORS = [
     "gate-check command",
-    "effective required gate set;",
+    "effective required gate set",
     "expected allow/block outcome",
-    "fail-closed indicator;",
+    "fail-closed indicator",
 ]
 
 
 def _read_plan() -> str:
     return PLAN.read_text(encoding="utf-8")
+
+
+def _section(text: str, start_heading: str, end_heading: str) -> str:
+    start = text.index(start_heading)
+    end = text.index(end_heading, start)
+    return text[start:end]
 
 
 def test_handoff_plan_file_exists() -> None:
@@ -222,6 +231,29 @@ def test_handoff_plan_has_no_stale_or_inaccurate_anchors() -> None:
         assert anchor not in text, anchor
 
 
+def test_ci_outcome_section_does_not_claim_fields_owned_by_other_artifacts() -> None:
+    text = _read_plan()
+    section = _section(
+        text,
+        "## CI outcome handoff",
+        "## Release authority manifest handoff",
+    )
+
+    for anchor in FORBIDDEN_CI_OUTCOME_SECTION_ANCHORS:
+        assert anchor not in section, anchor
+
+
+def test_release_authority_manifest_section_may_reference_fail_closed_indicator() -> None:
+    text = _read_plan()
+    section = _section(
+        text,
+        "## Release authority manifest handoff",
+        "## Audit bundle handoff",
+    )
+
+    assert "fail-closed indicator" in section
+
+
 def test_handoff_plan_status_block_has_no_trailing_whitespace() -> None:
     lines = _read_plan().splitlines()
 
@@ -246,6 +278,8 @@ def main() -> int:
         test_handoff_plan_mapping_anchors_present()
         test_handoff_plan_does_not_claim_release_authority()
         test_handoff_plan_has_no_stale_or_inaccurate_anchors()
+        test_ci_outcome_section_does_not_claim_fields_owned_by_other_artifacts()
+        test_release_authority_manifest_section_may_reference_fail_closed_indicator()
         test_handoff_plan_status_block_has_no_trailing_whitespace()
     except AssertionError as exc:
         print(f"ERROR: {exc}")

--- a/tests/test_pulse_ref_pass_fixture_to_evidence_packet_handoff_plan_v0.py
+++ b/tests/test_pulse_ref_pass_fixture_to_evidence_packet_handoff_plan_v0.py
@@ -2,17 +2,13 @@
 """Smoke guard for the PULSE-REF pass fixture to evidence packet handoff plan.
 
 This guard protects the handoff-plan document that maps the guarded
-release_reference_v1/pass fixture into the first packet-shaped evidence
-baseline candidate.
+release_reference_v1/pass fixture into the first packet-shaped evidence baseline
+candidate.
 
 It is a documentation contract guard.
-
 It does not build an evidence packet.
-
 It does not validate release-grade evidence.
-
 It does not run RA1.
-
 It does not authorize, block, override, or create release authority.
 """
 
@@ -30,17 +26,29 @@ PLAN = (
 
 
 REQUIRED_ANCHORS = [
-    "Status: planning handoff",
-    "Authority status: non-normative",
+    "Status: planning handoff / current builder relation",
+    "Authority status: non-normative handoff record",
     "Release-grade status: not release-grade evidence",
     "Verifier status: not a verifier",
     "Decision status: does not authorize, block, override, or create release authority",
-    "This document defines the handoff plan from the positive `release_reference_v1/pass` fixture to the first PULSE-REF evidence packet baseline candidate.",
-    "The release-reference evidence packet baseline identifies the positive pass fixture as the preferred first source candidate for a packet-shaped baseline.",
-    "This document defines how that source candidate should be mapped into the canonical evidence packet layout before any builder implementation changes are made.",
+    "This document defines the handoff relation from the positive `release_reference_v1/pass` fixture to the first PULSE-REF evidence packet baseline candidate.",
+    "The release-reference evidence packet baseline identifies the positive pass",
+    "fixture as the preferred first source candidate for a packet-shaped baseline.",
+    "This document records how that source candidate maps into the canonical evidence",
+    "packet layout and how the current schema-aligned builder covers the current v0",
+    "packet subset.",
     "The next proof state is a packet-shaped, digest-backed, reconstructable baseline candidate derived from a controlled positive release-reference fixture.",
-    "The `release_reference_v1/pass` fixture proves that a controlled candidate can satisfy the release-reference completeness guard.",
-    "The evidence packet handoff must preserve that candidate as recorded artifact state.",
+    "The `release_reference_v1/pass` fixture proves that a controlled candidate can",
+    "satisfy the release-reference completeness guard.",
+    "The evidence packet handoff preserves that candidate as recorded artifact state.",
+    "The current handoff relation is no longer only a future implementation plan.",
+    "tests/fixtures/release_reference_v1/pass/status.json",
+    "release-reference completeness guard",
+    "policy-derived materialized required gates",
+    "schema-aligned packet builder",
+    "canonical packet artifacts",
+    "schema-aligned packet validator",
+    "reconstructable packet-shaped baseline candidate",
     "recorded release evidence",
     "recorded `status.json` artifact",
     "declared gate policy",
@@ -61,7 +69,8 @@ REQUIRED_ANCHORS = [
     "external summaries present",
     "external aggregate passing",
     "expected outcome `PASS`",
-    "The source candidate is protected by the pass fixture packet-baseline candidate guard.",
+    "The source candidate is protected by the pass fixture packet-baseline candidate",
+    "guard.",
     "docs/PULSE_REF_EVIDENCE_PACKET_LAYOUT_v0.md",
     "pulse_ref_evidence_packet_v0/",
     "Source-to-packet mapping",
@@ -70,9 +79,25 @@ REQUIRED_ANCHORS = [
     "Policy handoff",
     "Registry handoff",
     "Materialized gate-set handoff",
+    "The materialized gate-set artifact records the current schema-aligned v0 fields:",
+    "`policy_path`",
+    "`policy_sha256`",
+    "`sets`",
+    "`effective_required_gates`",
     "CI outcome handoff",
+    "The artifact preserves the current schema-aligned v0 fields:",
+    "`gate_check_job`",
+    "`gate_check_conclusion`",
+    "Effective required gates are recorded in `gates/materialized_gate_sets.json`.",
+    "Detailed command replay is recorded in `handoff/operator_handoff_report.json`.",
+    "Declared decision reconstruction is recorded in",
+    "`release_authority/release_authority_manifest.json`.",
     "Release authority manifest handoff",
     "Audit bundle handoff",
+    "Current v0 audit bundle files:",
+    "audit/release_authority_audit_bundle/README.md",
+    "audit/release_authority_audit_bundle/status.json",
+    "audit/release_authority_audit_bundle/release_authority_manifest.json",
     "Digest handoff",
     "Operator handoff report",
     "Publication snapshot",
@@ -84,7 +109,7 @@ REQUIRED_ANCHORS = [
     "Reconstruction instructions",
     "Acceptance conditions",
     "Rejection conditions",
-    "Implementation sequence",
+    "Current implemented bridge",
     "Relation to minimal content packet builder",
     "Relation to RA1",
     "Relation to fellowship / HPC validation",
@@ -93,7 +118,6 @@ REQUIRED_ANCHORS = [
     "HPC validates the decision field.",
     "PULSEmech remains the release-authority mechanism.",
 ]
-
 
 REQUIRED_MAPPING_ANCHORS = [
     "`tests/fixtures/release_reference_v1/pass/status.json`",
@@ -108,18 +132,21 @@ REQUIRED_MAPPING_ANCHORS = [
     "`ci/ci_outcome.json`",
     "`release_authority/release_authority_manifest.json`",
     "`audit/release_authority_audit_bundle/`",
+    "`audit/release_authority_audit_bundle/README.md`",
+    "`audit/release_authority_audit_bundle/status.json`",
+    "`audit/release_authority_audit_bundle/release_authority_manifest.json`",
     "`package_manifest.json`",
     "`digests/package_digests.json`",
     "`handoff/operator_handoff_report.json`",
     "`publication/publication_snapshot.json`",
     "`field/field_point_authority_map_v0.json`",
     "`admissibility/evidence_fold_in_admissibility_v0.json`",
+    "`external/summaries/README.md`",
     "`external/summaries/`",
     "`hpc/hpc_evidence_bundle_v0.json`",
     "`recognition/recognition_surface_drift_v0.json`",
     "`reconstruction/reconstruction_instructions.md`",
 ]
-
 
 FORBIDDEN_CLAIMS = [
     "This document creates release authority.",
@@ -134,6 +161,28 @@ FORBIDDEN_CLAIMS = [
     "The handoff plan authorizes release.",
     "The packet candidate authorizes release by existing.",
     "HPC creates release authority.",
+]
+
+FORBIDDEN_STALE_OR_INACCURATE_ANCHORS = [
+    "This document defines the handoff plan from the positive `release_reference_v1/pass` fixture to the first PULSE-REF evidence packet baseline candidate.",
+    "This document defines how that source candidate should be mapped into the canonical evidence packet layout before any builder implementation changes are made.",
+    "Implementation sequence",
+    "before any builder implementation changes are made",
+    "This document does not build an evidence packet.",
+    "It defines the artifact mapping and handoff boundary for the next implementation step.",
+    "The handoff succeeds when a future implementation can produce a packet directory",
+    "The next implementation should proceed conservatively.",
+    "Suggested sequence:",
+    "write field-point authority map",
+    "write evidence fold-in admissibility",
+    "preserved status + manifest + report card",
+    "selected lane or policy scope",
+    "duplicate-handling rule",
+    "ordering rule",
+    "gate-check command",
+    "effective required gate set;",
+    "expected allow/block outcome",
+    "fail-closed indicator;",
 ]
 
 
@@ -166,12 +215,38 @@ def test_handoff_plan_does_not_claim_release_authority() -> None:
         assert claim not in text, claim
 
 
+def test_handoff_plan_has_no_stale_or_inaccurate_anchors() -> None:
+    text = _read_plan()
+
+    for anchor in FORBIDDEN_STALE_OR_INACCURATE_ANCHORS:
+        assert anchor not in text, anchor
+
+
+def test_handoff_plan_status_block_has_no_trailing_whitespace() -> None:
+    lines = _read_plan().splitlines()
+
+    protected_prefixes = (
+        "Status:",
+        "Authority status:",
+        "Scope:",
+        "Release-grade status:",
+        "Verifier status:",
+        "Decision status:",
+    )
+
+    for line in lines:
+        if line.startswith(protected_prefixes):
+            assert line == line.rstrip(), line
+
+
 def main() -> int:
     try:
         test_handoff_plan_file_exists()
         test_handoff_plan_required_anchors_present()
         test_handoff_plan_mapping_anchors_present()
         test_handoff_plan_does_not_claim_release_authority()
+        test_handoff_plan_has_no_stale_or_inaccurate_anchors()
+        test_handoff_plan_status_block_has_no_trailing_whitespace()
     except AssertionError as exc:
         print(f"ERROR: {exc}")
         return 1


### PR DESCRIPTION
## Summary

This PR reconciles the PULSE-REF pass-fixture-to-evidence-packet handoff plan against the current schema-aligned builder path.

## Purpose

The handoff plan still contained future-only builder language even though the schema-aligned pass-fixture packet builder and validator now exist.

This update records the current handoff relation:

```text
tests/fixtures/release_reference_v1/pass/status.json
→ release-reference completeness guard
→ policy-derived materialized required gates
→ schema-aligned packet builder
→ canonical packet artifacts
→ schema-aligned packet validator
→ reconstructable packet-shaped baseline candidate
```

## Cleanup performed

The document now distinguishes:

- guarded positive source fixture;
- current v0 builder-covered subset;
- reconstructable packet-shaped baseline candidate;
- reserved next-layer packet-completeness surfaces.

The smoke guard was updated to protect the revised anchors and reject stale future-only handoff language.

## Changed files

```text
docs/PULSE_REF_PASS_FIXTURE_TO_EVIDENCE_PACKET_HANDOFF_PLAN_v0.md
tests/test_pulse_ref_pass_fixture_to_evidence_packet_handoff_plan_v0.py
```

## Preserved

Preserved surfaces remain unchanged:

- PULSEmech release authority;
- gate policy semantics;
- required gate wiring;
- schemas;
- workflow mechanics;
- CI allow/block behavior;
- `check_gates.py`;
- Quality Ledger renderer behavior;
- Pages workflow behavior;
- release tags;
- DOI / Zenodo path.

## Validation

```bash
python tests/test_pulse_ref_pass_fixture_to_evidence_packet_handoff_plan_v0.py

python tests/test_pulse_ref_pass_fixture_packet_baseline_candidate_v0.py

python tests/test_build_pulse_ref_schema_aligned_pass_fixture_packet_v0.py

python tests/test_check_pulse_ref_schema_aligned_packet_v0.py

git diff --check -- docs/PULSE_REF_PASS_FIXTURE_TO_EVIDENCE_PACKET_HANDOFF_PLAN_v0.md tests/test_pulse_ref_pass_fixture_to_evidence_packet_handoff_plan_v0.py
```