### PR TITLE
test(ref): lock release authority manifest trace-carrier boundary v0

### DIFF
--- a/docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md
+++ b/docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md
@@ -168,6 +168,24 @@ Audit sidecar failure may be a visibility or traceability issue.
 
 It must not silently rewrite the primary release decision.
 
+### Trace-carrier dependency
+
+An audit sidecar may be required by a later provenance-binding layer as a trace carrier.
+
+That requirement must not be confused with release authority.
+
+A required trace carrier can make the provenance-binding layer fail if the carrier is missing, but it must not replace the primary artifact-bound release-authority path.
+
+Boundary:
+
+```text
+required trace carrier ≠ release authority
+required trace carrier ≠ primary allow/block decision
+required trace carrier ≠ gate materialization
+required trace carrier ≠ second decision engine
+```
+
+
 ## Public reader-surface boundary
 
 A public reader surface may expose current state.

--- a/docs/release_authority_manifest_v0.md
+++ b/docs/release_authority_manifest_v0.md
@@ -16,6 +16,38 @@ It is not a new release-decision engine.
 
 ---
 
+## Trace-carrier dependency boundary
+
+`release_authority_v0.json` is an audit / traceability sidecar.
+
+The release-authority manifest build/check/upload path is audit-only and does not compute, replace, or override the primary release decision.
+
+When artifact-provenance binding is enabled, `release_authority_v0.json` may be required as a trace-carrier input for the provenance-binding layer.
+
+A required trace carrier can make the provenance-binding layer fail if the carrier is missing.
+
+That trace-carrier requirement does not make `release_authority_v0.json` a second decision engine.
+
+It does not replace:
+
+- `status.json`
+- declared gate policy
+- workflow-effective materialized required gates
+- `check_gates.py`
+- strict fail-closed CI enforcement
+
+Boundary:
+
+```text
+trace-carrier required for provenance binding
+≠ release authority
+≠ primary allow/block decision
+≠ gate materialization
+≠ second decision engine
+```
+
+---
+
 ## Status
 
 Current status:

--- a/tests/test_artifact_provenance_binding_ci_wiring_smoke.py
+++ b/tests/test_artifact_provenance_binding_ci_wiring_smoke.py
@@ -41,3 +41,70 @@ def test_pulse_ci_binding_step_is_after_release_decision_materialization() -> No
     binding_idx = text.index('Release authority artifact binding v0: materialize and verify')
 
     assert release_decision_idx < binding_idx
+
+
+def test_release_authority_manifest_trace_carrier_dependency_is_documented_and_wired() -> None:
+    import pathlib
+
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+
+    workflow = (
+        repo_root / ".github" / "workflows" / "pulse_ci.yml"
+    ).read_text(encoding="utf-8")
+
+    manifest_doc_path = repo_root / "docs" / "release_authority_manifest_v0.md"
+    checklist_path = (
+        repo_root / "docs" / "PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md"
+    )
+
+    assert manifest_doc_path.is_file()
+    assert checklist_path.is_file()
+
+    manifest_doc = manifest_doc_path.read_text(encoding="utf-8")
+    checklist_doc = checklist_path.read_text(encoding="utf-8")
+
+    # Workflow wiring: artifact-provenance binding intentionally consumes the
+    # release authority manifest as a trace-carrier input.
+    assert "Release authority artifact binding v0: materialize and verify" in workflow
+    assert "build_artifact_provenance_binding_v0.py" in workflow
+    assert "verify_artifact_provenance_binding_v0.py" in workflow
+    assert "--release-authority-manifest" in workflow
+    assert "release_authority_v0.json" in workflow
+
+    # Release authority manifest docs: required trace-carrier dependency is
+    # classified without turning the sidecar into a decision engine.
+    assert "Trace-carrier dependency boundary" in manifest_doc
+    assert (
+        "When artifact-provenance binding is enabled, "
+        "`release_authority_v0.json` may be required as a trace-carrier input "
+        "for the provenance-binding layer."
+    ) in manifest_doc
+    assert (
+        "A required trace carrier can make the provenance-binding layer fail "
+        "if the carrier is missing."
+    ) in manifest_doc
+    assert (
+        "That trace-carrier requirement does not make "
+        "`release_authority_v0.json` a second decision engine."
+    ) in manifest_doc
+    assert "trace-carrier required for provenance binding" in manifest_doc
+    assert "≠ release authority" in manifest_doc
+    assert "≠ primary allow/block decision" in manifest_doc
+    assert "≠ gate materialization" in manifest_doc
+    assert "≠ second decision engine" in manifest_doc
+
+    # Reviewable mechanics checklist: the same dependency is recorded as a
+    # review boundary, not as release-authority promotion.
+    assert "Trace-carrier dependency" in checklist_doc
+    assert (
+        "An audit sidecar may be required by a later provenance-binding layer "
+        "as a trace carrier."
+    ) in checklist_doc
+    assert (
+        "That requirement must not be confused with release authority."
+    ) in checklist_doc
+    assert (
+        "A required trace carrier can make the provenance-binding layer fail "
+        "if the carrier is missing, but it must not replace the primary "
+        "artifact-bound release-authority path."
+    ) in checklist_doc


### PR DESCRIPTION
## Summary

This PR classifies the `release_authority_v0.json` trace-carrier dependency.

The release authority manifest build/check/upload path remains:

- audit-only
- warning-only
- non-authoritative

When artifact-provenance binding is enabled, `release_authority_v0.json` may be required as a trace-carrier input for that provenance-binding layer.

A required trace carrier can make the provenance-binding layer fail if the carrier is missing.

That requirement does not make `release_authority_v0.json` a second decision engine.

## Scope

Documentation + static test clarification.

Changed files:

- `docs/release_authority_manifest_v0.md`
- `docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md`
- `tests/test_artifact_provenance_binding_ci_wiring_smoke.py`

No workflow behavior is changed.

## What this locks

This PR records the distinction between:

```text
audit-only sidecar build/check/upload
```

and:

```text
required trace-carrier input for artifact-provenance binding
```

The boundary is:

```text
trace-carrier required for provenance binding
≠ release authority
≠ primary allow/block decision
≠ gate materialization
≠ second decision engine
```

## Non-goals

This PR does not change:

- `.github/workflows/pulse_ci.yml`
- production tools
- schemas
- checker behavior
- builder behavior
- `check_gates.py`
- `run_all.py`
- release policy
- gate registry
- status schemas
- CI authority path
- `--release-grade-materialized`

This PR does not create or enable:

- release authority from `release_authority_v0.json`
- a second decision engine
- gate materialization
- release-grade materialization
- primary allow/block replacement
- release eligibility from audit output

## Testing

```bash
python -m pytest tests/test_artifact_provenance_binding_ci_wiring_smoke.py
```

Related targeted confirmation:

```bash
python -m pytest \
  tests/test_artifact_provenance_binding_v0.py \
  tests/test_artifact_provenance_binding_attestation_wiring_smoke.py \
  tests/test_check_release_grade_reference_run_v0.py
```

Tools smoke:

```bash
python -m pytest tests/test_tools_tests_list_smoke.py
```