### PR TITLE
feat(ref): add verifier expectation comparison v0

### DIFF
--- a/PULSE_safe_pack_v0/tools/build_release_evidence_verifier_report_v0.py
+++ b/PULSE_safe_pack_v0/tools/build_release_evidence_verifier_report_v0.py
@@ -288,9 +288,7 @@ def _evidence_inputs_from_manifest(
         actual_sha256 = _sha256_file(resolved_path)
         sha_matches = actual_sha256 == expected_sha256
         if not sha_matches:
-            failed_checks.append(
-                f"candidate evidence digest mismatch: {evidence_id}"
-            )
+            failed_checks.append(f"candidate evidence digest mismatch: {evidence_id}")
 
         try:
             out.append(
@@ -313,7 +311,9 @@ def _evidence_inputs_from_manifest(
                 )
             )
         except Exception as exc:  # noqa: BLE001
-            failed_checks.append(f"candidate evidence could not be recorded: {evidence_id}: {exc}")
+            failed_checks.append(
+                f"candidate evidence could not be recorded: {evidence_id}: {exc}"
+            )
 
     if out:
         warnings.append(
@@ -322,6 +322,107 @@ def _evidence_inputs_from_manifest(
         )
 
     return out
+
+
+def _record_manifest_expectation_comparison(
+    *,
+    manifest: dict[str, Any],
+    recorded_evidence_inputs: list[dict[str, Any]],
+    failed_checks: list[str],
+    warnings: list[str],
+) -> None:
+    """Record explicit pending expectation state from an input manifest.
+
+    This does not verify evidence.
+    This does not satisfy relations.
+    This does not materialize gates.
+
+    It only makes the pre-materialization gap visible in the FAILED report.
+    """
+    candidate_evidence = manifest.get("candidate_evidence")
+    expected_relations = manifest.get("expected_relation_bindings")
+    expected_gates = manifest.get("expected_gate_materialization")
+
+    candidate_map = candidate_evidence if isinstance(candidate_evidence, dict) else {}
+    relation_map = expected_relations if isinstance(expected_relations, dict) else {}
+    gate_map = expected_gates if isinstance(expected_gates, dict) else {}
+
+    recorded_candidate_ids = {
+        provenance.get("candidate_evidence_id")
+        for item in recorded_evidence_inputs
+        if isinstance(item, dict)
+        for provenance in [item.get("provenance")]
+        if isinstance(provenance, dict)
+    }
+
+    warnings.append(
+        "input manifest expectation comparison is fail-closed and descriptive only"
+    )
+    warnings.append(
+        "input manifest declares "
+        f"{len(candidate_map)} candidate evidence item(s), "
+        f"{len(relation_map)} expected relation binding(s), and "
+        f"{len(gate_map)} expected gate materialization item(s)"
+    )
+
+    for evidence_id in sorted(candidate_map.keys(), key=str):
+        if evidence_id not in recorded_candidate_ids:
+            failed_checks.append(
+                f"expected candidate evidence not recorded: {evidence_id}"
+            )
+        else:
+            failed_checks.append(
+                f"expected candidate evidence recorded but not verified: {evidence_id}"
+            )
+
+    for relation_id, relation in sorted(relation_map.items(), key=lambda item: str(item[0])):
+        failed_checks.append(
+            f"expected relation binding pending verification: {relation_id}"
+        )
+
+        if not isinstance(relation, dict):
+            continue
+
+        source_evidence_id = relation.get("source_evidence_id")
+        if source_evidence_id not in candidate_map:
+            failed_checks.append(
+                f"expected relation binding references missing candidate evidence: "
+                f"{relation_id} -> {source_evidence_id}"
+            )
+
+        expected_gate_id = relation.get("expected_gate_id")
+        if expected_gate_id is not None and expected_gate_id not in gate_map:
+            failed_checks.append(
+                f"expected relation binding references missing expected gate: "
+                f"{relation_id} -> {expected_gate_id}"
+            )
+
+    for gate_id, gate in sorted(gate_map.items(), key=lambda item: str(item[0])):
+        failed_checks.append(
+            f"expected gate materialization pending verification: {gate_id}"
+        )
+
+        if not isinstance(gate, dict):
+            continue
+
+        for evidence_id in gate.get("candidate_evidence_ids", []):
+            if evidence_id not in candidate_map:
+                failed_checks.append(
+                    f"expected gate materialization references missing candidate "
+                    f"evidence: {gate_id} -> {evidence_id}"
+                )
+            elif evidence_id not in recorded_candidate_ids:
+                failed_checks.append(
+                    f"expected gate materialization candidate evidence not recorded: "
+                    f"{gate_id} -> {evidence_id}"
+                )
+
+        for relation_id in gate.get("relation_binding_ids", []):
+            if relation_id not in relation_map:
+                failed_checks.append(
+                    f"expected gate materialization references missing expected "
+                    f"relation: {gate_id} -> {relation_id}"
+                )
 
 
 def build_report(
@@ -350,7 +451,9 @@ def build_report(
         manifest_subject = manifest.get("subject")
         if isinstance(manifest_subject, dict):
             repository = repository or manifest_subject.get("repository")
-            release_candidate = release_candidate or manifest_subject.get("release_candidate")
+            release_candidate = release_candidate or manifest_subject.get(
+                "release_candidate"
+            )
             commit_sha = commit_sha or manifest_subject.get("commit_sha")
 
     failed_checks = [
@@ -369,6 +472,12 @@ def build_report(
                 failed_checks=failed_checks,
                 warnings=warnings,
             )
+        )
+        _record_manifest_expectation_comparison(
+            manifest=manifest,
+            recorded_evidence_inputs=evidence_inputs,
+            failed_checks=failed_checks,
+            warnings=warnings,
         )
         failed_checks.append(
             "input manifest expectations are recorded only; verification is not implemented"
@@ -393,7 +502,10 @@ def build_report(
             )
 
     if not evidence_inputs:
-        failed_checks.append("no candidate evidence inputs were supplied")
+        if manifest is None and not evidence_args:
+            failed_checks.append("no candidate evidence inputs were supplied")
+        else:
+            failed_checks.append("no candidate evidence inputs were recorded")
     else:
         failed_checks.append(
             "candidate evidence inputs are recorded only; verification is not implemented"
@@ -447,7 +559,10 @@ def build_report(
 
 def write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 
 
 def main() -> int:

--- a/docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md
+++ b/docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md
@@ -607,3 +607,32 @@ It does not write status.json.
 It does not reopen `--release-grade-materialized`.
 
 If the input manifest is invalid, the builder fails closed and does not write a verifier report.
+
+
+## Input manifest expectation comparison
+
+When the fail-closed builder consumes an input manifest, it records the manifest expectations as pending verifier work.
+
+The builder compares the input manifest’s declared expectations against the fail-closed report state and records descriptive failed checks for:
+
+- expected candidate evidence that was not recorded
+- expected candidate evidence that was recorded but not verified
+- expected relation bindings that remain pending verification
+- expected gate materialization entries that remain pending verification
+- expected gate materialization candidate evidence that was not recorded
+
+This comparison is pre-materialization diagnostics only.
+
+It does not verify evidence.
+
+It does not satisfy relation bindings.
+
+It does not emit `VERIFIED`.
+
+It does not materialize gates.
+
+It does not write `status.json`.
+
+It does not reopen `--release-grade-materialized`.
+
+Its purpose is to make the pre-materialization gap visible inside the fail-closed verifier report.

--- a/tests/test_build_release_evidence_verifier_report_v0.py
+++ b/tests/test_build_release_evidence_verifier_report_v0.py
@@ -33,7 +33,10 @@ def _load_json(path: pathlib.Path) -> dict[str, Any]:
 
 def _write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
 
 
 def _run_tool(*args: str) -> subprocess.CompletedProcess[str]:
@@ -102,10 +105,15 @@ def test_build_failed_report_without_inputs(tmp_path: pathlib.Path) -> None:
     assert report["relation_bindings"] == []
     assert report["gate_materialization"] == {}
     assert any("does not verify evidence yet" in item for item in report["failed_checks"])
-    assert any("no verified relation bindings present" in item for item in report["failed_checks"])
+    assert any(
+        "no verified relation bindings present" in item
+        for item in report["failed_checks"]
+    )
 
 
-def test_candidate_evidence_is_recorded_but_not_verified(tmp_path: pathlib.Path) -> None:
+def test_candidate_evidence_is_recorded_but_not_verified(
+    tmp_path: pathlib.Path,
+) -> None:
     evidence_path = tmp_path / "detector_report.json"
     evidence_payload = {
         "schema_version": "detector_report_v0",
@@ -195,9 +203,30 @@ def test_input_manifest_records_existing_candidate_without_verifying(
     assert evidence_input["provenance"]["candidate_evidence_id"] == "detector_report"
     assert evidence_input["provenance"]["expected_sha256"] == evidence_sha256
     assert evidence_input["provenance"]["actual_sha256_matches_expected"] is True
+
     assert any(
         "input manifest expectations are recorded only" in item
         for item in report["failed_checks"]
+    )
+    assert any(
+        "expected candidate evidence recorded but not verified: detector_report"
+        in item
+        for item in report["failed_checks"]
+    )
+    assert any(
+        "expected relation binding pending verification: detector_report_to_subject_commit"
+        in item
+        for item in report["failed_checks"]
+    )
+    assert any(
+        "expected gate materialization pending verification: detectors_materialized_ok"
+        in item
+        for item in report["failed_checks"]
+    )
+    assert any(
+        "input manifest expectation comparison is fail-closed and descriptive only"
+        in item
+        for item in report["warnings"]
     )
 
 
@@ -276,6 +305,15 @@ def test_input_manifest_missing_candidate_writes_failed_report(
     assert report["evidence_inputs"] == []
     assert any(
         "candidate evidence declared by manifest is missing" in item
+        for item in report["failed_checks"]
+    )
+    assert any(
+        "expected candidate evidence not recorded: detector_report" in item
+        for item in report["failed_checks"]
+    )
+    assert any(
+        "expected gate materialization candidate evidence not recorded: "
+        "detectors_materialized_ok -> detector_report" in item
         for item in report["failed_checks"]
     )
 


### PR DESCRIPTION
## Summary

This PR adds input-manifest expectation comparison to the fail-closed release evidence verifier report builder.

When the builder consumes a `release_evidence_input_manifest_v0` file, it now records descriptive failed checks for expected candidate evidence, expected relation bindings, and expected gate materialization entries that remain pending or unsatisfied.

## Why

The input manifest declares what the future verifier is expected to check.

The builder still does not verify those expectations, but it can now make the pre-materialization gap visible inside the FAILED verifier report.

## Boundary

This PR does not implement the trusted verifier.

It does not emit `VERIFIED`.

It does not satisfy relation bindings.

It does not materialize gates.

It does not write `status.json`.

It does not reopen `--release-grade-materialized`.

It does not define release authority.

It does not replace `check_gates.py`.

PULSEmech release authority remains:

recorded release evidence → `status.json` → declared gate policy → workflow-effective materialized required gate set → strict fail-closed CI enforcement → pre-deployment allow/block release decision

## What changed

- The builder records expected candidate evidence as pending or recorded-but-not-verified.
- The builder records expected relation bindings as pending verification.
- The builder records expected gate materialization as pending verification.
- Missing candidate evidence remains FAILED report state.
- Digest mismatch remains FAILED report state.
- Added tests for expectation comparison outputs.
- Documented the expectation comparison behavior.

## Non-goals

This PR does not change:

- release materialization behavior
- gate policy
- gate registry
- status schema
- `check_gates.py`
- CI allow/block behavior
- DOI/Zenodo artifacts
- release tags
- release artifacts

## Tests

- `pytest -q tests/test_build_release_evidence_verifier_report_v0.py`
- `pytest -q tests/test_release_evidence_input_manifest_v0.py`
- `pytest -q tests/test_check_release_evidence_verifier_report_v0.py`
- `pytest -q tests/test_release_evidence_verifier_report_schema_v0.py`
- `pytest -q tests/test_tools_tests_list_smoke.py`