### PR TITLE
feat(ref): add verifier relation binding integrity checker

### DIFF
--- a/PULSE_safe_pack_v0/tools/check_release_evidence_verifier_report_v0.py
+++ b/PULSE_safe_pack_v0/tools/check_release_evidence_verifier_report_v0.py
@@ -57,27 +57,20 @@ def _validate_schema(
     schema_path: Path,
     errors: list[str],
 ) -> None:
-    schema = _load_json(schema_path, "release_evidence_verifier_report_v0 schema", errors)
+    schema = _load_json(
+        schema_path,
+        "release_evidence_verifier_report_v0 schema",
+        errors,
+    )
     if schema is None:
         return
 
     if jsonschema is None:
-        required = schema.get("required")
-        if isinstance(required, list):
-            for key in required:
-                if key not in report:
-                    errors.append(f"schema validation error at <root>: {key!r} is required")
-
-        if report.get("schema_version") != "release_evidence_verifier_report_v0":
-            errors.append(
-                "schema validation error at schema_version: must be "
-                "'release_evidence_verifier_report_v0'"
-            )
-
-        if report.get("verifier_decision") not in {"VERIFIED", "FAILED"}:
-            errors.append(
-                "schema validation error at verifier_decision: must be VERIFIED or FAILED"
-            )
+        errors.append(
+            "jsonschema is required for "
+            "release_evidence_verifier_report_v0 schema validation; "
+            "partial fallback validation is not allowed"
+        )
         return
 
     try:
@@ -178,6 +171,7 @@ def _check_gate_relation_refs(
                     f"duplicate relation reference: {relation_id}"
                 )
                 continue
+
             seen_refs.add(relation_id)
 
             relation = relation_by_id.get(relation_id)

--- a/PULSE_safe_pack_v0/tools/check_release_evidence_verifier_report_v0.py
+++ b/PULSE_safe_pack_v0/tools/check_release_evidence_verifier_report_v0.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Check release_evidence_verifier_report_v0 relation integrity.
+
+This checker validates verifier report structure and relation binding integrity.
+
+It is not release authority.
+It does not replace check_gates.py.
+It does not change status.json, gate policy, CI behavior, or release semantics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import jsonschema
+except Exception:  # pragma: no cover
+    jsonschema = None
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCHEMA_PATH = (
+    REPO_ROOT / "schemas" / "release_evidence_verifier_report_v0.schema.json"
+)
+
+
+def _json_path(parts: Any) -> str:
+    items = [str(part) for part in parts]
+    return ".".join(items) if items else "<root>"
+
+
+def _load_json(path: Path, label: str, errors: list[str]) -> dict[str, Any] | None:
+    if not path.exists():
+        errors.append(f"{label} not found: {path}")
+        return None
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - CLI should report parse failures
+        errors.append(f"{label} is not valid JSON: {exc}")
+        return None
+
+    if not isinstance(payload, dict):
+        errors.append(f"{label} must be a JSON object: {path}")
+        return None
+
+    return payload
+
+
+def _validate_schema(
+    report: dict[str, Any],
+    *,
+    schema_path: Path,
+    errors: list[str],
+) -> None:
+    schema = _load_json(schema_path, "release_evidence_verifier_report_v0 schema", errors)
+    if schema is None:
+        return
+
+    if jsonschema is None:
+        required = schema.get("required")
+        if isinstance(required, list):
+            for key in required:
+                if key not in report:
+                    errors.append(f"schema validation error at <root>: {key!r} is required")
+
+        if report.get("schema_version") != "release_evidence_verifier_report_v0":
+            errors.append(
+                "schema validation error at schema_version: must be "
+                "'release_evidence_verifier_report_v0'"
+            )
+
+        if report.get("verifier_decision") not in {"VERIFIED", "FAILED"}:
+            errors.append(
+                "schema validation error at verifier_decision: must be VERIFIED or FAILED"
+            )
+        return
+
+    try:
+        jsonschema.Draft202012Validator.check_schema(schema)
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"release_evidence_verifier_report_v0 schema is invalid: {exc}")
+        return
+
+    validator = jsonschema.Draft202012Validator(schema)
+    for error in sorted(validator.iter_errors(report), key=lambda item: list(item.path)):
+        errors.append(
+            f"schema validation error at {_json_path(error.path)}: {error.message}"
+        )
+
+
+def _relation_bindings(
+    report: dict[str, Any],
+    errors: list[str],
+) -> dict[str, dict[str, Any]]:
+    raw = report.get("relation_bindings")
+    if not isinstance(raw, list):
+        errors.append("report.relation_bindings must be an array")
+        return {}
+
+    by_id: dict[str, dict[str, Any]] = {}
+
+    for idx, item in enumerate(raw):
+        if not isinstance(item, dict):
+            errors.append(f"report.relation_bindings[{idx}] must be an object")
+            continue
+
+        relation_id = item.get("relation_id")
+        if not isinstance(relation_id, str) or not relation_id.strip():
+            errors.append(
+                f"report.relation_bindings[{idx}].relation_id must be a non-empty string"
+            )
+            continue
+
+        relation_id = relation_id.strip()
+        if relation_id in by_id:
+            errors.append(
+                "duplicate relation_id in report.relation_bindings: "
+                f"{relation_id}"
+            )
+            continue
+
+        by_id[relation_id] = item
+
+    return by_id
+
+
+def _check_gate_relation_refs(
+    report: dict[str, Any],
+    relation_by_id: dict[str, dict[str, Any]],
+    errors: list[str],
+) -> None:
+    materialization = report.get("gate_materialization")
+    if not isinstance(materialization, dict):
+        errors.append("report.gate_materialization must be an object")
+        return
+
+    decision = report.get("verifier_decision")
+
+    if decision == "FAILED":
+        if materialization:
+            errors.append("FAILED verifier reports must not materialize gates")
+        return
+
+    if decision == "VERIFIED" and not materialization:
+        errors.append("VERIFIED verifier reports must materialize at least one gate")
+
+    for gate_id, entry in materialization.items():
+        if not isinstance(entry, dict):
+            errors.append(f"gate_materialization.{gate_id} must be an object")
+            continue
+
+        refs = entry.get("relation_bindings")
+        if not isinstance(refs, list) or not refs:
+            errors.append(
+                f"gate_materialization.{gate_id}.relation_bindings must be "
+                "a non-empty array"
+            )
+            continue
+
+        seen_refs: set[str] = set()
+        for raw_ref in refs:
+            if not isinstance(raw_ref, str) or not raw_ref.strip():
+                errors.append(
+                    f"gate_materialization.{gate_id}.relation_bindings contains "
+                    "a non-empty-string violation"
+                )
+                continue
+
+            relation_id = raw_ref.strip()
+            if relation_id in seen_refs:
+                errors.append(
+                    f"gate_materialization.{gate_id}.relation_bindings contains "
+                    f"duplicate relation reference: {relation_id}"
+                )
+                continue
+            seen_refs.add(relation_id)
+
+            relation = relation_by_id.get(relation_id)
+            if relation is None:
+                errors.append(
+                    f"gate_materialization.{gate_id}.relation_bindings references "
+                    f"missing relation_id: {relation_id}"
+                )
+                continue
+
+            if relation.get("verified") is not True:
+                errors.append(
+                    f"gate_materialization.{gate_id}.relation_bindings references "
+                    f"relation_id {relation_id} that is not verified=true"
+                )
+
+
+def check_release_evidence_verifier_report(
+    report_path: Path,
+    *,
+    schema_path: Path | None = None,
+) -> list[str]:
+    errors: list[str] = []
+
+    report = _load_json(report_path, "release_evidence_verifier_report_v0", errors)
+    if report is None:
+        return errors
+
+    _validate_schema(
+        report,
+        schema_path=schema_path or DEFAULT_SCHEMA_PATH,
+        errors=errors,
+    )
+
+    relation_by_id = _relation_bindings(report, errors)
+    _check_gate_relation_refs(report, relation_by_id, errors)
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check release_evidence_verifier_report_v0 relation integrity."
+    )
+    parser.add_argument(
+        "--report",
+        required=True,
+        help="Path to release_evidence_verifier_report_v0.json",
+    )
+    parser.add_argument(
+        "--schema",
+        default=str(DEFAULT_SCHEMA_PATH),
+        help="Path to release_evidence_verifier_report_v0 JSON schema.",
+    )
+
+    args = parser.parse_args()
+
+    errors = check_release_evidence_verifier_report(
+        Path(args.report),
+        schema_path=Path(args.schema),
+    )
+
+    if errors:
+        print("ERRORS (fail-closed):", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("OK: release evidence verifier report relation integrity satisfied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -32,6 +32,7 @@ tests/test_render_quality_ledger_tests_list_smoke.py
 tests/test_authority_boundary_repro_smoke.py 
 tests/test_operator_handoff_smoke.py
 tests/test_check_release_authority_manifest_v0.py
+tests/test_check_release_evidence_verifier_report_v0.py
 tests/test_build_release_authority_manifest_v0.py
 tests/test_release_authority_manifest_non_interference.py
 tests/test_release_decision_v0_smoke.py

--- a/docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md
+++ b/docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md
@@ -41,3 +41,38 @@ unverified relation
 A relation binding is not release authority.
 
 A relation binding qualifies evidence for possible materialization only after verifier checks pass.
+
+## Relation binding integrity checker
+
+The verifier report relation-binding integrity checker is:
+
+```text
+PULSE_safe_pack_v0/tools/check_release_evidence_verifier_report_v0.py
+```
+
+Example command:
+
+```text
+python PULSE_safe_pack_v0/tools/check_release_evidence_verifier_report_v0.py \
+  --report examples/release_evidence_verifier_report_v0.failed.example.json
+```
+
+The checker validates the verifier report schema when `jsonschema` is available, then applies relation integrity checks.
+
+It fails closed when:
+
+- `relation_bindings[].relation_id` values are duplicated
+- `gate_materialization.*.relation_bindings[]` references a missing relation ID
+- a referenced relation binding is not `verified=true`
+- a `VERIFIED` gate materialization entry has no relation binding IDs
+- verifier decision values use release-authority wording such as `PASS` or `ALLOW`
+
+A `FAILED` report may have empty `gate_materialization`.
+
+The checker does not implement the verifier.
+
+It does not reopen `--release-grade-materialized`.
+
+It does not replace `check_gates.py`.
+
+It only checks whether a verifier report has internally consistent relation bindings.

--- a/tests/test_check_release_evidence_verifier_report_v0.py
+++ b/tests/test_check_release_evidence_verifier_report_v0.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from PULSE_safe_pack_v0.tools.check_release_evidence_verifier_report_v0 import (
+    check_release_evidence_verifier_report,
+)
+
+
+CHECKER = (
+    REPO_ROOT
+    / "PULSE_safe_pack_v0"
+    / "tools"
+    / "check_release_evidence_verifier_report_v0.py"
+)
+FAILED_EXAMPLE = (
+    REPO_ROOT / "examples" / "release_evidence_verifier_report_v0.failed.example.json"
+)
+
+HEX40 = "a" * 40
+HEX64 = "b" * 64
+RUN_KEY = "GITHUB_RUN_ID=1|GITHUB_RUN_NUMBER=1|GITHUB_WORKFLOW=PULSE CI"
+
+
+def _write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _verified_artifact(path: str = "artifacts/detectors/detector_report.json") -> dict[str, Any]:
+    return {
+        "path": path,
+        "sha256": HEX64,
+        "schema_version": "detector_report_v0",
+        "verified": True,
+    }
+
+
+def _relation_binding(
+    *,
+    relation_id: str = "detector_report_to_subject_commit",
+    source: str = "artifacts/detectors/detector_report.json",
+    target: str = "subject.commit_sha",
+    verified: bool = True,
+) -> dict[str, Any]:
+    return {
+        "relation_id": relation_id,
+        "binding_type": "artifact_to_subject",
+        "source": source,
+        "target": target,
+        "verified": verified,
+        "evidence": [
+            _verified_artifact(source)
+        ],
+        "failure_reason": None if verified else "relation was not verified",
+    }
+
+
+def _verified_report() -> dict[str, Any]:
+    relation_id = "detector_report_to_subject_commit"
+
+    return {
+        "schema_version": "release_evidence_verifier_report_v0",
+        "created_utc": "2026-01-01T00:00:00Z",
+        "verifier_id": "pulse_release_evidence_verifier_v0",
+        "verifier_version": "0.1.0",
+        "verifier_decision": "VERIFIED",
+        "run_identity": {
+            "run_mode": "prod",
+            "run_key": RUN_KEY,
+            "git_sha": HEX40,
+        },
+        "subject": {
+            "repository": "HKati/pulse-release-gates-0.1",
+            "commit_sha": HEX40,
+            "release_candidate": "candidate-v0",
+        },
+        "policy_binding": {
+            "policy_path": "pulse_gate_policy_v0.yml",
+            "policy_sha256": HEX64,
+            "policy_set": "required+release_required",
+        },
+        "registry_binding": {
+            "registry_path": "pulse_gate_registry_v0.yml",
+            "registry_sha256": HEX64,
+        },
+        "evidence_inputs": [
+            {
+                "kind": "detector_evidence",
+                "path": "artifacts/detectors/detector_report.json",
+                "sha256": HEX64,
+                "schema_version": "detector_report_v0",
+                "subject_binding": {
+                    "git_sha": HEX40,
+                    "run_key": RUN_KEY,
+                },
+                "provenance": {
+                    "producer": "unit-test"
+                },
+            }
+        ],
+        "verified_artifacts": [
+            _verified_artifact()
+        ],
+        "relation_bindings": [
+            _relation_binding(relation_id=relation_id)
+        ],
+        "gate_materialization": {
+            "detectors_materialized_ok": {
+                "value": True,
+                "source": "release_evidence_verifier_report_v0",
+                "verified": True,
+                "evidence_artifacts": [
+                    _verified_artifact()
+                ],
+                "relation_bindings": [
+                    relation_id
+                ],
+                "policy_relation": "release_required",
+            }
+        },
+        "failed_checks": [],
+        "warnings": [],
+    }
+
+
+def test_failed_example_passes_checker() -> None:
+    errors = check_release_evidence_verifier_report(FAILED_EXAMPLE)
+
+    assert errors == []
+
+
+def test_valid_verified_report_passes_checker(tmp_path: pathlib.Path) -> None:
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    _write_json(report_path, _verified_report())
+
+    errors = check_release_evidence_verifier_report(report_path)
+
+    assert errors == []
+
+
+def test_missing_relation_id_reference_fails(tmp_path: pathlib.Path) -> None:
+    report = _verified_report()
+    report["gate_materialization"]["detectors_materialized_ok"]["relation_bindings"] = [
+        "missing_relation"
+    ]
+
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    _write_json(report_path, report)
+
+    errors = check_release_evidence_verifier_report(report_path)
+
+    assert any("missing relation_id: missing_relation" in error for error in errors)
+
+
+def test_duplicate_relation_id_fails(tmp_path: pathlib.Path) -> None:
+    report = _verified_report()
+    report["relation_bindings"].append(
+        _relation_binding(
+            relation_id="detector_report_to_subject_commit",
+            source="artifacts/detectors/other_report.json",
+            target="subject.release_candidate",
+        )
+    )
+
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    _write_json(report_path, report)
+
+    errors = check_release_evidence_verifier_report(report_path)
+
+    assert any(
+        "duplicate relation_id in report.relation_bindings" in error
+        for error in errors
+    )
+
+
+def test_unverified_referenced_relation_fails(tmp_path: pathlib.Path) -> None:
+    report = _verified_report()
+    report["relation_bindings"][0] = _relation_binding(verified=False)
+
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    _write_json(report_path, report)
+
+    errors = check_release_evidence_verifier_report(report_path)
+
+    assert any("not verified=true" in error for error in errors)
+
+
+def test_gate_materialization_without_relation_ids_fails(tmp_path: pathlib.Path) -> None:
+    report = _verified_report()
+    report["gate_materialization"]["detectors_materialized_ok"]["relation_bindings"] = []
+
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    _write_json(report_path, report)
+
+    errors = check_release_evidence_verifier_report(report_path)
+
+    assert any(
+        "gate_materialization.detectors_materialized_ok.relation_bindings"
+        in error
+        for error in errors
+    )
+
+
+@pytest.mark.parametrize("bad_decision", ["PASS", "ALLOW"])
+def test_release_authority_words_are_rejected_as_verifier_decisions(
+    tmp_path: pathlib.Path,
+    bad_decision: str,
+) -> None:
+    report = _verified_report()
+    report["verifier_decision"] = bad_decision
+
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    _write_json(report_path, report)
+
+    errors = check_release_evidence_verifier_report(report_path)
+
+    assert errors
+
+
+def test_checker_cli_passes_failed_example() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--report",
+            str(FAILED_EXAMPLE),
+        ],
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "OK: release evidence verifier report relation integrity satisfied" in result.stdout
+
+
+def test_checker_cli_reports_errors(tmp_path: pathlib.Path) -> None:
+    report = _verified_report()
+    report["gate_materialization"]["detectors_materialized_ok"]["relation_bindings"] = [
+        "missing_relation"
+    ]
+
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    _write_json(report_path, report)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--report",
+            str(report_path),
+        ],
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "ERRORS (fail-closed):" in result.stderr
+    assert "missing_relation" in result.stderr
+
+
+def test_checker_fails_closed_when_jsonschema_unavailable(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import PULSE_safe_pack_v0.tools.check_release_evidence_verifier_report_v0 as checker
+
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    _write_json(report_path, _verified_report())
+
+    monkeypatch.setattr(checker, "jsonschema", None)
+
+    errors = checker.check_release_evidence_verifier_report(report_path)
+
+    assert any("jsonschema is required" in error for error in errors)
+    assert any("partial fallback validation is not allowed" in error for error in errors)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

This PR adds `check_release_evidence_verifier_report_v0.py`, a targeted checker for `release_evidence_verifier_report_v0` relation integrity.

The checker validates the report schema when `jsonschema` is available, then applies relation-binding integrity checks that JSON Schema alone does not enforce well.

## What changed

- Added `PULSE_safe_pack_v0/tools/check_release_evidence_verifier_report_v0.py`.
- Added `tests/test_check_release_evidence_verifier_report_v0.py`.
- Registered the new test in `ci/tools-tests.list`.
- Documented the checker in `docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md`.

## Checker behavior

The checker fails closed when:

- top-level `relation_bindings[].relation_id` values are duplicated
- a gate materialization entry references a missing relation ID
- a referenced relation binding is not `verified=true`
- a VERIFIED gate materialization entry has no relation binding IDs
- verifier decision values use release-authority wording such as `PASS` or `ALLOW`

A FAILED report may have empty `gate_materialization`.

## Boundary

This PR does not implement the verifier.

It does not reopen the materialized prod path.

It does not define release authority.

It does not replace `check_gates.py`.

PULSEmech release authority remains:

recorded release evidence → `status.json` → declared gate policy → workflow-effective materialized required gate set → strict fail-closed CI enforcement → pre-deployment allow/block release decision

## Non-goals

This PR does not change:

- code materialization behavior
- gate policy
- gate registry
- status schema
- `check_gates.py`
- CI allow/block behavior
- DOI/Zenodo artifacts
- release tags
- release artifacts

## Tests

- `pytest -q tests/test_check_release_evidence_verifier_report_v0.py`
- `pytest -q tests/test_release_evidence_verifier_report_schema_v0.py`
- `pytest -q tests/test_tools_tests_list_smoke.py`