### PR TITLE
docs(ref): clarify continuous expansion scoped authority v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,19 @@ status.json
 
 ---
 
-> 💡 **Continuous expansion**
+> 💡 **Continuous expansion and scoped authority**
 >
-> PULSE is not a frozen snapshot. The release-authority materialization path is explicit and versioned,
-> while the safe pack, documentation, examples, profiles, detectors, diagnostic surfaces,
-> reader surfaces, and future evidence-packet work remain under active expansion.
+> PULSE is not a frozen snapshot.
+>
+> Continuous expansion does not invalidate the implemented release-authority path.
+>
+> The implemented release-authority path is explicit, versioned, and bounded to the artifacts, policies, gates, and CI checks that exist in the current release.
+>
+> Known hardening surfaces — including the safe pack, documentation, examples, profiles, detectors, diagnostic surfaces, reader surfaces, metadata consistency, provenance / attestation work, and future evidence-packet work — remain under active, staged expansion.
+>
+> Until a surface is implemented, tested, and explicitly promoted through declared policy, workflow-effective materialized required gates, and strict fail-closed CI enforcement, it remains non-authoritative.
+>
+> Open work is tracked as part of the hardening roadmap; it is not treated as release authority by assumption.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR clarifies the README continuous-expansion boundary.

The updated note keeps two points explicit:

```text
PULSE is not a frozen snapshot.
Continuous expansion does not invalidate the implemented release-authority path.
```

It also clarifies that known hardening surfaces remain under staged expansion and are not treated as release authority by assumption.

## Scope

Documentation-only.

Changed file:

- `README.md`

## What this clarifies

The README now states that the implemented release-authority path is:

- explicit
- versioned
- bounded to the artifacts, policies, gates, and CI checks that exist in the current release

It also states that hardening surfaces remain non-authoritative until they are:

- implemented
- tested
- explicitly promoted through declared policy
- bound to workflow-effective materialized required gates
- enforced by strict fail-closed CI

## Boundary

This PR does not change release behavior.

It does not implement new authority logic.

It does not change:

- schemas
- verifier builder behavior
- verifier checker behavior
- expectation summary behavior
- input manifest behavior
- workflows
- `check_gates.py`
- `run_all.py`
- release policy
- gate registry
- status schemas
- CI authority path
- `--release-grade-materialized`

This PR does not create or enable:

- `VERIFIED`
- trusted evidence
- verified evidence
- relation binding satisfaction
- gate materialization
- `status.json` writing
- `report_card.html` writing
- `release_authority_v0.json` writing
- release-authority audit bundles
- release authority from documentation

## Mechanical anchors

Continuous expansion does not invalidate the implemented release-authority path.

Open work is tracked as part of the hardening roadmap.

Open work is not treated as release authority by assumption.

## Testing

Documentation-only change.

```bash
git diff --check
```

```bash
rg -n \
  "Continuous expansion and scoped authority|Continuous expansion does not invalidate the implemented release-authority path|Open work is tracked as part of the hardening roadmap|it remains non-authoritative" \
  README.md
```