### PR TITLE
test(ref): lock PROD-PASS verifier decision rejection v0

### DIFF
--- a/tests/test_check_release_evidence_verifier_report_v0.py
+++ b/tests/test_check_release_evidence_verifier_report_v0.py
@@ -213,7 +213,7 @@ def test_gate_materialization_without_relation_ids_fails(tmp_path: pathlib.Path)
     )
 
 
-@pytest.mark.parametrize("bad_decision", ["PASS", "ALLOW"])
+@pytest.mark.parametrize("bad_decision", ["PASS", "ALLOW", "PROD-PASS"])
 def test_release_authority_words_are_rejected_as_verifier_decisions(
     tmp_path: pathlib.Path,
     bad_decision: str,

--- a/tests/test_release_evidence_verifier_report_schema_v0.py
+++ b/tests/test_release_evidence_verifier_report_schema_v0.py
@@ -197,6 +197,15 @@ def test_allow_is_not_a_verifier_decision() -> None:
     assert errors
 
 
+def test_prod_pass_is_not_a_verifier_decision() -> None:
+    report = _minimal_verified_report()
+    report["verifier_decision"] = "PROD-PASS"
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
 def test_failed_report_requires_failed_checks() -> None:
     report = _load_json(FAILED_EXAMPLE_PATH)
     report["failed_checks"] = []


### PR DESCRIPTION
## Summary

This PR locks explicit `PROD-PASS` rejection for release evidence verifier reports.

The verifier report decision vocabulary remains limited to:

- `VERIFIED`
- `FAILED`

The following release-authority words must remain invalid verifier decisions:

- `PASS`
- `ALLOW`
- `PROD-PASS`

`PASS` and `ALLOW` were already explicitly covered in schema/checker tests. This PR adds explicit `PROD-PASS` coverage to the same boundary.

## Scope

Test-only hardening.

Changed files:

- `tests/test_release_evidence_verifier_report_schema_v0.py`
- `tests/test_check_release_evidence_verifier_report_v0.py`

No `ci/tools-tests.list` update is required because this PR strengthens existing test files and does not add a new test file.

## What this locks

This PR asserts that:

- `PROD-PASS` is rejected by the verifier report schema path
- `PROD-PASS` is rejected by the verifier report checker path
- verifier reports do not accept release-authority wording as verifier decisions

## Boundary

This PR does not change the allowed verifier decisions.

Allowed verifier decisions remain:

- `VERIFIED`
- `FAILED`

This PR does not add or enable:

- `PASS`
- `ALLOW`
- `PROD-PASS`
- trusted evidence
- verified evidence promotion
- satisfied relation bindings
- gate materialization
- release eligibility

## Non-goals

This PR does not change:

- verifier report schema
- verifier checker logic
- verifier builder behavior
- expectation summary behavior
- input manifest behavior
- `ci/tools-tests.list`
- `check_gates.py`
- `run_all.py`
- release policy
- gate registry
- status schemas
- CI authority path
- `--release-grade-materialized`

This PR does not create or enable:

- `status.json`
- `report_card.html`
- `release_authority_v0.json`
- release-authority audit bundles
- gate materialization
- release-grade materialization

## Mechanical boundary

`PROD-PASS` is not a verifier decision.

Verifier report decisions remain schema-bound to `VERIFIED` / `FAILED`.

A verifier report must not use release-authority words as verifier decisions.

## Testing

```bash
python -m pytest \
  tests/test_release_evidence_verifier_report_schema_v0.py \
  tests/test_check_release_evidence_verifier_report_v0.py
```

Optional targeted confirmation:

```bash
python -m pytest \
  tests/test_release_evidence_verifier_report_schema_v0.py \
  tests/test_check_release_evidence_verifier_report_v0.py \
  tests/test_build_release_evidence_verifier_report_v0.py \
  tests/test_build_release_evidence_expectation_summary_v0.py
```

Tools smoke:

```bash
python -m pytest tests/test_tools_tests_list_smoke.py
```