### PR TITLE
feat(ref): wire input manifest into verifier skeleton

### DIFF
--- a/PULSE_safe_pack_v0/tools/build_release_evidence_verifier_report_v0.py
+++ b/PULSE_safe_pack_v0/tools/build_release_evidence_verifier_report_v0.py
@@ -29,6 +29,9 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from PULSE_safe_pack_v0.tools.check_release_evidence_input_manifest_v0 import (  # noqa: E402
+    check_release_evidence_input_manifest,
+)
 from PULSE_safe_pack_v0.tools.check_release_evidence_verifier_report_v0 import (  # noqa: E402
     check_release_evidence_verifier_report,
 )
@@ -72,7 +75,9 @@ def _git_sha() -> str | None:
     env_sha = os.getenv("GITHUB_SHA") or os.getenv("CI_COMMIT_SHA")
     if isinstance(env_sha, str) and env_sha.strip():
         candidate = env_sha.strip()
-        if len(candidate) == 40 and all(c in "0123456789abcdefABCDEF" for c in candidate):
+        if len(candidate) == 40 and all(
+            c in "0123456789abcdefABCDEF" for c in candidate
+        ):
             return candidate
 
     try:
@@ -128,6 +133,18 @@ def _load_json_schema_hint(path: pathlib.Path) -> str | None:
     return None
 
 
+def _load_json_object(path: pathlib.Path, *, label: str) -> dict[str, Any]:
+    try:
+        obj = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"{label} is not valid JSON: {exc}") from exc
+
+    if not isinstance(obj, dict):
+        raise ValueError(f"{label} must be a JSON object: {path}")
+
+    return obj
+
+
 def _parse_evidence_arg(raw: str) -> tuple[str, pathlib.Path, str]:
     if "=" not in raw:
         raise ValueError(
@@ -160,9 +177,19 @@ def _evidence_input(
     raw_path: str,
     git_sha: str | None,
     run_key: str | None,
+    provenance_extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     if not path.exists() or not path.is_file():
         raise FileNotFoundError(f"candidate evidence file not found: {path}")
+
+    provenance = {
+        "observed_by": VERIFIER_ID,
+        "trusted": False,
+        "verification_status": "not_verified",
+        "note": "candidate input recorded by fail-closed verifier skeleton",
+    }
+    if provenance_extra:
+        provenance.update(provenance_extra)
 
     return {
         "kind": kind,
@@ -173,13 +200,128 @@ def _evidence_input(
             "git_sha": git_sha,
             "run_key": run_key,
         },
-        "provenance": {
-            "observed_by": VERIFIER_ID,
-            "trusted": False,
-            "verification_status": "not_verified",
-            "note": "candidate input recorded by fail-closed verifier skeleton",
-        },
+        "provenance": provenance,
     }
+
+
+def _policy_binding_from_paths(policy_path: pathlib.Path) -> dict[str, Any]:
+    return {
+        "policy_path": _repo_relative_or_input(policy_path, str(policy_path)),
+        "policy_sha256": _sha256_file(policy_path) if policy_path.exists() else None,
+        "policy_set": "required+release_required",
+    }
+
+
+def _registry_binding_from_paths(registry_path: pathlib.Path) -> dict[str, Any]:
+    return {
+        "registry_path": _repo_relative_or_input(registry_path, str(registry_path)),
+        "registry_sha256": _sha256_file(registry_path) if registry_path.exists() else None,
+    }
+
+
+def _validate_and_load_input_manifest(path: pathlib.Path) -> dict[str, Any]:
+    errors = check_release_evidence_input_manifest(path)
+    if errors:
+        joined = "\n  - ".join(errors)
+        raise ValueError(
+            "release evidence input manifest failed validation:\n"
+            f"  - {joined}"
+        )
+
+    return _load_json_object(path, label="release evidence input manifest")
+
+
+def _candidate_path(raw_path: str, manifest_path: pathlib.Path) -> pathlib.Path:
+    candidate = pathlib.Path(raw_path)
+    if candidate.is_absolute():
+        return candidate.resolve()
+
+    repo_candidate = (REPO_ROOT / candidate).resolve()
+    if repo_candidate.exists():
+        return repo_candidate
+
+    return (manifest_path.parent / candidate).resolve()
+
+
+def _evidence_inputs_from_manifest(
+    *,
+    manifest: dict[str, Any],
+    manifest_path: pathlib.Path,
+    git_sha: str | None,
+    run_key: str | None,
+    failed_checks: list[str],
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    candidate_evidence = manifest.get("candidate_evidence")
+    if not isinstance(candidate_evidence, dict):
+        failed_checks.append("input manifest has no candidate_evidence object")
+        return []
+
+    out: list[dict[str, Any]] = []
+
+    for evidence_id, entry in sorted(candidate_evidence.items(), key=lambda item: str(item[0])):
+        if not isinstance(entry, dict):
+            failed_checks.append(f"candidate evidence entry is not an object: {evidence_id}")
+            continue
+
+        kind = entry.get("kind")
+        raw_path = entry.get("path")
+        expected_sha256 = entry.get("expected_sha256")
+
+        if not isinstance(kind, str) or kind not in VALID_EVIDENCE_KINDS:
+            failed_checks.append(f"candidate evidence has unsupported kind: {evidence_id}")
+            continue
+
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            failed_checks.append(f"candidate evidence path is missing: {evidence_id}")
+            continue
+
+        resolved_path = _candidate_path(raw_path.strip(), manifest_path)
+
+        if not resolved_path.exists() or not resolved_path.is_file():
+            failed_checks.append(
+                f"candidate evidence declared by manifest is missing: "
+                f"{evidence_id} -> {raw_path}"
+            )
+            continue
+
+        actual_sha256 = _sha256_file(resolved_path)
+        sha_matches = actual_sha256 == expected_sha256
+        if not sha_matches:
+            failed_checks.append(
+                f"candidate evidence digest mismatch: {evidence_id}"
+            )
+
+        try:
+            out.append(
+                _evidence_input(
+                    kind=kind,
+                    path=resolved_path,
+                    raw_path=raw_path.strip(),
+                    git_sha=git_sha,
+                    run_key=run_key,
+                    provenance_extra={
+                        "source_manifest": _repo_relative_or_input(
+                            manifest_path,
+                            str(manifest_path),
+                        ),
+                        "source_manifest_id": manifest.get("manifest_id"),
+                        "candidate_evidence_id": evidence_id,
+                        "expected_sha256": expected_sha256,
+                        "actual_sha256_matches_expected": sha_matches,
+                    },
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            failed_checks.append(f"candidate evidence could not be recorded: {evidence_id}: {exc}")
+
+    if out:
+        warnings.append(
+            "candidate evidence inputs were recorded from input manifest, "
+            "but verifier skeleton does not verify them"
+        )
+
+    return out
 
 
 def build_report(
@@ -191,32 +333,90 @@ def build_report(
     run_key: str | None,
     release_candidate: str | None,
     evidence_args: list[str],
+    input_manifest_path: pathlib.Path | None = None,
 ) -> dict[str, Any]:
     evidence_inputs: list[dict[str, Any]] = []
+    warnings: list[str] = []
 
-    for raw in evidence_args:
-        kind, evidence_path, raw_path = _parse_evidence_arg(raw)
-        evidence_inputs.append(
-            _evidence_input(
-                kind=kind,
-                path=evidence_path,
-                raw_path=raw_path,
-                git_sha=commit_sha,
-                run_key=run_key,
-            )
-        )
+    manifest: dict[str, Any] | None = None
+    if input_manifest_path is not None:
+        manifest = _validate_and_load_input_manifest(input_manifest_path)
+
+        manifest_run_identity = manifest.get("run_identity")
+        if isinstance(manifest_run_identity, dict):
+            commit_sha = commit_sha or manifest_run_identity.get("git_sha")
+            run_key = run_key or manifest_run_identity.get("run_key")
+
+        manifest_subject = manifest.get("subject")
+        if isinstance(manifest_subject, dict):
+            repository = repository or manifest_subject.get("repository")
+            release_candidate = release_candidate or manifest_subject.get("release_candidate")
+            commit_sha = commit_sha or manifest_subject.get("commit_sha")
 
     failed_checks = [
         "trusted release-evidence verifier skeleton does not verify evidence yet",
         "no verified relation bindings present",
         "no gate materialization performed",
     ]
+
+    if manifest is not None and input_manifest_path is not None:
+        evidence_inputs.extend(
+            _evidence_inputs_from_manifest(
+                manifest=manifest,
+                manifest_path=input_manifest_path,
+                git_sha=commit_sha,
+                run_key=run_key,
+                failed_checks=failed_checks,
+                warnings=warnings,
+            )
+        )
+        failed_checks.append(
+            "input manifest expectations are recorded only; verification is not implemented"
+        )
+        failed_checks.append(
+            "input manifest expected relation bindings are not verified by skeleton"
+        )
+        failed_checks.append(
+            "input manifest expected gate materialization bindings are not materialized by skeleton"
+        )
+    else:
+        for raw in evidence_args:
+            kind, evidence_path, raw_path = _parse_evidence_arg(raw)
+            evidence_inputs.append(
+                _evidence_input(
+                    kind=kind,
+                    path=evidence_path,
+                    raw_path=raw_path,
+                    git_sha=commit_sha,
+                    run_key=run_key,
+                )
+            )
+
     if not evidence_inputs:
         failed_checks.append("no candidate evidence inputs were supplied")
     else:
         failed_checks.append(
             "candidate evidence inputs are recorded only; verification is not implemented"
         )
+
+    policy_binding = _policy_binding_from_paths(policy_path)
+    registry_binding = _registry_binding_from_paths(registry_path)
+
+    if isinstance(manifest, dict):
+        manifest_policy = manifest.get("policy_binding")
+        if isinstance(manifest_policy, dict):
+            policy_binding = {
+                "policy_path": manifest_policy.get("policy_path"),
+                "policy_sha256": manifest_policy.get("policy_sha256"),
+                "policy_set": manifest_policy.get("policy_set"),
+            }
+
+        manifest_registry = manifest.get("registry_binding")
+        if isinstance(manifest_registry, dict):
+            registry_binding = {
+                "registry_path": manifest_registry.get("registry_path"),
+                "registry_sha256": manifest_registry.get("registry_sha256"),
+            }
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -234,21 +434,14 @@ def build_report(
             "commit_sha": commit_sha,
             "release_candidate": release_candidate,
         },
-        "policy_binding": {
-            "policy_path": _repo_relative_or_input(policy_path, str(policy_path)),
-            "policy_sha256": _sha256_file(policy_path) if policy_path.exists() else None,
-            "policy_set": "required+release_required",
-        },
-        "registry_binding": {
-            "registry_path": _repo_relative_or_input(registry_path, str(registry_path)),
-            "registry_sha256": _sha256_file(registry_path) if registry_path.exists() else None,
-        },
+        "policy_binding": policy_binding,
+        "registry_binding": registry_binding,
         "evidence_inputs": evidence_inputs,
         "verified_artifacts": [],
         "relation_bindings": [],
         "gate_materialization": {},
         "failed_checks": failed_checks,
-        "warnings": [],
+        "warnings": warnings,
     }
 
 
@@ -265,6 +458,14 @@ def main() -> int:
         "--out",
         default="PULSE_safe_pack_v0/artifacts/release_evidence_verifier_report_v0.json",
         help="Output path for release_evidence_verifier_report_v0.json.",
+    )
+    parser.add_argument(
+        "--input-manifest",
+        default=None,
+        help=(
+            "Optional release_evidence_input_manifest_v0 JSON file. "
+            "Manifest expectations are validated and recorded, but not verified."
+        ),
     )
     parser.add_argument(
         "--policy",
@@ -303,11 +504,27 @@ def main() -> int:
         metavar="KIND=PATH",
         help=(
             "Candidate evidence input to record without trusting it. "
-            "May be supplied multiple times."
+            "May be supplied multiple times. Cannot be combined with --input-manifest."
         ),
     )
 
     args = parser.parse_args()
+
+    if args.input_manifest and args.evidence:
+        print(
+            "ERROR: --input-manifest cannot be combined with --evidence; "
+            "use one candidate input source",
+            file=sys.stderr,
+        )
+        return 1
+
+    input_manifest_path: pathlib.Path | None = None
+    if args.input_manifest:
+        input_manifest_path = pathlib.Path(args.input_manifest)
+        if not input_manifest_path.is_absolute():
+            input_manifest_path = (REPO_ROOT / input_manifest_path).resolve()
+        else:
+            input_manifest_path = input_manifest_path.resolve()
 
     try:
         report = build_report(
@@ -322,6 +539,7 @@ def main() -> int:
             run_key=args.run_key,
             release_candidate=args.release_candidate,
             evidence_args=list(args.evidence or []),
+            input_manifest_path=input_manifest_path,
         )
     except Exception as exc:  # noqa: BLE001
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md
+++ b/docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md
@@ -566,3 +566,44 @@ The input manifest checker fails closed when:
 - expected gates reference missing relation bindings
 - any expected gate permits materialization without verifier output
 
+
+# Input manifest wiring in the fail-closed builder skeleton
+
+The fail-closed verifier report builder can consume an input manifest:
+
+```text
+python PULSE_safe_pack_v0/tools/build_release_evidence_verifier_report_v0.py \
+  --input-manifest examples/release_evidence_input_manifest_v0.minimal.example.json \
+  --out PULSE_safe_pack_v0/artifacts/release_evidence_verifier_report_v0.json
+```
+
+The builder validates the input manifest with:
+
+```text
+PULSE_safe_pack_v0/tools/check_release_evidence_input_manifest_v0.py
+```
+
+When the input manifest is valid, the builder may record candidate evidence inputs with digests and untrusted provenance.
+
+The builder still emits:
+
+```text
+verifier_decision = FAILED
+verified_artifacts = []
+relation_bindings = []
+gate_materialization = {}
+```
+
+The builder does not verify evidence.
+
+It does not satisfy relation bindings.
+
+It does not emit VERIFIED.
+
+It does not materialize gates.
+
+It does not write status.json.
+
+It does not reopen `--release-grade-materialized`.
+
+If the input manifest is invalid, the builder fails closed and does not write a verifier report.

--- a/tests/test_build_release_evidence_verifier_report_v0.py
+++ b/tests/test_build_release_evidence_verifier_report_v0.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import pathlib
@@ -17,12 +18,22 @@ TOOL = (
     / "tools"
     / "build_release_evidence_verifier_report_v0.py"
 )
+INPUT_MANIFEST_EXAMPLE = (
+    REPO_ROOT / "examples" / "release_evidence_input_manifest_v0.minimal.example.json"
+)
 
 HEX40 = "a" * 40
+HEX64 = "b" * 64
+RUN_KEY = "GITHUB_RUN_ID=1|GITHUB_RUN_NUMBER=1|GITHUB_WORKFLOW=PULSE CI"
 
 
 def _load_json(path: pathlib.Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
 
 def _run_tool(*args: str) -> subprocess.CompletedProcess[str]:
@@ -39,6 +50,32 @@ def _run_tool(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _input_manifest(
+    *,
+    evidence_path: pathlib.Path,
+    expected_sha256: str,
+) -> dict[str, Any]:
+    manifest = copy.deepcopy(_load_json(INPUT_MANIFEST_EXAMPLE))
+    manifest["run_identity"]["git_sha"] = HEX40
+    manifest["run_identity"]["run_key"] = RUN_KEY
+    manifest["subject"]["repository"] = "HKati/pulse-release-gates-0.1"
+    manifest["subject"]["commit_sha"] = HEX40
+    manifest["subject"]["release_candidate"] = "candidate-v0"
+    manifest["policy_binding"]["policy_sha256"] = HEX64
+    manifest["registry_binding"]["registry_sha256"] = HEX64
+    manifest["candidate_evidence"]["detector_report"]["path"] = str(evidence_path)
+    manifest["candidate_evidence"]["detector_report"]["expected_sha256"] = (
+        expected_sha256
+    )
+    manifest["candidate_evidence"]["detector_report"]["subject_binding"]["git_sha"] = (
+        HEX40
+    )
+    manifest["candidate_evidence"]["detector_report"]["subject_binding"]["run_key"] = (
+        RUN_KEY
+    )
+    return manifest
+
+
 def test_build_failed_report_without_inputs(tmp_path: pathlib.Path) -> None:
     out_path = tmp_path / "release_evidence_verifier_report_v0.json"
 
@@ -50,7 +87,7 @@ def test_build_failed_report_without_inputs(tmp_path: pathlib.Path) -> None:
         "--commit-sha",
         HEX40,
         "--run-key",
-        "GITHUB_RUN_ID=1|GITHUB_RUN_NUMBER=1|GITHUB_WORKFLOW=PULSE CI",
+        RUN_KEY,
         "--release-candidate",
         "candidate-v0",
     )
@@ -85,7 +122,7 @@ def test_candidate_evidence_is_recorded_but_not_verified(tmp_path: pathlib.Path)
         "--commit-sha",
         HEX40,
         "--run-key",
-        "GITHUB_RUN_ID=1|GITHUB_RUN_NUMBER=1|GITHUB_WORKFLOW=PULSE CI",
+        RUN_KEY,
         "--release-candidate",
         "candidate-v0",
         "--evidence",
@@ -109,6 +146,201 @@ def test_candidate_evidence_is_recorded_but_not_verified(tmp_path: pathlib.Path)
     assert evidence_input["schema_version"] == "detector_report_v0"
     assert evidence_input["provenance"]["trusted"] is False
     assert evidence_input["provenance"]["verification_status"] == "not_verified"
+
+
+def test_input_manifest_records_existing_candidate_without_verifying(
+    tmp_path: pathlib.Path,
+) -> None:
+    evidence_path = tmp_path / "detector_report.json"
+    evidence_payload = {
+        "schema_version": "detector_report_v0",
+        "result": "candidate-only",
+    }
+    evidence_path.write_text(json.dumps(evidence_payload), encoding="utf-8")
+    evidence_sha256 = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+
+    manifest_path = tmp_path / "release_evidence_input_manifest_v0.json"
+    _write_json(
+        manifest_path,
+        _input_manifest(
+            evidence_path=evidence_path,
+            expected_sha256=evidence_sha256,
+        ),
+    )
+
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--input-manifest",
+        str(manifest_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    report = _load_json(out_path)
+    assert report["verifier_decision"] == "FAILED"
+    assert report["verified_artifacts"] == []
+    assert report["relation_bindings"] == []
+    assert report["gate_materialization"] == {}
+
+    assert len(report["evidence_inputs"]) == 1
+    evidence_input = report["evidence_inputs"][0]
+    assert evidence_input["kind"] == "detector_evidence"
+    assert evidence_input["sha256"] == evidence_sha256
+    assert evidence_input["schema_version"] == "detector_report_v0"
+    assert evidence_input["provenance"]["trusted"] is False
+    assert evidence_input["provenance"]["verification_status"] == "not_verified"
+    assert evidence_input["provenance"]["candidate_evidence_id"] == "detector_report"
+    assert evidence_input["provenance"]["expected_sha256"] == evidence_sha256
+    assert evidence_input["provenance"]["actual_sha256_matches_expected"] is True
+    assert any(
+        "input manifest expectations are recorded only" in item
+        for item in report["failed_checks"]
+    )
+
+
+def test_input_manifest_digest_mismatch_records_failed_report(
+    tmp_path: pathlib.Path,
+) -> None:
+    evidence_path = tmp_path / "detector_report.json"
+    evidence_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "detector_report_v0",
+                "result": "candidate-only",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manifest_path = tmp_path / "release_evidence_input_manifest_v0.json"
+    _write_json(
+        manifest_path,
+        _input_manifest(
+            evidence_path=evidence_path,
+            expected_sha256=HEX64,
+        ),
+    )
+
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--input-manifest",
+        str(manifest_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    report = _load_json(out_path)
+    assert report["verifier_decision"] == "FAILED"
+    assert any(
+        "candidate evidence digest mismatch: detector_report" in item
+        for item in report["failed_checks"]
+    )
+    assert report["evidence_inputs"][0]["provenance"][
+        "actual_sha256_matches_expected"
+    ] is False
+
+
+def test_input_manifest_missing_candidate_writes_failed_report(
+    tmp_path: pathlib.Path,
+) -> None:
+    missing_evidence = tmp_path / "missing_detector_report.json"
+
+    manifest_path = tmp_path / "release_evidence_input_manifest_v0.json"
+    _write_json(
+        manifest_path,
+        _input_manifest(
+            evidence_path=missing_evidence,
+            expected_sha256=HEX64,
+        ),
+    )
+
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--input-manifest",
+        str(manifest_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    report = _load_json(out_path)
+    assert report["verifier_decision"] == "FAILED"
+    assert report["evidence_inputs"] == []
+    assert any(
+        "candidate evidence declared by manifest is missing" in item
+        for item in report["failed_checks"]
+    )
+
+
+def test_invalid_input_manifest_fails_closed_without_report(
+    tmp_path: pathlib.Path,
+) -> None:
+    evidence_path = tmp_path / "detector_report.json"
+    evidence_path.write_text("{}", encoding="utf-8")
+
+    manifest = _input_manifest(
+        evidence_path=evidence_path,
+        expected_sha256=HEX64,
+    )
+    manifest["expected_gate_materialization"][
+        "detectors_materialized_ok"
+    ]["materialization_allowed_without_verifier"] = True
+
+    manifest_path = tmp_path / "release_evidence_input_manifest_v0.json"
+    _write_json(manifest_path, manifest)
+
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--input-manifest",
+        str(manifest_path),
+    )
+
+    assert result.returncode != 0
+    assert "release evidence input manifest failed validation" in result.stderr
+    assert not out_path.exists()
+
+
+def test_input_manifest_cannot_be_combined_with_direct_evidence(
+    tmp_path: pathlib.Path,
+) -> None:
+    evidence_path = tmp_path / "detector_report.json"
+    evidence_path.write_text("{}", encoding="utf-8")
+    evidence_sha256 = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+
+    manifest_path = tmp_path / "release_evidence_input_manifest_v0.json"
+    _write_json(
+        manifest_path,
+        _input_manifest(
+            evidence_path=evidence_path,
+            expected_sha256=evidence_sha256,
+        ),
+    )
+
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--input-manifest",
+        str(manifest_path),
+        "--evidence",
+        f"detector_evidence={evidence_path}",
+    )
+
+    assert result.returncode != 0
+    assert "--input-manifest cannot be combined with --evidence" in result.stderr
+    assert not out_path.exists()
 
 
 def test_invalid_evidence_kind_fails_closed(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
## Summary

This PR wires `release_evidence_input_manifest_v0` into the fail-closed release evidence verifier report builder.

The builder can now consume a validated input manifest and record candidate evidence inputs with digests and untrusted provenance.

## Boundary

This PR does not implement the trusted verifier.

It does not emit `VERIFIED`.

It does not satisfy relation bindings.

It does not materialize gates.

It does not write `status.json`.

It does not reopen `--release-grade-materialized`.

It does not define release authority.

It does not replace `check_gates.py`.

PULSEmech release authority remains:

recorded release evidence → `status.json` → declared gate policy → workflow-effective materialized required gate set → strict fail-closed CI enforcement → pre-deployment allow/block release decision

## What changed

- Added `--input-manifest` to `build_release_evidence_verifier_report_v0.py`.
- The builder validates the input manifest through `check_release_evidence_input_manifest_v0.py`.
- Existing candidate evidence files declared by the manifest are recorded with actual SHA-256 digests and untrusted provenance.
- Digest mismatches remain FAILED report state.
- Missing candidate evidence remains FAILED report state.
- Invalid input manifests fail closed without writing a report.
- `--input-manifest` cannot be combined with direct `--evidence` inputs.
- Added tests for input manifest wiring.
- Documented the input manifest builder path.

## Non-goals

This PR does not change:

- release materialization behavior
- gate policy
- gate registry
- status schema
- `check_gates.py`
- CI allow/block behavior
- DOI/Zenodo artifacts
- release tags
- release artifacts

## Tests

- `pytest -q tests/test_build_release_evidence_verifier_report_v0.py`
- `pytest -q tests/test_release_evidence_input_manifest_v0.py`
- `pytest -q tests/test_check_release_evidence_verifier_report_v0.py`
- `pytest -q tests/test_release_evidence_verifier_report_schema_v0.py`
- `pytest -q tests/test_tools_tests_list_smoke.py`