### PR TITLE
feat(ref): add verifier relation bindings to report schema

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -98,5 +98,7 @@ f there is already a suitable section such as `Release evidence verification`, `
 
 - [PULSE_RELEASE_STATE_TRANSFORMATION_v0.md](PULSE_RELEASE_STATE_TRANSFORMATION_v0.md) — Informational reference note for reading PULSEmech as a closed release-state transformation path.
 
+## Pre-materialization mechanics
 
+- [PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md](PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md) — Informational reference note for pre-materialization gate mechanics and relation-binding pre-state hooks.
 

--- a/docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md
+++ b/docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md
@@ -1,333 +1,43 @@
-# PULSE Release Evidence Verifier v0
+## Relation binding anchor
 
-## Status
-
-Informational reference note / future implementation boundary.
-
-This document records the intended verifier boundary for future release-grade evidence materialization work.
-
-It is not an implemented contract, policy, schema, CI rule, or release-authority rule.
-
-It does not define release authority.
-
-It does not replace `check_gates.py`.
-
-It does not change gate policy, gate registry, status schema, CI allow/block behavior, DOI/Zenodo artifacts, release tags, or release artifacts.
-
-## Purpose
-
-This note records why a trusted release-evidence verifier is needed before local or self-declared artifacts can contribute to release-grade gate materialization.
-
-The current release-grade materialized path remains fail-closed until such a verifier is implemented.
-
-Future verifier work should prevent release-required gates from being derived directly from:
-
-- local detector materialization manifests
-- generic external detector summaries
-- refusal-delta summaries
-- copied artifact-directory files
-- self-declared boolean gate maps
-
-The verifier boundary exists to qualify recorded evidence before it can be represented in `status.json`.
-
-PULSEmech release authority remains the later path:
+The verifier report artifact now includes first-class relation bindings:
 
 ```text
-recorded release evidence
-→ status.json
-→ declared gate policy
-→ workflow-effective materialized required gate set
-→ strict fail-closed CI enforcement
-→ pre-deployment allow/block release decision
+relation_bindings
 ```
 
-## Verifier Role
+Relation bindings model the verified connections that make evidence eligible for future materialization.
 
-The release-evidence verifier is intended as an evidence-qualification layer.
-
-A future verifier would receive candidate evidence inputs, validate their identity, provenance, subject binding, schema, digest, freshness, and policy relation, then emit a verifier report.
-
-A verifier report may support later gate materialization only when the evidence is verified by implemented checks.
-
-The verifier report itself does not produce an allow/block release decision.
-
-Verifier report states should avoid release-authority wording and use evidence-qualification states such as:
+They express relations such as:
 
 ```text
-VERIFIED
-FAILED
+artifact → subject
+artifact → run
+artifact → policy
+artifact → registry
+artifact → digest
+artifact → detector
+artifact → gate
+gate → policy
+gate → verifier decision
 ```
 
-`VERIFIED` would mean that the evidence is eligible for materialization by the implemented materialization path.
+This does not implement the verifier.
 
-`FAILED` would mean that the evidence is not eligible to materialize release-required gates.
+It does not make `--release-grade-materialized` permissive.
 
-## Candidate Input Classes
+The current materialized prod path remains fail-closed until a trusted verifier is implemented and wired.
 
-A future release-evidence verifier may consume these input classes:
-
-- detector evidence artifacts
-- detector materialization reports
-- external detector summaries
-- refusal-delta evidence
-- run identity metadata
-- git / subject binding metadata
-- policy and registry references
-- artifact digests
-- provenance records
-
-These inputs are not trusted merely because they exist.
-
-They become usable only after implemented verifier checks pass.
-
-## Intended Trust Properties
-
-A future verifier should check properties such as:
-
-- schema validity
-- parseability
-- canonical artifact path
-- SHA-256 digest binding
-- run identity binding
-- subject / git SHA binding
-- detector identity binding
-- policy relation
-- gate registry relation
-- freshness / current-run relation
-- non-stub / non-scaffold evidence state
-- absence of self-declared release-required gate promotion
-
-This list is an implementation guide, not an active repository policy.
-
-## Unsafe Promotion Patterns
-
-This note treats the following direct mappings as unsafe unless a trusted verifier is implemented and explicitly validates them:
+A future verifier may use relation bindings to expose transition-risk before release:
 
 ```text
-detector_materialization_v0.json gates.* → status.gates.*
-external summary pass/rate/value → status.gates.external_all_pass
-refusal_delta_summary.json n/pass → status.gates.refusal_delta_evidence_present
-local artifact existence → release-required gate true
-self-declared boolean map → materialized release evidence
+missing relation
+broken relation
+stale relation
+self-declared relation
+unverified relation
 ```
 
-These files may be diagnostic inputs.
+A relation binding is not release authority.
 
-They may be recorded.
-
-They may be inspected.
-
-They may be included in an audit bundle.
-
-They should not directly set release-required gates.
-
-## Future Verifier Output
-
-A future verifier may emit:
-
-```text
-release_evidence_verifier_report_v0.json
-```
-
-A future report shape may include:
-
-- `schema_version`
-- `created_utc`
-- `verifier_id`
-- `verifier_version`
-- `verifier_decision`
-- `run_identity`
-- `subject`
-- `policy_binding`
-- `registry_binding`
-- `evidence_inputs`
-- `verified_artifacts`
-- `gate_materialization`
-- `failed_checks`
-- `warnings`
-
-This document does not implement or enforce that schema.
-
-A separate schema PR would be required before this report becomes an implemented artifact contract.
-
-## Illustrative Report Shape
-
-```json
-{
-  "schema_version": "release_evidence_verifier_report_v0",
-  "created_utc": "2026-01-01T00:00:00Z",
-  "verifier_id": "pulse_release_evidence_verifier_v0",
-  "verifier_version": "0.1.0",
-  "verifier_decision": "FAILED",
-  "run_identity": {
-    "run_mode": "prod",
-    "run_key": null,
-    "git_sha": null
-  },
-  "subject": {
-    "repository": null,
-    "commit_sha": null,
-    "release_candidate": null
-  },
-  "policy_binding": {
-    "policy_path": "pulse_gate_policy_v0.yml",
-    "policy_sha256": null,
-    "policy_set": "required+release_required"
-  },
-  "registry_binding": {
-    "registry_path": "pulse_gate_registry_v0.yml",
-    "registry_sha256": null
-  },
-  "evidence_inputs": [],
-  "verified_artifacts": [],
-  "gate_materialization": {},
-  "failed_checks": [
-    "trusted verifier is not implemented"
-  ],
-  "warnings": []
-}
-```
-
-## Future Gate Materialization Direction
-
-A future materialization path should only materialize release-required gates from an implemented verifier report when:
-
-```text
-verifier_decision == VERIFIED
-```
-
-and when each materialized gate is explicitly bound to verified evidence.
-
-A future gate materialization entry should identify:
-
-- gate id
-- source evidence artifact
-- evidence digest
-- evidence schema
-- detector or check identity
-- subject / git SHA binding
-- policy relation
-- verification result
-
-Illustrative shape:
-
-```json
-{
-  "gate_materialization": {
-    "detectors_materialized_ok": {
-      "value": true,
-      "source": "release_evidence_verifier_report_v0",
-      "evidence_artifacts": [
-        {
-          "path": "artifacts/detectors/detector_report.json",
-          "sha256": "..."
-        }
-      ],
-      "verified": true
-    }
-  }
-}
-```
-
-## Current Fail-Closed State
-
-The current `--release-grade-materialized` path is intentionally fail-closed until a trusted release-evidence verifier exists.
-
-In the current hotfix state, local detector, external summary, and refusal-delta artifacts cannot set release-required gates true.
-
-The materialized prod path may report which untrusted inputs were observed, but it must not promote those inputs into gate state.
-
-This current behavior is implemented in code; this document only records the boundary and intended future direction.
-
-## Relation to `run_all.py`
-
-`run_all.py --mode prod --release-grade-materialized` is a preparation path.
-
-At present, it remains fail-closed.
-
-A future implementation may follow this sequence:
-
-```text
-candidate evidence inputs
-→ release evidence verifier
-→ release_evidence_verifier_report_v0.json
-→ verified gate materialization
-→ status.json
-→ release authority manifest
-→ audit bundle
-```
-
-The verifier report should be checked before any release-required gate is set to true.
-
-## Relation to `check_gates.py`
-
-`check_gates.py` remains the release-authority evaluator.
-
-The verifier does not replace it.
-
-The verifier only qualifies evidence for possible materialization into `status.json`.
-
-`check_gates.py` still evaluates the workflow-effective required gate set under declared policy and strict fail-closed CI enforcement.
-
-## Relation to Quality Ledger
-
-The Quality Ledger remains a reader surface.
-
-It may display verifier report information after such a report exists.
-
-It must not recompute verifier decisions.
-
-It must not convert displayed evidence into release-required gate state.
-
-## Review Questions for Future Implementation PRs
-
-A future PR that implements verifier wiring should answer:
-
-- What verifier report is consumed?
-- Which schema validates the report?
-- Which subject / git SHA does the report bind?
-- Which policy and registry digests does it bind?
-- Which evidence artifacts are verified?
-- Which gate ids are materialized?
-- Which evidence artifact supports each gate?
-- What happens if the report is missing?
-- What happens if one gate lacks verified evidence?
-- What prevents a self-declared artifact from becoming release evidence?
-
-These are review questions, not an active rejection rule in this document.
-
-## Security Boundary Note
-
-The verifier boundary exists because release-grade gate state is security-critical.
-
-The following patterns should be treated as security risks in future implementation work:
-
-- self-declared detector booleans becoming release-required gates
-- generic external summaries becoming `external_all_pass`
-- refusal summaries becoming release evidence without subject binding
-- artifact existence being treated as evidence validity
-- copied files producing non-stubbed diagnostics
-- local artifact directory control producing release-grade PASS
-
-The correct current behavior is fail-closed until evidence is verified by an implemented verifier.
-
-## Minimal Anchor
-
-Evidence is not trusted because it exists.
-
-Evidence becomes eligible for materialization only after verification.
-
-Verification qualifies evidence for materialization.
-
-Materialization writes verified gate state into `status.json`.
-
-Release authority remains the PULSEmech path:
-
-```text
-recorded release evidence
-→ status.json
-→ declared gate policy
-→ workflow-effective materialized required gate set
-→ strict fail-closed CI enforcement
-→ pre-deployment allow/block release decision
-```
+A relation binding qualifies evidence for possible materialization only after verifier checks pass.

--- a/examples/release_evidence_verifier_report_v0.failed.example.json
+++ b/examples/release_evidence_verifier_report_v0.failed.example.json
@@ -2,7 +2,8 @@
   "created_utc": "2026-01-01T00:00:00Z",
   "evidence_inputs": [],
   "failed_checks": [
-    "trusted verifier is not implemented"
+    "trusted verifier is not implemented",
+    "no verified relation bindings present"
   ],
   "gate_materialization": {},
   "policy_binding": {
@@ -14,6 +15,7 @@
     "registry_path": "pulse_gate_registry_v0.yml",
     "registry_sha256": null
   },
+  "relation_bindings": [],
   "run_identity": {
     "git_sha": null,
     "run_key": null,

--- a/schemas/release_evidence_verifier_report_v0.schema.json
+++ b/schemas/release_evidence_verifier_report_v0.schema.json
@@ -16,6 +16,7 @@
     "registry_binding",
     "evidence_inputs",
     "verified_artifacts",
+    "relation_bindings",
     "gate_materialization",
     "failed_checks",
     "warnings"
@@ -158,6 +159,12 @@
         "$ref": "#/$defs/verified_artifact"
       }
     },
+    "relation_bindings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/relation_binding"
+      }
+    },
     "gate_materialization": {
       "type": "object",
       "propertyNames": {
@@ -281,6 +288,82 @@
         }
       }
     },
+    "relation_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "relation_id",
+        "binding_type",
+        "source",
+        "target",
+        "verified",
+        "evidence"
+      ],
+      "properties": {
+        "relation_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "binding_type": {
+          "type": "string",
+          "enum": [
+            "artifact_to_subject",
+            "artifact_to_run",
+            "artifact_to_policy",
+            "artifact_to_registry",
+            "artifact_to_digest",
+            "artifact_to_detector",
+            "artifact_to_gate",
+            "gate_to_policy",
+            "gate_to_verifier_decision"
+          ]
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "verified": {
+          "type": "boolean"
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/verified_artifact"
+          }
+        },
+        "failure_reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "verified_relation_binding": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/relation_binding"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "verified": {
+              "const": true
+            },
+            "evidence": {
+              "minItems": 1
+            },
+            "failure_reason": {
+              "type": "null"
+            }
+          }
+        }
+      ]
+    },
     "gate_materialization_entry": {
       "type": "object",
       "additionalProperties": false,
@@ -289,6 +372,7 @@
         "source",
         "verified",
         "evidence_artifacts",
+        "relation_bindings",
         "policy_relation"
       ],
       "properties": {
@@ -306,6 +390,14 @@
           "minItems": 1,
           "items": {
             "$ref": "#/$defs/verified_artifact"
+          }
+        },
+        "relation_bindings": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
           }
         },
         "policy_relation": {
@@ -359,6 +451,12 @@
           },
           "verified_artifacts": {
             "minItems": 1
+          },
+          "relation_bindings": {
+            "minItems": 1,
+            "items": {
+              "$ref": "#/$defs/verified_relation_binding"
+            }
           }
         }
       }

--- a/tests/test_release_evidence_verifier_report_schema_v0.py
+++ b/tests/test_release_evidence_verifier_report_schema_v0.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import copy
 import json
 import pathlib
 from typing import Any
@@ -22,10 +21,34 @@ FAILED_EXAMPLE_PATH = (
 
 HEX40 = "a" * 40
 HEX64 = "b" * 64
+RUN_KEY = "GITHUB_RUN_ID=1|GITHUB_RUN_NUMBER=1|GITHUB_WORKFLOW=PULSE CI"
 
 
 def _load_json(path: pathlib.Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _verified_artifact() -> dict[str, Any]:
+    return {
+        "path": "artifacts/detectors/detector_report.json",
+        "sha256": HEX64,
+        "schema_version": "detector_report_v0",
+        "verified": True,
+    }
+
+
+def _relation_binding() -> dict[str, Any]:
+    return {
+        "relation_id": "detector_report_to_subject_commit",
+        "binding_type": "artifact_to_subject",
+        "source": "artifacts/detectors/detector_report.json",
+        "target": "subject.commit_sha",
+        "verified": True,
+        "evidence": [
+            _verified_artifact()
+        ],
+        "failure_reason": None,
+    }
 
 
 def _minimal_verified_report() -> dict[str, Any]:
@@ -37,7 +60,7 @@ def _minimal_verified_report() -> dict[str, Any]:
         "verifier_decision": "VERIFIED",
         "run_identity": {
             "run_mode": "prod",
-            "run_key": "GITHUB_RUN_ID=1|GITHUB_RUN_NUMBER=1|GITHUB_WORKFLOW=PULSE CI",
+            "run_key": RUN_KEY,
             "git_sha": HEX40,
         },
         "subject": {
@@ -62,7 +85,7 @@ def _minimal_verified_report() -> dict[str, Any]:
                 "schema_version": "detector_report_v0",
                 "subject_binding": {
                     "git_sha": HEX40,
-                    "run_key": "GITHUB_RUN_ID=1|GITHUB_RUN_NUMBER=1|GITHUB_WORKFLOW=PULSE CI",
+                    "run_key": RUN_KEY,
                 },
                 "provenance": {
                     "producer": "unit-test"
@@ -70,12 +93,10 @@ def _minimal_verified_report() -> dict[str, Any]:
             }
         ],
         "verified_artifacts": [
-            {
-                "path": "artifacts/detectors/detector_report.json",
-                "sha256": HEX64,
-                "schema_version": "detector_report_v0",
-                "verified": True,
-            }
+            _verified_artifact()
+        ],
+        "relation_bindings": [
+            _relation_binding()
         ],
         "gate_materialization": {
             "detectors_materialized_ok": {
@@ -83,12 +104,10 @@ def _minimal_verified_report() -> dict[str, Any]:
                 "source": "release_evidence_verifier_report_v0",
                 "verified": True,
                 "evidence_artifacts": [
-                    {
-                        "path": "artifacts/detectors/detector_report.json",
-                        "sha256": HEX64,
-                        "schema_version": "detector_report_v0",
-                        "verified": True,
-                    }
+                    _verified_artifact()
+                ],
+                "relation_bindings": [
+                    "detector_report_to_subject_commit"
                 ],
                 "policy_relation": "release_required",
             }
@@ -119,10 +138,18 @@ def _validate(instance: dict[str, Any]) -> None:
         assert instance["failed_checks"] == []
         assert instance["gate_materialization"]
         assert instance["verified_artifacts"]
+        assert instance["relation_bindings"]
+
+        for relation in instance["relation_bindings"]:
+            assert relation["verified"] is True
+            assert relation["evidence"]
+            assert relation.get("failure_reason") is None
+
         for gate in instance["gate_materialization"].values():
             assert gate["source"] == "release_evidence_verifier_report_v0"
             assert gate["verified"] is True
             assert gate["evidence_artifacts"]
+            assert gate["relation_bindings"]
 
 
 def _validation_errors(instance: dict[str, Any]) -> list[str]:
@@ -161,6 +188,15 @@ def test_release_authority_words_are_not_verifier_decisions() -> None:
     assert errors
 
 
+def test_allow_is_not_a_verifier_decision() -> None:
+    report = _minimal_verified_report()
+    report["verifier_decision"] = "ALLOW"
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
 def test_failed_report_requires_failed_checks() -> None:
     report = _load_json(FAILED_EXAMPLE_PATH)
     report["failed_checks"] = []
@@ -173,6 +209,42 @@ def test_failed_report_requires_failed_checks() -> None:
 def test_verified_report_requires_gate_materialization() -> None:
     report = _minimal_verified_report()
     report["gate_materialization"] = {}
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_verified_report_requires_relation_bindings() -> None:
+    report = _minimal_verified_report()
+    report["relation_bindings"] = []
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_verified_relation_binding_must_be_verified() -> None:
+    report = _minimal_verified_report()
+    report["relation_bindings"][0]["verified"] = False
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_verified_relation_binding_requires_evidence() -> None:
+    report = _minimal_verified_report()
+    report["relation_bindings"][0]["evidence"] = []
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_verified_relation_binding_failure_reason_must_be_null() -> None:
+    report = _minimal_verified_report()
+    report["relation_bindings"][0]["failure_reason"] = "stale relation"
 
     errors = _validation_errors(report)
 
@@ -194,6 +266,17 @@ def test_gate_materialization_requires_verified_artifact_binding() -> None:
     report = _minimal_verified_report()
     report["gate_materialization"]["detectors_materialized_ok"][
         "evidence_artifacts"
+    ] = []
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_gate_materialization_requires_relation_binding_ids() -> None:
+    report = _minimal_verified_report()
+    report["gate_materialization"]["detectors_materialized_ok"][
+        "relation_bindings"
     ] = []
 
     errors = _validation_errors(report)


### PR DESCRIPTION
## Summary

This PR adds `relation_bindings` to the `release_evidence_verifier_report_v0` schema.

The purpose is to make the verifier report model not only verified artifacts, but also the verified relations that make evidence eligible for future gate materialization.

## What changed

- Added top-level `relation_bindings`.
- Added relation binding schema entries for:
  - artifact-to-subject
  - artifact-to-run
  - artifact-to-policy
  - artifact-to-registry
  - artifact-to-digest
  - artifact-to-detector
  - artifact-to-gate
  - gate-to-policy
  - gate-to-verifier-decision
- `VERIFIED` reports now require at least one verified relation binding.
- Gate materialization entries now require relation binding IDs.
- Updated the failed example report.
- Updated schema tests for relation binding requirements.
- Added verifier documentation anchor for relation bindings.
- Added pre-materialization documentation anchor for relation-binding pre-state hooks.
- Added docs index entry.
- Added schema test to tools-smoke manifest.

## Boundary

This PR updates the verifier report artifact contract only.

It does not implement the verifier.

It does not reopen the materialized prod path.

It does not define release authority.

It does not replace `check_gates.py`.

PULSEmech release authority remains:

recorded release evidence → `status.json` → declared gate policy → workflow-effective materialized required gate set → strict fail-closed CI enforcement → pre-deployment allow/block release decision

## Non-goals

This PR does not change:

- code materialization behavior
- gate policy
- gate registry
- status schema
- `check_gates.py`
- CI allow/block behavior
- DOI/Zenodo artifacts
- release tags
- release artifacts

## Tests

- `pytest -q tests/test_release_evidence_verifier_report_schema_v0.py`