### PR TITLE
docs(ref): close Kaggle HPC admission boundary checks v0

### DIFF
--- a/docs/PULSE_KAGGLE_HPC_EVIDENCE_ADMISSION_BOUNDARY_v0.md
+++ b/docs/PULSE_KAGGLE_HPC_EVIDENCE_ADMISSION_BOUNDARY_v0.md
@@ -1,7 +1,7 @@
 # PULSE Kaggle / HPC evidence admission boundary v0
 
-Status: boundary note  
-Normative status: non-normative clarification  
+Status: boundary note
+Normative status: non-normative clarification
 Scope: Kaggle traces, HPC benchmarks, notebook outputs, public competition artifacts, and related reproducibility surfaces
 
 ## Core statement

--- a/docs/PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md
+++ b/docs/PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md
@@ -670,6 +670,6 @@ The release-grade reference run is not the end state.
 
 It is the first strong anchor for large-scale evidence-to-decision validation.
 
-PULSEmech remains the release-authority mechanism.
+HPC may diagnostically test candidate decision-field behavior.
 
-HPC becomes the validation field.
+PULSEmech remains the only release-authority mechanism.


### PR DESCRIPTION
## Summary

This PR closes the Kaggle / HPC admission boundary documentation checks.

It updates:

- `docs/PULSE_KAGGLE_HPC_EVIDENCE_ADMISSION_BOUNDARY_v0.md`
- `docs/PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md`

## What changed

The Kaggle / HPC boundary note metadata no longer has trailing whitespace, so `git show --check HEAD` passes.

The release-grade next-run closing language now preserves the same boundary:

```text
HPC may diagnostically test candidate decision-field behavior.
PULSEmech remains the only release-authority mechanism.
```

## Boundary

This PR keeps Kaggle / HPC in the diagnostic / candidate evidence layer.

It does not make HPC a release-authority mechanism.

It does not create or enable:

- `VERIFIED`
- trusted evidence
- verified evidence
- `verified_artifacts`
- `relation_bindings`
- relation satisfaction
- gate materialization
- `status.json` writing
- release authority

## Non-goals

This PR does not change:

- schemas
- tools
- builder behavior
- checker behavior
- workflows
- `check_gates.py`
- `run_all.py`
- release policy
- gate registry
- CI authority path
- `--release-grade-materialized`

## Testing

```bash
git show --check HEAD
```

```bash
git status --short
```

```bash
rg -n \
  "HPC validates the decision field|PULSEmech remains the release-authority mechanism" \
  docs README.md examples PULSE_safe_pack_v0 || true
```

```bash
rg -n \
  "HPC may diagnostically test candidate decision-field behavior\.|PULSEmech remains the only release-authority mechanism\." \
  docs README.md tests
```

```bash
python -m pytest tests/test_tools_tests_list_smoke.py
```