### PR TITLE
feat(ref): add fail-closed release evidence verifier skeleton

### DIFF
--- a/PULSE_safe_pack_v0/tools/build_release_evidence_verifier_report_v0.py
+++ b/PULSE_safe_pack_v0/tools/build_release_evidence_verifier_report_v0.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Build a fail-closed release_evidence_verifier_report_v0 artifact.
+
+This is the first trusted release-evidence verifier skeleton.
+
+It intentionally never emits VERIFIED.
+It does not materialize gates.
+It does not write status.json.
+It does not replace check_gates.py.
+It does not reopen --release-grade-materialized.
+
+The output is a FAILED verifier report that can be schema-validated and
+relation-integrity checked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from PULSE_safe_pack_v0.tools.check_release_evidence_verifier_report_v0 import (  # noqa: E402
+    check_release_evidence_verifier_report,
+)
+
+
+SCHEMA_VERSION = "release_evidence_verifier_report_v0"
+VERIFIER_ID = "pulse_release_evidence_verifier_v0"
+VERIFIER_VERSION = "0.1.0"
+
+VALID_EVIDENCE_KINDS = {
+    "detector_evidence",
+    "detector_materialization_report",
+    "external_detector_summary",
+    "refusal_delta_evidence",
+    "provenance_record",
+    "policy_reference",
+    "registry_reference",
+}
+
+
+def _utc_now() -> str:
+    return datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def _sha256_file(path: pathlib.Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _repo_relative_or_input(path: pathlib.Path, raw: str) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return raw
+
+
+def _git_sha() -> str | None:
+    env_sha = os.getenv("GITHUB_SHA") or os.getenv("CI_COMMIT_SHA")
+    if isinstance(env_sha, str) and env_sha.strip():
+        candidate = env_sha.strip()
+        if len(candidate) == 40 and all(c in "0123456789abcdefABCDEF" for c in candidate):
+            return candidate
+
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(REPO_ROOT),
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except Exception:
+        return None
+
+    if len(out) == 40 and all(c in "0123456789abcdefABCDEF" for c in out):
+        return out
+    return None
+
+
+def _run_key() -> str | None:
+    parts: list[str] = []
+    for key in (
+        "GITHUB_RUN_ID",
+        "GITHUB_RUN_NUMBER",
+        "GITHUB_WORKFLOW",
+        "CI_PIPELINE_ID",
+        "BUILD_BUILDID",
+    ):
+        value = os.getenv(key)
+        if isinstance(value, str) and value.strip():
+            parts.append(f"{key}={value.strip()}")
+    return "|".join(parts) if parts else None
+
+
+def _load_json_schema_hint(path: pathlib.Path) -> str | None:
+    if path.suffix.lower() not in {".json", ".jsonl"}:
+        return None
+
+    if path.suffix.lower() == ".jsonl":
+        return None
+
+    try:
+        obj = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+    if not isinstance(obj, dict):
+        return None
+
+    for key in ("schema_version", "schema"):
+        value = obj.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    return None
+
+
+def _parse_evidence_arg(raw: str) -> tuple[str, pathlib.Path, str]:
+    if "=" not in raw:
+        raise ValueError(
+            "evidence arguments must use KIND=PATH format, "
+            "for example detector_evidence=artifacts/detectors/report.json"
+        )
+
+    kind, path_raw = raw.split("=", 1)
+    kind = kind.strip()
+    path_raw = path_raw.strip()
+
+    if kind not in VALID_EVIDENCE_KINDS:
+        allowed = ", ".join(sorted(VALID_EVIDENCE_KINDS))
+        raise ValueError(f"unsupported evidence kind {kind!r}; expected one of: {allowed}")
+
+    if not path_raw:
+        raise ValueError("evidence path must be non-empty")
+
+    path = pathlib.Path(path_raw)
+    if not path.is_absolute():
+        path = (REPO_ROOT / path).resolve()
+
+    return kind, path, path_raw
+
+
+def _evidence_input(
+    *,
+    kind: str,
+    path: pathlib.Path,
+    raw_path: str,
+    git_sha: str | None,
+    run_key: str | None,
+) -> dict[str, Any]:
+    if not path.exists() or not path.is_file():
+        raise FileNotFoundError(f"candidate evidence file not found: {path}")
+
+    return {
+        "kind": kind,
+        "path": _repo_relative_or_input(path, raw_path),
+        "sha256": _sha256_file(path),
+        "schema_version": _load_json_schema_hint(path),
+        "subject_binding": {
+            "git_sha": git_sha,
+            "run_key": run_key,
+        },
+        "provenance": {
+            "observed_by": VERIFIER_ID,
+            "trusted": False,
+            "verification_status": "not_verified",
+            "note": "candidate input recorded by fail-closed verifier skeleton",
+        },
+    }
+
+
+def build_report(
+    *,
+    policy_path: pathlib.Path,
+    registry_path: pathlib.Path,
+    repository: str | None,
+    commit_sha: str | None,
+    run_key: str | None,
+    release_candidate: str | None,
+    evidence_args: list[str],
+) -> dict[str, Any]:
+    evidence_inputs: list[dict[str, Any]] = []
+
+    for raw in evidence_args:
+        kind, evidence_path, raw_path = _parse_evidence_arg(raw)
+        evidence_inputs.append(
+            _evidence_input(
+                kind=kind,
+                path=evidence_path,
+                raw_path=raw_path,
+                git_sha=commit_sha,
+                run_key=run_key,
+            )
+        )
+
+    failed_checks = [
+        "trusted release-evidence verifier skeleton does not verify evidence yet",
+        "no verified relation bindings present",
+        "no gate materialization performed",
+    ]
+    if not evidence_inputs:
+        failed_checks.append("no candidate evidence inputs were supplied")
+    else:
+        failed_checks.append(
+            "candidate evidence inputs are recorded only; verification is not implemented"
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_utc": _utc_now(),
+        "verifier_id": VERIFIER_ID,
+        "verifier_version": VERIFIER_VERSION,
+        "verifier_decision": "FAILED",
+        "run_identity": {
+            "run_mode": "prod",
+            "run_key": run_key,
+            "git_sha": commit_sha,
+        },
+        "subject": {
+            "repository": repository,
+            "commit_sha": commit_sha,
+            "release_candidate": release_candidate,
+        },
+        "policy_binding": {
+            "policy_path": _repo_relative_or_input(policy_path, str(policy_path)),
+            "policy_sha256": _sha256_file(policy_path) if policy_path.exists() else None,
+            "policy_set": "required+release_required",
+        },
+        "registry_binding": {
+            "registry_path": _repo_relative_or_input(registry_path, str(registry_path)),
+            "registry_sha256": _sha256_file(registry_path) if registry_path.exists() else None,
+        },
+        "evidence_inputs": evidence_inputs,
+        "verified_artifacts": [],
+        "relation_bindings": [],
+        "gate_materialization": {},
+        "failed_checks": failed_checks,
+        "warnings": [],
+    }
+
+
+def write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build a fail-closed release_evidence_verifier_report_v0 artifact."
+    )
+    parser.add_argument(
+        "--out",
+        default="PULSE_safe_pack_v0/artifacts/release_evidence_verifier_report_v0.json",
+        help="Output path for release_evidence_verifier_report_v0.json.",
+    )
+    parser.add_argument(
+        "--policy",
+        default="pulse_gate_policy_v0.yml",
+        help="Declared gate policy path.",
+    )
+    parser.add_argument(
+        "--registry",
+        default="pulse_gate_registry_v0.yml",
+        help="Gate registry path.",
+    )
+    parser.add_argument(
+        "--repository",
+        default=os.getenv("GITHUB_REPOSITORY"),
+        help="Repository subject, if known.",
+    )
+    parser.add_argument(
+        "--commit-sha",
+        default=_git_sha(),
+        help="Subject commit SHA. Defaults to CI/git discovery when available.",
+    )
+    parser.add_argument(
+        "--run-key",
+        default=_run_key(),
+        help="Run identity key. Defaults to CI environment discovery when available.",
+    )
+    parser.add_argument(
+        "--release-candidate",
+        default=None,
+        help="Optional release candidate identifier.",
+    )
+    parser.add_argument(
+        "--evidence",
+        action="append",
+        default=[],
+        metavar="KIND=PATH",
+        help=(
+            "Candidate evidence input to record without trusting it. "
+            "May be supplied multiple times."
+        ),
+    )
+
+    args = parser.parse_args()
+
+    try:
+        report = build_report(
+            policy_path=(REPO_ROOT / args.policy).resolve()
+            if not pathlib.Path(args.policy).is_absolute()
+            else pathlib.Path(args.policy).resolve(),
+            registry_path=(REPO_ROOT / args.registry).resolve()
+            if not pathlib.Path(args.registry).is_absolute()
+            else pathlib.Path(args.registry).resolve(),
+            repository=args.repository,
+            commit_sha=args.commit_sha,
+            run_key=args.run_key,
+            release_candidate=args.release_candidate,
+            evidence_args=list(args.evidence or []),
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    out_path = pathlib.Path(args.out)
+    if not out_path.is_absolute():
+        out_path = (REPO_ROOT / out_path).resolve()
+
+    write_json(out_path, report)
+
+    errors = check_release_evidence_verifier_report(out_path)
+    if errors:
+        print("ERRORS (fail-closed):", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print(f"OK: wrote fail-closed release evidence verifier report: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -23,6 +23,7 @@ tests/test_render_space_relation_map_summary_tool.py
 tests/test_build_space_relation_map_summary_tool.py
 tests/test_build_recognition_surface_drift_v0.py
 tests/test_build_hpc_evidence_bundle_v0.py
+tests/test_build_release_evidence_verifier_report_v0.py
 tests/test_no_legacy_status_schema_refs_smoke.py
 tests/test_pack_tools_compile.py
 tests/test_paradox_diagram_example_v0_smoke.py

--- a/docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md
+++ b/docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md
@@ -471,3 +471,45 @@ recorded release evidence
 → strict fail-closed CI enforcement
 → pre-deployment allow/block release decision
 ```
+
+## Fail-closed verifier report builder skeleton
+
+The fail-closed verifier report builder skeleton is:
+
+```text
+PULSE_safe_pack_v0/tools/build_release_evidence_verifier_report_v0.py
+```
+
+Example command:
+
+```text
+python PULSE_safe_pack_v0/tools/build_release_evidence_verifier_report_v0.py \
+  --out PULSE_safe_pack_v0/artifacts/release_evidence_verifier_report_v0.json
+```
+
+The builder emits a `release_evidence_verifier_report_v0.json` report with:
+
+```text
+verifier_decision = FAILED
+verified_artifacts = []
+relation_bindings = []
+gate_materialization = {}
+```
+
+Candidate evidence inputs may be recorded, hashed, and marked as untrusted candidate inputs.
+
+The builder does not verify evidence.
+
+It does not emit `VERIFIED`.
+
+It does not materialize gates.
+
+It does not write `status.json`.
+
+It does not reopen `--release-grade-materialized`.
+
+It does not replace `check_gates.py`.
+
+The builder validates its output through the release evidence verifier report checker.
+
+If the report is invalid or relation-integrity checks fail, the builder fails closed.

--- a/tests/test_build_release_evidence_verifier_report_v0.py
+++ b/tests/test_build_release_evidence_verifier_report_v0.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+TOOL = (
+    REPO_ROOT
+    / "PULSE_safe_pack_v0"
+    / "tools"
+    / "build_release_evidence_verifier_report_v0.py"
+)
+
+HEX40 = "a" * 40
+
+
+def _load_json(path: pathlib.Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _run_tool(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(TOOL),
+            *args,
+        ],
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def test_build_failed_report_without_inputs(tmp_path: pathlib.Path) -> None:
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--repository",
+        "HKati/pulse-release-gates-0.1",
+        "--commit-sha",
+        HEX40,
+        "--run-key",
+        "GITHUB_RUN_ID=1|GITHUB_RUN_NUMBER=1|GITHUB_WORKFLOW=PULSE CI",
+        "--release-candidate",
+        "candidate-v0",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "OK: wrote fail-closed release evidence verifier report" in result.stdout
+
+    report = _load_json(out_path)
+    assert report["schema_version"] == "release_evidence_verifier_report_v0"
+    assert report["verifier_decision"] == "FAILED"
+    assert report["verified_artifacts"] == []
+    assert report["relation_bindings"] == []
+    assert report["gate_materialization"] == {}
+    assert any("does not verify evidence yet" in item for item in report["failed_checks"])
+    assert any("no verified relation bindings present" in item for item in report["failed_checks"])
+
+
+def test_candidate_evidence_is_recorded_but_not_verified(tmp_path: pathlib.Path) -> None:
+    evidence_path = tmp_path / "detector_report.json"
+    evidence_payload = {
+        "schema_version": "detector_report_v0",
+        "result": "candidate-only",
+    }
+    evidence_path.write_text(json.dumps(evidence_payload), encoding="utf-8")
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--repository",
+        "HKati/pulse-release-gates-0.1",
+        "--commit-sha",
+        HEX40,
+        "--run-key",
+        "GITHUB_RUN_ID=1|GITHUB_RUN_NUMBER=1|GITHUB_WORKFLOW=PULSE CI",
+        "--release-candidate",
+        "candidate-v0",
+        "--evidence",
+        f"detector_evidence={evidence_path}",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    report = _load_json(out_path)
+    assert report["verifier_decision"] == "FAILED"
+    assert report["verified_artifacts"] == []
+    assert report["relation_bindings"] == []
+    assert report["gate_materialization"] == {}
+
+    assert len(report["evidence_inputs"]) == 1
+    evidence_input = report["evidence_inputs"][0]
+    assert evidence_input["kind"] == "detector_evidence"
+    assert evidence_input["sha256"] == hashlib.sha256(
+        evidence_path.read_bytes()
+    ).hexdigest()
+    assert evidence_input["schema_version"] == "detector_report_v0"
+    assert evidence_input["provenance"]["trusted"] is False
+    assert evidence_input["provenance"]["verification_status"] == "not_verified"
+
+
+def test_invalid_evidence_kind_fails_closed(tmp_path: pathlib.Path) -> None:
+    evidence_path = tmp_path / "detector_report.json"
+    evidence_path.write_text("{}", encoding="utf-8")
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--commit-sha",
+        HEX40,
+        "--evidence",
+        f"unsupported_kind={evidence_path}",
+    )
+
+    assert result.returncode != 0
+    assert "unsupported evidence kind" in result.stderr
+    assert not out_path.exists()
+
+
+def test_missing_evidence_file_fails_closed(tmp_path: pathlib.Path) -> None:
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    missing = tmp_path / "missing_detector_report.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--commit-sha",
+        HEX40,
+        "--evidence",
+        f"detector_evidence={missing}",
+    )
+
+    assert result.returncode != 0
+    assert "candidate evidence file not found" in result.stderr
+    assert not out_path.exists()
+
+
+def test_pass_or_allow_are_never_emitted(tmp_path: pathlib.Path) -> None:
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--commit-sha",
+        HEX40,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    report = _load_json(out_path)
+    assert report["verifier_decision"] == "FAILED"
+    assert report["verifier_decision"] not in {"PASS", "ALLOW", "PROD-PASS"}


### PR DESCRIPTION
## Summary

This PR adds the first fail-closed release evidence verifier skeleton.

New tool:

- `PULSE_safe_pack_v0/tools/build_release_evidence_verifier_report_v0.py`

The builder emits `release_evidence_verifier_report_v0.json` reports with:

- `verifier_decision = FAILED`
- `verified_artifacts = []`
- `relation_bindings = []`
- `gate_materialization = {}`

Candidate evidence inputs may be recorded with digests and untrusted provenance, but they are not verified.

## Boundary

This PR does not implement the trusted verifier.

It does not emit `VERIFIED`.

It does not materialize gates.

It does not write `status.json`.

It does not reopen `--release-grade-materialized`.

It does not define release authority.

It does not replace `check_gates.py`.

PULSEmech release authority remains:

recorded release evidence → `status.json` → declared gate policy → workflow-effective materialized required gate set → strict fail-closed CI enforcement → pre-deployment allow/block release decision

## What changed

- Added fail-closed verifier report builder skeleton.
- Added tests for:
  - FAILED report creation
  - candidate evidence recording without verification
  - invalid evidence kind rejection
  - missing evidence rejection
  - PASS / ALLOW non-emission
- Registered the test in `ci/tools-tests.list`.
- Documented the builder skeleton in `docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md`.

## Non-goals

This PR does not change:

- release materialization behavior
- gate policy
- gate registry
- status schema
- `check_gates.py`
- CI allow/block behavior
- DOI/Zenodo artifacts
- release tags
- release artifacts

## Tests

- `pytest -q tests/test_build_release_evidence_verifier_report_v0.py`
- `pytest -q tests/test_check_release_evidence_verifier_report_v0.py`
- `pytest -q tests/test_release_evidence_verifier_report_schema_v0.py`
- `pytest -q tests/test_tools_tests_list_smoke.py`