### PR TITLE
test(ref): lock Stage B draft diagnostics checker boundary v0

### DIFF
--- a/tests/test_check_release_evidence_verifier_report_v0.py
+++ b/tests/test_check_release_evidence_verifier_report_v0.py
@@ -38,7 +38,9 @@ def _write_json(path: pathlib.Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
 
-def _verified_artifact(path: str = "artifacts/detectors/detector_report.json") -> dict[str, Any]:
+def _verified_artifact(
+    path: str = "artifacts/detectors/detector_report.json",
+) -> dict[str, Any]:
     return {
         "path": path,
         "sha256": HEX64,
@@ -61,7 +63,7 @@ def _relation_binding(
         "target": target,
         "verified": verified,
         "evidence": [
-            _verified_artifact(source)
+            _verified_artifact(source),
         ],
         "failure_reason": None if verified else "relation was not verified",
     }
@@ -106,15 +108,15 @@ def _verified_report() -> dict[str, Any]:
                     "run_key": RUN_KEY,
                 },
                 "provenance": {
-                    "producer": "unit-test"
+                    "producer": "unit-test",
                 },
             }
         ],
         "verified_artifacts": [
-            _verified_artifact()
+            _verified_artifact(),
         ],
         "relation_bindings": [
-            _relation_binding(relation_id=relation_id)
+            _relation_binding(relation_id=relation_id),
         ],
         "gate_materialization": {
             "detectors_materialized_ok": {
@@ -122,10 +124,10 @@ def _verified_report() -> dict[str, Any]:
                 "source": "release_evidence_verifier_report_v0",
                 "verified": True,
                 "evidence_artifacts": [
-                    _verified_artifact()
+                    _verified_artifact(),
                 ],
                 "relation_bindings": [
-                    relation_id
+                    relation_id,
                 ],
                 "policy_relation": "release_required",
             }
@@ -197,9 +199,13 @@ def test_unverified_referenced_relation_fails(tmp_path: pathlib.Path) -> None:
     assert any("not verified=true" in error for error in errors)
 
 
-def test_gate_materialization_without_relation_ids_fails(tmp_path: pathlib.Path) -> None:
+def test_gate_materialization_without_relation_ids_fails(
+    tmp_path: pathlib.Path,
+) -> None:
     report = _verified_report()
-    report["gate_materialization"]["detectors_materialized_ok"]["relation_bindings"] = []
+    report["gate_materialization"]["detectors_materialized_ok"][
+        "relation_bindings"
+    ] = []
 
     report_path = tmp_path / "release_evidence_verifier_report_v0.json"
     _write_json(report_path, report)
@@ -244,7 +250,10 @@ def test_checker_cli_passes_failed_example() -> None:
     )
 
     assert result.returncode == 0, result.stderr
-    assert "OK: release evidence verifier report relation integrity satisfied" in result.stdout
+    assert (
+        "OK: release evidence verifier report relation integrity satisfied"
+        in result.stdout
+    )
 
 
 def test_checker_cli_reports_errors(tmp_path: pathlib.Path) -> None:
@@ -369,6 +378,21 @@ def _checker_errors_for_report(
     return check_release_evidence_verifier_report(report_path)
 
 
+def _assert_valid_verified_report_fixture(
+    tmp_path: pathlib.Path,
+    report: dict[str, Any],
+) -> None:
+    assert report["verifier_decision"] == "VERIFIED"
+    assert report["failed_checks"] == []
+    assert report["verified_artifacts"]
+    assert report["relation_bindings"]
+    assert report["gate_materialization"]
+
+    errors = _checker_errors_for_report(tmp_path, report)
+
+    assert errors == []
+
+
 def test_checker_accepts_failed_candidate_schema_validation_draft_report(
     tmp_path: pathlib.Path,
 ) -> None:
@@ -392,9 +416,27 @@ def test_checker_accepts_failed_partial_diagnostics_draft_report(
 def test_checker_rejects_candidate_schema_validation_draft_on_verified_report(
     tmp_path: pathlib.Path,
 ) -> None:
-    report = _failed_report_with_candidate_schema_validation_draft()
-    report["verifier_decision"] = "VERIFIED"
-    report["failed_checks"] = []
+    report = _verified_report()
+    _assert_valid_verified_report_fixture(tmp_path, report)
+
+    report["evidence_inputs"][0]["provenance"] = {
+        "producer": "unit-test",
+        "trusted": False,
+        "verification_status": "not_verified",
+        "candidate_schema_validation": {
+            "status": "failed",
+            "schema_path": "schemas/detector_report_v0.schema.json",
+            "schema_version": "detector_report_v0",
+            "errors": [
+                {
+                    "code": "schema_validation_failed",
+                    "message": "candidate schema validation is diagnostic-only",
+                    "instance_path": "/",
+                    "schema_path": "#",
+                }
+            ],
+        },
+    }
 
     errors = _checker_errors_for_report(tmp_path, report)
 
@@ -404,9 +446,31 @@ def test_checker_rejects_candidate_schema_validation_draft_on_verified_report(
 def test_checker_rejects_partial_diagnostics_draft_on_verified_report(
     tmp_path: pathlib.Path,
 ) -> None:
-    report = _failed_report_with_partial_verification_diagnostics()
-    report["verifier_decision"] = "VERIFIED"
-    report["failed_checks"] = []
+    report = _verified_report()
+    _assert_valid_verified_report_fixture(tmp_path, report)
+
+    report["evidence_inputs"][0]["provenance"] = {
+        "producer": "unit-test",
+        "trusted": False,
+        "verification_status": "not_verified",
+        "partial_verification_diagnostics": {
+            "digest_binding": {
+                "status": "failed",
+                "errors": [
+                    {
+                        "code": "partial_verification_failed",
+                        "message": (
+                            "partial verification diagnostics are "
+                            "diagnostic-only"
+                        ),
+                        "expected": "declared digest binding",
+                        "actual": "not verified",
+                        "field_path": "digest_binding",
+                    }
+                ],
+            }
+        },
+    }
 
     errors = _checker_errors_for_report(tmp_path, report)
 
@@ -560,6 +624,7 @@ def test_checker_rejects_partial_diagnostics_failed_status_with_empty_errors(
     errors = _checker_errors_for_report(tmp_path, report)
 
     assert errors
+
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))

--- a/tests/test_check_release_evidence_verifier_report_v0.py
+++ b/tests/test_check_release_evidence_verifier_report_v0.py
@@ -291,5 +291,275 @@ def test_checker_fails_closed_when_jsonschema_unavailable(
     assert any("partial fallback validation is not allowed" in error for error in errors)
 
 
+def _failed_report_base() -> dict[str, Any]:
+    report = _verified_report()
+
+    report["verifier_decision"] = "FAILED"
+    report["verified_artifacts"] = []
+    report["relation_bindings"] = []
+    report["gate_materialization"] = {}
+    report["failed_checks"] = [
+        "Stage B draft diagnostics remain non-authoritative",
+    ]
+
+    return report
+
+
+def _failed_report_with_candidate_schema_validation_draft() -> dict[str, Any]:
+    report = _failed_report_base()
+
+    report["evidence_inputs"][0]["provenance"] = {
+        "producer": "unit-test",
+        "trusted": False,
+        "verification_status": "not_verified",
+        "candidate_schema_validation": {
+            "status": "failed",
+            "schema_path": "schemas/detector_report_v0.schema.json",
+            "schema_version": "detector_report_v0",
+            "errors": [
+                {
+                    "code": "schema_validation_failed",
+                    "message": "candidate schema validation is diagnostic-only",
+                    "instance_path": "/",
+                    "schema_path": "#",
+                }
+            ],
+        },
+    }
+
+    return report
+
+
+def _failed_report_with_partial_verification_diagnostics() -> dict[str, Any]:
+    report = _failed_report_base()
+
+    report["evidence_inputs"][0]["provenance"] = {
+        "producer": "unit-test",
+        "trusted": False,
+        "verification_status": "not_verified",
+        "partial_verification_diagnostics": {
+            "digest_binding": {
+                "status": "failed",
+                "errors": [
+                    {
+                        "code": "partial_verification_failed",
+                        "message": (
+                            "partial verification diagnostics are "
+                            "diagnostic-only"
+                        ),
+                        "expected": "declared digest binding",
+                        "actual": "not verified",
+                        "field_path": "digest_binding",
+                    }
+                ],
+            }
+        },
+    }
+
+    return report
+
+
+def _checker_errors_for_report(
+    tmp_path: pathlib.Path,
+    report: dict[str, Any],
+) -> list[str]:
+    report_path = tmp_path / "release_evidence_verifier_report_v0.json"
+    _write_json(report_path, report)
+
+    return check_release_evidence_verifier_report(report_path)
+
+
+def test_checker_accepts_failed_candidate_schema_validation_draft_report(
+    tmp_path: pathlib.Path,
+) -> None:
+    report = _failed_report_with_candidate_schema_validation_draft()
+
+    errors = _checker_errors_for_report(tmp_path, report)
+
+    assert errors == []
+
+
+def test_checker_accepts_failed_partial_diagnostics_draft_report(
+    tmp_path: pathlib.Path,
+) -> None:
+    report = _failed_report_with_partial_verification_diagnostics()
+
+    errors = _checker_errors_for_report(tmp_path, report)
+
+    assert errors == []
+
+
+def test_checker_rejects_candidate_schema_validation_draft_on_verified_report(
+    tmp_path: pathlib.Path,
+) -> None:
+    report = _failed_report_with_candidate_schema_validation_draft()
+    report["verifier_decision"] = "VERIFIED"
+    report["failed_checks"] = []
+
+    errors = _checker_errors_for_report(tmp_path, report)
+
+    assert errors
+
+
+def test_checker_rejects_partial_diagnostics_draft_on_verified_report(
+    tmp_path: pathlib.Path,
+) -> None:
+    report = _failed_report_with_partial_verification_diagnostics()
+    report["verifier_decision"] = "VERIFIED"
+    report["failed_checks"] = []
+
+    errors = _checker_errors_for_report(tmp_path, report)
+
+    assert errors
+
+
+@pytest.mark.parametrize(
+    "report_factory",
+    [
+        _failed_report_with_candidate_schema_validation_draft,
+        _failed_report_with_partial_verification_diagnostics,
+    ],
+)
+def test_checker_rejects_stage_b_draft_with_trusted_provenance(
+    tmp_path: pathlib.Path,
+    report_factory: Any,
+) -> None:
+    report = report_factory()
+    report["evidence_inputs"][0]["provenance"]["trusted"] = True
+
+    errors = _checker_errors_for_report(tmp_path, report)
+
+    assert errors
+
+
+@pytest.mark.parametrize(
+    "report_factory",
+    [
+        _failed_report_with_candidate_schema_validation_draft,
+        _failed_report_with_partial_verification_diagnostics,
+    ],
+)
+def test_checker_rejects_stage_b_draft_with_verified_provenance_status(
+    tmp_path: pathlib.Path,
+    report_factory: Any,
+) -> None:
+    report = report_factory()
+    report["evidence_inputs"][0]["provenance"][
+        "verification_status"
+    ] = "verified"
+
+    errors = _checker_errors_for_report(tmp_path, report)
+
+    assert errors
+
+
+@pytest.mark.parametrize(
+    "report_factory",
+    [
+        _failed_report_with_candidate_schema_validation_draft,
+        _failed_report_with_partial_verification_diagnostics,
+    ],
+)
+def test_checker_rejects_stage_b_draft_with_verified_artifacts(
+    tmp_path: pathlib.Path,
+    report_factory: Any,
+) -> None:
+    report = report_factory()
+    report["verified_artifacts"] = _verified_report()["verified_artifacts"]
+
+    errors = _checker_errors_for_report(tmp_path, report)
+
+    assert errors
+
+
+@pytest.mark.parametrize(
+    "report_factory",
+    [
+        _failed_report_with_candidate_schema_validation_draft,
+        _failed_report_with_partial_verification_diagnostics,
+    ],
+)
+def test_checker_rejects_stage_b_draft_with_relation_bindings(
+    tmp_path: pathlib.Path,
+    report_factory: Any,
+) -> None:
+    report = report_factory()
+    report["relation_bindings"] = _verified_report()["relation_bindings"]
+
+    errors = _checker_errors_for_report(tmp_path, report)
+
+    assert errors
+
+
+@pytest.mark.parametrize(
+    "report_factory",
+    [
+        _failed_report_with_candidate_schema_validation_draft,
+        _failed_report_with_partial_verification_diagnostics,
+    ],
+)
+def test_checker_rejects_stage_b_draft_with_gate_materialization(
+    tmp_path: pathlib.Path,
+    report_factory: Any,
+) -> None:
+    report = report_factory()
+    report["gate_materialization"] = _verified_report()["gate_materialization"]
+
+    errors = _checker_errors_for_report(tmp_path, report)
+
+    assert errors
+
+
+def test_checker_rejects_candidate_validation_failed_status_without_errors(
+    tmp_path: pathlib.Path,
+) -> None:
+    report = _failed_report_with_candidate_schema_validation_draft()
+    del report["evidence_inputs"][0]["provenance"][
+        "candidate_schema_validation"
+    ]["errors"]
+
+    errors = _checker_errors_for_report(tmp_path, report)
+
+    assert errors
+
+
+def test_checker_rejects_candidate_validation_failed_status_with_empty_errors(
+    tmp_path: pathlib.Path,
+) -> None:
+    report = _failed_report_with_candidate_schema_validation_draft()
+    report["evidence_inputs"][0]["provenance"][
+        "candidate_schema_validation"
+    ]["errors"] = []
+
+    errors = _checker_errors_for_report(tmp_path, report)
+
+    assert errors
+
+
+def test_checker_rejects_partial_diagnostics_failed_status_without_errors(
+    tmp_path: pathlib.Path,
+) -> None:
+    report = _failed_report_with_partial_verification_diagnostics()
+    del report["evidence_inputs"][0]["provenance"][
+        "partial_verification_diagnostics"
+    ]["digest_binding"]["errors"]
+
+    errors = _checker_errors_for_report(tmp_path, report)
+
+    assert errors
+
+
+def test_checker_rejects_partial_diagnostics_failed_status_with_empty_errors(
+    tmp_path: pathlib.Path,
+) -> None:
+    report = _failed_report_with_partial_verification_diagnostics()
+    report["evidence_inputs"][0]["provenance"][
+        "partial_verification_diagnostics"
+    ]["digest_binding"]["errors"] = []
+
+    errors = _checker_errors_for_report(tmp_path, report)
+
+    assert errors
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

This PR adds checker-path regressions for Stage B draft diagnostics.

The schema already constrains these draft surfaces:

- `candidate_schema_validation`
- `partial_verification_diagnostics`

to FAILED, candidate-scoped, diagnostic-only, non-authoritative report state.

This PR locks that the verifier report checker inherits those schema boundaries through the checker path.

## Scope

Test-only hardening.

Changed file:

- `tests/test_check_release_evidence_verifier_report_v0.py`

## What this locks

The checker accepts valid FAILED / non-authoritative draft reports:

- `candidate_schema_validation`
- `partial_verification_diagnostics`

The checker rejects promotion-like combinations:

- draft diagnostics on `VERIFIED` reports
- `provenance.trusted = true`
- `verification_status = verified`
- non-empty `verified_artifacts`
- non-empty `relation_bindings`
- non-empty `gate_materialization`
- failed diagnostics without non-empty `errors`

## Boundary

checker shape validation ≠ evidence promotion  
checker shape validation ≠ trusted verifier  
checker shape validation ≠ satisfied relation binding  
checker shape validation ≠ gate materialization  
checker shape validation ≠ release authority  

## Non-goals

This PR does not change:

- schemas
- checker behavior
- builder behavior
- expectation summary behavior
- input manifest behavior
- examples
- JSON fixtures
- workflows
- `check_gates.py`
- release policy
- gate registry
- CI authority path
- `--release-grade-materialized`

This PR does not create or enable:

- `VERIFIED`
- trusted evidence
- verified evidence promotion
- satisfied relation bindings
- gate materialization
- `status.json` writing
- release authority from verifier reports

## Testing

```bash
python -m pytest tests/test_check_release_evidence_verifier_report_v0.py
```

```bash
python -m pytest tests/test_release_evidence_verifier_report_schema_v0.py
```

```bash
python -m pytest \
  tests/test_build_release_evidence_verifier_report_v0.py \
  tests/test_build_release_evidence_expectation_summary_v0.py
```

```bash
python -m pytest \
  tests/test_release_evidence_input_manifest_v0.py \
  tests/test_release_evidence_pre_materialization_pipeline_v0.py
```

```bash
python -m pytest tests/test_tools_tests_list_smoke.py
```