### PR TITLE
docs(ref): fix README Quality Ledger bullet formatting v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ PULSE evaluates release evidence under declared policy. In Core and release-grad
 - Q₄ **SLOs** (p95 latency & cost budgets)
 
 **Release-decision outputs**
--- **Quality Ledger** — human-readable release decision surface. The Quality Ledger is a reader-facing surface. It may expose release-decision state for review, but it does not compute, replace, or override the artifact-bound release-authority path.
+- **Quality Ledger** — human-readable release decision surface. The Quality Ledger is a reader-facing surface. It may expose release-decision state for review, but it does not compute, replace, or override the artifact-bound release-authority path.
 - **RDSI** — Release Decision Stability Index with deltas / confidence intervals where available
 - **CI artifacts** — `status.json`, report card, JUnit, SARIF, badges, and registered diagnostic artifacts
 


### PR DESCRIPTION
## Summary

This PR fixes a README Markdown formatting issue in the Quality Ledger bullet.

The entry used a double dash:

`-- **Quality Ledger**`

It now uses the same Markdown bullet style as the adjacent artifact entries:

`- **Quality Ledger**`

## Scope

Documentation formatting only.

Changed file:

- `README.md`

## Boundary

This PR does not change README semantics.

It does not change:

- reviewable mechanics boundary wording
- release-authority semantics
- Quality Ledger boundary meaning
- `release_authority_v0` sidecar boundary
- coverage-score boundary
- green-tests boundary
- external-review boundary

## Non-goals

This PR does not change:

- code
- schemas
- verifier behavior
- checker behavior
- builder behavior
- release policy
- gate registry
- status schemas
- CI authority path
- `--release-grade-materialized`

This PR does not create or enable:

- release authority from reader surfaces
- release authority from Quality Ledger
- release authority from audit sidecars
- release authority from green tests
- release authority from external review
- gate materialization
- release-grade materialization

## Testing

Documentation formatting only.

```bash
git diff --check