### PR TITLE
schema(ref): add release evidence verifier report v0

### DIFF
--- a/examples/release_evidence_verifier_report_v0.failed.example.json
+++ b/examples/release_evidence_verifier_report_v0.failed.example.json
@@ -1,0 +1,33 @@
+{
+  "created_utc": "2026-01-01T00:00:00Z",
+  "evidence_inputs": [],
+  "failed_checks": [
+    "trusted verifier is not implemented"
+  ],
+  "gate_materialization": {},
+  "policy_binding": {
+    "policy_path": "pulse_gate_policy_v0.yml",
+    "policy_set": "required+release_required",
+    "policy_sha256": null
+  },
+  "registry_binding": {
+    "registry_path": "pulse_gate_registry_v0.yml",
+    "registry_sha256": null
+  },
+  "run_identity": {
+    "git_sha": null,
+    "run_key": null,
+    "run_mode": "prod"
+  },
+  "schema_version": "release_evidence_verifier_report_v0",
+  "subject": {
+    "commit_sha": null,
+    "release_candidate": null,
+    "repository": null
+  },
+  "verified_artifacts": [],
+  "verifier_decision": "FAILED",
+  "verifier_id": "pulse_release_evidence_verifier_v0",
+  "verifier_version": "0.1.0",
+  "warnings": []
+}


### PR DESCRIPTION
Add the release_evidence_verifier_report_v0 JSON schema, a failed example report, and schema tests.

The schema models evidence-qualification output for future verifier work. It uses VERIFIED / FAILED verifier decisions rather than release-authority PASS/ALLOW wording and requires gate materialization to bind gates to verified artifacts.

This does not implement the verifier and does not reopen the materialized prod path.

The current --release-grade-materialized path remains fail-closed until a trusted verifier is implemented and wired.

No release-authority semantics changed.
No gate policy, registry, status schema, check_gates.py behavior, CI allow/block behavior, DOI/Zenodo artifact, release tag, or release artifact changed.

<!-- PULSE PR Template v1.0 — keep sections; fill what applies. -->

## Summary
<!-- Short: what changes and why? -->

## What’s included
- [ ] Code
- [ ] Docs
- [ ] CI / workflow
- Paths / files touched:

## CI usage
```yaml
# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json
```

## Impact
- Additive / backwards-compatible
- Breaking change — details:
- Performance / SLO impact:
- Security considerations:

What’s included
 Code
 Docs
 CI / workflow

Paths / files touched:

CI usage

# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json

Impact
Additive / backwards-compatible

Breaking change — details:

Performance / SLO impact:

Security considerations:

### Security Intake (v0) — dependency / external code (if applicable)
**Intake v0:** PASS | REVIEW | HARD STOP  
**Isolation used (if REVIEW):** yes / no  

**Reasons (1–3 bullets):**
- 
- 
- 

**Checks**
- [ ] No password-protected ZIP / random binary download involved
- [ ] Repo age ≥ 12 months and maintainer history looks real
- [ ] No postinstall/preinstall scripts (or justified + reviewed)
- [ ] No obfuscation / base64 blobs / runtime-downloaded binaries
- [ ] No instructions like “disable Defender/AV”
- [ ] First run done in VM/container (if REVIEW)

> If any HIGH-risk signal appears → mark **HARD STOP** and do not merge.

Notes

Follow-ups:

Risks / mitigations:

PULSE checklist (release authority)
 PULSE CI is green on this PR
 Quality Ledger link (if enabled)
 Badges updated (PASS / RDSI / Q-Ledger)


## Notes
- Follow-ups:
- Risks / mitigations:

## PULSE checklist (release authority)
- [ ] PULSE CI is green on this PR
- [ ] Quality Ledger link (if enabled)
- [ ] Badges updated (PASS / RDSI / Q‑Ledger)
