### PR TITLE
docs(ref): define release-evidence verifier reference boundary

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -85,3 +85,7 @@ If you add/rename a doc under `docs/`, please update this index.
 ## Terminology / language rules
 
 - [PULSE_MECHANICAL_TRANSITION_LANGUAGE_v0.md](PULSE_MECHANICAL_TRANSITION_LANGUAGE_v0.md) — Repository-facing wording and review rule for preserving PULSEmech transition-bearing language.
+
+## Release evidence verification
+
+- [PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md](PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md) — Informational reference note for the future trusted verifier boundary required before release-grade evidence can materialize release-required gates.

--- a/docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md
+++ b/docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md
@@ -2,9 +2,11 @@
 
 ## Status
 
-Design contract / verifier boundary.
+Informational reference note / future implementation boundary.
 
-This document defines the trusted release-evidence verifier boundary required before release-grade evidence can be materialized into `status.json`.
+This document records the intended verifier boundary for future release-grade evidence materialization work.
+
+It is not an implemented contract, policy, schema, CI rule, or release-authority rule.
 
 It does not define release authority.
 
@@ -14,9 +16,11 @@ It does not change gate policy, gate registry, status schema, CI allow/block beh
 
 ## Purpose
 
-The release-evidence verifier prevents local or self-declared artifacts from becoming release-required gate state.
+This note records why a trusted release-evidence verifier is needed before local or self-declared artifacts can contribute to release-grade gate materialization.
 
-A release-grade candidate must not derive release-required gates directly from:
+The current release-grade materialized path remains fail-closed until such a verifier is implemented.
+
+Future verifier work should prevent release-required gates from being derived directly from:
 
 - local detector materialization manifests
 - generic external detector summaries
@@ -24,7 +28,7 @@ A release-grade candidate must not derive release-required gates directly from:
 - copied artifact-directory files
 - self-declared boolean gate maps
 
-The verifier exists to decide whether recorded evidence is eligible to be materialized into `status.json`.
+The verifier boundary exists to qualify recorded evidence before it can be represented in `status.json`.
 
 PULSEmech release authority remains the later path:
 
@@ -39,28 +43,28 @@ recorded release evidence
 
 ## Verifier Role
 
-The verifier is an evidence-qualification layer.
+The release-evidence verifier is intended as an evidence-qualification layer.
 
-It receives candidate evidence inputs, validates their identity, provenance, subject binding, schema, digest, freshness, and policy relation, then emits a verifier report.
+A future verifier would receive candidate evidence inputs, validate their identity, provenance, subject binding, schema, digest, freshness, and policy relation, then emit a verifier report.
 
-The verifier report may permit gate materialization only when the evidence is verified.
+A verifier report may support later gate materialization only when the evidence is verified by implemented checks.
 
-The verifier report must not produce an allow/block release decision.
+The verifier report itself does not produce an allow/block release decision.
 
-Verifier decisions are limited to:
+Verifier report states should avoid release-authority wording and use evidence-qualification states such as:
 
 ```text
 VERIFIED
 FAILED
 ```
 
-`VERIFIED` means the evidence is eligible for materialization.
+`VERIFIED` would mean that the evidence is eligible for materialization by the implemented materialization path.
 
-`FAILED` means the evidence must not materialize release-required gates.
+`FAILED` would mean that the evidence is not eligible to materialize release-required gates.
 
-## Required Input Classes
+## Candidate Input Classes
 
-A release-grade evidence verifier may consume these input classes:
+A future release-evidence verifier may consume these input classes:
 
 - detector evidence artifacts
 - detector materialization reports
@@ -74,11 +78,11 @@ A release-grade evidence verifier may consume these input classes:
 
 These inputs are not trusted merely because they exist.
 
-They become usable only after verifier checks pass.
+They become usable only after implemented verifier checks pass.
 
-## Trust Requirements
+## Intended Trust Properties
 
-A candidate evidence artifact is acceptable only when these properties are verified:
+A future verifier should check properties such as:
 
 - schema validity
 - parseability
@@ -93,9 +97,11 @@ A candidate evidence artifact is acceptable only when these properties are verif
 - non-stub / non-scaffold evidence state
 - absence of self-declared release-required gate promotion
 
-## Forbidden Promotion
+This list is an implementation guide, not an active repository policy.
 
-The following mappings are forbidden without a trusted verifier:
+## Unsafe Promotion Patterns
+
+This note treats the following direct mappings as unsafe unless a trusted verifier is implemented and explicitly validates them:
 
 ```text
 detector_materialization_v0.json gates.* → status.gates.*
@@ -113,17 +119,17 @@ They may be inspected.
 
 They may be included in an audit bundle.
 
-They must not directly set release-required gates.
+They should not directly set release-required gates.
 
-## Verifier Output
+## Future Verifier Output
 
-The verifier emits:
+A future verifier may emit:
 
 ```text
 release_evidence_verifier_report_v0.json
 ```
 
-The report must include:
+A future report shape may include:
 
 - `schema_version`
 - `created_utc`
@@ -140,7 +146,11 @@ The report must include:
 - `failed_checks`
 - `warnings`
 
-## Minimal Report Shape
+This document does not implement or enforce that schema.
+
+A separate schema PR would be required before this report becomes an implemented artifact contract.
+
+## Illustrative Report Shape
 
 ```json
 {
@@ -178,17 +188,17 @@ The report must include:
 }
 ```
 
-## Gate Materialization Rule
+## Future Gate Materialization Direction
 
-Release-required gates may be materialized only from a verifier report with:
+A future materialization path should only materialize release-required gates from an implemented verifier report when:
 
 ```text
 verifier_decision == VERIFIED
 ```
 
-and a gate materialization block that explicitly binds each gate to verified evidence.
+and when each materialized gate is explicitly bound to verified evidence.
 
-A valid gate materialization entry must identify:
+A future gate materialization entry should identify:
 
 - gate id
 - source evidence artifact
@@ -199,7 +209,7 @@ A valid gate materialization entry must identify:
 - policy relation
 - verification result
 
-Example shape:
+Illustrative shape:
 
 ```json
 {
@@ -219,26 +229,23 @@ Example shape:
 }
 ```
 
-## Fail-Closed Rule
+## Current Fail-Closed State
 
-If the verifier report is missing, invalid, stale, unbound, or `FAILED`, release-grade materialization must fail closed.
+The current `--release-grade-materialized` path is intentionally fail-closed until a trusted release-evidence verifier exists.
 
-In that state, the materialized prod path must not write:
+In the current hotfix state, local detector, external summary, and refusal-delta artifacts cannot set release-required gates true.
 
-- `status.json`
-- `report_card.html`
-- `release_authority_v0.json`
-- `release_authority_audit_bundle/`
+The materialized prod path may report which untrusted inputs were observed, but it must not promote those inputs into gate state.
 
-The materialized prod path may report which untrusted inputs were observed, but it must not promote them into gate state.
+This current behavior is implemented in code; this document only records the boundary and intended future direction.
 
 ## Relation to `run_all.py`
 
-`run_all.py --mode prod --release-grade-materialized` remains a preparation path.
+`run_all.py --mode prod --release-grade-materialized` is a preparation path.
 
-Until a trusted release-evidence verifier exists, this path remains fail-closed.
+At present, it remains fail-closed.
 
-Future wiring must follow this sequence:
+A future implementation may follow this sequence:
 
 ```text
 candidate evidence inputs
@@ -250,7 +257,7 @@ candidate evidence inputs
 → audit bundle
 ```
 
-The verifier report must be checked before any release-required gate is set to true.
+The verifier report should be checked before any release-required gate is set to true.
 
 ## Relation to `check_gates.py`
 
@@ -258,7 +265,7 @@ The verifier report must be checked before any release-required gate is set to t
 
 The verifier does not replace it.
 
-The verifier only determines whether evidence can be materialized into `status.json`.
+The verifier only qualifies evidence for possible materialization into `status.json`.
 
 `check_gates.py` still evaluates the workflow-effective required gate set under declared policy and strict fail-closed CI enforcement.
 
@@ -266,15 +273,15 @@ The verifier only determines whether evidence can be materialized into `status.j
 
 The Quality Ledger remains a reader surface.
 
-It may display verifier report information.
+It may display verifier report information after such a report exists.
 
 It must not recompute verifier decisions.
 
 It must not convert displayed evidence into release-required gate state.
 
-## Review Rule
+## Review Questions for Future Implementation PRs
 
-Any future PR that wires release-grade evidence materialization must answer:
+A future PR that implements verifier wiring should answer:
 
 - What verifier report is consumed?
 - Which schema validates the report?
@@ -287,13 +294,13 @@ Any future PR that wires release-grade evidence materialization must answer:
 - What happens if one gate lacks verified evidence?
 - What prevents a self-declared artifact from becoming release evidence?
 
-A PR must be rejected if it allows local self-declared artifacts to directly set release-required gates.
+These are review questions, not an active rejection rule in this document.
 
-## Security Boundary
+## Security Boundary Note
 
 The verifier boundary exists because release-grade gate state is security-critical.
 
-The following are security failures:
+The following patterns should be treated as security risks in future implementation work:
 
 - self-declared detector booleans becoming release-required gates
 - generic external summaries becoming `external_all_pass`
@@ -302,13 +309,13 @@ The following are security failures:
 - copied files producing non-stubbed diagnostics
 - local artifact directory control producing release-grade PASS
 
-The correct behavior is fail-closed until evidence is verified.
+The correct current behavior is fail-closed until evidence is verified by an implemented verifier.
 
 ## Minimal Anchor
 
 Evidence is not trusted because it exists.
 
-Evidence is trusted only after verification.
+Evidence becomes eligible for materialization only after verification.
 
 Verification qualifies evidence for materialization.
 


### PR DESCRIPTION
## Summary

This PR adds `docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md`, an informational reference note for the future trusted release-evidence verifier boundary.

The note records why local or self-declared artifacts must not directly materialize release-required gates.

It covers future verifier expectations for:

- detector evidence
- external summaries
- refusal-delta evidence
- run identity
- subject / git SHA binding
- policy and registry binding
- artifact digests
- provenance records
- verified gate materialization

## Boundary

This PR is documentation only.

It does not implement a verifier.

It does not define release authority.

It does not replace `check_gates.py`.

PULSEmech release authority remains:

recorded release evidence → `status.json` → declared gate policy → workflow-effective materialized required gate set → strict fail-closed CI enforcement → pre-deployment allow/block release decision

## Current behavior recorded

The current `--release-grade-materialized` path remains fail-closed until a trusted release-evidence verifier exists.

Local detector, external-summary, and refusal-delta artifacts cannot set release-required gates true.

## Non-goals

This PR does not change:

- code
- gate policy
- gate registry
- status schema
- `check_gates.py`
- CI allow/block behavior
- DOI/Zenodo artifacts
- release tags
- release artifacts

## Docs index

This PR also adds the new document to `docs/INDEX.md`.