### PR TITLE
fix(ref): update release-grade reference examples

### DIFF
--- a/examples/release_grade_reference_run_v0/release_authority_v0.release_grade.pass.example.json
+++ b/examples/release_grade_reference_run_v0/release_authority_v0.release_grade.pass.example.json
@@ -87,7 +87,8 @@
       "q4_slo_ok": true,
       "detectors_materialized_ok": true,
       "external_summaries_present": true,
-      "external_all_pass": true
+      "external_all_pass": true,
+      "refusal_delta_evidence_present": true
     },
     "failed_required_gates": [],
     "missing_required_gates": []

--- a/examples/release_grade_reference_run_v0/status.release_grade.pass.example.json
+++ b/examples/release_grade_reference_run_v0/status.release_grade.pass.example.json
@@ -50,7 +50,6 @@
   },
   "diagnostics": {
     "gates_stubbed": false,
-    "stub_profile": null,
     "scaffold": false
   }
 }


### PR DESCRIPTION
## Summary

This PR adds an explicit prod-only release-grade materialization preparation path for the first non-stubbed release-grade reference candidate.

Plain `--mode prod` now fails closed unless explicitly enabled with:

`--release-grade-materialized`

or:

`PULSE_RELEASE_GRADE_MATERIALIZED=1`

The materialized path requires real release-grade input artifacts before a prod candidate can be produced.

## What changed

- Added explicit prod-only release-grade materialization opt-in.
- Plain prod fails closed without explicit materialized evidence.
- Non-prod modes reject the materialization opt-in.
- Materialized prod requires `detector_materialization_v0.json`.
- Detector materialization rejects stub/scaffold manifests.
- Detector gate outcomes must be literal booleans.
- Referenced detector evidence files must exist.
- Canonical external summaries must be parseable and passing.
- `refusal_delta_summary.json` must have `n > 0` and pass.
- Materialized prod emits non-stubbed diagnostics:
  - `diagnostics.gates_stubbed = false`
  - `diagnostics.scaffold = false`
- Materialized prod writes:
  - `status.json`
  - `report_card.html`
  - `release_authority_v0.json`
  - `release_authority_audit_bundle/`
- Release-grade checker now requires:
  - `refusal_delta_evidence_present`
  - explicit `diagnostics.gates_stubbed = false`
  - explicit `diagnostics.scaffold = false`
- Release-grade examples and tests were updated to the stricter checker contract.

## Boundary

This PR prepares a release-grade reference candidate path.

It does not create a new release-decision engine.

PULSEmech release authority remains:

recorded release evidence → `status.json` → declared gate policy → workflow-effective materialized required gate set → strict fail-closed CI enforcement → pre-deployment allow/block release decision

## Non-goals

This PR does not change:

- gate policy
- gate registry
- status schema
- `check_gates.py` release-authority behavior
- CI allow/block semantics
- DOI/Zenodo artifacts
- release tags
- release artifacts

It does not run a release tag and does not create a GitHub Release.

## Verification

- plain prod fails closed without explicit materialized opt-in
- materialized prod path is prod-only
- core/demo smoke lanes remain unchanged
- core baseline passes
- release-grade checker contract passes
- release-grade example package passes
- targeted release-grade suite passes
- no release-authority semantic drift detected