### PR TITLE
docs(ref): make README reviewable mechanics checklist link clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Coverage scores and other metrics are descriptive unless they are explicitly pro
 
 A green test result is not release authority unless it is part of the declared, workflow-effective required gate set enforced by strict fail-closed CI.
 
-The mechanical review boundary is documented in `docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md`.
+The mechanical review boundary is documented in [docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md](docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md).
 
 ## Release boundary
 


### PR DESCRIPTION
## Summary

This PR makes the README reference to the reviewable mechanics checklist clickable.

The README previously rendered the checklist path as inline code:

`docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md`

It now uses a relative Markdown link:

[docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md](docs/PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md)

## Scope

Documentation formatting only.

Changed file:

- `README.md`

## Boundary

This PR does not change README semantics.

It does not change:

- reviewable mechanics boundary wording
- release-authority semantics
- `release_authority_v0` sidecar boundary
- coverage-score boundary
- green-test boundary
- external-review boundary

## Non-goals

This PR does not change:

- code
- schemas
- checker behavior
- builder behavior
- release policy
- gate registry
- status schemas
- CI authority path
- `--release-grade-materialized`

## Testing

```bash
git diff --check