### PR TITLE
docs(ref): clarify Stage B candidate-validation draft surface v0

### DIFF
--- a/docs/PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_ONLY_DRAFT_BOUNDARY_v0.md
+++ b/docs/PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_ONLY_DRAFT_BOUNDARY_v0.md
@@ -173,6 +173,299 @@ All partial verification examples must remain failed / pending / diagnostic.
 
 No partial verification result may populate `verified_artifacts`, `relation_bindings`, or `gate_materialization`.
 
+## Minimal Stage B candidate-validation draft surface
+
+The smallest safe future Stage B draft surface is candidate-scoped and diagnostic-only.
+
+It must not be top-level release state.
+
+It must not appear under `verified_artifacts`.
+
+It must not create non-empty `relation_bindings`.
+
+It must not create `gate_materialization`.
+
+Recommended future location:
+
+```text
+evidence_inputs[].provenance.candidate_schema_validation
+```
+
+This location keeps the draft result attached to a recorded candidate evidence input whose provenance remains:
+
+```text
+trusted = false
+verification_status = not_verified
+```
+
+### Minimal candidate validation draft object
+
+A future Stage B schema-only draft may later describe an object with this shape:
+
+```text
+candidate_schema_validation:
+  status: not_run | unavailable | failed
+  schema_path: string | null
+  schema_version: string | null
+  errors: diagnostic error objects
+  duplicate_key_validation: optional diagnostic sub-result
+```
+
+This is a draft surface only.
+
+It does not validate candidate evidence in current v0.
+
+It does not verify evidence.
+
+It does not create trust.
+
+It does not satisfy relation bindings.
+
+It does not materialize gates.
+
+It does not create release authority.
+
+### Stage B status vocabulary
+
+The Stage B-safe status vocabulary is intentionally non-promotional:
+
+```text
+not_run
+unavailable
+failed
+```
+
+Stage B examples must not use:
+
+```text
+valid
+passed
+success
+schema_valid
+verified
+trusted
+```
+
+Success-like vocabulary is postponed to a later candidate-validation implementation stage.
+
+A schema-valid candidate must not be shown as verified evidence in Stage B.
+
+### Structured diagnostic errors
+
+A future draft may later include structured diagnostic errors.
+
+Recommended diagnostic shape:
+
+```text
+errors[]:
+  code
+  message
+  instance_path
+  schema_path
+```
+
+These errors are diagnostic.
+
+They do not prove complete validation coverage.
+
+They do not promote the candidate artifact.
+
+### Duplicate-key validation sub-result
+
+A future draft may later include duplicate-key validation as a sub-result:
+
+```text
+duplicate_key_validation:
+  status: not_run | unavailable | failed
+  errors: diagnostic error objects
+```
+
+Duplicate-key validation must remain a parsing / validation prerequisite.
+
+It is not full evidence verification.
+
+A clean duplicate-key parse must not be interpreted as verified evidence.
+
+### Partial-validation unavailable / failed state
+
+If candidate validation cannot run completely, the result must fail closed.
+
+Allowed diagnostic states:
+
+```text
+unavailable
+failed
+```
+
+A partial or best-effort validation must not produce success.
+
+Boundary:
+
+```text
+partial validation ≠ verified evidence
+best-effort validation ≠ trusted evidence
+schema unavailable ≠ validation success
+validator unavailable ≠ validation success
+```
+
+## Minimal Stage B partial-verification diagnostics surface
+
+A future Stage B draft may later describe candidate-scoped partial diagnostics.
+
+Recommended future location:
+
+```text
+evidence_inputs[].provenance.partial_verification_diagnostics
+```
+
+This surface is candidate-scoped.
+
+It is not relation-scoped authority.
+
+It is not verified relation provenance.
+
+It must remain diagnostic-only.
+
+### Safe diagnostic sub-results
+
+The safe Stage B diagnostic sub-results are:
+
+```text
+digest_binding
+subject_binding
+run_binding
+candidate_schema_validation
+```
+
+These may later record failed, unavailable, not-run, or mismatch states.
+
+They must not record promotion.
+
+They must not populate:
+
+```text
+verified_artifacts
+relation_bindings
+gate_materialization
+```
+
+### Postponed diagnostic sub-results
+
+These are not minimal Stage B surfaces:
+
+```text
+verifier_identity
+trust_root
+relation_provenance_readiness
+deterministic_relation_id
+verified_relation_prototype
+gate_eligibility
+```
+
+They are postponed.
+
+Suggested placement:
+
+```text
+verifier_identity           → Stage E or later
+trust_root                  → Stage E or later
+relation_provenance         → Stage F or later
+deterministic_relation_id   → Stage F or later
+verified_relation_prototype → Stage F or later
+gate_eligibility            → Stage G or later
+```
+
+Boundary:
+
+```text
+identity diagnostic ≠ trusted verifier
+trust-root diagnostic ≠ active trust root
+relation provenance readiness ≠ verified relation
+deterministic-looking relation ID ≠ satisfied relation binding
+gate eligibility draft ≠ gate materialization
+```
+
+## Stage B example constraint
+
+If a future example is introduced later, it must be explicitly named:
+
+```text
+non_authoritative_failed_draft
+```
+
+It must remain:
+
+```text
+verifier_decision = FAILED
+provenance.trusted = false
+verification_status = not_verified
+verified_artifacts = []
+relation_bindings = []
+gate_materialization = {}
+```
+
+Stage B examples must not include:
+
+```text
+VERIFIED
+provenance.trusted = true
+verification_status = verified
+non-empty verified_artifacts
+non-empty relation_bindings
+non-empty gate_materialization
+realistic trust-root authority values
+gate eligibility outputs
+status.json writes
+release_authority_v0.json writes
+report_card.html writes
+release-authority audit bundles
+```
+
+## Stage B checker boundary
+
+A later checker may validate draft field shape only after a schema draft exists.
+
+Checker shape validation must not become promotion.
+
+Boundary:
+
+```text
+checker shape validation ≠ evidence promotion
+checker shape validation ≠ trusted verifier
+checker shape validation ≠ release authority
+```
+
+Future checker duties may include:
+
+- validate candidate validation draft shape
+- reject ambiguous success / trust states
+- reject `provenance.trusted = true`
+- reject `VERIFIED` when only draft fields are present
+- reject non-empty `relation_bindings` in Stage B failed examples
+- reject `gate_materialization` from draft fields
+
+## Stage B builder boundary
+
+A later builder may populate candidate-validation draft fields only in a declared later stage.
+
+Until then, and throughout Stage B, builder output must remain:
+
+```text
+verifier_decision = FAILED
+verified_artifacts = []
+relation_bindings = []
+gate_materialization = {}
+```
+
+Boundary:
+
+```text
+builder draft output ≠ VERIFIED
+builder draft output ≠ trusted evidence
+builder draft output ≠ gate materialization
+```
+
+
 ## High-risk Stage B surfaces
 
 The following surfaces are high-risk and must not be introduced casually.


### PR DESCRIPTION
## Summary

This PR clarifies the minimal safe Stage B draft surface for candidate evidence schema validation and partial verification diagnostics.

The change keeps Stage B candidate-scoped, diagnostic-only, and non-authoritative.

## Scope

Documentation-only.

Changed file:

- `docs/PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_ONLY_DRAFT_BOUNDARY_v0.md`

## What this records

The document now clarifies:

- the safest future Stage B location:
  `evidence_inputs[].provenance.candidate_schema_validation`
- the minimal diagnostic vocabulary:
  `not_run`, `unavailable`, `failed`
- duplicate-key validation as a diagnostic sub-result
- partial-validation unavailable / failed behavior
- safe partial-verification diagnostics:
  digest, subject, run, and candidate schema validation
- postponed high-risk surfaces:
  verifier identity, trust root, relation provenance, deterministic relation ID, verified relation prototype, and gate eligibility
- constraints for any future `non_authoritative_failed_draft` example

## Boundary

This PR does not edit schemas.

It does not add examples.

It does not add JSON fixtures.

It does not change checker behavior.

It does not change builder behavior.

It does not emit `VERIFIED`.

It does not promote candidate evidence.

It does not satisfy relation bindings.

It does not materialize gates.

It does not write `status.json`.

It does not reopen `--release-grade-materialized`.

## Non-goals

This PR does not change:

- schemas
- examples
- JSON fixtures
- verifier builder behavior
- verifier checker behavior
- expectation summary behavior
- input manifest behavior
- `check_gates.py`
- `run_all.py`
- release policy
- gate registry
- status schemas
- CI authority path

This PR does not create or enable:

- trusted evidence
- verified evidence promotion
- satisfied relation bindings
- gate materialization
- release authority from verifier reports
- release eligibility from diagnostic outputs

## Mechanical anchors

candidate schema validation draft ≠ verified evidence  
schema-valid candidate ≠ trusted evidence  
duplicate-key check ≠ full evidence verification  
partial pass ≠ satisfied relation binding  
checker shape validation ≠ evidence promotion  
builder draft output ≠ VERIFIED  

## Testing

Documentation-only change.

```bash
git diff --check
```

Anchor confirmation:

rg -n \
  "Minimal Stage B candidate-validation draft surface|candidate_schema_validation|not_run|unavailable|failed|non_authoritative_failed_draft|checker shape validation ≠ evidence promotion|builder draft output ≠ VERIFIED" \
  docs/PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_ONLY_DRAFT_BOUNDARY_v0.md