### PR TITLE
feat(ref): add release evidence expectation summary v0

### DIFF
--- a/PULSE_safe_pack_v0/tools/build_release_evidence_expectation_summary_v0.py
+++ b/PULSE_safe_pack_v0/tools/build_release_evidence_expectation_summary_v0.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Build a reader-only release evidence expectation summary v0.
+
+This tool summarizes a release_evidence_verifier_report_v0 artifact.
+
+It does not verify evidence.
+It does not satisfy relation bindings.
+It does not materialize gates.
+It does not write status.json.
+It does not reopen --release-grade-materialized.
+It does not replace check_gates.py.
+
+It is a pre-materialization reader/diagnostic surface only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import pathlib
+import sys
+from typing import Any
+
+try:
+    import jsonschema
+except Exception:  # pragma: no cover
+    jsonschema = None
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from PULSE_safe_pack_v0.tools.check_release_evidence_verifier_report_v0 import (  # noqa: E402
+    check_release_evidence_verifier_report,
+)
+
+
+SCHEMA_VERSION = "release_evidence_expectation_summary_v0"
+SUMMARY_ID = "pulse_release_evidence_expectation_summary_v0"
+SUMMARY_VERSION = "0.1.0"
+DEFAULT_SCHEMA_PATH = (
+    REPO_ROOT / "schemas" / "release_evidence_expectation_summary_v0.schema.json"
+)
+
+
+def _utc_now() -> str:
+    return datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def _sha256_file(path: pathlib.Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _repo_relative_or_input(path: pathlib.Path, raw: str) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return raw
+
+
+def _load_json_object(path: pathlib.Path, *, label: str) -> dict[str, Any]:
+    try:
+        obj = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"{label} is not valid JSON: {exc}") from exc
+
+    if not isinstance(obj, dict):
+        raise ValueError(f"{label} must be a JSON object: {path}")
+
+    return obj
+
+
+def _validate_summary(summary: dict[str, Any], *, schema_path: pathlib.Path) -> list[str]:
+    errors: list[str] = []
+
+    if jsonschema is None:
+        return [
+            "jsonschema is required for "
+            "release_evidence_expectation_summary_v0 schema validation; "
+            "partial fallback validation is not allowed"
+        ]
+
+    try:
+        schema = _load_json_object(schema_path, label="release evidence expectation summary schema")
+        jsonschema.Draft202012Validator.check_schema(schema)
+        validator = jsonschema.Draft202012Validator(schema)
+        for error in sorted(validator.iter_errors(summary), key=lambda item: list(item.path)):
+            path = ".".join(str(part) for part in error.path) or "<root>"
+            errors.append(f"schema validation error at {path}: {error.message}")
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"release evidence expectation summary schema validation failed: {exc}")
+
+    return errors
+
+
+def _gap_id_from_message(prefix: str, message: str) -> str | None:
+    if not message.startswith(prefix):
+        return None
+
+    suffix = message[len(prefix):].strip()
+    if not suffix:
+        return None
+
+    if " -> " in suffix:
+        return suffix.split(" -> ", 1)[0].strip() or None
+
+    return suffix
+
+
+def _classify_failed_check(message: str) -> dict[str, Any]:
+    classifiers = [
+        (
+            "expected candidate evidence recorded but not verified: ",
+            "candidate_evidence_not_verified",
+        ),
+        (
+            "expected candidate evidence not recorded: ",
+            "missing_candidate_evidence",
+        ),
+        (
+            "candidate evidence declared by manifest is missing: ",
+            "missing_candidate_evidence",
+        ),
+        (
+            "candidate evidence digest mismatch: ",
+            "digest_mismatch",
+        ),
+        (
+            "expected relation binding pending verification: ",
+            "pending_relation_binding",
+        ),
+        (
+            "expected gate materialization pending verification: ",
+            "pending_gate_materialization",
+        ),
+        (
+            "expected gate materialization candidate evidence not recorded: ",
+            "missing_gate_candidate_evidence",
+        ),
+        (
+            "no candidate evidence inputs were supplied",
+            "no_candidate_evidence",
+        ),
+        (
+            "no verified relation bindings present",
+            "no_verified_relation_bindings",
+        ),
+        (
+            "no gate materialization performed",
+            "no_gate_materialization",
+        )
+    ]
+
+    for prefix, kind in classifiers:
+        if message == prefix or message.startswith(prefix):
+            return {
+                "kind": kind,
+                "id": _gap_id_from_message(prefix, message),
+                "message": message,
+            }
+
+    return {
+        "kind": "other_failed_check",
+        "id": None,
+        "message": message,
+    }
+
+
+def build_summary(
+    *,
+    report_path: pathlib.Path,
+) -> dict[str, Any]:
+    checker_errors = check_release_evidence_verifier_report(report_path)
+    if checker_errors:
+        joined = "\n  - ".join(checker_errors)
+        raise ValueError(
+            "release evidence verifier report failed validation:\n"
+            f"  - {joined}"
+        )
+
+    report = _load_json_object(report_path, label="release evidence verifier report")
+
+    failed_checks = [
+        str(item)
+        for item in report.get("failed_checks", [])
+        if isinstance(item, str) and item.strip()
+    ]
+    warnings = [
+        str(item)
+        for item in report.get("warnings", [])
+        if isinstance(item, str) and item.strip()
+    ]
+
+    gaps = [_classify_failed_check(message) for message in failed_checks]
+
+    counts = {
+        "candidate_evidence_not_verified_count": sum(
+            1 for gap in gaps if gap["kind"] == "candidate_evidence_not_verified"
+        ),
+        "missing_candidate_evidence_count": sum(
+            1 for gap in gaps if gap["kind"] == "missing_candidate_evidence"
+        ),
+        "digest_mismatch_count": sum(
+            1 for gap in gaps if gap["kind"] == "digest_mismatch"
+        ),
+        "pending_relation_binding_count": sum(
+            1 for gap in gaps if gap["kind"] == "pending_relation_binding"
+        ),
+        "pending_gate_materialization_count": sum(
+            1 for gap in gaps if gap["kind"] == "pending_gate_materialization"
+        ),
+        "other_failed_check_count": sum(
+            1 for gap in gaps if gap["kind"] == "other_failed_check"
+        ),
+    }
+
+    decision = report.get("verifier_decision")
+    readiness = (
+        "REPORT_VERIFIED_NON_AUTHORITY"
+        if decision == "VERIFIED" and not gaps
+        else "NOT_READY"
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "created_utc": _utc_now(),
+        "summary_id": SUMMARY_ID,
+        "summary_version": SUMMARY_VERSION,
+        "source_report": {
+            "path": _repo_relative_or_input(report_path, str(report_path)),
+            "sha256": _sha256_file(report_path),
+            "verifier_decision": decision,
+        },
+        "summary": {
+            "verifier_readiness": readiness,
+            "evidence_inputs_total": len(report.get("evidence_inputs", []))
+            if isinstance(report.get("evidence_inputs"), list)
+            else 0,
+            "verified_artifacts_total": len(report.get("verified_artifacts", []))
+            if isinstance(report.get("verified_artifacts"), list)
+            else 0,
+            "relation_bindings_total": len(report.get("relation_bindings", []))
+            if isinstance(report.get("relation_bindings"), list)
+            else 0,
+            "gate_materialization_total": len(report.get("gate_materialization", {}))
+            if isinstance(report.get("gate_materialization"), dict)
+            else 0,
+            "failed_checks_total": len(failed_checks),
+            "warnings_total": len(warnings),
+            **counts,
+        },
+        "pre_materialization_gaps": gaps,
+        "warnings": warnings,
+        "authority_boundary": {
+            "is_release_authority": False,
+            "materializes_gates": False,
+            "writes_status_json": False,
+            "reopens_release_grade_materialization": False,
+            "replaces_check_gates": False,
+        },
+    }
+
+
+def write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build release_evidence_expectation_summary_v0 from a verifier report."
+    )
+    parser.add_argument(
+        "--report",
+        required=True,
+        help="Path to release_evidence_verifier_report_v0.json.",
+    )
+    parser.add_argument(
+        "--out",
+        default="PULSE_safe_pack_v0/artifacts/release_evidence_expectation_summary_v0.json",
+        help="Output path for release_evidence_expectation_summary_v0.json.",
+    )
+    parser.add_argument(
+        "--schema",
+        default=str(DEFAULT_SCHEMA_PATH),
+        help="Path to release_evidence_expectation_summary_v0 JSON schema.",
+    )
+
+    args = parser.parse_args()
+
+    report_path = pathlib.Path(args.report)
+    if not report_path.is_absolute():
+        report_path = (REPO_ROOT / report_path).resolve()
+    else:
+        report_path = report_path.resolve()
+
+    out_path = pathlib.Path(args.out)
+    if not out_path.is_absolute():
+        out_path = (REPO_ROOT / out_path).resolve()
+    else:
+        out_path = out_path.resolve()
+
+    schema_path = pathlib.Path(args.schema)
+    if not schema_path.is_absolute():
+        schema_path = (REPO_ROOT / schema_path).resolve()
+    else:
+        schema_path = schema_path.resolve()
+
+    try:
+        summary = build_summary(report_path=report_path)
+        validation_errors = _validate_summary(summary, schema_path=schema_path)
+        if validation_errors:
+            joined = "\n  - ".join(validation_errors)
+            raise ValueError(
+                "release evidence expectation summary failed validation:\n"
+                f"  - {joined}"
+            )
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    write_json(out_path, summary)
+    print(f"OK: wrote release evidence expectation summary: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -24,6 +24,7 @@ tests/test_build_space_relation_map_summary_tool.py
 tests/test_build_recognition_surface_drift_v0.py
 tests/test_build_hpc_evidence_bundle_v0.py
 tests/test_build_release_evidence_verifier_report_v0.py
+tests/test_build_release_evidence_expectation_summary_v0.py
 tests/test_no_legacy_status_schema_refs_smoke.py
 tests/test_pack_tools_compile.py
 tests/test_paradox_diagram_example_v0_smoke.py

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -102,3 +102,7 @@ f there is already a suitable section such as `Release evidence verification`, `
 
 - [PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md](PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md) — Informational reference note for pre-materialization gate mechanics and relation-binding pre-state hooks.
 
+
+## Release evidence expectation summary
+
+- [PULSE_RELEASE_EVIDENCE_EXPECTATION_SUMMARY_v0.md](PULSE_RELEASE_EVIDENCE_EXPECTATION_SUMMARY_v0.md) — Reader-only diagnostic summary for pre-materialization evidence, relation, and gate-materialization gaps.

--- a/docs/PULSE_RELEASE_EVIDENCE_EXPECTATION_SUMMARY_v0.md
+++ b/docs/PULSE_RELEASE_EVIDENCE_EXPECTATION_SUMMARY_v0.md
@@ -1,0 +1,150 @@
+# PULSE Release Evidence Expectation Summary v0
+
+## Status
+
+Reader / diagnostic summary surface.
+
+This document describes the release evidence expectation summary artifact.
+
+It is not release authority.
+
+It does not verify evidence.
+
+It does not satisfy relation bindings.
+
+It does not materialize gates.
+
+It does not write `status.json`.
+
+It does not reopen `--release-grade-materialized`.
+
+It does not replace `check_gates.py`.
+
+## Purpose
+
+The release evidence expectation summary makes the pre-materialization gap visible.
+
+It reads a valid `release_evidence_verifier_report_v0.json` artifact and summarizes which expected evidence, relation, and gate-materialization states remain pending, missing, mismatched, or unverified.
+
+The summary is a reader surface over the fail-closed verifier report.
+
+It does not create release permission.
+
+## Tool
+
+The builder is:
+
+```text
+PULSE_safe_pack_v0/tools/build_release_evidence_expectation_summary_v0.py
+```
+
+Example command:
+
+```bash
+python PULSE_safe_pack_v0/tools/build_release_evidence_expectation_summary_v0.py \
+  --report PULSE_safe_pack_v0/artifacts/release_evidence_verifier_report_v0.json \
+  --out PULSE_safe_pack_v0/artifacts/release_evidence_expectation_summary_v0.json
+```
+
+## Schema
+
+The schema is:
+
+```text
+schemas/release_evidence_expectation_summary_v0.schema.json
+```
+
+Example:
+
+```text
+examples/release_evidence_expectation_summary_v0.failed.example.json
+```
+
+## Output
+
+The summary records:
+
+- source verifier report path
+- source verifier report SHA-256 digest
+- source verifier decision
+- evidence input count
+- verified artifact count
+- relation binding count
+- gate materialization count
+- failed check count
+- warning count
+- classified pre-materialization gaps
+- authority boundary flags
+
+## Readiness State
+
+The summary uses:
+
+```text
+NOT_READY
+REPORT_VERIFIED_NON_AUTHORITY
+```
+
+`NOT_READY` means the source verifier report still has failed checks or is not verified.
+
+`REPORT_VERIFIED_NON_AUTHORITY` means the source verifier report is verified, but the summary remains non-authoritative.
+
+The summary does not produce PASS, ALLOW, or release permission.
+
+## Pre-materialization Gap Classes
+
+The summary classifies failed checks into gap kinds such as:
+
+- `candidate_evidence_not_verified`
+- `missing_candidate_evidence`
+- `digest_mismatch`
+- `pending_relation_binding`
+- `pending_gate_materialization`
+- `missing_gate_candidate_evidence`
+- `no_candidate_evidence`
+- `no_verified_relation_bindings`
+- `no_gate_materialization`
+- `other_failed_check`
+
+These are descriptive diagnostic classes.
+
+They do not materialize gates.
+
+## Authority Boundary
+
+The artifact records an explicit authority boundary:
+
+```text
+is_release_authority = false
+materializes_gates = false
+writes_status_json = false
+reopens_release_grade_materialization = false
+replaces_check_gates = false
+```
+
+## Relation to PULSEmech
+
+PULSEmech release authority remains:
+
+```text
+recorded release evidence
+→ status.json
+→ declared gate policy
+→ workflow-effective materialized required gate set
+→ strict fail-closed CI enforcement
+→ pre-deployment allow/block release decision
+```
+
+The expectation summary sits before materialization.
+
+It only helps reveal what remains unverified or unsatisfied.
+
+## Minimal Anchor
+
+The expectation summary makes pending relations visible.
+
+It does not satisfy them.
+
+It makes the pre-materialization gap readable.
+
+It does not close the gap.

--- a/ests/test_build_release_evidence_expectation_summary_v0.py
+++ b/ests/test_build_release_evidence_expectation_summary_v0.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+TOOL = (
+    REPO_ROOT
+    / "PULSE_safe_pack_v0"
+    / "tools"
+    / "build_release_evidence_expectation_summary_v0.py"
+)
+EXAMPLE = (
+    REPO_ROOT
+    / "examples"
+    / "release_evidence_expectation_summary_v0.failed.example.json"
+)
+
+HEX40 = "a" * 40
+HEX64 = "b" * 64
+RUN_KEY = "GITHUB_RUN_ID=1|GITHUB_RUN_NUMBER=1|GITHUB_WORKFLOW=PULSE CI"
+
+
+def _write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _load_json(path: pathlib.Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _run_tool(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(TOOL),
+            *args,
+        ],
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _failed_verifier_report() -> dict[str, Any]:
+    return {
+        "schema_version": "release_evidence_verifier_report_v0",
+        "created_utc": "2026-01-01T00:00:00Z",
+        "verifier_id": "pulse_release_evidence_verifier_v0",
+        "verifier_version": "0.1.0",
+        "verifier_decision": "FAILED",
+        "run_identity": {
+            "run_mode": "prod",
+            "run_key": RUN_KEY,
+            "git_sha": HEX40,
+        },
+        "subject": {
+            "repository": "HKati/pulse-release-gates-0.1",
+            "commit_sha": HEX40,
+            "release_candidate": "candidate-v0",
+        },
+        "policy_binding": {
+            "policy_path": "pulse_gate_policy_v0.yml",
+            "policy_sha256": HEX64,
+            "policy_set": "required+release_required",
+        },
+        "registry_binding": {
+            "registry_path": "pulse_gate_registry_v0.yml",
+            "registry_sha256": HEX64,
+        },
+        "evidence_inputs": [
+            {
+                "kind": "detector_evidence",
+                "path": "artifacts/detectors/detector_report.json",
+                "sha256": HEX64,
+                "schema_version": "detector_report_v0",
+                "subject_binding": {
+                    "git_sha": HEX40,
+                    "run_key": RUN_KEY,
+                },
+                "provenance": {
+                    "trusted": False,
+                    "verification_status": "not_verified",
+                    "candidate_evidence_id": "detector_report",
+                },
+            }
+        ],
+        "verified_artifacts": [],
+        "relation_bindings": [],
+        "gate_materialization": {},
+        "failed_checks": [
+            "trusted release-evidence verifier skeleton does not verify evidence yet",
+            "expected candidate evidence recorded but not verified: detector_report",
+            "expected relation binding pending verification: detector_report_to_subject_commit",
+            "expected relation binding pending verification: detector_report_to_gate",
+            "expected gate materialization pending verification: detectors_materialized_ok",
+            "input manifest expectations are recorded only; verification is not implemented",
+            "input manifest expected relation bindings are not verified by skeleton",
+            "input manifest expected gate materialization bindings are not materialized by skeleton",
+        ],
+        "warnings": [
+            "input manifest expectation comparison is fail-closed and descriptive only",
+            "input manifest declares 1 candidate evidence item(s), 2 expected relation binding(s), and 1 expected gate materialization item(s)",
+        ],
+    }
+
+
+def test_example_summary_validates() -> None:
+    schema_path = REPO_ROOT / "schemas" / "release_evidence_expectation_summary_v0.schema.json"
+
+    try:
+        import jsonschema
+    except Exception:  # pragma: no cover
+        pytest.fail("jsonschema is required for summary schema tests")
+
+    schema = _load_json(schema_path)
+    example = _load_json(EXAMPLE)
+
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.Draft202012Validator(schema).validate(example)
+
+
+def test_build_summary_from_failed_report(tmp_path: pathlib.Path) -> None:
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    out_path = tmp_path / "release_evidence_expectation_summary_v0.json"
+
+    _write_json(report_path, _failed_verifier_report())
+
+    result = _run_tool(
+        "--report",
+        str(report_path),
+        "--out",
+        str(out_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "OK: wrote release evidence expectation summary" in result.stdout
+
+    summary = _load_json(out_path)
+    assert summary["schema_version"] == "release_evidence_expectation_summary_v0"
+    assert summary["source_report"]["verifier_decision"] == "FAILED"
+    assert summary["summary"]["verifier_readiness"] == "NOT_READY"
+    assert summary["summary"]["evidence_inputs_total"] == 1
+    assert summary["summary"]["verified_artifacts_total"] == 0
+    assert summary["summary"]["relation_bindings_total"] == 0
+    assert summary["summary"]["gate_materialization_total"] == 0
+    assert summary["summary"]["candidate_evidence_not_verified_count"] == 1
+    assert summary["summary"]["pending_relation_binding_count"] == 2
+    assert summary["summary"]["pending_gate_materialization_count"] == 1
+
+    gap_kinds = {gap["kind"] for gap in summary["pre_materialization_gaps"]}
+    assert "candidate_evidence_not_verified" in gap_kinds
+    assert "pending_relation_binding" in gap_kinds
+    assert "pending_gate_materialization" in gap_kinds
+
+    assert summary["authority_boundary"]["is_release_authority"] is False
+    assert summary["authority_boundary"]["materializes_gates"] is False
+    assert summary["authority_boundary"]["writes_status_json"] is False
+    assert summary["authority_boundary"]["reopens_release_grade_materialization"] is False
+    assert summary["authority_boundary"]["replaces_check_gates"] is False
+
+
+def test_invalid_verifier_report_fails_closed_without_summary(
+    tmp_path: pathlib.Path,
+) -> None:
+    report = _failed_verifier_report()
+    report.pop("relation_bindings")
+
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    out_path = tmp_path / "release_evidence_expectation_summary_v0.json"
+    _write_json(report_path, report)
+
+    result = _run_tool(
+        "--report",
+        str(report_path),
+        "--out",
+        str(out_path),
+    )
+
+    assert result.returncode != 0
+    assert "release evidence verifier report failed validation" in result.stderr
+    assert not out_path.exists()
+
+
+def test_digest_mismatch_gap_is_classified(tmp_path: pathlib.Path) -> None:
+    report = _failed_verifier_report()
+    report["failed_checks"].append("candidate evidence digest mismatch: detector_report")
+
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    out_path = tmp_path / "release_evidence_expectation_summary_v0.json"
+    _write_json(report_path, report)
+
+    result = _run_tool(
+        "--report",
+        str(report_path),
+        "--out",
+        str(out_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    summary = _load_json(out_path)
+    assert summary["summary"]["digest_mismatch_count"] == 1
+    assert any(
+        gap["kind"] == "digest_mismatch" and gap["id"] == "detector_report"
+        for gap in summary["pre_materialization_gaps"]
+    )
+
+
+def test_no_candidate_evidence_gap_is_classified(tmp_path: pathlib.Path) -> None:
+    report = _failed_verifier_report()
+    report["evidence_inputs"] = []
+    report["failed_checks"] = [
+        "no candidate evidence inputs were supplied",
+        "no verified relation bindings present",
+        "no gate materialization performed",
+    ]
+
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    out_path = tmp_path / "release_evidence_expectation_summary_v0.json"
+    _write_json(report_path, report)
+
+    result = _run_tool(
+        "--report",
+        str(report_path),
+        "--out",
+        str(out_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    summary = _load_json(out_path)
+    gap_kinds = {gap["kind"] for gap in summary["pre_materialization_gaps"]}
+    assert "no_candidate_evidence" in gap_kinds
+    assert "no_verified_relation_bindings" in gap_kinds
+    assert "no_gate_materialization" in gap_kinds
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/examples/release_evidence_expectation_summary_v0.failed.example.json
+++ b/examples/release_evidence_expectation_summary_v0.failed.example.json
@@ -1,53 +1,35 @@
 {
-  "authority_boundary": {
-    "is_release_authority": false,
-    "materializes_gates": false,
-    "reopens_release_grade_materialization": false,
-    "replaces_check_gates": false,
-    "writes_status_json": false
-  },
   "created_utc": "2026-01-01T00:00:00Z",
-  "pre_materialization_gaps": [
-    {
-      "id": "detector_report",
-      "kind": "candidate_evidence_not_verified",
-      "message": "expected candidate evidence recorded but not verified: detector_report"
-    },
-    {
-      "id": "detector_report_to_subject_commit",
-      "kind": "pending_relation_binding",
-      "message": "expected relation binding pending verification: detector_report_to_subject_commit"
-    },
-    {
-      "id": "detectors_materialized_ok",
-      "kind": "pending_gate_materialization",
-      "message": "expected gate materialization pending verification: detectors_materialized_ok"
-    }
+  "evidence_inputs": [],
+  "failed_checks": [
+    "trusted verifier is not implemented",
+    "no verified relation bindings present"
   ],
-  "schema_version": "release_evidence_expectation_summary_v0",
-  "source_report": {
-    "path": "PULSE_safe_pack_v0/artifacts/release_evidence_verifier_report_v0.json",
-    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-    "verifier_decision": "FAILED"
+  "gate_materialization": {},
+  "policy_binding": {
+    "policy_path": "pulse_gate_policy_v0.yml",
+    "policy_set": "required+release_required",
+    "policy_sha256": null
   },
-  "summary": {
-    "candidate_evidence_not_verified_count": 1,
-    "digest_mismatch_count": 0,
-    "evidence_inputs_total": 1,
-    "failed_checks_total": 3,
-    "gate_materialization_total": 0,
-    "missing_candidate_evidence_count": 0,
-    "other_failed_check_count": 0,
-    "pending_gate_materialization_count": 1,
-    "pending_relation_binding_count": 1,
-    "relation_bindings_total": 0,
-    "verified_artifacts_total": 0,
-    "verifier_readiness": "NOT_READY",
-    "warnings_total": 1
+  "registry_binding": {
+    "registry_path": "pulse_gate_registry_v0.yml",
+    "registry_sha256": null
   },
-  "summary_id": "pulse_release_evidence_expectation_summary_v0",
-  "summary_version": "0.1.0",
-  "warnings": [
-    "input manifest expectation comparison is fail-closed and descriptive only"
-  ]
+  "relation_bindings": [],
+  "run_identity": {
+    "git_sha": null,
+    "run_key": null,
+    "run_mode": "prod"
+  },
+  "schema_version": "release_evidence_verifier_report_v0",
+  "subject": {
+    "commit_sha": null,
+    "release_candidate": null,
+    "repository": null
+  },
+  "verified_artifacts": [],
+  "verifier_decision": "FAILED",
+  "verifier_id": "pulse_release_evidence_verifier_v0",
+  "verifier_version": "0.1.0",
+  "warnings": []
 }

--- a/examples/release_evidence_expectation_summary_v0.failed.example.json
+++ b/examples/release_evidence_expectation_summary_v0.failed.example.json
@@ -1,0 +1,53 @@
+{
+  "authority_boundary": {
+    "is_release_authority": false,
+    "materializes_gates": false,
+    "reopens_release_grade_materialization": false,
+    "replaces_check_gates": false,
+    "writes_status_json": false
+  },
+  "created_utc": "2026-01-01T00:00:00Z",
+  "pre_materialization_gaps": [
+    {
+      "id": "detector_report",
+      "kind": "candidate_evidence_not_verified",
+      "message": "expected candidate evidence recorded but not verified: detector_report"
+    },
+    {
+      "id": "detector_report_to_subject_commit",
+      "kind": "pending_relation_binding",
+      "message": "expected relation binding pending verification: detector_report_to_subject_commit"
+    },
+    {
+      "id": "detectors_materialized_ok",
+      "kind": "pending_gate_materialization",
+      "message": "expected gate materialization pending verification: detectors_materialized_ok"
+    }
+  ],
+  "schema_version": "release_evidence_expectation_summary_v0",
+  "source_report": {
+    "path": "PULSE_safe_pack_v0/artifacts/release_evidence_verifier_report_v0.json",
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "verifier_decision": "FAILED"
+  },
+  "summary": {
+    "candidate_evidence_not_verified_count": 1,
+    "digest_mismatch_count": 0,
+    "evidence_inputs_total": 1,
+    "failed_checks_total": 3,
+    "gate_materialization_total": 0,
+    "missing_candidate_evidence_count": 0,
+    "other_failed_check_count": 0,
+    "pending_gate_materialization_count": 1,
+    "pending_relation_binding_count": 1,
+    "relation_bindings_total": 0,
+    "verified_artifacts_total": 0,
+    "verifier_readiness": "NOT_READY",
+    "warnings_total": 1
+  },
+  "summary_id": "pulse_release_evidence_expectation_summary_v0",
+  "summary_version": "0.1.0",
+  "warnings": [
+    "input manifest expectation comparison is fail-closed and descriptive only"
+  ]
+}

--- a/examples/release_evidence_expectation_summary_v0.failed.example.json
+++ b/examples/release_evidence_expectation_summary_v0.failed.example.json
@@ -1,35 +1,53 @@
 {
+  "authority_boundary": {
+    "is_release_authority": false,
+    "materializes_gates": false,
+    "reopens_release_grade_materialization": false,
+    "replaces_check_gates": false,
+    "writes_status_json": false
+  },
   "created_utc": "2026-01-01T00:00:00Z",
-  "evidence_inputs": [],
-  "failed_checks": [
-    "trusted verifier is not implemented",
-    "no verified relation bindings present"
+  "pre_materialization_gaps": [
+    {
+      "id": "detector_report",
+      "kind": "candidate_evidence_not_verified",
+      "message": "expected candidate evidence recorded but not verified: detector_report"
+    },
+    {
+      "id": "detector_report_to_subject_commit",
+      "kind": "pending_relation_binding",
+      "message": "expected relation binding pending verification: detector_report_to_subject_commit"
+    },
+    {
+      "id": "detectors_materialized_ok",
+      "kind": "pending_gate_materialization",
+      "message": "expected gate materialization pending verification: detectors_materialized_ok"
+    }
   ],
-  "gate_materialization": {},
-  "policy_binding": {
-    "policy_path": "pulse_gate_policy_v0.yml",
-    "policy_set": "required+release_required",
-    "policy_sha256": null
+  "schema_version": "release_evidence_expectation_summary_v0",
+  "source_report": {
+    "path": "PULSE_safe_pack_v0/artifacts/release_evidence_verifier_report_v0.json",
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "verifier_decision": "FAILED"
   },
-  "registry_binding": {
-    "registry_path": "pulse_gate_registry_v0.yml",
-    "registry_sha256": null
+  "summary": {
+    "candidate_evidence_not_verified_count": 1,
+    "digest_mismatch_count": 0,
+    "evidence_inputs_total": 1,
+    "failed_checks_total": 3,
+    "gate_materialization_total": 0,
+    "missing_candidate_evidence_count": 0,
+    "other_failed_check_count": 0,
+    "pending_gate_materialization_count": 1,
+    "pending_relation_binding_count": 1,
+    "relation_bindings_total": 0,
+    "verified_artifacts_total": 0,
+    "verifier_readiness": "NOT_READY",
+    "warnings_total": 1
   },
-  "relation_bindings": [],
-  "run_identity": {
-    "git_sha": null,
-    "run_key": null,
-    "run_mode": "prod"
-  },
-  "schema_version": "release_evidence_verifier_report_v0",
-  "subject": {
-    "commit_sha": null,
-    "release_candidate": null,
-    "repository": null
-  },
-  "verified_artifacts": [],
-  "verifier_decision": "FAILED",
-  "verifier_id": "pulse_release_evidence_verifier_v0",
-  "verifier_version": "0.1.0",
-  "warnings": []
+  "summary_id": "pulse_release_evidence_expectation_summary_v0",
+  "summary_version": "0.1.0",
+  "warnings": [
+    "input manifest expectation comparison is fail-closed and descriptive only"
+  ]
 }

--- a/schemas/release_evidence_expectation_summary_v0.schema.json
+++ b/schemas/release_evidence_expectation_summary_v0.schema.json
@@ -211,5 +211,97 @@
         }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "source_report": {
+            "properties": {
+              "verifier_decision": {
+                "const": "FAILED"
+              }
+            },
+            "required": [
+              "verifier_decision"
+            ]
+          }
+        },
+        "required": [
+          "source_report"
+        ]
+      },
+      "then": {
+        "properties": {
+          "summary": {
+            "properties": {
+              "verifier_readiness": {
+                "const": "NOT_READY"
+              },
+              "failed_checks_total": {
+                "minimum": 1
+              }
+            }
+          },
+          "pre_materialization_gaps": {
+            "minItems": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "source_report": {
+            "properties": {
+              "verifier_decision": {
+                "const": "VERIFIED"
+              }
+            },
+            "required": [
+              "verifier_decision"
+            ]
+          }
+        },
+        "required": [
+          "source_report"
+        ]
+      },
+      "then": {
+        "properties": {
+          "summary": {
+            "properties": {
+              "verifier_readiness": {
+                "const": "REPORT_VERIFIED_NON_AUTHORITY"
+              },
+              "failed_checks_total": {
+                "const": 0
+              },
+              "candidate_evidence_not_verified_count": {
+                "const": 0
+              },
+              "missing_candidate_evidence_count": {
+                "const": 0
+              },
+              "digest_mismatch_count": {
+                "const": 0
+              },
+              "pending_relation_binding_count": {
+                "const": 0
+              },
+              "pending_gate_materialization_count": {
+                "const": 0
+              },
+              "other_failed_check_count": {
+                "const": 0
+              }
+            }
+          },
+          "pre_materialization_gaps": {
+            "maxItems": 0
+          }
+        }
+      }
+    }
+  ]
 }

--- a/schemas/release_evidence_expectation_summary_v0.schema.json
+++ b/schemas/release_evidence_expectation_summary_v0.schema.json
@@ -1,0 +1,215 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulse.local/schemas/release_evidence_expectation_summary_v0.schema.json",
+  "title": "PULSE Release Evidence Expectation Summary v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "created_utc",
+    "summary_id",
+    "summary_version",
+    "source_report",
+    "summary",
+    "pre_materialization_gaps",
+    "warnings",
+    "authority_boundary"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "release_evidence_expectation_summary_v0"
+    },
+    "created_utc": {
+      "type": "string",
+      "minLength": 1
+    },
+    "summary_id": {
+      "const": "pulse_release_evidence_expectation_summary_v0"
+    },
+    "summary_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_report": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "sha256",
+        "verifier_decision"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$"
+        },
+        "verifier_decision": {
+          "type": "string",
+          "enum": [
+            "VERIFIED",
+            "FAILED"
+          ]
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "verifier_readiness",
+        "evidence_inputs_total",
+        "verified_artifacts_total",
+        "relation_bindings_total",
+        "gate_materialization_total",
+        "failed_checks_total",
+        "warnings_total",
+        "candidate_evidence_not_verified_count",
+        "missing_candidate_evidence_count",
+        "digest_mismatch_count",
+        "pending_relation_binding_count",
+        "pending_gate_materialization_count",
+        "other_failed_check_count"
+      ],
+      "properties": {
+        "verifier_readiness": {
+          "type": "string",
+          "enum": [
+            "NOT_READY",
+            "REPORT_VERIFIED_NON_AUTHORITY"
+          ]
+        },
+        "evidence_inputs_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "verified_artifacts_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "relation_bindings_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "gate_materialization_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failed_checks_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "warnings_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "candidate_evidence_not_verified_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "missing_candidate_evidence_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "digest_mismatch_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "pending_relation_binding_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "pending_gate_materialization_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "other_failed_check_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "pre_materialization_gaps": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/pre_materialization_gap"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "authority_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "is_release_authority",
+        "materializes_gates",
+        "writes_status_json",
+        "reopens_release_grade_materialization",
+        "replaces_check_gates"
+      ],
+      "properties": {
+        "is_release_authority": {
+          "const": false
+        },
+        "materializes_gates": {
+          "const": false
+        },
+        "writes_status_json": {
+          "const": false
+        },
+        "reopens_release_grade_materialization": {
+          "const": false
+        },
+        "replaces_check_gates": {
+          "const": false
+        }
+      }
+    }
+  },
+  "$defs": {
+    "pre_materialization_gap": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "id",
+        "message"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "candidate_evidence_not_verified",
+            "missing_candidate_evidence",
+            "digest_mismatch",
+            "pending_relation_binding",
+            "pending_gate_materialization",
+            "missing_gate_candidate_evidence",
+            "no_candidate_evidence",
+            "no_verified_relation_bindings",
+            "no_gate_materialization",
+            "other_failed_check"
+          ]
+        },
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/tests/test_build_release_evidence_expectation_summary_v0.py
+++ b/tests/test_build_release_evidence_expectation_summary_v0.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+TOOL = (
+    REPO_ROOT
+    / "PULSE_safe_pack_v0"
+    / "tools"
+    / "build_release_evidence_expectation_summary_v0.py"
+)
+EXAMPLE = (
+    REPO_ROOT
+    / "examples"
+    / "release_evidence_expectation_summary_v0.failed.example.json"
+)
+SCHEMA = REPO_ROOT / "schemas" / "release_evidence_expectation_summary_v0.schema.json"
+
+HEX40 = "a" * 40
+HEX64 = "b" * 64
+RUN_KEY = "GITHUB_RUN_ID=1|GITHUB_RUN_NUMBER=1|GITHUB_WORKFLOW=PULSE CI"
+
+
+def _write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _load_json(path: pathlib.Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _run_tool(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(TOOL),
+            *args,
+        ],
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _failed_verifier_report() -> dict[str, Any]:
+    return {
+        "schema_version": "release_evidence_verifier_report_v0",
+        "created_utc": "2026-01-01T00:00:00Z",
+        "verifier_id": "pulse_release_evidence_verifier_v0",
+        "verifier_version": "0.1.0",
+        "verifier_decision": "FAILED",
+        "run_identity": {
+            "run_mode": "prod",
+            "run_key": RUN_KEY,
+            "git_sha": HEX40,
+        },
+        "subject": {
+            "repository": "HKati/pulse-release-gates-0.1",
+            "commit_sha": HEX40,
+            "release_candidate": "candidate-v0",
+        },
+        "policy_binding": {
+            "policy_path": "pulse_gate_policy_v0.yml",
+            "policy_sha256": HEX64,
+            "policy_set": "required+release_required",
+        },
+        "registry_binding": {
+            "registry_path": "pulse_gate_registry_v0.yml",
+            "registry_sha256": HEX64,
+        },
+        "evidence_inputs": [
+            {
+                "kind": "detector_evidence",
+                "path": "artifacts/detectors/detector_report.json",
+                "sha256": HEX64,
+                "schema_version": "detector_report_v0",
+                "subject_binding": {
+                    "git_sha": HEX40,
+                    "run_key": RUN_KEY,
+                },
+                "provenance": {
+                    "trusted": False,
+                    "verification_status": "not_verified",
+                    "candidate_evidence_id": "detector_report",
+                },
+            }
+        ],
+        "verified_artifacts": [],
+        "relation_bindings": [],
+        "gate_materialization": {},
+        "failed_checks": [
+            "trusted release-evidence verifier skeleton does not verify evidence yet",
+            "expected candidate evidence recorded but not verified: detector_report",
+            "expected relation binding pending verification: detector_report_to_subject_commit",
+            "expected relation binding pending verification: detector_report_to_gate",
+            "expected gate materialization pending verification: detectors_materialized_ok",
+            "input manifest expectations are recorded only; verification is not implemented",
+            "input manifest expected relation bindings are not verified by skeleton",
+            "input manifest expected gate materialization bindings are not materialized by skeleton",
+        ],
+        "warnings": [
+            "input manifest expectation comparison is fail-closed and descriptive only",
+            "input manifest declares 1 candidate evidence item(s), 2 expected relation binding(s), and 1 expected gate materialization item(s)",
+        ],
+    }
+
+
+def test_schema_and_example_exist() -> None:
+    assert SCHEMA.exists()
+    assert EXAMPLE.exists()
+    assert TOOL.exists()
+
+
+def test_example_summary_validates() -> None:
+    try:
+        import jsonschema
+    except Exception:  # pragma: no cover
+        pytest.fail("jsonschema is required for summary schema tests")
+
+    schema = _load_json(SCHEMA)
+    example = _load_json(EXAMPLE)
+
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.Draft202012Validator(schema).validate(example)
+
+
+def test_build_summary_from_failed_report(tmp_path: pathlib.Path) -> None:
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    out_path = tmp_path / "release_evidence_expectation_summary_v0.json"
+
+    _write_json(report_path, _failed_verifier_report())
+
+    result = _run_tool(
+        "--report",
+        str(report_path),
+        "--out",
+        str(out_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "OK: wrote release evidence expectation summary" in result.stdout
+
+    summary = _load_json(out_path)
+
+    assert summary["schema_version"] == "release_evidence_expectation_summary_v0"
+    assert summary["source_report"]["verifier_decision"] == "FAILED"
+    assert summary["summary"]["verifier_readiness"] == "NOT_READY"
+
+    assert summary["summary"]["evidence_inputs_total"] == 1
+    assert summary["summary"]["verified_artifacts_total"] == 0
+    assert summary["summary"]["relation_bindings_total"] == 0
+    assert summary["summary"]["gate_materialization_total"] == 0
+
+    assert summary["summary"]["candidate_evidence_not_verified_count"] == 1
+    assert summary["summary"]["pending_relation_binding_count"] == 2
+    assert summary["summary"]["pending_gate_materialization_count"] == 1
+
+    gap_kinds = {gap["kind"] for gap in summary["pre_materialization_gaps"]}
+    assert "candidate_evidence_not_verified" in gap_kinds
+    assert "pending_relation_binding" in gap_kinds
+    assert "pending_gate_materialization" in gap_kinds
+
+    assert summary["authority_boundary"]["is_release_authority"] is False
+    assert summary["authority_boundary"]["materializes_gates"] is False
+    assert summary["authority_boundary"]["writes_status_json"] is False
+    assert summary["authority_boundary"]["reopens_release_grade_materialization"] is False
+    assert summary["authority_boundary"]["replaces_check_gates"] is False
+
+
+def test_invalid_verifier_report_fails_closed_without_summary(
+    tmp_path: pathlib.Path,
+) -> None:
+    report = _failed_verifier_report()
+    report.pop("relation_bindings")
+
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    out_path = tmp_path / "release_evidence_expectation_summary_v0.json"
+
+    _write_json(report_path, report)
+
+    result = _run_tool(
+        "--report",
+        str(report_path),
+        "--out",
+        str(out_path),
+    )
+
+    assert result.returncode != 0
+    assert "release evidence verifier report failed validation" in result.stderr
+    assert not out_path.exists()
+
+
+def test_digest_mismatch_gap_is_classified(tmp_path: pathlib.Path) -> None:
+    report = _failed_verifier_report()
+    report["failed_checks"].append("candidate evidence digest mismatch: detector_report")
+
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    out_path = tmp_path / "release_evidence_expectation_summary_v0.json"
+
+    _write_json(report_path, report)
+
+    result = _run_tool(
+        "--report",
+        str(report_path),
+        "--out",
+        str(out_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    summary = _load_json(out_path)
+    assert summary["summary"]["digest_mismatch_count"] == 1
+    assert any(
+        gap["kind"] == "digest_mismatch" and gap["id"] == "detector_report"
+        for gap in summary["pre_materialization_gaps"]
+    )
+
+
+def test_no_candidate_evidence_gap_is_classified(tmp_path: pathlib.Path) -> None:
+    report = _failed_verifier_report()
+    report["evidence_inputs"] = []
+    report["failed_checks"] = [
+        "no candidate evidence inputs were supplied",
+        "no verified relation bindings present",
+        "no gate materialization performed",
+    ]
+
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    out_path = tmp_path / "release_evidence_expectation_summary_v0.json"
+
+    _write_json(report_path, report)
+
+    result = _run_tool(
+        "--report",
+        str(report_path),
+        "--out",
+        str(out_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    summary = _load_json(out_path)
+    gap_kinds = {gap["kind"] for gap in summary["pre_materialization_gaps"]}
+
+    assert "no_candidate_evidence" in gap_kinds
+    assert "no_verified_relation_bindings" in gap_kinds
+    assert "no_gate_materialization" in gap_kinds
+
+
+def test_failed_source_report_cannot_be_marked_ready_by_schema() -> None:
+    try:
+        import jsonschema
+    except Exception:  # pragma: no cover
+        pytest.fail("jsonschema is required for summary schema tests")
+
+    schema = _load_json(SCHEMA)
+    summary = _load_json(EXAMPLE)
+
+    summary["source_report"]["verifier_decision"] = "FAILED"
+    summary["summary"]["verifier_readiness"] = "REPORT_VERIFIED_NON_AUTHORITY"
+
+    errors = list(jsonschema.Draft202012Validator(schema).iter_errors(summary))
+
+    assert errors
+
+
+def test_summary_never_claims_release_authority(tmp_path: pathlib.Path) -> None:
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    out_path = tmp_path / "release_evidence_expectation_summary_v0.json"
+
+    _write_json(report_path, _failed_verifier_report())
+
+    result = _run_tool(
+        "--report",
+        str(report_path),
+        "--out",
+        str(out_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    summary = _load_json(out_path)
+    boundary = summary["authority_boundary"]
+
+    assert boundary == {
+        "is_release_authority": False,
+        "materializes_gates": False,
+        "reopens_release_grade_materialization": False,
+        "replaces_check_gates": False,
+        "writes_status_json": False,
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

This PR adds `release_evidence_expectation_summary_v0`, a reader-only diagnostic summary surface over `release_evidence_verifier_report_v0`.

The summary makes the pre-materialization gap visible by classifying fail-closed verifier report checks into evidence, relation, and gate-materialization gap kinds.

## What changed

- Added `schemas/release_evidence_expectation_summary_v0.schema.json`.
- Added `examples/release_evidence_expectation_summary_v0.failed.example.json`.
- Added `PULSE_safe_pack_v0/tools/build_release_evidence_expectation_summary_v0.py`.
- Added `tests/test_build_release_evidence_expectation_summary_v0.py`.
- Added `docs/PULSE_RELEASE_EVIDENCE_EXPECTATION_SUMMARY_v0.md`.
- Added docs index entry.
- Registered the test in `ci/tools-tests.list`.

## Boundary

This PR does not implement the trusted verifier.

It does not verify evidence.

It does not satisfy relation bindings.

It does not materialize gates.

It does not write `status.json`.

It does not reopen `--release-grade-materialized`.

It does not define release authority.

It does not replace `check_gates.py`.

PULSEmech release authority remains:

recorded release evidence → `status.json` → declared gate policy → workflow-effective materialized required gate set → strict fail-closed CI enforcement → pre-deployment allow/block release decision

## What the summary shows

The summary records:

- source verifier report path and SHA-256 digest
- source verifier decision
- evidence input counts
- verified artifact counts
- relation binding counts
- gate materialization counts
- failed check counts
- warning counts
- classified pre-materialization gaps
- explicit non-authority boundary flags

## Tests

- `pytest -q tests/test_build_release_evidence_expectation_summary_v0.py`
- `pytest -q tests/test_check_release_evidence_verifier_report_v0.py`
- `pytest -q tests/test_release_evidence_verifier_report_schema_v0.py`
- `pytest -q tests/test_tools_tests_list_smoke.py`