### PR TITLE
feat(ref): add partial verification diagnostic draft schema v0

### DIFF
--- a/schemas/release_evidence_verifier_report_v0.schema.json
+++ b/schemas/release_evidence_verifier_report_v0.schema.json
@@ -334,6 +334,112 @@
         }
       ]
     },
+    "partial_verification_diagnostic_status": {
+      "type": "string",
+      "enum": [
+        "not_run",
+        "unavailable",
+        "failed"
+      ]
+    },
+    "partial_verification_diagnostic_error": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "actual": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "field_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "partial_verification_diagnostic_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status"
+      ],
+      "properties": {
+        "status": {
+          "$ref": "#/$defs/partial_verification_diagnostic_status"
+        },
+        "errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/partial_verification_diagnostic_error"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "failed"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "required": [
+              "errors"
+            ],
+            "properties": {
+              "errors": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/$defs/partial_verification_diagnostic_error"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "partial_verification_diagnostics_draft": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "digest_binding": {
+          "$ref": "#/$defs/partial_verification_diagnostic_result"
+        },
+        "subject_binding": {
+          "$ref": "#/$defs/partial_verification_diagnostic_result"
+        },
+        "run_binding": {
+          "$ref": "#/$defs/partial_verification_diagnostic_result"
+        }
+      }
+    },
     "evidence_input": {
       "type": "object",
       "additionalProperties": false,
@@ -399,6 +505,9 @@
           "properties": {
             "candidate_schema_validation": {
               "$ref": "#/$defs/candidate_schema_validation_draft"
+            },
+            "partial_verification_diagnostics": {
+              "$ref": "#/$defs/partial_verification_diagnostics_draft"
             }
           },
           "additionalProperties": true,
@@ -407,6 +516,27 @@
               "if": {
                 "required": [
                   "candidate_schema_validation"
+                ]
+              },
+              "then": {
+                "required": [
+                  "trusted",
+                  "verification_status"
+                ],
+                "properties": {
+                  "trusted": {
+                    "const": false
+                  },
+                  "verification_status": {
+                    "const": "not_verified"
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "required": [
+                  "partial_verification_diagnostics"
                 ]
               },
               "then": {
@@ -643,6 +773,50 @@
                   "type": "object",
                   "required": [
                     "candidate_schema_validation"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "evidence_inputs"
+        ]
+      },
+      "then": {
+        "properties": {
+          "verifier_decision": {
+            "const": "FAILED"
+          },
+          "verified_artifacts": {
+            "type": "array",
+            "maxItems": 0
+          },
+          "relation_bindings": {
+            "type": "array",
+            "maxItems": 0
+          },
+          "gate_materialization": {
+            "type": "object",
+            "maxProperties": 0
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "evidence_inputs": {
+            "contains": {
+              "type": "object",
+              "required": [
+                "provenance"
+              ],
+              "properties": {
+                "provenance": {
+                  "type": "object",
+                  "required": [
+                    "partial_verification_diagnostics"
                   ]
                 }
               }

--- a/tests/test_release_evidence_verifier_report_schema_v0.py
+++ b/tests/test_release_evidence_verifier_report_schema_v0.py
@@ -576,5 +576,282 @@ def test_candidate_schema_validation_draft_keeps_failed_report_non_materialized(
     )
 
 
+def _failed_report_with_partial_verification_diagnostics(
+    result_key: str = "digest_binding",
+    status: str = "failed",
+) -> dict[str, Any]:
+    report = _minimal_verified_report()
+
+    report["verifier_decision"] = "FAILED"
+    report["verified_artifacts"] = []
+    report["relation_bindings"] = []
+    report["gate_materialization"] = {}
+    report["failed_checks"] = [
+        "partial verification diagnostics draft is diagnostic-only",
+    ]
+
+    partial_result: dict[str, Any] = {
+        "status": status,
+        "errors": [
+            {
+                "code": "partial_verification_failed",
+                "message": "partial verification diagnostics are diagnostic-only",
+                "expected": "declared binding",
+                "actual": "not verified",
+                "field_path": result_key,
+            }
+        ],
+    }
+
+    report["evidence_inputs"][0]["provenance"] = {
+        "producer": "unit-test",
+        "trusted": False,
+        "verification_status": "not_verified",
+        "partial_verification_diagnostics": {
+            result_key: partial_result,
+        },
+    }
+
+    return report
+
+
+@pytest.mark.parametrize(
+    "result_key",
+    [
+        "digest_binding",
+        "subject_binding",
+        "run_binding",
+    ],
+)
+@pytest.mark.parametrize("status", ["not_run", "unavailable", "failed"])
+def test_partial_verification_diagnostics_accepts_diagnostic_statuses(
+    result_key: str,
+    status: str,
+) -> None:
+    report = _failed_report_with_partial_verification_diagnostics(
+        result_key=result_key,
+        status=status,
+    )
+
+    _validate(report)
+
+
+@pytest.mark.parametrize(
+    "result_key",
+    [
+        "digest_binding",
+        "subject_binding",
+        "run_binding",
+    ],
+)
+@pytest.mark.parametrize(
+    "bad_status",
+    [
+        "valid",
+        "passed",
+        "success",
+        "schema_valid",
+        "matched",
+        "match",
+        "verified",
+        "trusted",
+        "satisfied",
+    ],
+)
+def test_partial_verification_diagnostics_rejects_promotion_statuses(
+    result_key: str,
+    bad_status: str,
+) -> None:
+    report = _failed_report_with_partial_verification_diagnostics(
+        result_key=result_key,
+        status=bad_status,
+    )
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+@pytest.mark.parametrize(
+    "bad_result_key",
+    [
+        "candidate_schema_validation",
+        "verifier_identity",
+        "trust_root",
+        "relation_provenance_readiness",
+        "deterministic_relation_id",
+        "verified_relation_prototype",
+        "gate_eligibility",
+    ],
+)
+def test_partial_verification_diagnostics_rejects_postponed_surfaces(
+    bad_result_key: str,
+) -> None:
+    report = _failed_report_with_partial_verification_diagnostics(
+        result_key="digest_binding",
+        status="failed",
+    )
+
+    result = report["evidence_inputs"][0]["provenance"][
+        "partial_verification_diagnostics"
+    ].pop("digest_binding")
+    report["evidence_inputs"][0]["provenance"][
+        "partial_verification_diagnostics"
+    ][bad_result_key] = result
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_partial_verification_diagnostics_is_rejected_on_verified_report() -> None:
+    report = _minimal_verified_report()
+
+    report["evidence_inputs"][0]["provenance"] = {
+        "trusted": False,
+        "verification_status": "not_verified",
+        "partial_verification_diagnostics": {
+            "digest_binding": {
+                "status": "failed",
+                "errors": [
+                    {
+                        "code": "partial_verification_failed",
+                        "message": "partial verification diagnostics are diagnostic-only",
+                        "expected": "declared binding",
+                        "actual": "not verified",
+                        "field_path": "digest_binding",
+                    }
+                ],
+            }
+        },
+    }
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_partial_verification_diagnostics_rejects_non_empty_verified_artifacts() -> None:
+    report = _failed_report_with_partial_verification_diagnostics()
+
+    verified_report = _minimal_verified_report()
+    report["verified_artifacts"] = verified_report["verified_artifacts"]
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_partial_verification_diagnostics_rejects_non_empty_relation_bindings() -> None:
+    report = _failed_report_with_partial_verification_diagnostics()
+
+    verified_report = _minimal_verified_report()
+    report["relation_bindings"] = verified_report["relation_bindings"]
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_partial_verification_diagnostics_rejects_gate_materialization() -> None:
+    report = _failed_report_with_partial_verification_diagnostics()
+
+    verified_report = _minimal_verified_report()
+    report["gate_materialization"] = verified_report["gate_materialization"]
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_partial_verification_diagnostics_rejects_trusted_provenance() -> None:
+    report = _failed_report_with_partial_verification_diagnostics()
+    report["evidence_inputs"][0]["provenance"]["trusted"] = True
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_partial_verification_diagnostics_rejects_verified_provenance_status() -> None:
+    report = _failed_report_with_partial_verification_diagnostics()
+    report["evidence_inputs"][0]["provenance"][
+        "verification_status"
+    ] = "verified"
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+@pytest.mark.parametrize(
+    "result_key",
+    [
+        "digest_binding",
+        "subject_binding",
+        "run_binding",
+    ],
+)
+def test_partial_verification_diagnostics_failed_status_requires_errors(
+    result_key: str,
+) -> None:
+    report = _failed_report_with_partial_verification_diagnostics(
+        result_key=result_key,
+        status="failed",
+    )
+
+    del report["evidence_inputs"][0]["provenance"][
+        "partial_verification_diagnostics"
+    ][result_key]["errors"]
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+@pytest.mark.parametrize(
+    "result_key",
+    [
+        "digest_binding",
+        "subject_binding",
+        "run_binding",
+    ],
+)
+def test_partial_verification_diagnostics_failed_status_rejects_empty_errors(
+    result_key: str,
+) -> None:
+    report = _failed_report_with_partial_verification_diagnostics(
+        result_key=result_key,
+        status="failed",
+    )
+
+    report["evidence_inputs"][0]["provenance"][
+        "partial_verification_diagnostics"
+    ][result_key]["errors"] = []
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_partial_verification_diagnostics_keeps_failed_report_non_materialized() -> None:
+    report = _failed_report_with_partial_verification_diagnostics(
+        result_key="digest_binding",
+        status="failed",
+    )
+
+    _validate(report)
+
+    assert report["verifier_decision"] == "FAILED"
+    assert report["verified_artifacts"] == []
+    assert report["relation_bindings"] == []
+    assert report["gate_materialization"] == {}
+    assert report["evidence_inputs"][0]["provenance"]["trusted"] is False
+    assert (
+        report["evidence_inputs"][0]["provenance"]["verification_status"]
+        == "not_verified"
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

This PR adds the Stage B schema-only draft surface for partial verification diagnostics.

The new optional field is:

`evidence_inputs[].provenance.partial_verification_diagnostics`

It is candidate-scoped, diagnostic-only, and non-authoritative.

The first allowed diagnostic sub-results are:

- `digest_binding`
- `subject_binding`
- `run_binding`

Allowed diagnostic statuses are limited to:

- `not_run`
- `unavailable`
- `failed`

## Scope

Schema + schema tests only.

Changed files:

- `schemas/release_evidence_verifier_report_v0.schema.json`
- `tests/test_release_evidence_verifier_report_schema_v0.py`

No builder, checker, workflow, example, fixture, policy, registry, or CI authority behavior is changed.

## Boundary

`partial_verification_diagnostics` draft ≠ partial verification  
partial diagnostic ≠ relation satisfaction  
digest diagnostic ≠ verified evidence  
subject/run diagnostic ≠ satisfied relation binding  
schema-only draft ≠ VERIFIED  
schema-valid report ≠ release authority  

When `partial_verification_diagnostics` is present:

- `verifier_decision = FAILED`
- `provenance.trusted = false`
- `verification_status = not_verified`
- `verified_artifacts = []`
- `relation_bindings = []`
- `gate_materialization = {}`

## Non-goals

This PR does not change:

- verifier builder behavior
- verifier checker behavior
- expectation summary behavior
- input manifest behavior
- examples
- JSON fixtures
- workflows
- `check_gates.py`
- release policy
- gate registry
- CI authority path
- `--release-grade-materialized`

This PR does not create or enable:

- `VERIFIED`
- trusted evidence
- verified evidence promotion
- satisfied relation bindings
- gate materialization
- `status.json` writing
- release authority from verifier reports

## Testing

```bash
python -m pytest tests/test_release_evidence_verifier_report_schema_v0.py
```

```bash
python -m pytest \
  tests/test_build_release_evidence_verifier_report_v0.py \
  tests/test_build_release_evidence_expectation_summary_v0.py
```

```bash
python -m pytest \
  tests/test_release_evidence_input_manifest_v0.py \
  tests/test_release_evidence_pre_materialization_pipeline_v0.py
```

```bash
python -m pytest tests/test_tools_tests_list_smoke.py
```