### PR TITLE
feat(ref): add candidate validation diagnostic draft schema v0

### DIFF
--- a/schemas/release_evidence_verifier_report_v0.schema.json
+++ b/schemas/release_evidence_verifier_report_v0.schema.json
@@ -243,7 +243,35 @@
             "$ref": "#/$defs/candidate_validation_diagnostic_error"
           }
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "failed"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "required": [
+              "errors"
+            ],
+            "properties": {
+              "errors": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/$defs/candidate_validation_diagnostic_error"
+                }
+              }
+            }
+          }
+        }
+      ]
     },
     "candidate_schema_validation_draft": {
       "type": "object",
@@ -276,7 +304,35 @@
         "duplicate_key_validation": {
           "$ref": "#/$defs/duplicate_key_validation_draft"
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "failed"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "required": [
+              "errors"
+            ],
+            "properties": {
+              "errors": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/$defs/candidate_validation_diagnostic_error"
+                }
+              }
+            }
+          }
+        }
+      ]
     },
     "evidence_input": {
       "type": "object",
@@ -345,7 +401,30 @@
               "$ref": "#/$defs/candidate_schema_validation_draft"
             }
           },
-          "additionalProperties": true
+          "additionalProperties": true,
+          "allOf": [
+            {
+              "if": {
+                "required": [
+                  "candidate_schema_validation"
+                ]
+              },
+              "then": {
+                "required": [
+                  "trusted",
+                  "verification_status"
+                ],
+                "properties": {
+                  "trusted": {
+                    "const": false
+                  },
+                  "verification_status": {
+                    "const": "not_verified"
+                  }
+                }
+              }
+            }
+          ]
         }
       }
     },
@@ -546,6 +625,50 @@
             "items": {
               "$ref": "#/$defs/verified_relation_binding"
             }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "evidence_inputs": {
+            "contains": {
+              "type": "object",
+              "required": [
+                "provenance"
+              ],
+              "properties": {
+                "provenance": {
+                  "type": "object",
+                  "required": [
+                    "candidate_schema_validation"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "evidence_inputs"
+        ]
+      },
+      "then": {
+        "properties": {
+          "verifier_decision": {
+            "const": "FAILED"
+          },
+          "verified_artifacts": {
+            "type": "array",
+            "maxItems": 0
+          },
+          "relation_bindings": {
+            "type": "array",
+            "maxItems": 0
+          },
+          "gate_materialization": {
+            "type": "object",
+            "maxProperties": 0
           }
         }
       }

--- a/schemas/release_evidence_verifier_report_v0.schema.json
+++ b/schemas/release_evidence_verifier_report_v0.schema.json
@@ -195,6 +195,89 @@
       "type": "string",
       "pattern": "^[0-9a-fA-F]{64}$"
     },
+    "candidate_validation_diagnostic_status": {
+      "type": "string",
+      "enum": [
+        "not_run",
+        "unavailable",
+        "failed"
+      ]
+    },
+    "candidate_validation_diagnostic_error": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "instance_path": {
+          "type": "string"
+        },
+        "schema_path": {
+          "type": "string"
+        }
+      }
+    },
+    "duplicate_key_validation_draft": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status"
+      ],
+      "properties": {
+        "status": {
+          "$ref": "#/$defs/candidate_validation_diagnostic_status"
+        },
+        "errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/candidate_validation_diagnostic_error"
+          }
+        }
+      }
+    },
+    "candidate_schema_validation_draft": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status"
+      ],
+      "properties": {
+        "status": {
+          "$ref": "#/$defs/candidate_validation_diagnostic_status"
+        },
+        "schema_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "schema_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/candidate_validation_diagnostic_error"
+          }
+        },
+        "duplicate_key_validation": {
+          "$ref": "#/$defs/duplicate_key_validation_draft"
+        }
+      }
+    },
     "evidence_input": {
       "type": "object",
       "additionalProperties": false,
@@ -256,7 +339,13 @@
           }
         },
         "provenance": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "candidate_schema_validation": {
+              "$ref": "#/$defs/candidate_schema_validation_draft"
+            }
+          },
+          "additionalProperties": true
         }
       }
     },

--- a/tests/test_release_evidence_verifier_report_schema_v0.py
+++ b/tests/test_release_evidence_verifier_report_schema_v0.py
@@ -302,5 +302,150 @@ def test_verified_artifact_must_be_marked_verified() -> None:
     assert errors
 
 
+def _failed_report_with_candidate_schema_validation(
+    status: str = "failed",
+    duplicate_key_status: str | None = None,
+) -> dict[str, Any]:
+    report = _minimal_verified_report()
+
+    report["verifier_decision"] = "FAILED"
+    report["verified_artifacts"] = []
+    report["relation_bindings"] = []
+    report["gate_materialization"] = {}
+    report["failed_checks"] = [
+        "candidate schema validation draft is diagnostic-only"
+    ]
+
+    candidate_schema_validation: dict[str, Any] = {
+        "status": status,
+        "schema_path": "schemas/detector_report_v0.schema.json",
+        "schema_version": "detector_report_v0",
+        "errors": [
+            {
+                "code": "schema_validation_failed",
+                "message": "candidate evidence schema validation is diagnostic-only",
+                "instance_path": "/",
+                "schema_path": "#",
+            }
+        ],
+    }
+
+    if duplicate_key_status is not None:
+        candidate_schema_validation["duplicate_key_validation"] = {
+            "status": duplicate_key_status,
+            "errors": [
+                {
+                    "code": "duplicate_key_validation_failed",
+                    "message": "duplicate-key validation is diagnostic-only",
+                    "instance_path": "/",
+                    "schema_path": "#",
+                }
+            ],
+        }
+
+    report["evidence_inputs"][0]["provenance"] = {
+        "producer": "unit-test",
+        "trusted": False,
+        "verification_status": "not_verified",
+        "candidate_schema_validation": candidate_schema_validation,
+    }
+
+    return report
+
+
+@pytest.mark.parametrize("status", ["not_run", "unavailable", "failed"])
+def test_candidate_schema_validation_draft_accepts_diagnostic_statuses(
+    status: str,
+) -> None:
+    report = _failed_report_with_candidate_schema_validation(status=status)
+
+    _validate(report)
+
+
+@pytest.mark.parametrize(
+    "bad_status",
+    [
+        "valid",
+        "passed",
+        "success",
+        "schema_valid",
+        "verified",
+        "trusted",
+    ],
+)
+def test_candidate_schema_validation_draft_rejects_promotion_statuses(
+    bad_status: str,
+) -> None:
+    report = _failed_report_with_candidate_schema_validation(
+        status=bad_status,
+    )
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+@pytest.mark.parametrize("status", ["not_run", "unavailable", "failed"])
+def test_duplicate_key_validation_draft_accepts_diagnostic_statuses(
+    status: str,
+) -> None:
+    report = _failed_report_with_candidate_schema_validation(
+        status="failed",
+        duplicate_key_status=status,
+    )
+
+    _validate(report)
+
+
+@pytest.mark.parametrize(
+    "bad_status",
+    [
+        "valid",
+        "passed",
+        "success",
+        "schema_valid",
+        "verified",
+        "trusted",
+    ],
+)
+def test_duplicate_key_validation_draft_rejects_promotion_statuses(
+    bad_status: str,
+) -> None:
+    report = _failed_report_with_candidate_schema_validation(
+        status="failed",
+        duplicate_key_status=bad_status,
+    )
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_candidate_schema_validation_draft_does_not_make_verified_report_valid() -> None:
+    report = _failed_report_with_candidate_schema_validation(status="failed")
+    report["verifier_decision"] = "VERIFIED"
+    report["failed_checks"] = []
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_candidate_schema_validation_draft_keeps_failed_report_non_materialized() -> None:
+    report = _failed_report_with_candidate_schema_validation(status="failed")
+
+    _validate(report)
+
+    assert report["verifier_decision"] == "FAILED"
+    assert report["verified_artifacts"] == []
+    assert report["relation_bindings"] == []
+    assert report["gate_materialization"] == {}
+    assert report["evidence_inputs"][0]["provenance"]["trusted"] is False
+    assert (
+        report["evidence_inputs"][0]["provenance"]["verification_status"]
+        == "not_verified"
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))

--- a/tests/test_release_evidence_verifier_report_schema_v0.py
+++ b/tests/test_release_evidence_verifier_report_schema_v0.py
@@ -45,7 +45,7 @@ def _relation_binding() -> dict[str, Any]:
         "target": "subject.commit_sha",
         "verified": True,
         "evidence": [
-            _verified_artifact()
+            _verified_artifact(),
         ],
         "failure_reason": None,
     }
@@ -88,15 +88,15 @@ def _minimal_verified_report() -> dict[str, Any]:
                     "run_key": RUN_KEY,
                 },
                 "provenance": {
-                    "producer": "unit-test"
+                    "producer": "unit-test",
                 },
             }
         ],
         "verified_artifacts": [
-            _verified_artifact()
+            _verified_artifact(),
         ],
         "relation_bindings": [
-            _relation_binding()
+            _relation_binding(),
         ],
         "gate_materialization": {
             "detectors_materialized_ok": {
@@ -104,10 +104,10 @@ def _minimal_verified_report() -> dict[str, Any]:
                 "source": "release_evidence_verifier_report_v0",
                 "verified": True,
                 "evidence_artifacts": [
-                    _verified_artifact()
+                    _verified_artifact(),
                 ],
                 "relation_bindings": [
-                    "detector_report_to_subject_commit"
+                    "detector_report_to_subject_commit",
                 ],
                 "policy_relation": "release_required",
             }
@@ -115,6 +115,57 @@ def _minimal_verified_report() -> dict[str, Any]:
         "failed_checks": [],
         "warnings": [],
     }
+
+
+def _failed_report_with_candidate_schema_validation(
+    status: str = "failed",
+    duplicate_key_status: str | None = None,
+) -> dict[str, Any]:
+    report = _minimal_verified_report()
+
+    report["verifier_decision"] = "FAILED"
+    report["verified_artifacts"] = []
+    report["relation_bindings"] = []
+    report["gate_materialization"] = {}
+    report["failed_checks"] = [
+        "candidate schema validation draft is diagnostic-only",
+    ]
+
+    candidate_schema_validation: dict[str, Any] = {
+        "status": status,
+        "schema_path": "schemas/detector_report_v0.schema.json",
+        "schema_version": "detector_report_v0",
+        "errors": [
+            {
+                "code": "schema_validation_failed",
+                "message": "candidate evidence schema validation is diagnostic-only",
+                "instance_path": "/",
+                "schema_path": "#",
+            }
+        ],
+    }
+
+    if duplicate_key_status is not None:
+        candidate_schema_validation["duplicate_key_validation"] = {
+            "status": duplicate_key_status,
+            "errors": [
+                {
+                    "code": "duplicate_key_validation_failed",
+                    "message": "duplicate-key validation is diagnostic-only",
+                    "instance_path": "/",
+                    "schema_path": "#",
+                }
+            ],
+        }
+
+    report["evidence_inputs"][0]["provenance"] = {
+        "producer": "unit-test",
+        "trusted": False,
+        "verification_status": "not_verified",
+        "candidate_schema_validation": candidate_schema_validation,
+    }
+
+    return report
 
 
 def _validate(instance: dict[str, Any]) -> None:
@@ -127,6 +178,7 @@ def _validate(instance: dict[str, Any]) -> None:
 
     for key in schema["required"]:
         assert key in instance
+
     assert instance["schema_version"] == "release_evidence_verifier_report_v0"
     assert instance["verifier_decision"] in {"VERIFIED", "FAILED"}
 
@@ -163,6 +215,7 @@ def _validation_errors(instance: dict[str, Any]) -> list[str]:
         _validate(instance)
     except AssertionError as exc:
         return [str(exc)]
+
     return []
 
 
@@ -302,57 +355,6 @@ def test_verified_artifact_must_be_marked_verified() -> None:
     assert errors
 
 
-def _failed_report_with_candidate_schema_validation(
-    status: str = "failed",
-    duplicate_key_status: str | None = None,
-) -> dict[str, Any]:
-    report = _minimal_verified_report()
-
-    report["verifier_decision"] = "FAILED"
-    report["verified_artifacts"] = []
-    report["relation_bindings"] = []
-    report["gate_materialization"] = {}
-    report["failed_checks"] = [
-        "candidate schema validation draft is diagnostic-only"
-    ]
-
-    candidate_schema_validation: dict[str, Any] = {
-        "status": status,
-        "schema_path": "schemas/detector_report_v0.schema.json",
-        "schema_version": "detector_report_v0",
-        "errors": [
-            {
-                "code": "schema_validation_failed",
-                "message": "candidate evidence schema validation is diagnostic-only",
-                "instance_path": "/",
-                "schema_path": "#",
-            }
-        ],
-    }
-
-    if duplicate_key_status is not None:
-        candidate_schema_validation["duplicate_key_validation"] = {
-            "status": duplicate_key_status,
-            "errors": [
-                {
-                    "code": "duplicate_key_validation_failed",
-                    "message": "duplicate-key validation is diagnostic-only",
-                    "instance_path": "/",
-                    "schema_path": "#",
-                }
-            ],
-        }
-
-    report["evidence_inputs"][0]["provenance"] = {
-        "producer": "unit-test",
-        "trusted": False,
-        "verification_status": "not_verified",
-        "candidate_schema_validation": candidate_schema_validation,
-    }
-
-    return report
-
-
 @pytest.mark.parametrize("status", ["not_run", "unavailable", "failed"])
 def test_candidate_schema_validation_draft_accepts_diagnostic_statuses(
     status: str,
@@ -421,10 +423,137 @@ def test_duplicate_key_validation_draft_rejects_promotion_statuses(
     assert errors
 
 
+def test_candidate_schema_validation_draft_is_rejected_on_verified_report() -> None:
+    report = _minimal_verified_report()
+
+    report["evidence_inputs"][0]["provenance"] = {
+        "trusted": False,
+        "verification_status": "not_verified",
+        "candidate_schema_validation": {
+            "status": "failed",
+            "errors": [
+                {
+                    "code": "schema_validation_failed",
+                    "message": "candidate validation draft is diagnostic-only",
+                    "instance_path": "/",
+                    "schema_path": "#",
+                }
+            ],
+        },
+    }
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
 def test_candidate_schema_validation_draft_does_not_make_verified_report_valid() -> None:
     report = _failed_report_with_candidate_schema_validation(status="failed")
     report["verifier_decision"] = "VERIFIED"
     report["failed_checks"] = []
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_candidate_schema_validation_draft_rejects_non_empty_verified_artifacts() -> None:
+    report = _failed_report_with_candidate_schema_validation(status="failed")
+
+    verified_report = _minimal_verified_report()
+    report["verified_artifacts"] = verified_report["verified_artifacts"]
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_candidate_schema_validation_draft_rejects_non_empty_relation_bindings() -> None:
+    report = _failed_report_with_candidate_schema_validation(status="failed")
+
+    verified_report = _minimal_verified_report()
+    report["relation_bindings"] = verified_report["relation_bindings"]
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_candidate_schema_validation_draft_rejects_gate_materialization() -> None:
+    report = _failed_report_with_candidate_schema_validation(status="failed")
+
+    verified_report = _minimal_verified_report()
+    report["gate_materialization"] = verified_report["gate_materialization"]
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_candidate_schema_validation_draft_rejects_trusted_provenance() -> None:
+    report = _failed_report_with_candidate_schema_validation(status="failed")
+    report["evidence_inputs"][0]["provenance"]["trusted"] = True
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_candidate_schema_validation_draft_rejects_verified_provenance_status() -> None:
+    report = _failed_report_with_candidate_schema_validation(status="failed")
+    report["evidence_inputs"][0]["provenance"][
+        "verification_status"
+    ] = "verified"
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_candidate_schema_validation_failed_status_requires_errors() -> None:
+    report = _failed_report_with_candidate_schema_validation(status="failed")
+    del report["evidence_inputs"][0]["provenance"][
+        "candidate_schema_validation"
+    ]["errors"]
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_candidate_schema_validation_failed_status_rejects_empty_errors() -> None:
+    report = _failed_report_with_candidate_schema_validation(status="failed")
+    report["evidence_inputs"][0]["provenance"][
+        "candidate_schema_validation"
+    ]["errors"] = []
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_duplicate_key_validation_failed_status_requires_errors() -> None:
+    report = _failed_report_with_candidate_schema_validation(
+        status="failed",
+        duplicate_key_status="failed",
+    )
+    del report["evidence_inputs"][0]["provenance"][
+        "candidate_schema_validation"
+    ]["duplicate_key_validation"]["errors"]
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_duplicate_key_validation_failed_status_rejects_empty_errors() -> None:
+    report = _failed_report_with_candidate_schema_validation(
+        status="failed",
+        duplicate_key_status="failed",
+    )
+    report["evidence_inputs"][0]["provenance"][
+        "candidate_schema_validation"
+    ]["duplicate_key_validation"]["errors"] = []
 
     errors = _validation_errors(report)
 


### PR DESCRIPTION
## Summary

This PR adds the first Stage B schema-only draft surface for candidate evidence schema validation diagnostics.

The new optional field is:

`evidence_inputs[].provenance.candidate_schema_validation`

It is candidate-scoped, diagnostic-only, and non-authoritative.

Allowed diagnostic statuses are limited to:

- `not_run`
- `unavailable`
- `failed`

This PR does not implement candidate validation.

## Scope

Schema + schema tests only.

Changed files:

- `schemas/release_evidence_verifier_report_v0.schema.json`
- `tests/test_release_evidence_verifier_report_schema_v0.py`

## What this adds

New schema definitions:

- `candidate_validation_diagnostic_status`
- `candidate_validation_diagnostic_error`
- `candidate_schema_validation_draft`
- `duplicate_key_validation_draft`

The draft object supports:

- `status`
- `schema_path`
- `schema_version`
- `errors`
- `duplicate_key_validation`

## Boundary

`candidate_schema_validation` draft ≠ verified evidence  
schema-valid candidate ≠ trusted evidence  
duplicate-key check ≠ full evidence verification  
schema-only draft ≠ VERIFIED  
schema-valid report ≠ release authority  

## Non-goals

This PR does not change:

- verifier builder behavior
- verifier checker behavior
- expectation summary behavior
- input manifest behavior
- examples
- JSON fixtures
- workflows
- `check_gates.py`
- release policy
- gate registry
- CI authority path
- `--release-grade-materialized`

This PR does not create or enable:

- `VERIFIED`
- trusted evidence
- verified evidence promotion
- satisfied relation bindings
- gate materialization
- `status.json` writing
- release authority from verifier reports

## Testing

```bash
python -m pytest tests/test_release_evidence_verifier_report_schema_v0.py
```

```bash
python -m pytest \
  tests/test_build_release_evidence_verifier_report_v0.py \
  tests/test_build_release_evidence_expectation_summary_v0.py
```

```bash
python -m pytest \
  tests/test_release_evidence_input_manifest_v0.py \
  tests/test_release_evidence_pre_materialization_pipeline_v0.py
```

```bash
python -m pytest tests/test_tools_tests_list_smoke.py
```