### PR TITLE
docs(provenance): record PULSE title continuity

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -23,6 +23,7 @@ If you add/rename a doc under `docs/`, please update this index.
 - [PULSEMECH_ARCHITECTURE_MAP_v0_1.md](PULSEMECH_ARCHITECTURE_MAP_v0_1.md) — How to read the PULSEmech architecture map and its release-authority boundary.
 - [release_authority_manifest_v0.md](release_authority_manifest_v0.md) — Implemented v0 audit-manifest contract surface for recording the release-authority chain across evidence, policy, evaluator, workflow lane, decision output, and diagnostic context. 
 - [release_grade_reference_run_v0.md](release_grade_reference_run_v0.md) — Operational definition of a non-stubbed release-grade PULSE reference run, including evidence requirements, artifact expectations, authority boundary, and reviewer checklist.
+- [PULSE_TITLE_CONTINUITY_v0.md](PULSE_TITLE_CONTINUITY_v0.md) — Title-continuity provenance note connecting the current repository-facing title with the earlier Kaggle/publication-facing title.
 
 ## Status, ledger & external signals
 

--- a/docs/PULSE_TITLE_CONTINUITY_v0.md
+++ b/docs/PULSE_TITLE_CONTINUITY_v0.md
@@ -1,0 +1,19 @@
+# PULSE Title Continuity v0
+
+## Title continuity
+
+The current repository-facing title is:
+
+**PULSE — Artifact-Bound Release Authority for AI Release Decisions**
+
+Earlier Kaggle-facing, publication-facing, and external reference material used the title:
+
+**PULSE: Deterministic Release Gates for Safe & Useful AI**
+
+These titles refer to the same continuous work line, provenance path, and workshop relationship.
+
+The current title clarifies the mechanism more precisely: PULSE is an artifact-bound release-authority system for AI release decisions. The earlier title remains a valid historical and publication-facing reference for the same project trajectory.
+
+**PULSEmech** names the explicit mechanism inside this continuity: recorded release evidence, `status.json`, declared gate policy, workflow-effective materialized required gates, and strict fail-closed CI enforcement.
+
+This note preserves title continuity across repository history, Kaggle material, publication records, and external references.


### PR DESCRIPTION
## Summary

This PR adds `docs/PULSE_TITLE_CONTINUITY_v0.md`.

The note records title continuity between:

**PULSE — Artifact-Bound Release Authority for AI Release Decisions**

and the earlier Kaggle-facing / publication-facing title:

**PULSE: Deterministic Release Gates for Safe & Useful AI**

These titles refer to the same continuous work line, provenance path, and workshop relationship.

The current title clarifies the mechanism more precisely: PULSE as an artifact-bound release-authority system for AI release decisions. The earlier title remains a valid Kaggle-facing, publication-facing, and external-reference title for the same project trajectory.

## Boundary

This is a documentation / provenance note only.

No release-authority semantics are changed.
No gate policy, registry, status schema, check_gates.py behavior, CI allow/block behavior, DOI/Zenodo artifact, release tag, or release artifact is changed.