### PR TITLE
test(ref): lock release authority audit bundle workflow neutrality v0

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -962,7 +962,7 @@ jobs:
             echo
             echo "| Field | Value |"
             echo "|---|---|"
-            echo "| Role | Audit / traceability bundle |"
+            echo "| Role | Review / traceability bundle |"
             echo "| Authority | Non-normative / non-blocking |"
             echo "| Artifact | \`release-authority-audit-bundle\` |"
             echo "| Workspace path | \`$BUNDLE\` |"

--- a/tests/test_release_authority_audit_bundle_workflow_neutrality_v0.py
+++ b/tests/test_release_authority_audit_bundle_workflow_neutrality_v0.py
@@ -34,6 +34,27 @@ def _extract_step(workflow: str, step_name: str) -> str:
     return match.group(0)
 
 
+def _extract_step_containing(
+    workflow: str,
+    required_tokens: list[str],
+    label: str,
+) -> str:
+    step_pattern = re.compile(
+        r"(?ms)^\s*-\s+name:\s+.*?$.*?(?=^\s*-\s+name:\s+|\Z)"
+    )
+    matches = [
+        match.group(0)
+        for match in step_pattern.finditer(workflow)
+        if all(token in match.group(0) for token in required_tokens)
+    ]
+
+    assert len(matches) == 1, (
+        f"Expected exactly one {label} step containing {required_tokens}, "
+        f"found {len(matches)}"
+    )
+    return matches[0]
+
+
 def _assert_contains_all(text: str, required: list[str], label: str) -> None:
     missing = [item for item in required if item not in text]
     assert not missing, f"{label} is missing expected tokens: {missing}"
@@ -62,13 +83,12 @@ def test_release_authority_audit_bundle_workflow_neutrality_v0() -> None:
         workflow,
         "Upload release authority audit bundle (audit-only)",
     )
-    enforcement_step = _extract_step(
+    enforcement_step = _extract_step_containing(
         workflow,
-        "\"ci: enforce gates via check_gates (policy-derived)\"",
+        ["policy_to_require_args.py", "check_gates.py"],
+        "policy-derived check_gates enforcement",
     )
 
-    # The audit bundle is staged into the dedicated artifacts workspace and
-    # contains review / traceability copies only.
     _assert_contains_all(
         stage_step,
         [
@@ -92,8 +112,6 @@ def test_release_authority_audit_bundle_workflow_neutrality_v0() -> None:
         "audit bundle staging boundary wording",
     )
 
-    # Upload must remain artifact-only / warning-only. A missing bundle must
-    # not become a release-authority signal.
     _assert_contains_all(
         upload_step,
         [
@@ -105,8 +123,6 @@ def test_release_authority_audit_bundle_workflow_neutrality_v0() -> None:
     )
     _assert_exact_audit_bundle_upload_path(upload_step)
 
-    # Primary release enforcement remains policy-derived and separate from
-    # audit-bundle staging/upload.
     _assert_contains_all(
         workflow,
         [
@@ -117,18 +133,14 @@ def test_release_authority_audit_bundle_workflow_neutrality_v0() -> None:
         "primary policy-derived check_gates enforcement path",
     )
 
-    # The audit bundle steps must not be the enforcement carrier.
-    forbidden_stage_tokens = [
+    forbidden_stage_or_upload_tokens = [
         "policy_to_require_args.py",
         "check_gates.py",
         "--release-grade-materialized",
-        "gate_materialization",
-        "materialized required gate",
-        "release eligibility",
-        "second decision engine",
+        "--audit-bundle-dir",
     ]
 
-    for token in forbidden_stage_tokens:
+    for token in forbidden_stage_or_upload_tokens:
         assert token not in stage_step, (
             "audit bundle staging must not contain enforcement / authority "
             f"token: {token}"
@@ -138,19 +150,18 @@ def test_release_authority_audit_bundle_workflow_neutrality_v0() -> None:
             f"token: {token}"
         )
 
-     forbidden_enforcement_tokens = [
+    forbidden_enforcement_tokens = [
         "release_authority_audit_bundle",
         "release-authority-audit-bundle",
         "--audit-bundle-dir",
     ]
+
     for token in forbidden_enforcement_tokens:
         assert token not in enforcement_step, (
-            "policy-derived gate enforcement must not consume the audit "
-            f"bundle as a release-authority carrier: {token}"
+            "policy-derived check_gates enforcement must not consume the "
+            f"audit bundle as a release-authority carrier: {token}"
         )
 
-# The upload artifact name must remain the audit-bundle artifact, not a
-    # status, gate, policy, or release-decision artifact.
     assert "name: release-authority-audit-bundle" in upload_step
     assert "name: status.json" not in upload_step
     assert "name: release-authority-v0" not in upload_step

--- a/tests/test_release_authority_audit_bundle_workflow_neutrality_v0.py
+++ b/tests/test_release_authority_audit_bundle_workflow_neutrality_v0.py
@@ -62,6 +62,10 @@ def test_release_authority_audit_bundle_workflow_neutrality_v0() -> None:
         workflow,
         "Upload release authority audit bundle (audit-only)",
     )
+    enforcement_step = _extract_step(
+        workflow,
+        "\"ci: enforce gates via check_gates (policy-derived)\"",
+    )
 
     # The audit bundle is staged into the dedicated artifacts workspace and
     # contains review / traceability copies only.
@@ -80,7 +84,7 @@ def test_release_authority_audit_bundle_workflow_neutrality_v0() -> None:
     _assert_contains_all(
         stage_step_l,
         [
-            "audit",
+            "review",
             "traceability",
             "non-normative",
             "non-blocking",
@@ -90,7 +94,6 @@ def test_release_authority_audit_bundle_workflow_neutrality_v0() -> None:
 
     # Upload must remain artifact-only / warning-only. A missing bundle must
     # not become a release-authority signal.
- 
     _assert_contains_all(
         upload_step,
         [
@@ -135,7 +138,18 @@ def test_release_authority_audit_bundle_workflow_neutrality_v0() -> None:
             f"token: {token}"
         )
 
-    # The upload artifact name must remain the audit-bundle artifact, not a
+     forbidden_enforcement_tokens = [
+        "release_authority_audit_bundle",
+        "release-authority-audit-bundle",
+        "--audit-bundle-dir",
+    ]
+    for token in forbidden_enforcement_tokens:
+        assert token not in enforcement_step, (
+            "policy-derived gate enforcement must not consume the audit "
+            f"bundle as a release-authority carrier: {token}"
+        )
+
+# The upload artifact name must remain the audit-bundle artifact, not a
     # status, gate, policy, or release-decision artifact.
     assert "name: release-authority-audit-bundle" in upload_step
     assert "name: status.json" not in upload_step


### PR DESCRIPTION
## Summary

This PR locks the release authority audit bundle workflow neutrality boundary.

The audit bundle is a review / traceability surface.

It must not become:

- release authority
- primary allow/block decision
- gate materialization
- release eligibility
- second decision engine
- `check_gates.py` replacement

## Scope

Test-only hardening plus workflow-summary wording alignment.

Changed files:

- `.github/workflows/pulse_ci.yml`
- `tests/test_release_authority_audit_bundle_workflow_neutrality_v0.py`
- `ci/pytest-tests.list`
- `ci/tools-tests.list`

The workflow change is summary wording only.

No workflow behavior is changed.

## What this locks

The static workflow test verifies:

- `Stage release authority audit bundle (audit-only)` exists
- `Upload release authority audit bundle (audit-only)` exists
- the upload artifact name remains `release-authority-audit-bundle`
- the upload uses `continue-on-error: true`
- the upload uses `if-no-files-found: warn`
- the upload path remains the exact audit bundle artifacts path
- staging / summary wording keeps the review / traceability and non-normative / non-blocking boundaries
- strict release enforcement remains policy-derived and separate through `check_gates.py`
- the policy-derived `check_gates.py` enforcement step does not consume the audit bundle, the audit-bundle artifact name, or audit-bundle directory arguments as release-authority carriers

The regression is wired into both CI manifests.

## Boundary

Audit bundle success does not create release authority.

Audit bundle failure does not rewrite the primary allow/block decision.

Audit bundle generation does not materialize gates.

Audit bundle upload does not create release eligibility.

Audit bundle wording does not turn the bundle into a second decision engine.

## Non-goals

This PR does not change:

- workflow behavior
- production tools
- schemas
- checker behavior
- builder behavior
- `check_gates.py`
- `run_all.py`
- release policy
- gate registry
- status schemas
- CI authority path
- `--release-grade-materialized`

This PR does not create or enable:

- release authority from audit bundles
- gate materialization
- release-grade materialization
- primary allow/block replacement
- release eligibility from audit output

## Mechanical anchors

audit bundle ≠ release authority  
audit bundle ≠ primary allow/block decision  
audit bundle ≠ gate materialization  
audit bundle ≠ second decision engine  
audit bundle upload ≠ release eligibility  

## Testing

```bash
python -m pytest tests/test_release_authority_audit_bundle_workflow_neutrality_v0.py
```

```bash
python tests/test_release_authority_audit_bundle_workflow_neutrality_v0.py
```

```bash
python -m pytest tests/test_tools_tests_list_smoke.py
```

```bash
python -m pytest \
  tests/test_check_release_grade_reference_run_v0.py \
  tests/test_artifact_provenance_binding_v0.py \
  tests/test_artifact_provenance_binding_ci_wiring_smoke.py
```

```bash
rg -n "^tests/test_release_authority_audit_bundle_workflow_neutrality_v0\.py$" \
  ci/pytest-tests.list \
  ci/tools-tests.list
```

```bash
python - <<'PY'
from pathlib import Path

entry = "tests/test_release_authority_audit_bundle_workflow_neutrality_v0.py"

for manifest in ("ci/pytest-tests.list", "ci/tools-tests.list"):
    lines = [
        line.strip()
        for line in Path(manifest).read_text(encoding="utf-8").splitlines()
        if line.strip() and not line.lstrip().startswith("#")
    ]
    count = lines.count(entry)
    assert count == 1, f"{entry} appears {count} times in {manifest}"
    print(f"OK: {entry} appears exactly once in {manifest}")
PY
```