### PR TITLE
docs(ref): record PULSEmech release-authority bridge v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ recorded release evidence
 
 See [`docs/PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md`](docs/PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md).
 
+
+## PULSE - PULSEmech
+
+> [!NOTE]
+> **Execution is not authority.**
+>
+> - [PULSE - PULSEmech](docs/PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md) — release execution, green CI, approval, and post-failure audit are separated from artifact-bound release authority.
+
+
 ## Authority boundary
 
 | Surface / artifact | Mechanical role | Authority boundary |

--- a/docs/PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md
+++ b/docs/PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md
@@ -1,0 +1,243 @@
+# PULSE - PULSEmech
+
+## 1. Kiinduló repedés
+
+A release elkészülése nem bizonyítja, hogy a release jogosult.
+
+Angolul:
+
+**Release execution is not release authority.**
+
+Magyarul:
+
+**A release végrehajtása nem azonos a release-authorityvel.**
+
+Egy release végrehajtható lehet úgy is, hogy a döntési jogosultsága nincs igazolt állapothoz kötve.
+
+## 2. A zöld teszt határa
+
+A zöld teszt nem bizonyít release-authorityt.
+
+Angolul:
+
+**Green CI is not release authority.**
+
+Magyarul:
+
+**A zöld CI nem release-authority.**
+
+A zöld CI azt mutatja, hogy egy adott tesztkészlet lefutott és átment.
+Nem bizonyítja, hogy a release-döntés jogosult bizonyítékútból, deklarált policyből és materializált kötelező gate-ekből állt elő.
+
+Ezért:
+
+**A zöld teszt végrehajtási állapotot mutathat.
+Nem bizonyít release-jogosultságot.**
+
+## 3. Az approval határa
+
+Az approval önmagában nem release-authority.
+
+Angolul:
+
+**Approval is not release authority.**
+
+Magyarul:
+
+**A jóváhagyás nem release-authority.**
+
+Egy ember, board, review vagy intézményi szerep jóváhagyhat egy release-t.
+De ha a jóváhagyás nincs rögzített bizonyítékhoz, deklarált policyhez, materializált gate-ekhez és fail-closed döntési úthoz kötve, akkor az approval csak kijelentett engedély, nem igazolt release-authority.
+
+Ezért:
+
+**A jóváhagyás nem pótolja a jogosultsági állapotot.**
+
+## 4. Az utólagos audit határa
+
+A hiba utáni audit már túl késő ahhoz, hogy release-authorityt hozzon létre.
+
+Angolul:
+
+**Post-failure audit is too late to create release authority.**
+
+Magyarul:
+
+**A hiba utáni audit már túl késő ahhoz, hogy release-authorityt hozzon létre.**
+
+Az utólagos audit fontos lehet romeltakarításra, tanulságra, felelősségi vizsgálatra vagy javításra.
+De nem pótolja azt a deployment előtti feltételt, amelynek a release előtt kellett volna működnie.
+
+Ezért:
+
+**Az audit megmagyarázhatja a romot, de nem tudja visszamenőleg jogosulttá tenni a hibás átmenetet.**
+
+## 5. A release-authority nem automatikus
+
+A release-authority nem keletkezik automatikusan attól, hogy:
+
+* a release elkészült,
+* a CI zöld,
+* valaki jóváhagyta,
+* a dokumentáció létezik,
+* a governance folyamat lefutott,
+* az audit később elvégezhető.
+
+Ezek mind lehetnek hasznos elemek, de önmagukban nem bizonyítják, hogy a release jogosult állapotból jött létre.
+
+Angolul:
+
+**Release authority is not inferred from execution, approval, documentation, governance, or post-failure audit.**
+
+Magyarul:
+
+**A release-authority nem vezethető le pusztán végrehajtásból, jóváhagyásból, dokumentációból, governance-folyamatból vagy hiba utáni auditból.**
+
+## 6. A PULSE belépési pontja
+
+A PULSE nem azt kérdezi először, hogy a release elkészült-e.
+
+A PULSE azt kérdezi:
+
+**Van-e deployment előtt igazolt bizonyítékút, deklarált policy, materializált kötelező gate-készlet és strict fail-closed CI, amelyhez a release-authority köthető?**
+
+Angolul:
+
+**PULSE binds release authority to recorded evidence, declared policy, materialized required gates, and strict fail-closed CI before deployment.**
+
+Magyarul:
+
+**A PULSE a release-authorityt deployment előtt rögzített bizonyítékhoz, deklarált policyhez, materializált kötelező gate-ekhez és strict fail-closed CI-hez köti.**
+
+Ez a PULSE első tiszta mechanikai állítása.
+
+## 7. A PULSE mechanikai azonosítása
+
+A PULSE nem governance-címke.
+
+A PULSE nem approval tool.
+
+A PULSE nem compliance-doboz.
+
+A PULSE nem utólagos auditfelület.
+
+A PULSE nem egyszerű release tool.
+
+A PULSE artifact-bound release-authority mechanika.
+
+Angolul:
+
+**PULSE is not a governance label, approval tool, compliance wrapper, post-failure audit surface, or ordinary release utility.
+PULSE is an artifact-bound release-authority mechanism.**
+
+Magyarul:
+
+**A PULSE nem governance-címke, nem jóváhagyó eszköz, nem compliance-burkolat, nem hiba utáni auditfelület és nem szokványos release utility.
+A PULSE artifact-bound release-authority mechanika.**
+
+## 8. Megállapítás
+
+Angolul:
+
+**PULSE separates release execution from release authority and binds release authority to pre-deployment evidence.**
+
+Magyarul:
+
+**A PULSE szétválasztja a release végrehajtását a release-authoritytől, és a release-authorityt deployment előtti bizonyítékhoz köti.**
+
+Eredmény:
+
+**végrehajtás ≠ jogosultság**
+
+## 9. Tétel
+
+Egy release-döntés jogosultsága nem adottság, nem pozícióból eredő kijelentés, és nem utólagos magyarázat.
+
+A release-authority csak akkor tekinthető igazolt állapotnak, ha deployment előtt rögzített bizonyítékhoz, deklarált policyhez, materializált kötelező gate-ekhez és strict fail-closed CI-hez van kötve.
+
+Angolul:
+
+**Release authority is a pre-deployment evidence-bound state, not an assumption derived from execution, approval, or institutional position.**
+
+Magyarul:
+
+**A release-authority deployment előtti bizonyítékhoz kötött állapot, nem végrehajtásból, jóváhagyásból vagy intézményi pozícióból levezetett feltételezés.**
+
+## 10. Miért nem elég az utólagos rendszer?
+
+A hiba utáni vizsgálat már a bekövetkezett eseményt elemzi.
+
+A PULSE ezzel szemben a hibás átmeneti út jogosultságát vizsgálja deployment előtt.
+
+Ezért:
+
+**Post-failure review explains what happened.
+PULSE controls whether the release path was authorized before it happened.**
+
+Magyarul:
+
+**A hiba utáni review azt magyarázza, mi történt.
+A PULSE azt kontrollálja, hogy a release-út jogosult volt-e, mielőtt megtörtént.**
+
+Ez a különbség választja el a romeltakarítást a pre-deployment release-authority mechanikától.
+
+## 11. PULSE
+
+**A PULSE nem release-eket hagy jóvá.
+A PULSE azokat az artifact-bound bizonyítékfeltételeket határozza meg, amelyek mellett release-authority deployment előtt felismerhető.**
+
+## 12. A release-authority hét mechanikai tétele
+
+1. **Release execution is not release authority.**
+   A release végrehajtása nem azonos a release-authorityvel.
+
+2. **Green CI is not release authority.**
+   A zöld CI nem release-authority.
+
+3. **Approval is not release authority.**
+   A jóváhagyás nem release-authority.
+
+4. **Post-failure audit is too late to create release authority.**
+   A hiba utáni audit már túl késő ahhoz, hogy release-authorityt hozzon létre.
+
+5. **Release authority must be bound before deployment.**
+   A release-authorityt deployment előtt kell kötni.
+
+6. **PULSE binds release authority to recorded evidence, declared policy, materialized required gates, and strict fail-closed CI before deployment.**
+   A PULSE a release-authorityt deployment előtt rögzített bizonyítékhoz, deklarált policyhez, materializált kötelező gate-ekhez és strict fail-closed CI-hez köti.
+
+7. **Therefore, PULSE is not a governance label or approval tool; it is an artifact-bound release-authority mechanism.**
+   Ezért a PULSE nem governance-címke vagy jóváhagyó eszköz, hanem artifact-bound release-authority mechanika.
+
+## 13. Legrövidebb horgony
+
+Angolul:
+
+**Execution is not authority.**
+
+Magyarul:
+
+**A végrehajtás nem jogosultság.**
+
+## 14. PULSE-horgony
+
+Angolul:
+
+**PULSE binds authority before release, not after failure.**
+
+Magyarul:
+
+**A PULSE a jogosultságot release előtt köti, nem hiba után magyarázza.**
+
+## 15. Záró meghatározás
+
+A PULSE artifact-bound release-authority mechanika AI release-döntésekhez.
+
+Nem abból indul ki, hogy egy release elkészült-e, vagy hogy a tesztek zöldek-e.
+Nem fogadja el, hogy a jóváhagyás, dokumentáció, governance vagy utólagos audit önmagában release-authorityt bizonyít.
+
+A PULSE a release-authorityt deployment előtt rögzített bizonyítékhoz, deklarált policyhez, materializált kötelező gate-ekhez és strict fail-closed CI-hez köti.
+
+Ezért a PULSE nem romeltakarítás.
+
+A PULSE pre-deployment release-authority mechanika.


### PR DESCRIPTION
## Summary

This PR records the PULSEmech release-authority bridge and links it from the README.

The new document explains the core mechanical distinction:

```text
release execution ≠ release authority
```

It separates:

- release execution
- green CI
- approval
- documentation
- governance process
- post-failure audit

from artifact-bound release authority.

## Scope

Documentation-only.

Changed files:

- `README.md`
- `docs/PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md`

## README placement

The README now includes a visible section:

```markdown
## PULSE - PULSEmech

- [PULSE - PULSEmech](docs/PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md) — release execution, green CI, approval, and post-failure audit are separated from artifact-bound release authority.
```

## Core boundary

The document records these mechanical anchors:

```text
Release execution is not release authority.
Green CI is not release authority.
Approval is not release authority.
Post-failure audit is too late to create release authority.
Release authority must be bound before deployment.
```

It also records the PULSE anchor:

```text
PULSE binds authority before release, not after failure.
```

## PULSE mechanism

The document states that PULSE binds release authority before deployment to:

- recorded evidence
- declared policy
- materialized required gates
- strict fail-closed CI

## Boundary

This PR does not change release behavior.

It does not implement new authority logic.

It does not change:

- schemas
- verifier builder behavior
- verifier checker behavior
- expectation summary behavior
- input manifest behavior
- workflows
- `check_gates.py`
- `run_all.py`
- release policy
- gate registry
- status schemas
- CI authority path
- `--release-grade-materialized`

This PR does not create or enable:

- `VERIFIED`
- trusted evidence
- verified evidence
- relation binding satisfaction
- gate materialization
- `status.json` writing
- `report_card.html` writing
- `release_authority_v0.json` writing
- release-authority audit bundles
- release authority from documentation

## Mechanical anchors

Execution is not authority.  
Green CI is not release authority.  
Approval is not release authority.  
Post-failure audit cannot create pre-deployment authority.  
PULSE binds authority before release, not after failure.  

## Testing

Documentation-only change.

```bash
git diff --check
```

```bash
test -f docs/PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md && echo "release-authority mechanics bridge present"
```

```bash
rg -n \
  "\[PULSE - PULSEmech\]\(docs/PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0\.md\)" \
  README.md
```

```bash
rg -n \
  "Release execution is not release authority|Green CI is not release authority|Approval is not release authority|Post-failure audit is too late to create release authority|Execution is not authority|PULSE binds authority before release, not after failure" \
  docs/PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md
```