### PR TITLE
docs(cleanup): align public wording with PULSEmech release authority

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -101,7 +101,7 @@ Follow-ups:
 
 Risks / mitigations:
 
-PULSE checklist (governance)
+PULSE checklist (release authority)
  PULSE CI is green on this PR
  Quality Ledger link (if enabled)
  Badges updated (PASS / RDSI / Q-Ledger)
@@ -111,7 +111,7 @@ PULSE checklist (governance)
 - Follow-ups:
 - Risks / mitigations:
 
-## PULSE checklist (governance)
+## PULSE checklist (release authority)
 - [ ] PULSE CI is green on this PR
 - [ ] Quality Ledger link (if enabled)
 - [ ] Badges updated (PASS / RDSI / Q‑Ledger)


### PR DESCRIPTION

## Summary

This PR performs a documentation and public-surface cleanup to make the PULSEmech identity clearer as an artifact-bound release-authority mechanism.

The cleanup narrows or removes governance-facing wording where it could cause PULSE to be read as an organizational governance component, governance framework, dashboard, compliance layer, or control-plane surface.

The intended PULSEmech authority path remains unchanged:

recorded release evidence → status.json → declared gate policy → workflow-effective materialized required gate set → strict fail-closed CI enforcement → pre-deployment allow/block release decision

## Scope

This PR updates wording and boundary statements in public-facing documentation, templates, entry paths, and diagnostic/research surfaces.

It keeps governance terminology only where it explicitly refers to repository stewardship, maintainer/repository authority, external governance literature, or legacy/non-canonical terminology.

## Non-goals

This PR does not change release-authority semantics.

It does not change gate policy, gate registry, status schema, check_gates.py behavior, CI allow/block behavior, release tags, DOI/Zenodo artifacts, or release artifacts.

## Mechanical boundary

PULSEmech release authority remains carried only by the recorded artifact path:

status.json + declared gate policy + workflow-effective materialized required gates + strict fail-closed CI enforcement

Reader surfaces, optional layers, review packs, maintainer documents, research notes, field/decisions notes, and Quality Ledger displays remain non-normative unless they are recorded as release evidence, declared in policy, materialized as required gates, and enforced through strict fail-closed CI.

## Testing

- [ ] git diff --check
- [ ] grep/search confirms no unintended "governance triage" wording remains
- [ ] grep/search confirms "release-governance" appears only in legacy/future-metadata/deprecated terminology context, if at all
- [ ] relevant docs/rendering tests pass
- [ ] no policy/schema/check_gates/CI release-authority files were changed
Merge commit / squash merge szöveg