### PR TITLE
feat(ref): add verifier subject-run binding check v0

### DIFF
--- a/PULSE_safe_pack_v0/tools/build_release_evidence_verifier_report_v0.py
+++ b/PULSE_safe_pack_v0/tools/build_release_evidence_verifier_report_v0.py
@@ -145,6 +145,21 @@ def _load_json_object(path: pathlib.Path, *, label: str) -> dict[str, Any]:
     return obj
 
 
+def _normalize_git_sha(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+
+    stripped = value.strip()
+    if not stripped:
+        return None
+
+    return stripped.lower()
+
+
+def _git_sha_equal(left: Any, right: Any) -> bool:
+    return _normalize_git_sha(left) == _normalize_git_sha(right)
+
+
 def _parse_evidence_arg(raw: str) -> tuple[str, pathlib.Path, str]:
     if "=" not in raw:
         raise ValueError(
@@ -266,10 +281,21 @@ def _evidence_inputs_from_manifest(
     manifest_run_git_sha = run_identity.get("git_sha")
     manifest_run_key = run_identity.get("run_key")
     manifest_subject_commit_sha = subject.get("commit_sha")
-    
+
+    # These are the effective identities emitted into the verifier report.
+    # Explicit --commit-sha / --run-key CLI overrides can differ from the input
+    # manifest identity, so subject/run binding must be checked against the
+    # report identity as well as the manifest-declared identity.
+    report_subject_commit_sha = git_sha
+    report_run_git_sha = git_sha
+    report_run_key = run_key
+
     out: list[dict[str, Any]] = []
 
-    for evidence_id, entry in sorted(candidate_evidence.items(), key=lambda item: str(item[0])):
+    for evidence_id, entry in sorted(
+        candidate_evidence.items(),
+        key=lambda item: str(item[0]),
+    ):
         if not isinstance(entry, dict):
             failed_checks.append(f"candidate evidence entry is not an object: {evidence_id}")
             continue
@@ -284,34 +310,53 @@ def _evidence_inputs_from_manifest(
         candidate_subject_git_sha = subject_binding.get("git_sha")
         candidate_subject_run_key = subject_binding.get("run_key")
 
-        subject_git_sha_matches_subject_commit = (
-            candidate_subject_git_sha == manifest_subject_commit_sha
+        subject_git_sha_matches_subject_commit = _git_sha_equal(
+            candidate_subject_git_sha,
+            manifest_subject_commit_sha,
         )
-        subject_git_sha_matches_run_identity = (
-            candidate_subject_git_sha == manifest_run_git_sha
+        subject_git_sha_matches_run_identity = _git_sha_equal(
+            candidate_subject_git_sha,
+            manifest_run_git_sha,
         )
-        run_key_matches_run_identity = (
-            candidate_subject_run_key == manifest_run_key
-        )
+        run_key_matches_run_identity = candidate_subject_run_key == manifest_run_key
 
-        if not subject_git_sha_matches_subject_commit:
+        subject_git_sha_matches_report_subject_commit = _git_sha_equal(
+            candidate_subject_git_sha,
+            report_subject_commit_sha,
+        )
+        subject_git_sha_matches_report_run_identity = _git_sha_equal(
+            candidate_subject_git_sha,
+            report_run_git_sha,
+        )
+        run_key_matches_report_run_identity = candidate_subject_run_key == report_run_key
+
+        if not (
+            subject_git_sha_matches_subject_commit
+            and subject_git_sha_matches_report_subject_commit
+        ):
             failed_checks.append(
                 "candidate evidence subject git_sha mismatch against subject commit: "
                 f"{evidence_id}"
             )
 
-        if not subject_git_sha_matches_run_identity:
+        if not (
+            subject_git_sha_matches_run_identity
+            and subject_git_sha_matches_report_run_identity
+        ):
             failed_checks.append(
                 "candidate evidence subject git_sha mismatch against run identity: "
                 f"{evidence_id}"
             )
 
-        if not run_key_matches_run_identity:
+        if not (
+            run_key_matches_run_identity
+            and run_key_matches_report_run_identity
+        ):
             failed_checks.append(
                 "candidate evidence run_key mismatch against run identity: "
                 f"{evidence_id}"
             )
-        
+
         if not isinstance(kind, str) or kind not in VALID_EVIDENCE_KINDS:
             failed_checks.append(f"candidate evidence has unsupported kind: {evidence_id}")
             continue
@@ -364,6 +409,9 @@ def _evidence_inputs_from_manifest(
                         "manifest_subject_commit_sha": manifest_subject_commit_sha,
                         "manifest_run_identity_git_sha": manifest_run_git_sha,
                         "manifest_run_identity_run_key": manifest_run_key,
+                        "report_subject_commit_sha": report_subject_commit_sha,
+                        "report_run_identity_git_sha": report_run_git_sha,
+                        "report_run_identity_run_key": report_run_key,
                         "subject_git_sha_matches_subject_commit": (
                             subject_git_sha_matches_subject_commit
                         ),
@@ -371,6 +419,15 @@ def _evidence_inputs_from_manifest(
                             subject_git_sha_matches_run_identity
                         ),
                         "run_key_matches_run_identity": run_key_matches_run_identity,
+                        "subject_git_sha_matches_report_subject_commit": (
+                            subject_git_sha_matches_report_subject_commit
+                        ),
+                        "subject_git_sha_matches_report_run_identity": (
+                            subject_git_sha_matches_report_run_identity
+                        ),
+                        "run_key_matches_report_run_identity": (
+                            run_key_matches_report_run_identity
+                        ),
                     },
                 )
             )
@@ -663,13 +720,21 @@ def main() -> int:
     )
     parser.add_argument(
         "--commit-sha",
-        default=_git_sha(),
-        help="Subject commit SHA. Defaults to CI/git discovery when available.",
+        default=None,
+        help=(
+            "Subject commit SHA. When --input-manifest is omitted, defaults to "
+            "CI/git discovery when available. With --input-manifest, an explicit "
+            "value overrides the manifest identity."
+        ),
     )
     parser.add_argument(
         "--run-key",
-        default=_run_key(),
-        help="Run identity key. Defaults to CI environment discovery when available.",
+        default=None,
+        help=(
+            "Run identity key. When --input-manifest is omitted, defaults to CI "
+            "environment discovery when available. With --input-manifest, an "
+            "explicit value overrides the manifest identity."
+        ),
     )
     parser.add_argument(
         "--release-candidate",
@@ -705,6 +770,13 @@ def main() -> int:
         else:
             input_manifest_path = input_manifest_path.resolve()
 
+    commit_sha = args.commit_sha
+    run_key = args.run_key
+
+    if input_manifest_path is None:
+        commit_sha = commit_sha or _git_sha()
+        run_key = run_key or _run_key()
+
     try:
         report = build_report(
             policy_path=(REPO_ROOT / args.policy).resolve()
@@ -714,8 +786,8 @@ def main() -> int:
             if not pathlib.Path(args.registry).is_absolute()
             else pathlib.Path(args.registry).resolve(),
             repository=args.repository,
-            commit_sha=args.commit_sha,
-            run_key=args.run_key,
+            commit_sha=commit_sha,
+            run_key=run_key,
             release_candidate=args.release_candidate,
             evidence_args=list(args.evidence or []),
             input_manifest_path=input_manifest_path,

--- a/PULSE_safe_pack_v0/tools/build_release_evidence_verifier_report_v0.py
+++ b/PULSE_safe_pack_v0/tools/build_release_evidence_verifier_report_v0.py
@@ -257,6 +257,16 @@ def _evidence_inputs_from_manifest(
         failed_checks.append("input manifest has no candidate_evidence object")
         return []
 
+    manifest_run_identity = manifest.get("run_identity")
+    run_identity = manifest_run_identity if isinstance(manifest_run_identity, dict) else {}
+
+    manifest_subject = manifest.get("subject")
+    subject = manifest_subject if isinstance(manifest_subject, dict) else {}
+
+    manifest_run_git_sha = run_identity.get("git_sha")
+    manifest_run_key = run_identity.get("run_key")
+    manifest_subject_commit_sha = subject.get("commit_sha")
+    
     out: list[dict[str, Any]] = []
 
     for evidence_id, entry in sorted(candidate_evidence.items(), key=lambda item: str(item[0])):
@@ -268,6 +278,40 @@ def _evidence_inputs_from_manifest(
         raw_path = entry.get("path")
         expected_sha256 = entry.get("expected_sha256")
 
+        subject_binding_raw = entry.get("subject_binding")
+        subject_binding = subject_binding_raw if isinstance(subject_binding_raw, dict) else {}
+
+        candidate_subject_git_sha = subject_binding.get("git_sha")
+        candidate_subject_run_key = subject_binding.get("run_key")
+
+        subject_git_sha_matches_subject_commit = (
+            candidate_subject_git_sha == manifest_subject_commit_sha
+        )
+        subject_git_sha_matches_run_identity = (
+            candidate_subject_git_sha == manifest_run_git_sha
+        )
+        run_key_matches_run_identity = (
+            candidate_subject_run_key == manifest_run_key
+        )
+
+        if not subject_git_sha_matches_subject_commit:
+            failed_checks.append(
+                "candidate evidence subject git_sha mismatch against subject commit: "
+                f"{evidence_id}"
+            )
+
+        if not subject_git_sha_matches_run_identity:
+            failed_checks.append(
+                "candidate evidence subject git_sha mismatch against run identity: "
+                f"{evidence_id}"
+            )
+
+        if not run_key_matches_run_identity:
+            failed_checks.append(
+                "candidate evidence run_key mismatch against run identity: "
+                f"{evidence_id}"
+            )
+        
         if not isinstance(kind, str) or kind not in VALID_EVIDENCE_KINDS:
             failed_checks.append(f"candidate evidence has unsupported kind: {evidence_id}")
             continue
@@ -296,8 +340,16 @@ def _evidence_inputs_from_manifest(
                     kind=kind,
                     path=resolved_path,
                     raw_path=raw_path.strip(),
-                    git_sha=git_sha,
-                    run_key=run_key,
+                    git_sha=(
+                        str(candidate_subject_git_sha)
+                        if isinstance(candidate_subject_git_sha, str)
+                        else None
+                    ),
+                    run_key=(
+                        str(candidate_subject_run_key)
+                        if isinstance(candidate_subject_run_key, str)
+                        else None
+                    ),
                     provenance_extra={
                         "source_manifest": _repo_relative_or_input(
                             manifest_path,
@@ -307,6 +359,18 @@ def _evidence_inputs_from_manifest(
                         "candidate_evidence_id": evidence_id,
                         "expected_sha256": expected_sha256,
                         "actual_sha256_matches_expected": sha_matches,
+                        "candidate_subject_git_sha": candidate_subject_git_sha,
+                        "candidate_subject_run_key": candidate_subject_run_key,
+                        "manifest_subject_commit_sha": manifest_subject_commit_sha,
+                        "manifest_run_identity_git_sha": manifest_run_git_sha,
+                        "manifest_run_identity_run_key": manifest_run_key,
+                        "subject_git_sha_matches_subject_commit": (
+                            subject_git_sha_matches_subject_commit
+                        ),
+                        "subject_git_sha_matches_run_identity": (
+                            subject_git_sha_matches_run_identity
+                        ),
+                        "run_key_matches_run_identity": run_key_matches_run_identity,
                     },
                 )
             )

--- a/docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md
+++ b/docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md
@@ -608,6 +608,53 @@ It does not reopen `--release-grade-materialized`.
 
 If the input manifest is invalid, the builder fails closed and does not write a verifier report.
 
+## Subject/run binding check v0
+
+The fail-closed verifier report builder records manifest-declared candidate evidence subject/run binding.
+
+For manifest-declared candidate evidence, the builder compares:
+
+```text
+candidate_evidence.<id>.subject_binding.git_sha
+→ subject.commit_sha
+candidate_evidence.<id>.subject_binding.git_sha
+→ run_identity.git_sha
+candidate_evidence.<id>.subject_binding.run_key
+→ run_identity.run_key
+```
+
+The check is descriptive and pre-materialization only.
+
+A matching subject/run binding does not verify evidence.
+
+It does not satisfy relation bindings.
+
+It does not emit VERIFIED.
+
+It does not materialize gates.
+
+It does not write status.json.
+
+It does not reopen --release-grade-materialized.
+
+It does not replace check_gates.py.
+
+Mismatch states are recorded as fail-closed verifier report checks, for example:
+
+```text
+candidate evidence subject git_sha mismatch against subject commit: <candidate_evidence_id>
+candidate evidence subject git_sha mismatch against run identity: <candidate_evidence_id>
+candidate evidence run_key mismatch against run identity: <candidate_evidence_id>
+```
+
+The verifier report remains non-authoritative:
+
+```text
+verifier_decision = FAILED
+verified_artifacts = []
+relation_bindings = []
+gate_materialization = {}
+```
 
 ## Input manifest expectation comparison
 

--- a/tests/test_build_release_evidence_verifier_report_v0.py
+++ b/tests/test_build_release_evidence_verifier_report_v0.py
@@ -33,10 +33,7 @@ def _load_json(path: pathlib.Path) -> dict[str, Any]:
 
 def _write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(payload, indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
 
 def _run_tool(*args: str) -> subprocess.CompletedProcess[str]:
@@ -57,25 +54,35 @@ def _input_manifest(
     *,
     evidence_path: pathlib.Path,
     expected_sha256: str,
+    candidate_git_sha: str = HEX40,
+    candidate_run_key: str = RUN_KEY,
+    run_identity_git_sha: str = HEX40,
+    run_identity_run_key: str = RUN_KEY,
+    subject_commit_sha: str = HEX40,
 ) -> dict[str, Any]:
     manifest = copy.deepcopy(_load_json(INPUT_MANIFEST_EXAMPLE))
-    manifest["run_identity"]["git_sha"] = HEX40
-    manifest["run_identity"]["run_key"] = RUN_KEY
+
+    manifest["run_identity"]["git_sha"] = run_identity_git_sha
+    manifest["run_identity"]["run_key"] = run_identity_run_key
+
     manifest["subject"]["repository"] = "HKati/pulse-release-gates-0.1"
-    manifest["subject"]["commit_sha"] = HEX40
+    manifest["subject"]["commit_sha"] = subject_commit_sha
     manifest["subject"]["release_candidate"] = "candidate-v0"
+
     manifest["policy_binding"]["policy_sha256"] = HEX64
     manifest["registry_binding"]["registry_sha256"] = HEX64
+
     manifest["candidate_evidence"]["detector_report"]["path"] = str(evidence_path)
     manifest["candidate_evidence"]["detector_report"]["expected_sha256"] = (
         expected_sha256
     )
     manifest["candidate_evidence"]["detector_report"]["subject_binding"]["git_sha"] = (
-        HEX40
+        candidate_git_sha
     )
     manifest["candidate_evidence"]["detector_report"]["subject_binding"]["run_key"] = (
-        RUN_KEY
+        candidate_run_key
     )
+
     return manifest
 
 
@@ -104,11 +111,11 @@ def test_build_failed_report_without_inputs(tmp_path: pathlib.Path) -> None:
     assert report["verified_artifacts"] == []
     assert report["relation_bindings"] == []
     assert report["gate_materialization"] == {}
+
     assert any("does not verify evidence yet" in item for item in report["failed_checks"])
-    assert any(
-        "no verified relation bindings present" in item
-        for item in report["failed_checks"]
-    )
+    assert any("no verified relation bindings present" in item for item in report["failed_checks"])
+    assert any("no gate materialization performed" in item for item in report["failed_checks"])
+    assert any("no candidate evidence inputs were supplied" in item for item in report["failed_checks"])
 
 
 def test_candidate_evidence_is_recorded_but_not_verified(
@@ -152,6 +159,8 @@ def test_candidate_evidence_is_recorded_but_not_verified(
         evidence_path.read_bytes()
     ).hexdigest()
     assert evidence_input["schema_version"] == "detector_report_v0"
+    assert evidence_input["subject_binding"]["git_sha"] == HEX40
+    assert evidence_input["subject_binding"]["run_key"] == RUN_KEY
     assert evidence_input["provenance"]["trusted"] is False
     assert evidence_input["provenance"]["verification_status"] == "not_verified"
 
@@ -183,6 +192,10 @@ def test_input_manifest_records_existing_candidate_without_verifying(
         str(out_path),
         "--input-manifest",
         str(manifest_path),
+        "--commit-sha",
+        HEX40,
+        "--run-key",
+        RUN_KEY,
     )
 
     assert result.returncode == 0, result.stderr
@@ -195,22 +208,58 @@ def test_input_manifest_records_existing_candidate_without_verifying(
 
     assert len(report["evidence_inputs"]) == 1
     evidence_input = report["evidence_inputs"][0]
+    provenance = evidence_input["provenance"]
+
     assert evidence_input["kind"] == "detector_evidence"
     assert evidence_input["sha256"] == evidence_sha256
     assert evidence_input["schema_version"] == "detector_report_v0"
-    assert evidence_input["provenance"]["trusted"] is False
-    assert evidence_input["provenance"]["verification_status"] == "not_verified"
-    assert evidence_input["provenance"]["candidate_evidence_id"] == "detector_report"
-    assert evidence_input["provenance"]["expected_sha256"] == evidence_sha256
-    assert evidence_input["provenance"]["actual_sha256_matches_expected"] is True
+
+    assert evidence_input["subject_binding"]["git_sha"] == HEX40
+    assert evidence_input["subject_binding"]["run_key"] == RUN_KEY
+
+    assert provenance["trusted"] is False
+    assert provenance["verification_status"] == "not_verified"
+    assert provenance["candidate_evidence_id"] == "detector_report"
+    assert provenance["expected_sha256"] == evidence_sha256
+    assert provenance["actual_sha256_matches_expected"] is True
+
+    assert provenance["candidate_subject_git_sha"] == HEX40
+    assert provenance["candidate_subject_run_key"] == RUN_KEY
+    assert provenance["manifest_subject_commit_sha"] == HEX40
+    assert provenance["manifest_run_identity_git_sha"] == HEX40
+    assert provenance["manifest_run_identity_run_key"] == RUN_KEY
+    assert provenance["report_subject_commit_sha"] == HEX40
+    assert provenance["report_run_identity_git_sha"] == HEX40
+    assert provenance["report_run_identity_run_key"] == RUN_KEY
+
+    assert provenance["subject_git_sha_matches_subject_commit"] is True
+    assert provenance["subject_git_sha_matches_run_identity"] is True
+    assert provenance["run_key_matches_run_identity"] is True
+    assert provenance["subject_git_sha_matches_report_subject_commit"] is True
+    assert provenance["subject_git_sha_matches_report_run_identity"] is True
+    assert provenance["run_key_matches_report_run_identity"] is True
+
+    failed_checks = "\n".join(report["failed_checks"])
+    assert "candidate evidence digest mismatch: detector_report" not in failed_checks
+    assert (
+        "candidate evidence subject git_sha mismatch against subject commit: detector_report"
+        not in failed_checks
+    )
+    assert (
+        "candidate evidence subject git_sha mismatch against run identity: detector_report"
+        not in failed_checks
+    )
+    assert (
+        "candidate evidence run_key mismatch against run identity: detector_report"
+        not in failed_checks
+    )
 
     assert any(
         "input manifest expectations are recorded only" in item
         for item in report["failed_checks"]
     )
     assert any(
-        "expected candidate evidence recorded but not verified: detector_report"
-        in item
+        "expected candidate evidence recorded but not verified: detector_report" in item
         for item in report["failed_checks"]
     )
     assert any(
@@ -222,11 +271,6 @@ def test_input_manifest_records_existing_candidate_without_verifying(
         "expected gate materialization pending verification: detectors_materialized_ok"
         in item
         for item in report["failed_checks"]
-    )
-    assert any(
-        "input manifest expectation comparison is fail-closed and descriptive only"
-        in item
-        for item in report["warnings"]
     )
 
 
@@ -260,30 +304,40 @@ def test_input_manifest_digest_mismatch_records_failed_report(
         str(out_path),
         "--input-manifest",
         str(manifest_path),
+        "--commit-sha",
+        HEX40,
+        "--run-key",
+        RUN_KEY,
     )
 
     assert result.returncode == 0, result.stderr
 
     report = _load_json(out_path)
     assert report["verifier_decision"] == "FAILED"
-    assert any(
-        "candidate evidence digest mismatch: detector_report" in item
-        for item in report["failed_checks"]
-    )
-    assert report["evidence_inputs"][0]["provenance"][
-        "actual_sha256_matches_expected"
-    ] is False
-    actual_sha256 = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
-    evidence_input = report["evidence_inputs"][0]
-
-    assert evidence_input["sha256"] == actual_sha256
-    assert evidence_input["provenance"]["expected_sha256"] == HEX64
-    assert evidence_input["sha256"] != evidence_input["provenance"]["expected_sha256"]
-
-    assert report["verifier_decision"] == "FAILED"
     assert report["verified_artifacts"] == []
     assert report["relation_bindings"] == []
     assert report["gate_materialization"] == {}
+
+    failed_checks = "\n".join(report["failed_checks"])
+    assert "candidate evidence digest mismatch: detector_report" in failed_checks
+
+    actual_sha256 = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+    evidence_input = report["evidence_inputs"][0]
+    provenance = evidence_input["provenance"]
+
+    assert evidence_input["sha256"] == actual_sha256
+    assert provenance["expected_sha256"] == HEX64
+    assert evidence_input["sha256"] != provenance["expected_sha256"]
+    assert provenance["actual_sha256_matches_expected"] is False
+
+    assert provenance["trusted"] is False
+    assert provenance["verification_status"] == "not_verified"
+    assert provenance["subject_git_sha_matches_subject_commit"] is True
+    assert provenance["subject_git_sha_matches_run_identity"] is True
+    assert provenance["run_key_matches_run_identity"] is True
+    assert provenance["subject_git_sha_matches_report_subject_commit"] is True
+    assert provenance["subject_git_sha_matches_report_run_identity"] is True
+    assert provenance["run_key_matches_report_run_identity"] is True
 
 
 def test_input_manifest_missing_candidate_writes_failed_report(
@@ -307,6 +361,10 @@ def test_input_manifest_missing_candidate_writes_failed_report(
         str(out_path),
         "--input-manifest",
         str(manifest_path),
+        "--commit-sha",
+        HEX40,
+        "--run-key",
+        RUN_KEY,
     )
 
     assert result.returncode == 0, result.stderr
@@ -314,19 +372,17 @@ def test_input_manifest_missing_candidate_writes_failed_report(
     report = _load_json(out_path)
     assert report["verifier_decision"] == "FAILED"
     assert report["evidence_inputs"] == []
-    assert any(
-        "candidate evidence declared by manifest is missing" in item
-        for item in report["failed_checks"]
-    )
-    assert any(
-        "expected candidate evidence not recorded: detector_report" in item
-        for item in report["failed_checks"]
-    )
-    assert any(
+    assert report["verified_artifacts"] == []
+    assert report["relation_bindings"] == []
+    assert report["gate_materialization"] == {}
+
+    failed_checks = "\n".join(report["failed_checks"])
+    assert "candidate evidence declared by manifest is missing" in failed_checks
+    assert "expected candidate evidence not recorded: detector_report" in failed_checks
+    assert (
         "expected gate materialization candidate evidence not recorded: "
-        "detectors_materialized_ok -> detector_report" in item
-        for item in report["failed_checks"]
-    )
+        "detectors_materialized_ok -> detector_report"
+    ) in failed_checks
 
 
 def test_invalid_input_manifest_fails_closed_without_report(
@@ -353,6 +409,10 @@ def test_invalid_input_manifest_fails_closed_without_report(
         str(out_path),
         "--input-manifest",
         str(manifest_path),
+        "--commit-sha",
+        HEX40,
+        "--run-key",
+        RUN_KEY,
     )
 
     assert result.returncode != 0
@@ -385,6 +445,10 @@ def test_input_manifest_cannot_be_combined_with_direct_evidence(
         str(manifest_path),
         "--evidence",
         f"detector_evidence={evidence_path}",
+        "--commit-sha",
+        HEX40,
+        "--run-key",
+        RUN_KEY,
     )
 
     assert result.returncode != 0
@@ -444,3 +508,469 @@ def test_pass_or_allow_are_never_emitted(tmp_path: pathlib.Path) -> None:
     report = _load_json(out_path)
     assert report["verifier_decision"] == "FAILED"
     assert report["verifier_decision"] not in {"PASS", "ALLOW", "PROD-PASS"}
+
+
+def test_input_manifest_records_candidate_subject_run_binding_without_verifying(
+    tmp_path: pathlib.Path,
+) -> None:
+    evidence_path = tmp_path / "detector_report.json"
+    evidence_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "detector_report_v0",
+                "result": "candidate-only",
+            }
+        ),
+        encoding="utf-8",
+    )
+    evidence_sha256 = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+
+    manifest_path = tmp_path / "release_evidence_input_manifest_v0.json"
+    _write_json(
+        manifest_path,
+        _input_manifest(
+            evidence_path=evidence_path,
+            expected_sha256=evidence_sha256,
+        ),
+    )
+
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--input-manifest",
+        str(manifest_path),
+        "--commit-sha",
+        HEX40,
+        "--run-key",
+        RUN_KEY,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    report = _load_json(out_path)
+    evidence_input = report["evidence_inputs"][0]
+    provenance = evidence_input["provenance"]
+
+    assert evidence_input["subject_binding"]["git_sha"] == HEX40
+    assert evidence_input["subject_binding"]["run_key"] == RUN_KEY
+
+    assert provenance["candidate_subject_git_sha"] == HEX40
+    assert provenance["candidate_subject_run_key"] == RUN_KEY
+    assert provenance["manifest_subject_commit_sha"] == HEX40
+    assert provenance["manifest_run_identity_git_sha"] == HEX40
+    assert provenance["manifest_run_identity_run_key"] == RUN_KEY
+    assert provenance["report_subject_commit_sha"] == HEX40
+    assert provenance["report_run_identity_git_sha"] == HEX40
+    assert provenance["report_run_identity_run_key"] == RUN_KEY
+
+    assert provenance["subject_git_sha_matches_subject_commit"] is True
+    assert provenance["subject_git_sha_matches_run_identity"] is True
+    assert provenance["run_key_matches_run_identity"] is True
+    assert provenance["subject_git_sha_matches_report_subject_commit"] is True
+    assert provenance["subject_git_sha_matches_report_run_identity"] is True
+    assert provenance["run_key_matches_report_run_identity"] is True
+
+    assert report["verifier_decision"] == "FAILED"
+    assert provenance["trusted"] is False
+    assert provenance["verification_status"] == "not_verified"
+    assert report["verified_artifacts"] == []
+    assert report["relation_bindings"] == []
+    assert report["gate_materialization"] == {}
+
+
+def test_input_manifest_subject_commit_mismatch_stays_failed(
+    tmp_path: pathlib.Path,
+) -> None:
+    evidence_path = tmp_path / "detector_report.json"
+    evidence_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "detector_report_v0",
+                "result": "candidate-only",
+            }
+        ),
+        encoding="utf-8",
+    )
+    evidence_sha256 = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+
+    candidate_git_sha = "a" * 40
+    subject_commit_sha = "c" * 40
+
+    manifest_path = tmp_path / "release_evidence_input_manifest_v0.json"
+    _write_json(
+        manifest_path,
+        _input_manifest(
+            evidence_path=evidence_path,
+            expected_sha256=evidence_sha256,
+            candidate_git_sha=candidate_git_sha,
+            run_identity_git_sha=candidate_git_sha,
+            subject_commit_sha=subject_commit_sha,
+        ),
+    )
+
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--input-manifest",
+        str(manifest_path),
+        "--commit-sha",
+        candidate_git_sha,
+        "--run-key",
+        RUN_KEY,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    report = _load_json(out_path)
+    failed_checks = "\n".join(report["failed_checks"])
+    evidence_input = report["evidence_inputs"][0]
+    provenance = evidence_input["provenance"]
+
+    assert (
+        "candidate evidence subject git_sha mismatch against subject commit: "
+        "detector_report"
+    ) in failed_checks
+
+    assert provenance["subject_git_sha_matches_subject_commit"] is False
+    assert provenance["subject_git_sha_matches_run_identity"] is True
+    assert provenance["run_key_matches_run_identity"] is True
+    assert provenance["subject_git_sha_matches_report_subject_commit"] is True
+    assert provenance["subject_git_sha_matches_report_run_identity"] is True
+    assert provenance["run_key_matches_report_run_identity"] is True
+
+    assert evidence_input["subject_binding"]["git_sha"] == candidate_git_sha
+    assert evidence_input["subject_binding"]["run_key"] == RUN_KEY
+
+    assert report["verifier_decision"] == "FAILED"
+    assert provenance["trusted"] is False
+    assert provenance["verification_status"] == "not_verified"
+    assert report["verified_artifacts"] == []
+    assert report["relation_bindings"] == []
+    assert report["gate_materialization"] == {}
+
+
+def test_input_manifest_run_identity_git_sha_mismatch_stays_failed(
+    tmp_path: pathlib.Path,
+) -> None:
+    evidence_path = tmp_path / "detector_report.json"
+    evidence_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "detector_report_v0",
+                "result": "candidate-only",
+            }
+        ),
+        encoding="utf-8",
+    )
+    evidence_sha256 = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+
+    candidate_git_sha = "a" * 40
+    run_identity_git_sha = "d" * 40
+
+    manifest_path = tmp_path / "release_evidence_input_manifest_v0.json"
+    _write_json(
+        manifest_path,
+        _input_manifest(
+            evidence_path=evidence_path,
+            expected_sha256=evidence_sha256,
+            candidate_git_sha=candidate_git_sha,
+            run_identity_git_sha=run_identity_git_sha,
+            subject_commit_sha=candidate_git_sha,
+        ),
+    )
+
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--input-manifest",
+        str(manifest_path),
+        "--commit-sha",
+        candidate_git_sha,
+        "--run-key",
+        RUN_KEY,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    report = _load_json(out_path)
+    failed_checks = "\n".join(report["failed_checks"])
+    evidence_input = report["evidence_inputs"][0]
+    provenance = evidence_input["provenance"]
+
+    assert (
+        "candidate evidence subject git_sha mismatch against run identity: "
+        "detector_report"
+    ) in failed_checks
+
+    assert provenance["subject_git_sha_matches_subject_commit"] is True
+    assert provenance["subject_git_sha_matches_run_identity"] is False
+    assert provenance["run_key_matches_run_identity"] is True
+    assert provenance["subject_git_sha_matches_report_subject_commit"] is True
+    assert provenance["subject_git_sha_matches_report_run_identity"] is True
+    assert provenance["run_key_matches_report_run_identity"] is True
+
+    assert evidence_input["subject_binding"]["git_sha"] == candidate_git_sha
+    assert evidence_input["subject_binding"]["run_key"] == RUN_KEY
+
+    assert report["verifier_decision"] == "FAILED"
+    assert provenance["trusted"] is False
+    assert provenance["verification_status"] == "not_verified"
+    assert report["verified_artifacts"] == []
+    assert report["relation_bindings"] == []
+    assert report["gate_materialization"] == {}
+
+
+def test_input_manifest_run_key_mismatch_stays_failed(
+    tmp_path: pathlib.Path,
+) -> None:
+    evidence_path = tmp_path / "detector_report.json"
+    evidence_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "detector_report_v0",
+                "result": "candidate-only",
+            }
+        ),
+        encoding="utf-8",
+    )
+    evidence_sha256 = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+
+    candidate_run_key = "GITHUB_RUN_ID=1|GITHUB_RUN_NUMBER=1|GITHUB_WORKFLOW=PULSE CI"
+    manifest_run_key = "GITHUB_RUN_ID=2|GITHUB_RUN_NUMBER=2|GITHUB_WORKFLOW=PULSE CI"
+
+    manifest_path = tmp_path / "release_evidence_input_manifest_v0.json"
+    _write_json(
+        manifest_path,
+        _input_manifest(
+            evidence_path=evidence_path,
+            expected_sha256=evidence_sha256,
+            candidate_run_key=candidate_run_key,
+            run_identity_run_key=manifest_run_key,
+        ),
+    )
+
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--input-manifest",
+        str(manifest_path),
+        "--commit-sha",
+        HEX40,
+        "--run-key",
+        candidate_run_key,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    report = _load_json(out_path)
+    failed_checks = "\n".join(report["failed_checks"])
+    evidence_input = report["evidence_inputs"][0]
+    provenance = evidence_input["provenance"]
+
+    assert (
+        "candidate evidence run_key mismatch against run identity: "
+        "detector_report"
+    ) in failed_checks
+
+    assert provenance["subject_git_sha_matches_subject_commit"] is True
+    assert provenance["subject_git_sha_matches_run_identity"] is True
+    assert provenance["run_key_matches_run_identity"] is False
+    assert provenance["subject_git_sha_matches_report_subject_commit"] is True
+    assert provenance["subject_git_sha_matches_report_run_identity"] is True
+    assert provenance["run_key_matches_report_run_identity"] is True
+
+    assert evidence_input["subject_binding"]["git_sha"] == HEX40
+    assert evidence_input["subject_binding"]["run_key"] == candidate_run_key
+
+    assert report["verifier_decision"] == "FAILED"
+    assert provenance["trusted"] is False
+    assert provenance["verification_status"] == "not_verified"
+    assert report["verified_artifacts"] == []
+    assert report["relation_bindings"] == []
+    assert report["gate_materialization"] == {}
+
+
+def test_input_manifest_subject_run_binding_normalizes_git_sha_case(
+    tmp_path: pathlib.Path,
+) -> None:
+    evidence_path = tmp_path / "detector_report.json"
+    evidence_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "detector_report_v0",
+                "result": "candidate-only",
+            }
+        ),
+        encoding="utf-8",
+    )
+    evidence_sha256 = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+
+    lowercase_sha = "a" * 40
+    uppercase_sha = "A" * 40
+
+    manifest_path = tmp_path / "release_evidence_input_manifest_v0.json"
+    _write_json(
+        manifest_path,
+        _input_manifest(
+            evidence_path=evidence_path,
+            expected_sha256=evidence_sha256,
+            candidate_git_sha=lowercase_sha,
+            run_identity_git_sha=uppercase_sha,
+            subject_commit_sha=uppercase_sha,
+        ),
+    )
+
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--input-manifest",
+        str(manifest_path),
+        "--commit-sha",
+        uppercase_sha,
+        "--run-key",
+        RUN_KEY,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    report = _load_json(out_path)
+    failed_checks = "\n".join(report["failed_checks"])
+    evidence_input = report["evidence_inputs"][0]
+    provenance = evidence_input["provenance"]
+
+    assert (
+        "candidate evidence subject git_sha mismatch against subject commit: "
+        "detector_report"
+    ) not in failed_checks
+    assert (
+        "candidate evidence subject git_sha mismatch against run identity: "
+        "detector_report"
+    ) not in failed_checks
+
+    assert evidence_input["subject_binding"]["git_sha"] == lowercase_sha
+    assert evidence_input["subject_binding"]["run_key"] == RUN_KEY
+
+    assert provenance["manifest_subject_commit_sha"] == uppercase_sha
+    assert provenance["manifest_run_identity_git_sha"] == uppercase_sha
+    assert provenance["report_subject_commit_sha"] == uppercase_sha
+    assert provenance["report_run_identity_git_sha"] == uppercase_sha
+
+    assert provenance["subject_git_sha_matches_subject_commit"] is True
+    assert provenance["subject_git_sha_matches_run_identity"] is True
+    assert provenance["subject_git_sha_matches_report_subject_commit"] is True
+    assert provenance["subject_git_sha_matches_report_run_identity"] is True
+
+    assert report["verifier_decision"] == "FAILED"
+    assert provenance["trusted"] is False
+    assert provenance["verification_status"] == "not_verified"
+    assert report["verified_artifacts"] == []
+    assert report["relation_bindings"] == []
+    assert report["gate_materialization"] == {}
+
+
+def test_input_manifest_explicit_report_identity_override_mismatch_stays_failed(
+    tmp_path: pathlib.Path,
+) -> None:
+    evidence_path = tmp_path / "detector_report.json"
+    evidence_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "detector_report_v0",
+                "result": "candidate-only",
+            }
+        ),
+        encoding="utf-8",
+    )
+    evidence_sha256 = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+
+    manifest_sha = "a" * 40
+    override_sha = "d" * 40
+    manifest_run_key = "GITHUB_RUN_ID=1|GITHUB_RUN_NUMBER=1|GITHUB_WORKFLOW=PULSE CI"
+    override_run_key = "GITHUB_RUN_ID=2|GITHUB_RUN_NUMBER=2|GITHUB_WORKFLOW=PULSE CI"
+
+    manifest_path = tmp_path / "release_evidence_input_manifest_v0.json"
+    _write_json(
+        manifest_path,
+        _input_manifest(
+            evidence_path=evidence_path,
+            expected_sha256=evidence_sha256,
+            candidate_git_sha=manifest_sha,
+            candidate_run_key=manifest_run_key,
+            run_identity_git_sha=manifest_sha,
+            run_identity_run_key=manifest_run_key,
+            subject_commit_sha=manifest_sha,
+        ),
+    )
+
+    out_path = tmp_path / "release_evidence_verifier_report_v0.json"
+
+    result = _run_tool(
+        "--out",
+        str(out_path),
+        "--input-manifest",
+        str(manifest_path),
+        "--commit-sha",
+        override_sha,
+        "--run-key",
+        override_run_key,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+    report = _load_json(out_path)
+    failed_checks = "\n".join(report["failed_checks"])
+    evidence_input = report["evidence_inputs"][0]
+    provenance = evidence_input["provenance"]
+
+    assert report["run_identity"]["git_sha"] == override_sha
+    assert report["run_identity"]["run_key"] == override_run_key
+    assert report["subject"]["commit_sha"] == override_sha
+
+    assert (
+        "candidate evidence subject git_sha mismatch against subject commit: "
+        "detector_report"
+    ) in failed_checks
+    assert (
+        "candidate evidence subject git_sha mismatch against run identity: "
+        "detector_report"
+    ) in failed_checks
+    assert (
+        "candidate evidence run_key mismatch against run identity: "
+        "detector_report"
+    ) in failed_checks
+
+    assert evidence_input["subject_binding"]["git_sha"] == manifest_sha
+    assert evidence_input["subject_binding"]["run_key"] == manifest_run_key
+
+    assert provenance["subject_git_sha_matches_subject_commit"] is True
+    assert provenance["subject_git_sha_matches_run_identity"] is True
+    assert provenance["run_key_matches_run_identity"] is True
+
+    assert provenance["subject_git_sha_matches_report_subject_commit"] is False
+    assert provenance["subject_git_sha_matches_report_run_identity"] is False
+    assert provenance["run_key_matches_report_run_identity"] is False
+
+    assert provenance["report_subject_commit_sha"] == override_sha
+    assert provenance["report_run_identity_git_sha"] == override_sha
+    assert provenance["report_run_identity_run_key"] == override_run_key
+
+    assert report["verifier_decision"] == "FAILED"
+    assert provenance["trusted"] is False
+    assert provenance["verification_status"] == "not_verified"
+    assert report["verified_artifacts"] == []
+    assert report["relation_bindings"] == []
+    assert report["gate_materialization"] == {}
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_release_evidence_input_manifest_v0.py
+++ b/tests/test_release_evidence_input_manifest_v0.py
@@ -242,5 +242,47 @@ def test_checker_cli_reports_errors(tmp_path: pathlib.Path) -> None:
     assert "missing_relation" in result.stderr
 
 
+def test_candidate_evidence_requires_subject_binding(
+    tmp_path: pathlib.Path,
+) -> None:
+    manifest = _minimal_manifest()
+    manifest["candidate_evidence"]["detector_report"].pop("subject_binding")
+
+    manifest_path = tmp_path / "release_evidence_input_manifest_v0.json"
+    _write_json(manifest_path, manifest)
+
+    errors = check_release_evidence_input_manifest(manifest_path)
+
+    assert errors
+
+
+def test_candidate_evidence_subject_binding_requires_git_sha(
+    tmp_path: pathlib.Path,
+) -> None:
+    manifest = _minimal_manifest()
+    manifest["candidate_evidence"]["detector_report"]["subject_binding"].pop("git_sha")
+
+    manifest_path = tmp_path / "release_evidence_input_manifest_v0.json"
+    _write_json(manifest_path, manifest)
+
+    errors = check_release_evidence_input_manifest(manifest_path)
+
+    assert errors
+
+
+def test_candidate_evidence_subject_binding_requires_run_key(
+    tmp_path: pathlib.Path,
+) -> None:
+    manifest = _minimal_manifest()
+    manifest["candidate_evidence"]["detector_report"]["subject_binding"].pop("run_key")
+
+    manifest_path = tmp_path / "release_evidence_input_manifest_v0.json"
+    _write_json(manifest_path, manifest)
+
+    errors = check_release_evidence_input_manifest(manifest_path)
+
+    assert errors
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))

--- a/tests/test_release_evidence_pre_materialization_pipeline_v0.py
+++ b/tests/test_release_evidence_pre_materialization_pipeline_v0.py
@@ -247,6 +247,11 @@ def test_pre_materialization_pipeline_exposes_gaps_without_authority(
     assert evidence_input["provenance"]["verification_status"] == "not_verified"
     assert evidence_input["provenance"]["candidate_evidence_id"] == "detector_report"
     assert evidence_input["provenance"]["actual_sha256_matches_expected"] is True
+    assert evidence_input["subject_binding"]["git_sha"] == HEX40
+    assert evidence_input["subject_binding"]["run_key"] == RUN_KEY
+    assert evidence_input["provenance"]["subject_git_sha_matches_subject_commit"] is True
+    assert evidence_input["provenance"]["subject_git_sha_matches_run_identity"] is True
+    assert evidence_input["provenance"]["run_key_matches_run_identity"] is True
     assert evidence_input["sha256"] == evidence_sha256
     assert evidence_input["provenance"]["expected_sha256"] == evidence_sha256
    
@@ -498,6 +503,98 @@ def test_pre_materialization_pipeline_invalid_manifest_fails_before_report(
     assert "release evidence input manifest failed validation" in build_report.stderr
     assert not verifier_report_path.exists()
     assert not summary_path.exists()
+
+    _assert_authority_artifacts_unchanged(authority_before, tmp_path)
+
+
+def test_pre_materialization_pipeline_subject_run_mismatch_is_visible_but_non_authorizing(
+    tmp_path: pathlib.Path,
+) -> None:
+    authority_before = _authority_artifact_snapshot(tmp_path)
+
+    evidence_path = tmp_path / "detector_report.json"
+    _write_json(
+        evidence_path,
+        {
+            "schema_version": "detector_report_v0",
+            "result": "candidate-only",
+        },
+    )
+    evidence_sha256 = hashlib.sha256(evidence_path.read_bytes()).hexdigest()
+
+    manifest = _input_manifest(
+        evidence_path=evidence_path,
+        expected_sha256=evidence_sha256,
+    )
+    manifest["subject"]["commit_sha"] = "c" * 40
+    manifest["run_identity"]["git_sha"] = "d" * 40
+    manifest["run_identity"]["run_key"] = (
+        "GITHUB_RUN_ID=2|GITHUB_RUN_NUMBER=2|GITHUB_WORKFLOW=PULSE CI"
+    )
+
+    manifest_path = tmp_path / "release_evidence_input_manifest_v0.json"
+    _write_json(manifest_path, manifest)
+
+    verifier_report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    summary_path = tmp_path / "release_evidence_expectation_summary_v0.json"
+
+    build_report = _run(
+        str(BUILD_VERIFIER_REPORT),
+        "--out",
+        str(verifier_report_path),
+        "--input-manifest",
+        str(manifest_path),
+    )
+
+    assert build_report.returncode == 0, build_report.stderr
+
+    report = _load_json(verifier_report_path)
+    evidence_input = report["evidence_inputs"][0]
+    provenance = evidence_input["provenance"]
+    failed_checks = "\n".join(report["failed_checks"])
+
+    assert (
+        "candidate evidence subject git_sha mismatch against subject commit: "
+        "detector_report"
+    ) in failed_checks
+    assert (
+        "candidate evidence subject git_sha mismatch against run identity: "
+        "detector_report"
+    ) in failed_checks
+    assert (
+        "candidate evidence run_key mismatch against run identity: "
+        "detector_report"
+    ) in failed_checks
+
+    assert evidence_input["subject_binding"]["git_sha"] == HEX40
+    assert evidence_input["subject_binding"]["run_key"] == RUN_KEY
+
+    assert provenance["subject_git_sha_matches_subject_commit"] is False
+    assert provenance["subject_git_sha_matches_run_identity"] is False
+    assert provenance["run_key_matches_run_identity"] is False
+
+    assert report["verifier_decision"] == "FAILED"
+    assert provenance["trusted"] is False
+    assert provenance["verification_status"] == "not_verified"
+    assert report["verified_artifacts"] == []
+    assert report["relation_bindings"] == []
+    assert report["gate_materialization"] == {}
+
+    _assert_authority_artifacts_unchanged(authority_before, tmp_path)
+
+    build_summary = _run(
+        str(BUILD_EXPECTATION_SUMMARY),
+        "--report",
+        str(verifier_report_path),
+        "--out",
+        str(summary_path),
+    )
+
+    assert build_summary.returncode == 0, build_summary.stderr
+
+    summary = _load_json(summary_path)
+    assert summary["summary"]["verifier_readiness"] == "NOT_READY"
+    assert summary["summary"]["other_failed_check_count"] >= 3
 
     _assert_authority_artifacts_unchanged(authority_before, tmp_path)
 


### PR DESCRIPTION
## Summary

This PR adds the first subject/run binding check for manifest-declared candidate evidence.

The builder now reads `candidate_evidence.<id>.subject_binding.git_sha` and `candidate_evidence.<id>.subject_binding.run_key` from `release_evidence_input_manifest_v0`, records the declared subject/run binding on the verifier report evidence input, and records descriptive mismatch checks when the candidate binding does not match the manifest subject or run identity.

## What this checks

- candidate evidence subject git SHA against `subject.commit_sha`
- candidate evidence subject git SHA against `run_identity.git_sha`
- candidate evidence run key against `run_identity.run_key`

## Boundary

This PR does not implement the trusted verifier.

A subject/run binding match does not imply:

- `VERIFIED`
- `PASS`
- `ALLOW`
- `PROD-PASS`
- trusted evidence
- satisfied relation binding
- gate materialization
- `status.json`
- `report_card.html`
- `release_authority_v0.json`
- release-authority audit bundle
- release eligibility

The verifier report remains fail-closed and non-authoritative:

- `verifier_decision = FAILED`
- `provenance.trusted = false`
- `verification_status = not_verified`
- `verified_artifacts = []`
- `relation_bindings = []`
- `gate_materialization = {}`

## Non-goals

This PR does not change:

- `run_all.py`
- `check_gates.py`
- release policy
- gate registry
- status schemas
- CI authority path
- `--release-grade-materialized`
- release-authority semantics

## Tests

- `pytest -q tests/test_build_release_evidence_verifier_report_v0.py`
- `pytest -q tests/test_release_evidence_pre_materialization_pipeline_v0.py`
- `pytest -q tests/test_release_evidence_input_manifest_v0.py`
- `pytest -q tests/test_build_release_evidence_expectation_summary_v0.py`
- `pytest -q tests/test_tools_tests_list_smoke.py`