### PR TITLE
docs(ref): tighten README reviewable mechanics wording v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ See [`docs/PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md`](docs/PULSE_PRE_MATER
 
 ### Reviewable mechanics boundary
 
-PULSE does not use external review, reader surfaces, audit sidecars, coverage scores, green test results, or documentation claims as release authority.
+PULSE does not derive release authority from external review, reader surfaces, audit sidecars, coverage scores, green test results, or documentation claims.
 
-External review can inspect the mechanism, the claims, the implementation, and the reproducibility of the repository.
+External review may inspect the mechanism, declared claims, implementation, and repository reproducibility.
 
 External review cannot replace the artifact-bound release-authority path.
 
@@ -105,9 +105,9 @@ External review cannot replace the artifact-bound release-authority path.
 
 Coverage scores and other metrics are descriptive unless they are explicitly promoted into declared policy, workflow-effective materialized required gates, and strict fail-closed CI enforcement.
 
-Green tests alone do not create release authority.
+A green test result is not release authority unless it is part of the declared, workflow-effective required gate set enforced by strict fail-closed CI.
 
-The mechanical review boundary is documented in [`docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md`](docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md).
+The mechanical review boundary is documented in `docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md`.
 
 ## Release boundary
 


### PR DESCRIPTION
## Summary

This PR tightens the README wording for the reviewable mechanics boundary.

The change keeps the same boundary but makes the language more mechanically precise:

- `does not use ... as release authority`
  becomes:
  `does not derive release authority from ...`

- the green-test boundary is clarified so that green tests do not become release authority unless they are part of the declared, workflow-effective required gate set enforced by strict fail-closed CI.

## Scope

Documentation-only.

Changed file:

- `README.md`

## What this clarifies

PULSE does not derive release authority from:

- external review
- reader surfaces
- audit sidecars
- coverage scores
- green test results
- documentation claims

The README also clarifies:

```text
A green test result is not release authority unless it is part of the declared, workflow-effective required gate set enforced by strict fail-closed CI.
```

## Boundary

This PR does not change the PULSEmech release-authority path:

```text
recorded release evidence
→ status.json
→ declared gate policy
→ workflow-effective materialized required gate set
→ strict fail-closed CI enforcement
→ pre-deployment allow/block release decision
```

This PR does not make any reader, audit, review, metric, documentation, or generic green-test surface a release-authority carrier.

## Non-goals

This PR does not change:

- code
- schemas
- checker behavior
- builder behavior
- verifier behavior
- release policy
- gate registry
- status schemas
- CI authority path
- `--release-grade-materialized`

This PR does not create or enable:

- release authority from external review
- release authority from reader surfaces
- release authority from audit sidecars
- release authority from coverage scores
- release authority from green tests outside the declared required-gate path
- gate materialization
- release-grade materialization

## Mechanical anchors

external review ≠ release authority  
reader surface ≠ release authority  
audit sidecar ≠ decision engine  
coverage score ≠ release authority  
generic green test result ≠ release authority  
visible information ≠ normative release authority  

## Testing

Documentation-only change.

```bash
git diff --check
```

Anchor confirmation:

```bash
rg -n \
  "does not derive release authority|A green test result is not release authority|declared, workflow-effective required gate set|strict fail-closed CI|PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0" \
  README.md
```