### PR TITLE
test(ref): lock release authority sidecar input non-interference v0

### DIFF
--- a/tests/test_release_authority_manifest_non_interference.py
+++ b/tests/test_release_authority_manifest_non_interference.py
@@ -146,7 +146,7 @@ def assert_builder_non_interference(
     tmp_path: Path,
     status: Path,
 ) -> tuple[subprocess.CompletedProcess[str], subprocess.CompletedProcess[str], dict]:
-     watched_before = release_authority_input_snapshot(status)
+    watched_before = release_authority_input_snapshot(status)
 
     before = run_check_gates(status)
     assert_release_authority_inputs_unchanged(
@@ -156,17 +156,14 @@ def assert_builder_non_interference(
     )
 
     manifest_path = run_builder(tmp_path, status)
-
-     assert_release_authority_inputs_unchanged(
+    assert_release_authority_inputs_unchanged(
         watched_before,
         status,
         "release authority manifest builder",
     )
 
-
     after = run_check_gates(status)
-
-     assert_release_authority_inputs_unchanged(
+    assert_release_authority_inputs_unchanged(
         watched_before,
         status,
         "post-builder check_gates run",
@@ -175,8 +172,8 @@ def assert_builder_non_interference(
     assert after.returncode == before.returncode
     assert after.stdout == before.stdout
     assert after.stderr == before.stderr
-  
-   manifest_check = run_manifest_checker(manifest_path)
+
+    manifest_check = run_manifest_checker(manifest_path)
     assert manifest_check.returncode == 0, manifest_check.stderr
     assert_release_authority_inputs_unchanged(
         watched_before,

--- a/tests/test_release_authority_manifest_non_interference.py
+++ b/tests/test_release_authority_manifest_non_interference.py
@@ -32,6 +32,29 @@ def sha256(path: Path) -> str:
     return h.hexdigest()
 
 
+def release_authority_input_snapshot(status: Path) -> dict[str, str]:
+    watched_paths = [
+        status,
+        POLICY,
+        REGISTRY,
+        CHECK_GATES,
+    ]
+    return {str(path): sha256(path) for path in watched_paths}
+
+
+def assert_release_authority_inputs_unchanged(
+    before: dict[str, str],
+    status: Path,
+    label: str,
+) -> None:
+    after = release_authority_input_snapshot(status)
+    assert after == before, (
+        f"{label} modified release-authority inputs.\n"
+        f"before={before}\n"
+        f"after={after}"
+    )
+
+
 def write_status(tmp_path: Path, gates: dict[str, object]) -> Path:
     status = {
         "version": "test",
@@ -123,26 +146,43 @@ def assert_builder_non_interference(
     tmp_path: Path,
     status: Path,
 ) -> tuple[subprocess.CompletedProcess[str], subprocess.CompletedProcess[str], dict]:
-    status_before = sha256(status)
+     watched_before = release_authority_input_snapshot(status)
 
     before = run_check_gates(status)
+    assert_release_authority_inputs_unchanged(
+        watched_before,
+        status,
+        "pre-builder check_gates run",
+    )
 
     manifest_path = run_builder(tmp_path, status)
 
-    status_after_builder = sha256(status)
-    assert status_after_builder == status_before, "builder modified status.json"
+     assert_release_authority_inputs_unchanged(
+        watched_before,
+        status,
+        "release authority manifest builder",
+    )
+
 
     after = run_check_gates(status)
 
-    status_after_check = sha256(status)
-    assert status_after_check == status_before, "post-builder check_gates modified status.json"
+     assert_release_authority_inputs_unchanged(
+        watched_before,
+        status,
+        "post-builder check_gates run",
+    )
 
     assert after.returncode == before.returncode
     assert after.stdout == before.stdout
     assert after.stderr == before.stderr
-
-    manifest_check = run_manifest_checker(manifest_path)
+  
+   manifest_check = run_manifest_checker(manifest_path)
     assert manifest_check.returncode == 0, manifest_check.stderr
+    assert_release_authority_inputs_unchanged(
+        watched_before,
+        status,
+        "release authority manifest checker",
+    )
 
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     return before, after, manifest


### PR DESCRIPTION
## Summary

This PR strengthens release_authority_v0 audit-sidecar non-interference coverage.

The existing test already proves that manifest building does not mutate `status.json` and does not change the `check_gates.py` outcome.

This PR adds byte-level SHA-256 snapshots for release-authority inputs around builder, checker, and evaluator calls.

Watched inputs:

- temporary `status.json`
- `pulse_gate_policy_v0.yml`
- `pulse_gate_registry_v0.yml`
- `PULSE_safe_pack_v0/tools/check_gates.py`

## Scope

Test-only hardening.

Changed file:

- `tests/test_release_authority_manifest_non_interference.py`

No `ci/tools-tests.list` update is required because this PR strengthens an existing test file and does not add a new test file.

## What this locks

The release_authority_v0 audit sidecar builder/checker path must not mutate:

- `status.json`
- declared gate policy
- gate registry
- `check_gates.py`

The sidecar may write its own manifest output.

It must not modify the artifact-bound release-authority inputs.

## Boundary

`release_authority_v0` is an audit / traceability sidecar.

It is not a second decision engine.

This PR does not make audit-sidecar output a release-authority carrier.

## Non-goals

This PR does not change:

- production tool behavior
- schemas
- checker behavior
- builder behavior
- `check_gates.py`
- `run_all.py`
- release policy
- gate registry
- status schemas
- CI authority path
- `--release-grade-materialized`

This PR does not create or enable:

- release authority from audit sidecars
- release authority from audit bundles
- gate materialization
- release-grade materialization
- `status.json` writing from sidecars
- release eligibility from audit output

## Mechanical anchors

audit sidecar ≠ decision engine  
audit sidecar validity ≠ release authority  
audit sidecar output ≠ gate materialization  
audit sidecar traceability ≠ primary allow/block decision  

## Testing

```bash
python -m pytest tests/test_release_authority_manifest_non_interference.py
```

Related targeted confirmation:

```bash
python -m pytest \
  tests/test_build_release_authority_manifest_v0.py \
  tests/test_check_release_authority_manifest_v0.py
```

Tools smoke:

```bash
python -m pytest tests/test_tools_tests_list_smoke.py
```