### PR TITLE
docs(ref): align README with reviewable mechanics boundary v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,22 @@ See [`docs/PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md`](docs/PULSE_PRE_MATER
 | Dashboards, badges, Pages | Publication / reader carriers derived from recorded release-state artifacts | Derived carriers only |
 | Diagnostic and shadow outputs | Diagnostic / shadow carriers for candidate evidence signals and review state | Authority participation requires recorded evidence inclusion and required-gate enforcement under declared policy |
 
+### Reviewable mechanics boundary
+
+PULSE does not use external review, reader surfaces, audit sidecars, coverage scores, green test results, or documentation claims as release authority.
+
+External review can inspect the mechanism, the claims, the implementation, and the reproducibility of the repository.
+
+External review cannot replace the artifact-bound release-authority path.
+
+`release_authority_v0` is an audit / traceability sidecar, not a second decision engine.
+
+Coverage scores and other metrics are descriptive unless they are explicitly promoted into declared policy, workflow-effective materialized required gates, and strict fail-closed CI enforcement.
+
+Green tests alone do not create release authority.
+
+The mechanical review boundary is documented in [`docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md`](docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md).
+
 ## Release boundary
 
 PULSE acts at the release boundary, before deployment.
@@ -494,7 +510,7 @@ PULSE evaluates release evidence under declared policy. In Core and release-grad
 - Q₄ **SLOs** (p95 latency & cost budgets)
 
 **Release-decision outputs**
-- **Quality Ledger** — human-readable release decision surface
+-- **Quality Ledger** — human-readable release decision surface. The Quality Ledger is a reader-facing surface. It may expose release-decision state for review, but it does not compute, replace, or override the artifact-bound release-authority path.
 - **RDSI** — Release Decision Stability Index with deltas / confidence intervals where available
 - **CI artifacts** — `status.json`, report card, JUnit, SARIF, badges, and registered diagnostic artifacts
 


### PR DESCRIPTION
## Summary

This PR aligns the README entrypoint with the reviewable mechanics boundary.

It adds a concise README anchor stating that external review, reader surfaces, audit sidecars, coverage scores, green test results, and documentation claims do not create release authority.

It also links:

- `docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md`

and clarifies that:

- `release_authority_v0` is an audit / traceability sidecar, not a second decision engine
- coverage scores and metrics are descriptive unless explicitly promoted into declared policy, workflow-effective materialized required gates, and strict fail-closed CI enforcement
- green tests alone do not create release authority
- external review can inspect the mechanism but cannot replace the artifact-bound release-authority path
- reader-facing surfaces may expose release state for review, but do not compute, replace, or override the artifact-bound release-authority path

## Scope

Documentation-only.

Changed file:

- `README.md`

No code, schema, checker, builder, policy, registry, status schema, CI authority path, or release-grade materialization behavior is changed.

## Boundary

This PR does not change the PULSEmech release-authority path:

```text
recorded release evidence
→ status.json
→ declared gate policy
→ workflow-effective materialized required gate set
→ strict fail-closed CI enforcement
→ pre-deployment allow/block release decision
```

This PR does not make any of the following release-authority carriers:

- external review
- reader surfaces
- public Pages
- summaries
- dashboards
- badges
- Quality Ledger views
- audit sidecars
- audit bundles
- coverage scores
- green test results
- documentation claims

## Mechanical anchors

external review ≠ release authority  
reader surface ≠ release authority  
audit sidecar ≠ decision engine  
coverage score ≠ release authority  
green tests alone ≠ release authority  
visible information ≠ normative release authority  

## Non-goals

This PR does not change:

- code
- schemas
- verifier behavior
- checker behavior
- builder behavior
- release policy
- gate registry
- status schemas
- CI authority path
- `--release-grade-materialized`

This PR does not create or enable:

- release authority from external review
- release authority from reader surfaces
- release authority from audit sidecars
- release authority from coverage scores
- release authority from green tests
- gate materialization
- release-grade materialization

## Testing

Documentation-only change.

Recommended verification:

```bash
git diff --check
```

Link / anchor confirmation:

```bash
test -f docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md && echo "reviewable mechanics checklist present"

rg -n \
  "Reviewable mechanics boundary|release_authority_v0|Coverage scores|Green tests alone|External review cannot replace|PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0|audit / traceability sidecar|not a second decision engine" \
  README.md
```

Optional tools smoke:

```bash
python -m pytest tests/test_tools_tests_list_smoke.py
```