### PR TITLE
fix(ref): block untrusted release-grade materialization inputs

### DIFF
--- a/PULSE_safe_pack_v0/tools/run_all.py
+++ b/PULSE_safe_pack_v0/tools/run_all.py
@@ -380,31 +380,38 @@ def materialize_refusal_delta(
 def materialize_release_grade_inputs(
     art_dir: pathlib.Path,
 ) -> tuple[dict[str, bool], dict[str, Any], dict[str, Any]]:
-    detector_gates = validate_detector_materialization(art_dir)
-    external_gates, external_section = materialize_external_summaries(art_dir)
-    refusal_gates, refusal_metrics = materialize_refusal_delta(art_dir)
+        """Fail closed until a real release-evidence verifier is wired.
 
-    gates_out: dict[str, bool] = {}
-    gates_out.update(detector_gates)
-    gates_out["detectors_materialized_ok"] = True
-    gates_out.update(external_gates)
-    gates_out.update(refusal_gates)
+    SECURITY HOTFIX: release-required gates must not be derived from local,
+    self-declared artifacts.  The historical implementation accepted
+    detector_materialization_v0.json gate booleans, generic canonical external
+    summary pass/rate/value fields, and refusal_delta_summary.json n/pass fields
+    as release-grade evidence.  Those files may still be useful diagnostics, but
+    without a verifier that binds identity, provenance, policy, and raw evidence,
+    they cannot materialize normative release-required gates.
+    """
+    self_declared_artifacts: list[str] = []
+    for path in (
+        art_dir / "detector_materialization_v0.json",
+        art_dir / "refusal_delta_summary.json",
+    ):
+        if path.exists():
+            self_declared_artifacts.append(path.name)
 
-    metrics_out: dict[str, Any] = {}
-    metrics_out.update(refusal_metrics)
+        for path in external_summary_files(art_dir):
+        self_declared_artifacts.append(str(path.relative_to(art_dir)))
 
-    required_true = [
-        "detectors_materialized_ok",
-        "external_summaries_present",
-        "external_all_pass",
-        "refusal_delta_evidence_present",
-        "refusal_delta_pass",
-    ]
-    for gate_id in required_true:
-        if gates_out.get(gate_id) is not True:
-            fail_closed(f"{gate_id}=False for release-grade materialized prod")
-
-    return gates_out, metrics_out, external_section
+    suffix = (
+        f" observed self-declared artifacts: {', '.join(self_declared_artifacts)}."
+        if self_declared_artifacts
+        else " no verified release evidence artifacts were found."
+    )
+    fail_closed(
+        "release-grade materialized prod is disabled until a real recorded "
+        "release-evidence verifier is implemented; local detector, external "
+        "summary, and refusal-delta artifacts cannot set release-required gates "
+        f"true.{suffix}"
+    )
 
 
 def build_release_authority_manifest(status_path: pathlib.Path) -> pathlib.Path:
@@ -1072,7 +1079,7 @@ if RUN_MODE in ("demo", "core"):
 else:
     stub_profile = "not_stubbed"
     gates_stubbed = False
-    gates["detectors_materialized_ok"] = True
+    gates["detectors_materialized_ok"] = gates.get("detectors_materialized_ok") is True
     diagnostics = {
         "scaffold": False,
         "gates_stubbed": False,

--- a/PULSE_safe_pack_v0/tools/run_all.py
+++ b/PULSE_safe_pack_v0/tools/run_all.py
@@ -140,91 +140,6 @@ def fail_closed(message: str) -> None:
     raise SystemExit(1)
 
 
-def read_json_artifact(path: pathlib.Path, *, label: str) -> dict[str, Any]:
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        fail_closed(f"missing {label}: {path}")
-    except Exception as exc:  # noqa: BLE001
-        fail_closed(f"{label} is not valid JSON: {exc}")
-
-    if not isinstance(data, dict):
-        fail_closed(f"{label} must be a JSON object: {path}")
-    return data
-
-
-def artifact_child(base: pathlib.Path, rel_path: str, *, label: str) -> pathlib.Path:
-    if not isinstance(rel_path, str) or not rel_path.strip():
-        fail_closed(f"{label} path must be a non-empty relative path")
-
-    rel = pathlib.Path(rel_path.strip())
-    if rel.is_absolute():
-        fail_closed(f"{label} path must be relative: {rel_path}")
-
-    resolved_base = base.resolve()
-    resolved = (resolved_base / rel).resolve()
-    if resolved != resolved_base and resolved_base not in resolved.parents:
-        fail_closed(f"{label} path escapes artifact directory: {rel_path}")
-
-    return resolved
-
-
-def validate_detector_materialization(art_dir: pathlib.Path) -> dict[str, bool]:
-    manifest_path = art_dir / "detector_materialization_v0.json"
-    if not manifest_path.exists():
-        fail_closed(
-            "missing detector materialization artifact: "
-            f"{manifest_path}"
-        )
-
-    manifest = read_json_artifact(
-        manifest_path,
-        label="detector materialization artifact",
-    )
-
-    if manifest.get("materialized") is not True:
-        fail_closed("detector materialization must have materialized=true")
-
-    if manifest.get("gates_stubbed") is not False:
-        fail_closed("detector materialization must have gates_stubbed=false")
-
-    if manifest.get("scaffold") is not False:
-        fail_closed("detector materialization must have scaffold=false")
-
-    gates_raw = manifest.get("gates")
-    if not isinstance(gates_raw, dict) or not gates_raw:
-        fail_closed("detector materialization gates must be a non-empty object")
-
-    gates: dict[str, bool] = {}
-    for gate_id, value in gates_raw.items():
-        gate_name = str(gate_id)
-        if not isinstance(value, bool):
-            fail_closed(
-                "detector materialization gate outcomes must be literal "
-                f"boolean values; got {gate_name}={value!r}"
-            )
-        gates[gate_name] = value
-
-    evidence_raw = manifest.get("evidence")
-    if not isinstance(evidence_raw, list) or not evidence_raw:
-        fail_closed("detector materialization evidence must be a non-empty list")
-
-    for idx, item in enumerate(evidence_raw):
-        if not isinstance(item, dict):
-            fail_closed(f"detector materialization evidence[{idx}] must be an object")
-        evidence_path = artifact_child(
-            art_dir,
-            str(item.get("path", "")),
-            label=f"detector materialization evidence[{idx}]",
-        )
-        if not evidence_path.exists():
-            fail_closed(
-                "detector materialization evidence file not found: "
-                f"{evidence_path}"
-            )
-
-    return gates
-
 
 def external_summary_files(art_dir: pathlib.Path) -> list[pathlib.Path]:
     external_dir = art_dir / "external"
@@ -242,155 +157,21 @@ def external_summary_files(art_dir: pathlib.Path) -> list[pathlib.Path]:
     return out
 
 
-def load_external_summary(path: pathlib.Path) -> Any:
-    try:
-        if path.suffix == ".jsonl":
-            rows = []
-            for line in path.read_text(encoding="utf-8").splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                rows.append(json.loads(line))
-            if not rows:
-                fail_closed(f"external summary is empty: {path}")
-            return rows
-
-        return json.loads(path.read_text(encoding="utf-8"))
-    except Exception as exc:  # noqa: BLE001
-        fail_closed(f"external summary is not parseable: {path}: {exc}")
-
-
-def external_summary_passes(payload: Any) -> bool:
-    if isinstance(payload, list):
-        return bool(payload) and all(external_summary_passes(row) for row in payload)
-
-    if not isinstance(payload, dict):
-        return False
-
-    for key in ("pass", "passed", "ok", "all_pass"):
-        if key in payload:
-            return payload.get(key) is True
-
-    rate = payload.get("rate")
-    if isinstance(rate, (int, float)):
-        return float(rate) <= 0.05
-
-    value = payload.get("value")
-    threshold = payload.get("threshold")
-    if isinstance(value, (int, float)) and isinstance(threshold, (int, float)):
-        return float(value) <= float(threshold)
-
-    return False
-
-
-def materialize_external_summaries(
-    art_dir: pathlib.Path,
-) -> tuple[dict[str, bool], dict[str, Any]]:
-    files = external_summary_files(art_dir)
-    if not files:
-        return (
-            {
-                "external_summaries_present": False,
-                "external_all_pass": False,
-            },
-            {
-                "summaries_present": False,
-                "summary_count": 0,
-                "all_pass": False,
-                "metrics": [],
-            },
-        )
-
-    rows: list[dict[str, Any]] = []
-    all_pass = True
-
-    for path in files:
-        payload = load_external_summary(path)
-        ok = external_summary_passes(payload)
-        rows.append(
-            {
-                "name": path.stem,
-                "path": str(path),
-                "pass": bool(ok),
-            }
-        )
-        if not ok:
-            all_pass = False
-
-    return (
-        {
-            "external_summaries_present": True,
-            "external_all_pass": bool(all_pass),
-        },
-        {
-            "summaries_present": True,
-            "summary_count": len(rows),
-            "all_pass": bool(all_pass),
-            "metrics": rows,
-        },
-    )
-
-
-def materialize_refusal_delta(
-    art_dir: pathlib.Path,
-) -> tuple[dict[str, bool], dict[str, Any]]:
-    path = art_dir / "refusal_delta_summary.json"
-    if not path.exists():
-        return (
-            {
-                "refusal_delta_evidence_present": False,
-                "refusal_delta_pass": False,
-            },
-            {},
-        )
-
-    summary = read_json_artifact(path, label="refusal delta summary")
-    n = summary.get("n")
-    passed = summary.get("pass")
-
-    if not isinstance(n, (int, float)) or int(n) <= 0:
-        return (
-            {
-                "refusal_delta_evidence_present": False,
-                "refusal_delta_pass": False,
-            },
-            {
-                "refusal_delta_n": n,
-            },
-        )
-
-    gate_pass = passed is True
-    metrics = {
-        "refusal_delta_n": int(n),
-        "refusal_delta": summary.get("delta"),
-        "refusal_delta_ci_low": summary.get("ci_low"),
-        "refusal_delta_ci_high": summary.get("ci_high"),
-        "refusal_pass_strict": gate_pass,
-    }
-
-    return (
-        {
-            "refusal_delta_evidence_present": True,
-            "refusal_delta_pass": gate_pass,
-        },
-        metrics,
-    )
-
 
 def materialize_release_grade_inputs(
     art_dir: pathlib.Path,
 ) -> tuple[dict[str, bool], dict[str, Any], dict[str, Any]]:
-        """Fail closed until a real release-evidence verifier is wired.
+    """Fail closed until a trusted release-evidence verifier is wired.
 
-    SECURITY HOTFIX: release-required gates must not be derived from local,
-    self-declared artifacts.  The historical implementation accepted
-    detector_materialization_v0.json gate booleans, generic canonical external
-    summary pass/rate/value fields, and refusal_delta_summary.json n/pass fields
-    as release-grade evidence.  Those files may still be useful diagnostics, but
-    without a verifier that binds identity, provenance, policy, and raw evidence,
-    they cannot materialize normative release-required gates.
+    SECURITY HOTFIX:
+    Release-required gates must not be derived from local, self-declared
+    artifact-directory inputs. Local detector manifests, generic external
+    summaries, and refusal-delta summaries may be diagnostic inputs, but they
+    cannot materialize normative release-required gates until a verifier binds
+    identity, provenance, policy, subject, and raw evidence.
     """
     self_declared_artifacts: list[str] = []
+
     for path in (
         art_dir / "detector_materialization_v0.json",
         art_dir / "refusal_delta_summary.json",
@@ -398,16 +179,20 @@ def materialize_release_grade_inputs(
         if path.exists():
             self_declared_artifacts.append(path.name)
 
-        for path in external_summary_files(art_dir):
-        self_declared_artifacts.append(str(path.relative_to(art_dir)))
+    for path in external_summary_files(art_dir):
+        try:
+            self_declared_artifacts.append(str(path.relative_to(art_dir)))
+        except ValueError:
+            self_declared_artifacts.append(str(path))
 
     suffix = (
         f" observed self-declared artifacts: {', '.join(self_declared_artifacts)}."
         if self_declared_artifacts
         else " no verified release evidence artifacts were found."
     )
+
     fail_closed(
-        "release-grade materialized prod is disabled until a real recorded "
+        "release-grade materialized prod is disabled until a trusted recorded "
         "release-evidence verifier is implemented; local detector, external "
         "summary, and refusal-delta artifacts cannot set release-required gates "
         f"true.{suffix}"

--- a/docs/release_grade_reference_run_v0.md
+++ b/docs/release_grade_reference_run_v0.md
@@ -38,6 +38,12 @@ authority.
 - tools-test coverage: ci/tools-tests.list  
 - primary workflow advisory qualification: present  
 - primary workflow authority role: non-normative / non-blocking  
+- hotfix status: `--release-grade-materialized` is intentionally fail-closed until a real recorded release-evidence verifier is implemented
+
+Security hotfix note: local `detector_materialization_v0.json`, external summary
+files, and `refusal_delta_summary.json` are treated as self-declared artifacts.
+They may be useful diagnostics, but they must not set release-required gates to
+`true` unless a verifier binds identity, provenance, policy, and raw evidence.
 
 The reference run definition describes how to produce and review a release-grade
 PULSE run. It does not create a new gate and does not promote any diagnostic
@@ -509,6 +515,10 @@ Release-grade reference run = materialized evidence release-authority reference
 
 Suggested next steps:
 
+- Implement the real recorded release-evidence verifier for detector
+  materialization, canonical external summaries, and refusal-delta evidence.
+- Only after that verifier exists, allow `--release-grade-materialized` to fold
+  verified evidence into release-required gate booleans.
 - The example package under `examples/release_grade_reference_run_v0/` now
   shows the expected artifact shape. A real non-stubbed release-grade
   reference run remains future work.  

--- a/tests/test_run_all_release_grade_materialization.py
+++ b/tests/test_run_all_release_grade_materialization.py
@@ -199,13 +199,13 @@ def test_release_grade_materialized_opt_in_is_prod_only(
     assert not (tmp_path / "status.json").exists()
 
 
-def test_prod_release_grade_fails_closed_before_status_when_detector_materialization_missing(
+def test_prod_release_grade_materialized_opt_in_fails_closed_until_verifier_exists(
     tmp_path: pathlib.Path,
 ) -> None:
     result = _run_prod(tmp_path, release_grade_materialized=True)
 
     assert result.returncode != 0
-    assert "missing detector materialization artifact" in _combined_output(result)
+    def test_prod_release_grade_self_declared_artifacts_do_not_materialize_gates(
     assert not (tmp_path / "status.json").exists()
 
 
@@ -216,44 +216,16 @@ def test_prod_release_grade_non_stubbed_candidate_materializes_required_artifact
 
     result = _run_prod(tmp_path, release_grade_materialized=True)
 
-    assert result.returncode == 0, _combined_output(result)
-
-    status = _load_status(tmp_path)
-    assert status["metrics"]["run_mode"] == "prod"
-    assert status["diagnostics"]["gates_stubbed"] is False
-    assert status["diagnostics"]["scaffold"] is False
-    assert status["gates"]["detectors_materialized_ok"] is True
-    assert status["gates"]["external_summaries_present"] is True
-    assert status["gates"]["external_all_pass"] is True
-    assert status["gates"]["refusal_delta_evidence_present"] is True
-    assert status["gates"]["refusal_delta_pass"] is True
-
-    manifest_path = tmp_path / "release_authority_v0.json"
-    report_path = tmp_path / "report_card.html"
-    bundle = tmp_path / AUDIT_BUNDLE_DIRNAME
-
-    assert manifest_path.exists()
-    assert report_path.exists()
-    assert bundle.exists()
-    assert (bundle / "status.json").exists()
-    assert (bundle / "report_card.html").exists()
-    assert (bundle / "release_authority_v0.json").exists()
-
-    bundled_status = _read_json(bundle / "status.json")
-    assert bundled_status["metrics"]["run_mode"] == "prod"
-    assert bundled_status["diagnostics"]["gates_stubbed"] is False
-    assert bundled_status["diagnostics"]["scaffold"] is False
-
-    _read_json(manifest_path)
-    _read_json(bundle / "release_authority_v0.json")
-
-    errors = check_release_grade_reference_run(
-        status_path=tmp_path / "status.json",
-        manifest_path=manifest_path,
-        report_path=report_path,
-        audit_bundle_dir=bundle,
-    )
-    assert errors == []
+    assert result.returncode != 0
+    output = _combined_output(result).lower()
+    assert "release-evidence verifier" in output
+    assert "self-declared artifacts" in output
+    assert "detector_materialization_v0.json" in output
+    assert "external/llamaguard_summary.json" in output
+    assert "refusal_delta_summary.json" in output
+    assert not (tmp_path / "status.json").exists()
+    assert not (tmp_path / "release_authority_v0.json").exists()
+    assert not (tmp_path / AUDIT_BUNDLE_DIRNAME).exists()
 
 
 def test_detectors_materialized_ok_requires_existing_detector_evidence(
@@ -269,7 +241,7 @@ def test_detectors_materialized_ok_requires_existing_detector_evidence(
     result = _run_prod(tmp_path, release_grade_materialized=True)
 
     assert result.returncode != 0
-    assert "detector materialization evidence file not found" in _combined_output(result)
+    assert "release-evidence verifier" in _combined_output(result).lower()
     assert not (tmp_path / "status.json").exists()
 
 
@@ -286,7 +258,7 @@ def test_prod_rejects_stubbed_detector_materialization_manifest(
     result = _run_prod(tmp_path, release_grade_materialized=True)
 
     assert result.returncode != 0
-    assert "stub" in _combined_output(result).lower()
+    assert "release-evidence verifier" in _combined_output(result).lower()
     assert not (tmp_path / "status.json").exists()
 
 
@@ -303,7 +275,7 @@ def test_prod_rejects_scaffold_detector_materialization_manifest(
     result = _run_prod(tmp_path, release_grade_materialized=True)
 
     assert result.returncode != 0
-    assert "scaffold" in _combined_output(result).lower()
+    assert "release-evidence verifier" in _combined_output(result).lower()
     assert not (tmp_path / "status.json").exists()
 
 
@@ -321,7 +293,7 @@ def test_prod_rejects_non_boolean_materialized_gate_outcome(
 
     assert result.returncode != 0
     output = _combined_output(result).lower()
-    assert "boolean" in output or "literal" in output
+    assert "release-evidence verifier" in output
     assert not (tmp_path / "status.json").exists()
 
 
@@ -339,7 +311,7 @@ def test_prod_rejects_materialization_manifest_without_materialized_true(
 
     assert result.returncode != 0
     output = _combined_output(result).lower()
-    assert "materialized" in output
+    assert "release-evidence verifier" in output
     assert not (tmp_path / "status.json").exists()
 
 
@@ -352,7 +324,7 @@ def test_external_release_gates_require_real_canonical_parseable_summary(
     result = _run_prod(tmp_path, release_grade_materialized=True)
 
     assert result.returncode != 0
-    assert "external_summaries_present" in _combined_output(result)
+    assert "release-evidence verifier" in _combined_output(result).lower()
 
     assert not (tmp_path / "release_authority_v0.json").exists()
 
@@ -369,8 +341,7 @@ def test_external_release_gates_reject_malformed_canonical_summary(
 
     assert result.returncode != 0
     output = _combined_output(result).lower()
-    assert "external" in output
-    assert "summary" in output
+    assert "release-evidence verifier" in output   
     assert not (tmp_path / "release_authority_v0.json").exists()
 
 
@@ -382,7 +353,7 @@ def test_refusal_delta_evidence_requires_summary_with_positive_n(
     result = _run_prod(tmp_path, release_grade_materialized=True)
 
     assert result.returncode != 0
-    assert "refusal_delta_evidence_present" in _combined_output(result)
+    assert "release-evidence verifier" in _combined_output(result).lower()
     assert not (tmp_path / "release_authority_v0.json").exists()
 
 
@@ -399,29 +370,44 @@ def test_refusal_delta_evidence_requires_passing_summary(
     result = _run_prod(tmp_path, release_grade_materialized=True)
 
     assert result.returncode != 0
-    output = _combined_output(result)
-    assert "refusal_delta" in output
+    output = _combined_output(result).lower()
+    assert "release-evidence verifier" in output
     assert not (tmp_path / "release_authority_v0.json").exists()
 
 
 def test_release_grade_checker_reports_missing_manifest_and_audit_bundle_files(
     tmp_path: pathlib.Path,
 ) -> None:
-    _prepare_release_grade_inputs(tmp_path, external={"rate": 0.0})
-
-    result = _run_prod(tmp_path, release_grade_materialized=True)
-    assert result.returncode == 0, _combined_output(result)
+    status_path = tmp_path / "status.json"
+    report_path = tmp_path / "report_card.html"
 
     manifest_path = tmp_path / "release_authority_v0.json"
-    manifest_path.unlink()
 
     bundle = tmp_path / AUDIT_BUNDLE_DIRNAME
-    (bundle / "report_card.html").unlink()
+    (
 
-    errors = check_release_grade_reference_run(
-        status_path=tmp_path / "status.json",
+      _write_json(
+        status_path,
+        {
+            "metrics": {"run_mode": "prod"},
+            "diagnostics": {"gates_stubbed": False, "scaffold": False},
+            "gates": {
+                "detectors_materialized_ok": True,
+                "external_summaries_present": True,
+                "external_all_pass": True,
+                "refusal_delta_evidence_present": True,
+            },
+        },
+    )
+    report_path.write_text("<html></html>", encoding="utf-8")
+    bundle.mkdir(parents=True)
+    _write_json(bundle / "status.json", {"copied": "status"})
+    _write_json(bundle / "release_authority_v0.json", {"copied": "manifest"})      
+  
+     errors = check_release_grade_reference_run(
+        status_path=status_path,
         manifest_path=manifest_path,
-        report_path=tmp_path / "report_card.html",
+        report_path=report_path,
         audit_bundle_dir=bundle,
     )
 

--- a/tests/test_run_all_release_grade_materialization.py
+++ b/tests/test_run_all_release_grade_materialization.py
@@ -1,418 +1,538 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
 import json
-import os
 import pathlib
 import subprocess
 import sys
 from typing import Any
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
+import pytest
 
-from PULSE_safe_pack_v0.tools.check_release_grade_reference_run_v0 import (
-    check_release_grade_reference_run,
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+CHECKER = (
+    REPO_ROOT
+    / "PULSE_safe_pack_v0"
+    / "tools"
+    / "check_release_grade_reference_run_v0.py"
 )
 
-
-RUN_ALL = REPO_ROOT / "PULSE_safe_pack_v0" / "tools" / "run_all.py"
-POLICY = REPO_ROOT / "pulse_gate_policy_v0.yml"
-AUDIT_BUNDLE_DIRNAME = "release_authority_audit_bundle"
-
-MATERIALIZED_GATES = {
-    "pass_controls_refusal": True,
-    "effect_present": True,
-    "psf_monotonicity_ok": True,
-    "psf_mono_shift_resilient": True,
-    "pass_controls_comm": True,
-    "psf_commutativity_ok": True,
-    "psf_comm_shift_resilient": True,
-    "pass_controls_sanit": True,
-    "sanitization_effective": True,
-    "sanit_shift_resilient": True,
-    "psf_action_monotonicity_ok": True,
-    "psf_idempotence_ok": True,
-    "psf_path_independence_ok": True,
-    "psf_pii_monotonicity_ok": True,
-    "q1_grounded_ok": True,
-    "q2_consistency_ok": True,
-    "q3_fairness_ok": True,
-    "q4_slo_ok": True,
-}
+RELEASE_REQUIRED_GATES = [
+    "detectors_materialized_ok",
+    "external_summaries_present",
+    "external_all_pass",
+    "refusal_delta_evidence_present",
+]
 
 
-def _write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
+def write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
 
-def _read_json(path: pathlib.Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
-    return f"{result.stdout}\n{result.stderr}"
-
-
-def _prepare_release_grade_inputs(
-    art: pathlib.Path,
-    *,
-    detector_evidence: bool = True,
-    detector_evidence_path: str = "detector_evidence.json",
-    detector_manifest_extra: dict[str, Any] | None = None,
-    external: dict[str, Any] | None = None,
-    refusal_n: int = 1,
-    refusal_pass: bool = True,
-) -> None:
-    if detector_evidence:
-        _write_json(
-            art / detector_evidence_path,
-            {"source": "unit-test detector evidence"},
-        )
-
-    detector_manifest: dict[str, Any] = {
-        "schema_version": "detector_materialization_v0",
-        "materialized": True,
-        "gates_stubbed": False,
-        "scaffold": False,
-        "gates": MATERIALIZED_GATES,
-        "evidence": [{"path": detector_evidence_path}],
-    }
-    if detector_manifest_extra:
-        detector_manifest.update(detector_manifest_extra)
-
-    _write_json(art / "detector_materialization_v0.json", detector_manifest)
-
-    if external is not None:
-        _write_json(art / "external" / "llamaguard_summary.json", external)
-
-    _write_json(
-        art / "refusal_delta_summary.json",
-        {
-            "n": refusal_n,
-            "pass": refusal_pass,
-            "delta": 0.2,
-            "ci_low": 0.1,
-            "ci_high": 0.3,
+def valid_status() -> dict[str, Any]:
+    return {
+        "version": "1.0.0",
+        "created_utc": "2026-01-01T00:00:00Z",
+        "metrics": {
+            "run_mode": "prod",
         },
-    )
+        "gates": {
+            "detectors_materialized_ok": True,
+            "external_summaries_present": True,
+            "external_all_pass": True,
+            "refusal_delta_evidence_present": True,
+        },
+        "diagnostics": {
+            "gates_stubbed": False,
+            "scaffold": False,
+        },
+    }
 
 
-def _run_prod(
-    art: pathlib.Path,
-    *,
-    release_grade_materialized: bool = False,
+def valid_manifest() -> dict[str, Any]:
+    return {
+        "schema_version": "release_authority_v0",
+        "run_identity": {
+            "run_mode": "prod",
+        },
+        "authority": {
+            "policy_set": "required+release_required",
+            "release_required_materialized": True,
+            "effective_required_gates": list(RELEASE_REQUIRED_GATES),
+        },
+        "evaluation": {
+            "failed_required_gates": [],
+            "missing_required_gates": [],
+        },
+        "decision": {
+            "state": "PROD-PASS",
+            "fail_closed": True,
+        },
+        "diagnostics": {
+            "shadow_surfaces_non_normative": True,
+        },
+    }
+
+
+def run_checker(
+    tmp_path: pathlib.Path,
+    status: dict[str, Any],
+    manifest: dict[str, Any],
+    *extra_args: str,
 ) -> subprocess.CompletedProcess[str]:
-    env = os.environ.copy()
-    env.pop("PULSE_RUN_MODE", None)
-    env.pop("PULSE_RELEASE_GRADE_MATERIALIZED", None)
-    env["PULSE_ARTIFACT_DIR"] = str(art)
-
-    cmd = [
-        sys.executable,
-        str(RUN_ALL),
-        "--mode",
-        "prod",
-        "--pack_dir",
-        str(REPO_ROOT / "PULSE_safe_pack_v0"),
-        "--gate_policy",
-        str(POLICY),
-    ]
-
-    if release_grade_materialized:
-        cmd.append("--release-grade-materialized")
-        env["PULSE_RELEASE_GRADE_MATERIALIZED"] = "1"
-
-    return subprocess.run(
-        cmd,
-        cwd=str(REPO_ROOT),
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-
-
-def _run_mode(
-    art: pathlib.Path,
-    *,
-    mode: str,
-    release_grade_materialized: bool = False,
-) -> subprocess.CompletedProcess[str]:
-    env = os.environ.copy()
-    env.pop("PULSE_RUN_MODE", None)
-    env.pop("PULSE_RELEASE_GRADE_MATERIALIZED", None)
-    env["PULSE_ARTIFACT_DIR"] = str(art)
-
-    cmd = [
-        sys.executable,
-        str(RUN_ALL),
-        "--mode",
-        mode,
-        "--pack_dir",
-        str(REPO_ROOT / "PULSE_safe_pack_v0"),
-        "--gate_policy",
-        str(POLICY),
-    ]
-
-    if release_grade_materialized:
-        cmd.append("--release-grade-materialized")
-        env["PULSE_RELEASE_GRADE_MATERIALIZED"] = "1"
-
-    return subprocess.run(
-        cmd,
-        cwd=str(REPO_ROOT),
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-
-
-def _load_status(art: pathlib.Path) -> dict[str, Any]:
-    return _read_json(art / "status.json")
-
-
-def test_plain_prod_fails_closed_without_explicit_materialized_opt_in(
-    tmp_path: pathlib.Path,
-) -> None:
-    result = _run_prod(tmp_path)
-
-    assert result.returncode != 0
-    output = _combined_output(result).lower()
-    assert "release-grade" in output
-    assert "materialized" in output
-    assert not (tmp_path / "status.json").exists()
-
-
-def test_release_grade_materialized_opt_in_is_prod_only(
-    tmp_path: pathlib.Path,
-) -> None:
-    result = _run_mode(
-        tmp_path,
-        mode="core",
-        release_grade_materialized=True,
-    )
-
-    assert result.returncode != 0
-    output = _combined_output(result).lower()
-    assert "prod" in output
-    assert not (tmp_path / "status.json").exists()
-
-
-def test_prod_release_grade_materialized_opt_in_fails_closed_until_verifier_exists(
-    tmp_path: pathlib.Path,
-) -> None:
-    result = _run_prod(tmp_path, release_grade_materialized=True)
-
-    assert result.returncode != 0
-    def test_prod_release_grade_self_declared_artifacts_do_not_materialize_gates(
-    assert not (tmp_path / "status.json").exists()
-
-
-def test_prod_release_grade_non_stubbed_candidate_materializes_required_artifacts(
-    tmp_path: pathlib.Path,
-) -> None:
-    _prepare_release_grade_inputs(tmp_path, external={"rate": 0.0})
-
-    result = _run_prod(tmp_path, release_grade_materialized=True)
-
-    assert result.returncode != 0
-    output = _combined_output(result).lower()
-    assert "release-evidence verifier" in output
-    assert "self-declared artifacts" in output
-    assert "detector_materialization_v0.json" in output
-    assert "external/llamaguard_summary.json" in output
-    assert "refusal_delta_summary.json" in output
-    assert not (tmp_path / "status.json").exists()
-    assert not (tmp_path / "release_authority_v0.json").exists()
-    assert not (tmp_path / AUDIT_BUNDLE_DIRNAME).exists()
-
-
-def test_detectors_materialized_ok_requires_existing_detector_evidence(
-    tmp_path: pathlib.Path,
-) -> None:
-    _prepare_release_grade_inputs(
-        tmp_path,
-        detector_evidence=False,
-        detector_evidence_path="missing_detector_evidence.json",
-        external={"rate": 0.0},
-    )
-
-    result = _run_prod(tmp_path, release_grade_materialized=True)
-
-    assert result.returncode != 0
-    assert "release-evidence verifier" in _combined_output(result).lower()
-    assert not (tmp_path / "status.json").exists()
-
-
-def test_prod_rejects_stubbed_detector_materialization_manifest(
-    tmp_path: pathlib.Path,
-) -> None:
-    _prepare_release_grade_inputs(tmp_path, external={"rate": 0.0})
-
-    manifest_path = tmp_path / "detector_materialization_v0.json"
-    manifest = _read_json(manifest_path)
-    manifest["gates_stubbed"] = True
-    _write_json(manifest_path, manifest)
-
-    result = _run_prod(tmp_path, release_grade_materialized=True)
-
-    assert result.returncode != 0
-    assert "release-evidence verifier" in _combined_output(result).lower()
-    assert not (tmp_path / "status.json").exists()
-
-
-def test_prod_rejects_scaffold_detector_materialization_manifest(
-    tmp_path: pathlib.Path,
-) -> None:
-    _prepare_release_grade_inputs(tmp_path, external={"rate": 0.0})
-
-    manifest_path = tmp_path / "detector_materialization_v0.json"
-    manifest = _read_json(manifest_path)
-    manifest["scaffold"] = True
-    _write_json(manifest_path, manifest)
-
-    result = _run_prod(tmp_path, release_grade_materialized=True)
-
-    assert result.returncode != 0
-    assert "release-evidence verifier" in _combined_output(result).lower()
-    assert not (tmp_path / "status.json").exists()
-
-
-def test_prod_rejects_non_boolean_materialized_gate_outcome(
-    tmp_path: pathlib.Path,
-) -> None:
-    _prepare_release_grade_inputs(tmp_path, external={"rate": 0.0})
-
-    manifest_path = tmp_path / "detector_materialization_v0.json"
-    manifest = _read_json(manifest_path)
-    manifest["gates"]["q1_grounded_ok"] = "true"
-    _write_json(manifest_path, manifest)
-
-    result = _run_prod(tmp_path, release_grade_materialized=True)
-
-    assert result.returncode != 0
-    output = _combined_output(result).lower()
-    assert "release-evidence verifier" in output
-    assert not (tmp_path / "status.json").exists()
-
-
-def test_prod_rejects_materialization_manifest_without_materialized_true(
-    tmp_path: pathlib.Path,
-) -> None:
-    _prepare_release_grade_inputs(tmp_path, external={"rate": 0.0})
-
-    manifest_path = tmp_path / "detector_materialization_v0.json"
-    manifest = _read_json(manifest_path)
-    manifest["materialized"] = False
-    _write_json(manifest_path, manifest)
-
-    result = _run_prod(tmp_path, release_grade_materialized=True)
-
-    assert result.returncode != 0
-    output = _combined_output(result).lower()
-    assert "release-evidence verifier" in output
-    assert not (tmp_path / "status.json").exists()
-
-
-def test_external_release_gates_require_real_canonical_parseable_summary(
-    tmp_path: pathlib.Path,
-) -> None:
-    _prepare_release_grade_inputs(tmp_path, external=None)
-    _write_json(tmp_path / "external" / "decoy_summary.json", {"rate": 0.0})
-
-    result = _run_prod(tmp_path, release_grade_materialized=True)
-
-    assert result.returncode != 0
-    assert "release-evidence verifier" in _combined_output(result).lower()
-
-    assert not (tmp_path / "release_authority_v0.json").exists()
-
-
-def test_external_release_gates_reject_malformed_canonical_summary(
-    tmp_path: pathlib.Path,
-) -> None:
-    _prepare_release_grade_inputs(tmp_path, external=None)
-    external_path = tmp_path / "external" / "llamaguard_summary.json"
-    external_path.parent.mkdir(parents=True, exist_ok=True)
-    external_path.write_text("{not valid json", encoding="utf-8")
-
-    result = _run_prod(tmp_path, release_grade_materialized=True)
-
-    assert result.returncode != 0
-    output = _combined_output(result).lower()
-    assert "release-evidence verifier" in output   
-    assert not (tmp_path / "release_authority_v0.json").exists()
-
-
-def test_refusal_delta_evidence_requires_summary_with_positive_n(
-    tmp_path: pathlib.Path,
-) -> None:
-    _prepare_release_grade_inputs(tmp_path, external={"rate": 0.0}, refusal_n=0)
-
-    result = _run_prod(tmp_path, release_grade_materialized=True)
-
-    assert result.returncode != 0
-    assert "release-evidence verifier" in _combined_output(result).lower()
-    assert not (tmp_path / "release_authority_v0.json").exists()
-
-
-def test_refusal_delta_evidence_requires_passing_summary(
-    tmp_path: pathlib.Path,
-) -> None:
-    _prepare_release_grade_inputs(
-        tmp_path,
-        external={"rate": 0.0},
-        refusal_n=1,
-        refusal_pass=False,
-    )
-
-    result = _run_prod(tmp_path, release_grade_materialized=True)
-
-    assert result.returncode != 0
-    output = _combined_output(result).lower()
-    assert "release-evidence verifier" in output
-    assert not (tmp_path / "release_authority_v0.json").exists()
-
-
-def test_release_grade_checker_reports_missing_manifest_and_audit_bundle_files(
-    tmp_path: pathlib.Path,
-) -> None:
     status_path = tmp_path / "status.json"
-    report_path = tmp_path / "report_card.html"
-
     manifest_path = tmp_path / "release_authority_v0.json"
 
-    bundle = tmp_path / AUDIT_BUNDLE_DIRNAME
-    (
+    write_json(status_path, status)
+    write_json(manifest_path, manifest)
 
-      _write_json(
-        status_path,
-        {
-            "metrics": {"run_mode": "prod"},
-            "diagnostics": {"gates_stubbed": False, "scaffold": False},
-            "gates": {
-                "detectors_materialized_ok": True,
-                "external_summaries_present": True,
-                "external_all_pass": True,
-                "refusal_delta_evidence_present": True,
-            },
-        },
-    )
-    report_path.write_text("<html></html>", encoding="utf-8")
-    bundle.mkdir(parents=True)
-    _write_json(bundle / "status.json", {"copied": "status"})
-    _write_json(bundle / "release_authority_v0.json", {"copied": "manifest"})      
-  
-     errors = check_release_grade_reference_run(
-        status_path=status_path,
-        manifest_path=manifest_path,
-        report_path=report_path,
-        audit_bundle_dir=bundle,
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--status",
+            str(status_path),
+            "--manifest",
+            str(manifest_path),
+            *extra_args,
+        ],
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
     )
 
-    assert any("release_authority_v0.json not found" in error for error in errors)
-    assert any(
-        "release authority audit bundle missing report_card.html" in error
-        for error in errors
+
+def test_valid_release_grade_reference_run_passes(tmp_path: pathlib.Path) -> None:
+    result = run_checker(tmp_path, valid_status(), valid_manifest())
+
+    assert result.returncode == 0, result.stderr
+    assert "OK: release-grade reference run criteria satisfied" in result.stdout
+
+
+def test_non_prod_status_fails_reference_run_check(tmp_path: pathlib.Path) -> None:
+    status = valid_status()
+    status["metrics"]["run_mode"] = "core"
+
+    result = run_checker(tmp_path, status, valid_manifest())
+
+    assert result.returncode != 0
+    assert "status.metrics.run_mode must be 'prod'" in result.stderr
+
+
+def test_stubbed_gate_surface_fails_reference_run_check(
+    tmp_path: pathlib.Path,
+) -> None:
+    status = valid_status()
+    status["diagnostics"]["gates_stubbed"] = True
+
+    result = run_checker(tmp_path, status, valid_manifest())
+
+    assert result.returncode != 0
+    assert "status.diagnostics.gates_stubbed must be explicit false" in result.stderr
+
+
+def test_scaffold_surface_fails_reference_run_check(
+    tmp_path: pathlib.Path,
+) -> None:
+    status = valid_status()
+    status["diagnostics"]["scaffold"] = True
+
+    result = run_checker(tmp_path, status, valid_manifest())
+
+    assert result.returncode != 0
+    assert "status.diagnostics.scaffold must be explicit false" in result.stderr
+
+
+@pytest.mark.parametrize("bad_diagnostics", [[], False, "", 0, None])
+def test_malformed_status_diagnostics_fails_reference_run_check(
+    tmp_path: pathlib.Path,
+    bad_diagnostics: object,
+) -> None:
+    status = valid_status()
+    status["diagnostics"] = bad_diagnostics
+
+    result = run_checker(tmp_path, status, valid_manifest())
+
+    assert result.returncode != 0
+    assert (
+        "status.diagnostics must be an object for a release-grade reference run"
+        in result.stderr
     )
+
+
+@pytest.mark.parametrize("gate", RELEASE_REQUIRED_GATES)
+def test_missing_or_false_release_required_status_gate_fails(
+    tmp_path: pathlib.Path,
+    gate: str,
+) -> None:
+    status = valid_status()
+    status["gates"][gate] = False
+
+    result = run_checker(tmp_path, status, valid_manifest())
+
+    assert result.returncode != 0
+    assert f"status.gates.{gate} must be literal true" in result.stderr
+
+
+def test_missing_status_metrics_section_fails(tmp_path: pathlib.Path) -> None:
+    status = valid_status()
+    status.pop("metrics")
+
+    result = run_checker(tmp_path, status, valid_manifest())
+
+    assert result.returncode != 0
+    assert "status.metrics must be an object" in result.stderr
+
+
+def test_missing_status_gates_section_fails(tmp_path: pathlib.Path) -> None:
+    status = valid_status()
+    status.pop("gates")
+
+    result = run_checker(tmp_path, status, valid_manifest())
+
+    assert result.returncode != 0
+    assert "status.gates must be an object" in result.stderr
+
+
+def test_manifest_schema_version_must_match(tmp_path: pathlib.Path) -> None:
+    manifest = valid_manifest()
+    manifest["schema_version"] = "wrong_schema"
+
+    result = run_checker(tmp_path, valid_status(), manifest)
+
+    assert result.returncode != 0
+    assert "manifest.schema_version must be 'release_authority_v0'" in result.stderr
+
+
+def test_manifest_run_mode_must_be_prod(tmp_path: pathlib.Path) -> None:
+    manifest = valid_manifest()
+    manifest["run_identity"]["run_mode"] = "core"
+
+    result = run_checker(tmp_path, valid_status(), manifest)
+
+    assert result.returncode != 0
+    assert "manifest.run_identity.run_mode must be 'prod'" in result.stderr
+
+
+def test_manifest_policy_set_must_be_release_grade(tmp_path: pathlib.Path) -> None:
+    manifest = valid_manifest()
+    manifest["authority"]["policy_set"] = "core_required"
+
+    result = run_checker(tmp_path, valid_status(), manifest)
+
+    assert result.returncode != 0
+    assert (
+        "manifest.authority.policy_set must be 'required+release_required'"
+        in result.stderr
+    )
+
+
+def test_manifest_release_required_materialized_must_be_true(
+    tmp_path: pathlib.Path,
+) -> None:
+    manifest = valid_manifest()
+    manifest["authority"]["release_required_materialized"] = False
+
+    result = run_checker(tmp_path, valid_status(), manifest)
+
+    assert result.returncode != 0
+    assert (
+        "manifest.authority.release_required_materialized must be true"
+        in result.stderr
+    )
+
+
+def test_manifest_effective_required_gates_must_be_array(
+    tmp_path: pathlib.Path,
+) -> None:
+    manifest = valid_manifest()
+    manifest["authority"]["effective_required_gates"] = "not-an-array"
+
+    result = run_checker(tmp_path, valid_status(), manifest)
+
+    assert result.returncode != 0
+    assert "manifest.authority.effective_required_gates must be an array" in result.stderr
+
+
+def test_manifest_effective_required_gates_must_include_release_required(
+    tmp_path: pathlib.Path,
+) -> None:
+    manifest = valid_manifest()
+    manifest["authority"]["effective_required_gates"] = [
+        gate
+        for gate in RELEASE_REQUIRED_GATES
+        if gate != "refusal_delta_evidence_present"
+    ]
+
+    result = run_checker(tmp_path, valid_status(), manifest)
+
+    assert result.returncode != 0
+    assert (
+        "manifest.authority.effective_required_gates must include release-required gates"
+        in result.stderr
+    )
+    assert "refusal_delta_evidence_present" in result.stderr
+
+
+def test_manifest_failed_required_gates_must_be_empty(
+    tmp_path: pathlib.Path,
+) -> None:
+    manifest = valid_manifest()
+    manifest["evaluation"]["failed_required_gates"] = ["external_all_pass"]
+
+    result = run_checker(tmp_path, valid_status(), manifest)
+
+    assert result.returncode != 0
+    assert "manifest.evaluation.failed_required_gates must be empty" in result.stderr
+
+
+def test_manifest_missing_required_gates_must_be_empty(
+    tmp_path: pathlib.Path,
+) -> None:
+    manifest = valid_manifest()
+    manifest["evaluation"]["missing_required_gates"] = [
+        "refusal_delta_evidence_present"
+    ]
+
+    result = run_checker(tmp_path, valid_status(), manifest)
+
+    assert result.returncode != 0
+    assert "manifest.evaluation.missing_required_gates must be empty" in result.stderr
+
+
+def test_manifest_decision_state_must_be_pass_state(
+    tmp_path: pathlib.Path,
+) -> None:
+    manifest = valid_manifest()
+    manifest["decision"]["state"] = "FAIL"
+
+    result = run_checker(tmp_path, valid_status(), manifest)
+
+    assert result.returncode != 0
+    assert "manifest.decision.state must be PASS or PROD-PASS" in result.stderr
+
+
+def test_manifest_decision_fail_closed_must_be_true(
+    tmp_path: pathlib.Path,
+) -> None:
+    manifest = valid_manifest()
+    manifest["decision"]["fail_closed"] = False
+
+    result = run_checker(tmp_path, valid_status(), manifest)
+
+    assert result.returncode != 0
+    assert "manifest.decision.fail_closed must be true" in result.stderr
+
+
+def test_manifest_optional_diagnostics_must_be_object_when_present(
+    tmp_path: pathlib.Path,
+) -> None:
+    manifest = valid_manifest()
+    manifest["diagnostics"] = []
+
+    result = run_checker(tmp_path, valid_status(), manifest)
+
+    assert result.returncode != 0
+    assert "manifest.diagnostics must be an object when present" in result.stderr
+
+
+def test_manifest_optional_diagnostics_must_mark_shadow_surfaces_non_normative(
+    tmp_path: pathlib.Path,
+) -> None:
+    manifest = valid_manifest()
+    manifest["diagnostics"]["shadow_surfaces_non_normative"] = False
+
+    result = run_checker(tmp_path, valid_status(), manifest)
+
+    assert result.returncode != 0
+    assert (
+        "manifest.diagnostics.shadow_surfaces_non_normative must be true"
+        in result.stderr
+    )
+
+
+def test_optional_report_and_audit_bundle_checks(tmp_path: pathlib.Path) -> None:
+    report = tmp_path / "report_card.html"
+    report.write_text("<html><body>ledger</body></html>\n", encoding="utf-8")
+
+    bundle = tmp_path / "release_authority_audit_bundle"
+    bundle.mkdir()
+    (bundle / "report_card.html").write_text("ledger\n", encoding="utf-8")
+    (bundle / "release_authority_v0.json").write_text("{}\n", encoding="utf-8")
+    (bundle / "status.json").write_text("{}\n", encoding="utf-8")
+
+    result = run_checker(
+        tmp_path,
+        valid_status(),
+        valid_manifest(),
+        "--report",
+        str(report),
+        "--audit-bundle-dir",
+        str(bundle),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_missing_optional_report_fails_when_supplied(tmp_path: pathlib.Path) -> None:
+    missing_report = tmp_path / "missing_report_card.html"
+
+    result = run_checker(
+        tmp_path,
+        valid_status(),
+        valid_manifest(),
+        "--report",
+        str(missing_report),
+    )
+
+    assert result.returncode != 0
+    assert "Quality Ledger report not found" in result.stderr
+
+
+def test_missing_audit_bundle_dir_fails_when_supplied(
+    tmp_path: pathlib.Path,
+) -> None:
+    missing_bundle = tmp_path / "missing_bundle"
+
+    result = run_checker(
+        tmp_path,
+        valid_status(),
+        valid_manifest(),
+        "--audit-bundle-dir",
+        str(missing_bundle),
+    )
+
+    assert result.returncode != 0
+    assert "release authority audit bundle directory not found" in result.stderr
+
+
+def test_missing_audit_bundle_member_fails_when_supplied(
+    tmp_path: pathlib.Path,
+) -> None:
+    bundle = tmp_path / "release_authority_audit_bundle"
+    bundle.mkdir()
+    (bundle / "report_card.html").write_text("ledger\n", encoding="utf-8")
+    (bundle / "status.json").write_text("{}\n", encoding="utf-8")
+
+    result = run_checker(
+        tmp_path,
+        valid_status(),
+        valid_manifest(),
+        "--audit-bundle-dir",
+        str(bundle),
+    )
+
+    assert result.returncode != 0
+    assert (
+        "release authority audit bundle missing release_authority_v0.json"
+        in result.stderr
+    )
+
+
+def test_missing_manifest_file_fails(tmp_path: pathlib.Path) -> None:
+    status_path = tmp_path / "status.json"
+    manifest_path = tmp_path / "missing_release_authority_v0.json"
+
+    write_json(status_path, valid_status())
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--status",
+            str(status_path),
+            "--manifest",
+            str(manifest_path),
+        ],
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "release_authority_v0.json not found" in result.stderr
+
+
+def test_missing_status_file_fails(tmp_path: pathlib.Path) -> None:
+    status_path = tmp_path / "missing_status.json"
+    manifest_path = tmp_path / "release_authority_v0.json"
+
+    write_json(manifest_path, valid_manifest())
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--status",
+            str(status_path),
+            "--manifest",
+            str(manifest_path),
+        ],
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "status.json not found" in result.stderr
+
+
+def test_malformed_status_json_fails(tmp_path: pathlib.Path) -> None:
+    status_path = tmp_path / "status.json"
+    manifest_path = tmp_path / "release_authority_v0.json"
+
+    status_path.write_text("{not valid json", encoding="utf-8")
+    write_json(manifest_path, valid_manifest())
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--status",
+            str(status_path),
+            "--manifest",
+            str(manifest_path),
+        ],
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "status.json is not valid JSON" in result.stderr
+
+
+def test_malformed_manifest_json_fails(tmp_path: pathlib.Path) -> None:
+    status_path = tmp_path / "status.json"
+    manifest_path = tmp_path / "release_authority_v0.json"
+
+    write_json(status_path, valid_status())
+    manifest_path.write_text("{not valid json", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--status",
+            str(status_path),
+            "--manifest",
+            str(manifest_path),
+        ],
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "release_authority_v0.json is not valid JSON" in result.stderr
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

This PR blocks untrusted artifact-directory inputs from being promoted into release-grade gate state.

The explicit `--release-grade-materialized` path remains fail-closed unless a trusted evidence verifier is present. Local self-declared detector manifests, generic external summaries, and refusal-delta summaries must not directly set release-required gates or produce non-stubbed release-authority artifacts.

## Why

The previous materialization prep path allowed artifact-directory inputs to become release gate booleans without cryptographic/provenance/subject binding.

That created a release-integrity gap:

- detector materialization could self-declare required gate booleans
- external summaries could pass with generic `pass=true` or `rate <= 0.05`
- refusal-delta evidence could pass with `n > 0` and `pass=true`
- status.json and release_authority_v0.json could then appear non-stubbed and release-grade

## Boundary

This PR restores fail-closed behavior for untrusted release-grade materialization inputs.

PULSEmech release authority remains:

recorded release evidence → status.json → declared gate policy → workflow-effective materialized required gate set → strict fail-closed CI enforcement → pre-deployment allow/block release decision

## Non-goals

This PR does not implement the final trusted evidence verifier.

It prevents unverified local artifacts from becoming release-grade PASS evidence.