### PR TITLE
fix(ledger): align public reader surface with PULSEmech boundary

### DIFF
--- a/PULSE_safe_pack_v0/tools/render_quality_ledger.py
+++ b/PULSE_safe_pack_v0/tools/render_quality_ledger.py
@@ -124,6 +124,15 @@ def html_short_hash(value: Any, prefix_len: int = 12) -> str:
     return f'<span title="{escape(s)}">{escape(s[:prefix_len])}…</span>'
 
 
+def public_topology_label(value: Any) -> Any:
+    """Return the canonical public topology label for diagnostic display."""
+    if not isinstance(value, str):
+        return value
+    if value.strip() == "stably_bad":
+        return "stable_bad"
+    return value
+
+
 def gate_status_parts(ok: bool) -> Tuple[str, str]:
     return ("PASS", "status-pass") if ok else ("FAIL", "status-fail")
 
@@ -279,15 +288,24 @@ def public_surface_profile(status: Dict[str, Any], decision_label: str) -> str:
 
     if run_grade == "core":
         if markers:
-            return "CORE READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE"
+            return (
+                "CORE READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE — "
+                "NOT RELEASE-GRADE AUTHORITY"
+            )
         return "CORE READER SURFACE"
     if run_grade == "demo":
         if markers:
-            return "DEMO READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE"
+            return (
+                "DEMO READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE — "
+                "NOT RELEASE-GRADE AUTHORITY"
+            )
         return "DEMO READER SURFACE"
     if run_grade == "prod":
         if markers:
-            return "PROD READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE"
+             return (
+                "PROD READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE — "
+                "NOT RELEASE-GRADE AUTHORITY"
+            )
         return "PROD READER SURFACE — MATERIALIZATION PENDING"
     return "RECORDED READER SURFACE"
 
@@ -321,10 +339,11 @@ def public_evidence_profile(status: Dict[str, Any], decision_label: str) -> str:
 
 
 def render_public_surface_state(status: Dict[str, Any], decision_label: str) -> str:
-    marker_summary = ", ".join(active_stub_scaffold_markers(status)) or "clear"
+   surface_profile = public_surface_profile(status, decision_label)
+   marker_summary = ", ".join(active_stub_scaffold_markers(status)) or "clear"
     rows_html = render_meta_list(
         [
-            ("Public surface", public_surface_profile(status, decision_label)),
+            ("Public surface", surface_profile),
             ("Recorded run mode", surface_run_grade(status)),
             ("Evidence materialization", public_evidence_profile(status, decision_label)),
             ("Stub/scaffold marker state", marker_summary),
@@ -337,7 +356,7 @@ def render_public_surface_state(status: Dict[str, Any], decision_label: str) -> 
     )
     return (
         '<div class="surface-boundary">'
-        "<h2>PULSE PUBLIC SURFACE STATE</h2>"
+        f"<h2>{escape(surface_profile)}</h2>"
         "<p>The Quality Ledger presents the recorded <code>status.json</code> "
         "state as a public reader surface.</p>"
         f'<div class="meta-grid">{rows_html}</div>'
@@ -577,13 +596,16 @@ def render_hazard_section(metrics: Dict[str, Any]) -> str:
         ("metrics.hazard_S", metrics.get("hazard_S")),
         ("metrics.hazard_D", metrics.get("hazard_D")),
         ("metrics.hazard_reason", metrics.get("hazard_reason")),
-        ("metrics.hazard_topology_region", metrics.get("hazard_topology_region")),
+        (
+            "metrics.hazard_topology_region",
+            public_topology_label(metrics.get("hazard_topology_region")),
+        ),
         ("metrics.hazard_baseline_ok", metrics.get("hazard_baseline_ok")),
         ("metrics.hazard_gate_id", metrics.get("hazard_gate_id")),
         ("metrics.hazard_T_scaled", metrics.get("hazard_T_scaled")),
         (
-         "metrics.hazard_stability_map_schema",
-          metrics.get("hazard_stability_map_schema"),
+           "metrics.hazard_stability_map_schema",
+            metrics.get("hazard_stability_map_schema"),
         ),
         ("metrics.hazard_stability_map_path", metrics.get("hazard_stability_map_path")),
     ]
@@ -827,6 +849,7 @@ def render_quality_ledger(status: Dict[str, Any], *, status_path: Path) -> str:
 </head>
 <body>
   <div class="wrap">
+    {render_public_surface_state(status, decision_label)}
     <section class="panel">
       <div class="decision">
         <div>
@@ -840,7 +863,6 @@ def render_quality_ledger(status: Dict[str, Any], *, status_path: Path) -> str:
       </div>
     
     </section>
-    {render_public_surface_state(status, decision_label)}
     {render_gate_table("Safety gates", gate_buckets["safety"])}
     {render_gate_table("Quality gates", gate_buckets["quality"])}
     {render_refusal_delta_section(metrics, gates)}

--- a/PULSE_safe_pack_v0/tools/render_quality_ledger.py
+++ b/PULSE_safe_pack_v0/tools/render_quality_ledger.py
@@ -293,6 +293,7 @@ def public_surface_profile(status: Dict[str, Any], decision_label: str) -> str:
                 "NOT RELEASE-GRADE AUTHORITY"
             )
         return "CORE READER SURFACE"
+
     if run_grade == "demo":
         if markers:
             return (
@@ -300,13 +301,15 @@ def public_surface_profile(status: Dict[str, Any], decision_label: str) -> str:
                 "NOT RELEASE-GRADE AUTHORITY"
             )
         return "DEMO READER SURFACE"
+
     if run_grade == "prod":
         if markers:
-             return (
+            return (
                 "PROD READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE — "
                 "NOT RELEASE-GRADE AUTHORITY"
             )
         return "PROD READER SURFACE — MATERIALIZATION PENDING"
+
     return "RECORDED READER SURFACE"
 
 
@@ -320,18 +323,22 @@ def public_evidence_profile(status: Dict[str, Any], decision_label: str) -> str:
 
     if markers:
         parts.append("stub/scaffold markers recorded")
+
     if gates.get("detectors_materialized_ok") is True:
         parts.append("detector evidence materialized")
     else:
         parts.append("detector evidence pending")
+
     if gates.get("external_summaries_present") is True:
         parts.append("external summaries present")
     elif "external_summaries_present" in gates:
         parts.append("external summaries pending")
+
     if gates.get("external_all_pass") is True:
         parts.append("external evidence passing")
     elif "external_all_pass" in gates:
         parts.append("external evidence pending")
+
     if decision_label != "PROD-PASS":
         parts.append(f"declared-policy decision display: {decision_label}")
 
@@ -339,18 +346,22 @@ def public_evidence_profile(status: Dict[str, Any], decision_label: str) -> str:
 
 
 def render_public_surface_state(status: Dict[str, Any], decision_label: str) -> str:
-   surface_profile = public_surface_profile(status, decision_label)
-   marker_summary = ", ".join(active_stub_scaffold_markers(status)) or "clear"
+    surface_profile = public_surface_profile(status, decision_label)
+    marker_summary = ", ".join(active_stub_scaffold_markers(status)) or "clear"
     rows_html = render_meta_list(
         [
             ("Public surface", surface_profile),
             ("Recorded run mode", surface_run_grade(status)),
-            ("Evidence materialization", public_evidence_profile(status, decision_label)),
+            (
+                "Evidence materialization",
+                public_evidence_profile(status, decision_label),
+            ),
             ("Stub/scaffold marker state", marker_summary),
             ("Decision display", decision_label),
             (
                 "Authority carrier",
-                "status.json → declared gate policy → materialized required gate set → strict fail-closed CI enforcement",
+                "status.json → declared gate policy → workflow-effective "
+                "materialized required gate set → strict fail-closed CI enforcement",
             ),
         ]
     )

--- a/docs/PULSE_TERMINOLOGY_RISK_REGISTER_v0.md
+++ b/docs/PULSE_TERMINOLOGY_RISK_REGISTER_v0.md
@@ -54,19 +54,11 @@ The following terms may appear only when their scope is explicit and they are no
 | productization maturity | Can make PULSEmech appear to be measured as a plug-and-play product category | Use only for packaging, operational support, or deployment readiness around PULSEmech |
 | enterprise platform | Can make PULSEmech appear to be an enterprise software product category | Use only when discussing deployment packaging or integration environment, not the release-authority mechanism |
 | industrial standard | Can make PULSEmech appear to require broad market adoption before its mechanism can be evaluated | Use only for ecosystem/adoption status; not for mechanical validity |
- HKati-patch-919488
-| release-grade lane eligibility | Can be misread as release permission or final release authorization | Use only as eligibility for stricter release-grade checks; actual release permission still requires the enforced PULSEmech authority path |
-| external evidence presence | Can be misread as proof that evidence has materialized into a required gate | Use only as available candidate evidence until recorded, declared, materialized, and enforced |
-| publication exposure | Can make public visibility appear to grant release authority | Use only as a reader/publication surface; exposure does not authorize release |
-| third-party integration / adoption | Can make ecosystem uptake appear to define PULSEmech identity | Use only as external integration or adoption context; not as PULSEmech identity |
-| hardening layer | Can make repository or supply-chain hardening appear to define PULSEmech | Use only as an operating-environment strengthening layer around PULSEmech |
-=======
 | release-grade lane eligibility | Can be misread as release permission or CI allow outcome | Use only as lane/materialization review status; never as release permission |
 | external evidence presence | Can be misread as materialized release evidence | Use only as artifact/file presence unless recorded, parseable, subject-bound, freshness-bound when required, mapped by declared rules, folded into status/gate state, and enforced when release-required |
 | publication exposure | Can be misread as release authority | Use only as public/private artifact classification; publication does not authorize release |
 | third-party integration / adoption | Can be misread as PULSEmech identity or mechanical maturity | Use only as deployment/adoption context around PULSEmech; not as PULSEmech identity |
 | hardening layer | Can be misread as PULSEmech definition | Use only as surrounding repository, security, artifact, verifier, or operational hardening; not as the PULSEmech mechanism definition |
- main
 
 ## Preferred PULSE-facing descriptors
 

--- a/tests/test_render_quality_ledger_check_gates_parity.py
+++ b/tests/test_render_quality_ledger_check_gates_parity.py
@@ -10,6 +10,7 @@ from PULSE_safe_pack_v0.tools.check_gates import main as check_gates_main  # noq
 from PULSE_safe_pack_v0.tools.render_quality_ledger import (  # noqa: E402
     decision_from_status,
     select_required_gates,
+    write_quality_ledger,
 )
 
 
@@ -181,4 +182,36 @@ def test_unresolved_gate_selection_yields_unknown_without_check_gates(
     assert decision_from_status(status, status_path=status_path) == (
         "UNKNOWN",
         "badge-unknown",
+    )
+
+
+def test_rendered_gate_rows_use_status_gates_over_conflicting_mirrors(
+    tmp_path: Path,
+) -> None:
+    status_path = tmp_path / "status.json"
+    out_path = tmp_path / "report_card.html"
+    status = status_payload(
+        run_mode="core",
+        required_gates=["refusal_delta_evidence_present"],
+        gates={"refusal_delta_evidence_present": True},
+    )
+    status["refusal_delta_evidence_present"] = False
+    status["metrics"]["refusal_delta_evidence_present"] = False
+    status["meta"] = {"gates": {"refusal_delta_evidence_present": False}}
+    status["external"] = {"gates": {"refusal_delta_evidence_present": False}}
+    write_json(status_path, status)
+
+    write_quality_ledger(status_path, out_path)
+
+    html = out_path.read_text(encoding="utf-8")
+    gate_name_idx = html.index("refusal_delta_evidence_present")
+    row_end_idx = html.index("</tr>", gate_name_idx)
+    row_html = html[gate_name_idx:row_end_idx]
+    assert "status-pass" in row_html
+    assert ">PASS<" in row_html
+    assert "status-fail" not in row_html
+    assert ">FAIL<" not in row_html
+    assert decision_from_status(status, status_path=status_path) == (
+        "STAGE-PASS",
+        "badge-pass",
     )

--- a/tests/test_render_quality_ledger_diagnostic_sections.py
+++ b/tests/test_render_quality_ledger_diagnostic_sections.py
@@ -183,6 +183,28 @@ def test_epf_hazard_overlay_renders_with_diagnostic_copy(tmp_path: Path) -> None
     assert "artifacts/stability_map_v0.json" in html
 
 
+def test_epf_hazard_overlay_maps_legacy_stably_bad_to_public_canonical_label(
+    tmp_path: Path,
+) -> None:
+    status_path = tmp_path / "status.json"
+    out_path = tmp_path / "report_card.html"
+
+    status = base_status()
+    status["metrics"].update(
+        {
+            "hazard_zone": "green",
+            "hazard_topology_region": "stably_bad",
+            "hazard_baseline_ok": False,
+        }
+    )
+
+    html = render_html(status_path, out_path, status)
+
+    assert "metrics.hazard_topology_region" in html
+    assert "stable_bad" in html
+    assert "stably_bad" not in html
+
+
 def test_optional_diagnostic_sections_are_absent_when_inputs_are_missing(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_render_quality_ledger_public_surface_state.py
+++ b/tests/test_render_quality_ledger_public_surface_state.py
@@ -14,6 +14,10 @@ MATERIALIZED_PROD_SURFACE = (
     "PROD READER SURFACE — MATERIALIZED RELEASE-GRADE EVIDENCE STATE"
 )
 STUBBED_PROD_SURFACE = "PROD READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE"
+CORE_STUBBED_PUBLIC_BOUNDARY = (
+    "CORE READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE — "
+    "NOT RELEASE-GRADE AUTHORITY"
+)
 PENDING_PROD_SURFACE = "PROD READER SURFACE — MATERIALIZATION PENDING"
 
 
@@ -127,12 +131,16 @@ def test_core_stubbed_surface_uses_positive_reader_state_wording() -> None:
     html = render(status)
 
     assert "STAGE-PASS" in html
-    assert "CORE READER SURFACE" in html
-    assert "STUBBED/SCAFFOLD" in html
+    assert CORE_STUBBED_PUBLIC_BOUNDARY in html
+    assert "declared-policy decision display: STAGE-PASS" in html
+    assert html.index(CORE_STUBBED_PUBLIC_BOUNDARY) < html.index("STAGE-PASS")
+    assert html.index(CORE_STUBBED_PUBLIC_BOUNDARY) < html.index("PASS")
+    assert html.index(CORE_STUBBED_PUBLIC_BOUNDARY) < html.index(
+        "declared-policy decision display: STAGE-PASS"
+    )
     for bad in [
         "PUBLIC READER SURFACE — NON-NORMATIVE",
         "NON-RELEASE VIEW",
-        "NOT RELEASE-GRADE",
         "Non-normative display surface",
         "It is not itself the release authority",
     ]:
@@ -187,3 +195,18 @@ def test_prod_surface_keeps_pending_wording_for_neutral_stub_profiles() -> None:
         assert PENDING_PROD_SURFACE in html, path
         assert STUBBED_PROD_SURFACE not in html, path
         assert MATERIALIZED_PROD_SURFACE not in html, path
+
+
+def test_terminology_risk_register_has_no_conflict_remnants() -> None:
+    text = (REPO_ROOT / "docs" / "PULSE_TERMINOLOGY_RISK_REGISTER_v0.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "HKati-patch" not in text
+    assert "=======" not in text
+    assert "\nmain\n" not in text
+    assert text.count("| release-grade lane eligibility |") == 1
+    assert text.count("| external evidence presence |") == 1
+    assert text.count("| publication exposure |") == 1
+    assert text.count("| third-party integration / adoption |") == 1
+    assert text.count("| hardening layer |") == 1


### PR DESCRIPTION
## Summary

This PR finishes the targeted PULSEmech public reader-surface cleanup.

It fixes the remaining public-surface drift identified after the documentation visibility cleanup:

- the Quality Ledger reader-surface boundary now renders before any STAGE-PASS / PASS / PROD-PASS decision badge
- core/stub/scaffold states explicitly display NOT RELEASE-GRADE AUTHORITY
- declared-policy decisions remain display-only inside the public reader surface
- generic gate rows continue to be sourced from status["gates"]
- refusal_delta_evidence_present parity is covered by renderer tests
- legacy stably_bad diagnostic input is normalized to stable_bad in public Ledger output
- docs/PULSE_TERMINOLOGY_RISK_REGISTER_v0.md is cleaned of merge/conflict remnants and duplicate rows

## Mechanical boundary

This PR does not change PULSEmech release-authority semantics.

PULSEmech release authority remains:

recorded release evidence → status.json → declared gate policy → workflow-effective materialized required gate set → strict fail-closed CI enforcement → pre-deployment allow/block release decision

The Quality Ledger remains a public reader/renderer surface, not release authority.

## Files changed

- PULSE_safe_pack_v0/tools/render_quality_ledger.py
- docs/PULSE_TERMINOLOGY_RISK_REGISTER_v0.md
- tests/test_render_quality_ledger_check_gates_parity.py
- tests/test_render_quality_ledger_diagnostic_sections.py
- tests/test_render_quality_ledger_public_surface_state.py

## Non-goals

This PR does not change:

- gate policy
- gate registry
- status schema
- check_gates.py release-authority semantics
- CI allow/block behavior
- DOI/Zenodo artifacts
- release artifacts
- release tags

## Testing

- [x] git diff --check
- [x] grep -RInE "HKati-patch|=======|stably_bad|PULSE checklist \(governance\)|governance triage" docs PULSE_safe_pack_v0 tests .github README.md 2>/dev/null || true
- [x] python -m pytest -q tests/test_core_baseline_v0.py
- [x] python -m pytest -q tests/test_render_quality_ledger.py tests/test_render_quality_ledger_decision_logic.py tests/test_render_quality_ledger_check_gates_parity.py tests/test_render_quality_ledger_diagnostic_sections.py tests/test_render_quality_ledger_public_surface_state.py tests/test_render_quality_ledger_decision_edges.py tests/test_render_quality_ledger_cli.py

## Expected public result after merge / Pages rebuild

The public Quality Ledger should start from the reader-surface boundary, not from the decision badge.

Expected order:

1. CORE READER SURFACE — STUBBED/SCAFFOLD EVIDENCE STATE — NOT RELEASE-GRADE AUTHORITY
2. declared-policy decision display: STAGE-PASS

The public Ledger should not emit stably_bad as a canonical public value.

The refusal_delta_evidence_present row should match status["gates"]["refusal_delta_evidence_present"].