### PR TITLE
test(ref): lock verifier digest-binding v0 behavior

### DIFF
--- a/tests/test_build_release_evidence_verifier_report_v0.py
+++ b/tests/test_build_release_evidence_verifier_report_v0.py
@@ -273,6 +273,17 @@ def test_input_manifest_digest_mismatch_records_failed_report(
     assert report["evidence_inputs"][0]["provenance"][
         "actual_sha256_matches_expected"
     ] is False
+    actual_sha256 = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+    evidence_input = report["evidence_inputs"][0]
+
+    assert evidence_input["sha256"] == actual_sha256
+    assert evidence_input["provenance"]["expected_sha256"] == HEX64
+    assert evidence_input["sha256"] != evidence_input["provenance"]["expected_sha256"]
+
+    assert report["verifier_decision"] == "FAILED"
+    assert report["verified_artifacts"] == []
+    assert report["relation_bindings"] == []
+    assert report["gate_materialization"] == {}
 
 
 def test_input_manifest_missing_candidate_writes_failed_report(

--- a/tests/test_release_evidence_pre_materialization_pipeline_v0.py
+++ b/tests/test_release_evidence_pre_materialization_pipeline_v0.py
@@ -247,7 +247,9 @@ def test_pre_materialization_pipeline_exposes_gaps_without_authority(
     assert evidence_input["provenance"]["verification_status"] == "not_verified"
     assert evidence_input["provenance"]["candidate_evidence_id"] == "detector_report"
     assert evidence_input["provenance"]["actual_sha256_matches_expected"] is True
-
+    assert evidence_input["sha256"] == evidence_sha256
+    assert evidence_input["provenance"]["expected_sha256"] == evidence_sha256
+   
     failed_checks = "\n".join(report["failed_checks"])
     assert "expected candidate evidence recorded but not verified: detector_report" in failed_checks
     assert (
@@ -361,7 +363,18 @@ def test_pre_materialization_pipeline_digest_mismatch_is_visible_but_non_authori
     assert report["evidence_inputs"][0]["provenance"][
         "actual_sha256_matches_expected"
     ] is False
+    actual_sha256 = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+    evidence_input = report["evidence_inputs"][0]
 
+    assert evidence_input["sha256"] == actual_sha256
+    assert evidence_input["provenance"]["expected_sha256"] == HEX64
+    assert evidence_input["sha256"] != evidence_input["provenance"]["expected_sha256"]
+
+    assert report["verifier_decision"] == "FAILED"
+    assert report["verified_artifacts"] == []
+    assert report["relation_bindings"] == []
+    assert report["gate_materialization"] == {}
+ 
     _assert_authority_artifacts_unchanged(authority_before, tmp_path)
 
     build_summary = _run(


### PR DESCRIPTION
## Summary

This PR locks the existing verifier digest-binding v0 behavior with stronger regression assertions.

The current builder already records manifest-declared candidate evidence digests, compares actual SHA-256 against `expected_sha256`, records match/mismatch state, and keeps the verifier report fail-closed.

This PR does not add new verifier authority. It only hardens tests around the existing artifact → digest binding behavior.

## What this verifies

- matching digest records the actual digest
- matching digest preserves `expected_sha256`
- matching digest records `actual_sha256_matches_expected = true`
- digest mismatch records the actual digest
- digest mismatch preserves the manifest `expected_sha256`
- digest mismatch proves actual digest differs from expected digest
- digest mismatch records `actual_sha256_matches_expected = false`
- verifier report remains `FAILED`
- `verified_artifacts` remains empty
- `relation_bindings` remains empty
- `gate_materialization` remains empty
- evidence remains `trusted = false`
- evidence remains `verification_status = not_verified`

## Boundary

Digest match does not imply:

- `VERIFIED`
- trusted evidence
- satisfied relation binding
- gate materialization
- `status.json`
- `report_card.html`
- `release_authority_v0.json`
- release-authority audit bundle
- release eligibility

## Non-goals

This PR does not change:

- `run_all.py`
- `check_gates.py`
- release policy
- gate registry
- status schemas
- CI authority path
- `--release-grade-materialized`
- release-authority semantics

## Tests

- `pytest -q tests/test_build_release_evidence_verifier_report_v0.py`
- `pytest -q tests/test_release_evidence_pre_materialization_pipeline_v0.py`
- `pytest -q tests/test_build_release_evidence_expectation_summary_v0.py`
- `pytest -q tests/test_tools_tests_list_smoke.py`