### PR TITLE
test(ref): add local Kaggle HPC diagnostic packet fixture v0

### DIFF
--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_input_manifest.demo.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_input_manifest.demo.json
@@ -1,0 +1,16 @@
+{
+  "artifacts": [
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_payload/demo_output.json",
+      "role": "summary_metric"
+    },
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_payload/demo_log.txt",
+      "role": "raw_trace"
+    }
+  ],
+  "dataset_identity": "kaggle-demo-dataset-metadata-only",
+  "notes": "Local fixture only. No Kaggle run. No HPC run. Diagnostic metadata only.",
+  "sample_identity": "local-minimal-demo-sample",
+  "schema": "kaggle_hpc_input_manifest_demo_v0"
+}

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_minimal_diagnostic.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_minimal_diagnostic.json
@@ -1,0 +1,87 @@
+{
+  "authority_status": "diagnostic_non_normative",
+  "code_identity": {
+    "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "ref": "local-fixture-review",
+    "repository": "HKati/pulse-release-gates-0.1"
+  },
+  "creates_release_authority": false,
+  "environment": {
+    "accelerator_class": "cpu",
+    "node_count": 1,
+    "package_versions_note": "not a Kaggle or HPC runtime attestation",
+    "python_version": "metadata-only-local",
+    "runtime_surface": "local_hpc_sim",
+    "scheduler": "local"
+  },
+  "evidence_items": [
+    {
+      "artifact_kind": "local_demo_output",
+      "diagnostic_metadata_only": true,
+      "evidence_status": "present",
+      "folded_into_status": false,
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_payload/demo_output.json",
+      "role": "summary_metric",
+      "sha256": "3d8578b263dd0c53106a126436b6f4e5d6eb6e396e1a663453ec5539f5b47f2e"
+    },
+    {
+      "artifact_kind": "local_demo_log",
+      "diagnostic_metadata_only": true,
+      "evidence_status": "present",
+      "folded_into_status": false,
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_payload/demo_log.txt",
+      "role": "raw_trace",
+      "sha256": "50bb6b3839151388fb9ed6d620bd5e538d7ef4df569033efc750667ef0760a01"
+    }
+  ],
+  "input_manifest": {
+    "dataset_identity": "kaggle-demo-dataset-metadata-only",
+    "kaggle": {
+      "competition_id": "metadata-only-demo",
+      "dataset_id": "metadata-only-demo",
+      "external_state_warning": "Kaggle state is not consulted by this local fixture",
+      "license_terms_note": "metadata only; no Kaggle download or run in this fixture",
+      "notebook_id": "none-local-fixture",
+      "notebook_version": "none-local-fixture",
+      "observed_utc": "2026-06-12T00:00:00Z",
+      "source_url": "metadata-only-not-recorded-evidence"
+    },
+    "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_input_manifest.demo.json",
+    "sample_identity": "local-minimal-demo-sample",
+    "sha256": "462180a8aa3983075957828eff5df93af763bef38c1385f1beb4a6f1d99b97d0"
+  },
+  "notes": "This packet is diagnostic. This packet does not create release authority. This packet does not verify evidence. This packet does not satisfy relation bindings. This packet does not materialize gates. This packet does not write status.json. This packet does not affect check_gates.py.",
+  "provenance": {
+    "command": "local fixture only; no Kaggle run; no HPC run",
+    "external_state_note": "No external Kaggle state was fetched, trusted, verified, or folded into status authority.",
+    "notebook_execution_path": "none",
+    "seed": 0,
+    "source_url": "metadata only; not evidence"
+  },
+  "reconstruction": {
+    "instructions": [
+      "Verify the SHA-256 of the local input manifest file recorded in input_manifest.path.",
+      "Verify each present evidence_items[].path against its recorded evidence_items[].sha256.",
+      "Do not treat this packet as verified evidence, relation satisfaction, gate materialization, status.json writing, or release authority."
+    ]
+  },
+  "result": "complete",
+  "run_identity": {
+    "packet_created_utc": "2026-06-12T00:00:00Z",
+    "packet_id": "kaggle-hpc-local-minimal-diagnostic-001",
+    "packet_version": "kaggle_hpc_diagnostic_packet_v0",
+    "producer": "local fixture",
+    "purpose": "diagnostic reproducibility and review only",
+    "run_completed_utc": "2026-06-12T00:00:00Z",
+    "run_id": "kaggle-hpc-local-minimal-diagnostic-001",
+    "run_mode": "local_hpc_sim",
+    "run_started_utc": "2026-06-12T00:00:00Z"
+  },
+  "schema": "hpc_evidence_bundle_v0",
+  "summary_metrics": {
+    "demo_artifact_count": 2,
+    "diagnostic_fixture": true,
+    "hpc_run_performed": false,
+    "kaggle_run_performed": false
+  }
+}

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_payload/demo_log.txt
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_payload/demo_log.txt
@@ -1,0 +1,4 @@
+local Kaggle/HPC diagnostic fixture
+no Kaggle run
+no HPC run
+no external state fetched

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_payload/demo_output.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_payload/demo_output.json
@@ -1,0 +1,10 @@
+{
+  "diagnostic_metadata_only": true,
+  "metric": {
+    "name": "demo_artifact_count",
+    "unit": "count",
+    "value": 2
+  },
+  "notes": "Local diagnostic output. Not a verifier.",
+  "schema": "kaggle_hpc_demo_output_v0"
+}

--- a/tests/test_hpc_evidence_bundle_v0_contract.py
+++ b/tests/test_hpc_evidence_bundle_v0_contract.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 import sys
@@ -15,6 +16,13 @@ ROOT = Path(__file__).resolve().parents[1]
 CHECKER = ROOT / "scripts" / "check_hpc_evidence_bundle_v0_contract.py"
 COMPLETE_FIXTURE = ROOT / "tests" / "fixtures" / "hpc_evidence_bundle_v0" / "complete.json"
 INCOMPLETE_FIXTURE = ROOT / "tests" / "fixtures" / "hpc_evidence_bundle_v0" / "incomplete.json"
+KAGGLE_HPC_MINIMAL_DIAGNOSTIC_FIXTURE = (
+    ROOT
+    / "tests"
+    / "fixtures"
+    / "hpc_evidence_bundle_v0"
+    / "kaggle_hpc_minimal_diagnostic.json"
+)
 
 
 def _run(path: Path) -> subprocess.CompletedProcess[str]:
@@ -36,6 +44,30 @@ def _write(path: Path, payload: dict[str, Any]) -> None:
         json.dumps(payload, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+
+    return h.hexdigest()
+
+
+def _walk_mapping_keys(value: Any) -> list[str]:
+    keys: list[str] = []
+
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            keys.append(str(key))
+            keys.extend(_walk_mapping_keys(nested_value))
+    elif isinstance(value, list):
+        for item in value:
+            keys.extend(_walk_mapping_keys(item))
+
+    return keys
 
 
 def test_complete_fixture_is_valid() -> None:
@@ -119,6 +151,76 @@ def test_creates_release_authority_true_is_rejected() -> None:
 
     assert result.returncode == 1
     assert "creates_release_authority" in (result.stderr + result.stdout)
+
+
+def test_kaggle_hpc_minimal_diagnostic_fixture_contract_passes() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--in",
+            str(KAGGLE_HPC_MINIMAL_DIAGNOSTIC_FIXTURE),
+        ],
+        cwd=str(ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_kaggle_hpc_minimal_diagnostic_fixture_is_non_authoritative() -> None:
+    bundle = _read(KAGGLE_HPC_MINIMAL_DIAGNOSTIC_FIXTURE)
+
+    assert bundle["schema"] == "hpc_evidence_bundle_v0"
+    assert bundle["authority_status"] == "diagnostic_non_normative"
+    assert bundle["creates_release_authority"] is False
+
+    evidence_items = bundle["evidence_items"]
+
+    assert evidence_items
+
+    for item in evidence_items:
+        assert item["folded_into_status"] is False
+        assert "policy_route" not in item
+
+
+def test_kaggle_hpc_minimal_diagnostic_fixture_uses_real_digests() -> None:
+    bundle = _read(KAGGLE_HPC_MINIMAL_DIAGNOSTIC_FIXTURE)
+
+    input_manifest_path = ROOT / bundle["input_manifest"]["path"]
+
+    assert input_manifest_path.exists()
+    assert _sha256_file(input_manifest_path) == bundle["input_manifest"]["sha256"]
+
+    for item in bundle["evidence_items"]:
+        if item["evidence_status"] != "present":
+            continue
+
+        artifact_path = ROOT / item["path"]
+
+        assert artifact_path.exists()
+        assert _sha256_file(artifact_path) == item["sha256"]
+
+
+def test_kaggle_hpc_minimal_diagnostic_fixture_has_no_authority_surfaces() -> None:
+    bundle = _read(KAGGLE_HPC_MINIMAL_DIAGNOSTIC_FIXTURE)
+
+    forbidden_keys = {
+        "verified_artifacts",
+        "relation_bindings",
+        "status",
+        "status_json",
+        "release_authority",
+        "release_authority_v0",
+        "gate_materialization",
+        "policy_route",
+    }
+
+    keys = set(_walk_mapping_keys(bundle))
+
+    assert not (keys & forbidden_keys)
 
 
 def main() -> int:

--- a/tests/test_hpc_evidence_bundle_v0_contract.py
+++ b/tests/test_hpc_evidence_bundle_v0_contract.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Smoke tests for hpc_evidence_bundle_v0 contract checker."""
 
-from __future__ import annotations
+from __future__ import annotations 
 
 import hashlib
 import json

--- a/tests/test_hpc_evidence_bundle_v0_contract.py
+++ b/tests/test_hpc_evidence_bundle_v0_contract.py
@@ -232,6 +232,10 @@ def main() -> int:
         test_folded_evidence_requires_policy_route()
         test_folded_evidence_with_policy_route_is_valid()
         test_creates_release_authority_true_is_rejected()
+        test_kaggle_hpc_minimal_diagnostic_fixture_contract_passes()
+        test_kaggle_hpc_minimal_diagnostic_fixture_is_non_authoritative()
+        test_kaggle_hpc_minimal_diagnostic_fixture_uses_real_digests()
+        test_kaggle_hpc_minimal_diagnostic_fixture_has_no_authority_surfaces()
     except AssertionError as exc:
         print(f"ERROR: {exc}")
         return 1


### PR DESCRIPTION
## Summary

This PR adds a local minimal Kaggle / HPC diagnostic packet fixture.

The fixture uses the existing:

`hpc_evidence_bundle_v0`

surface.

## Scope

Fixture + test only.

Added files:

- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_minimal_diagnostic.json`
- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_input_manifest.demo.json`
- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_payload/demo_output.json`
- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_payload/demo_log.txt`

Changed file:

- `tests/test_hpc_evidence_bundle_v0_contract.py`

## Boundary

The fixture is diagnostic and non-authoritative.

```text
authority_status = diagnostic_non_normative
creates_release_authority = false
folded_into_status = false
```

## What this proves

The fixture proves the local packet shape before any Kaggle notebook or Kaggle run is introduced.

It keeps:

- Kaggle metadata as metadata only
- input manifest digest separate from payload artifact digest
- payload artifacts SHA-256-bound separately
- all evidence items folded out of status by default

## Non-goals

This PR does not change:

- schemas
- builders
- checkers
- workflows
- `check_gates.py`
- `run_all.py`
- release policy
- gate registry
- CI authority path
- `--release-grade-materialized`

This PR does not create or enable:

- `VERIFIED`
- trusted evidence
- verified evidence
- `verified_artifacts`
- `relation_bindings`
- relation satisfaction
- gate materialization
- `status.json` writing
- release authority

## Testing

```bash
python -m pytest tests/test_hpc_evidence_bundle_v0_contract.py
python -m pytest tests/test_build_hpc_evidence_bundle_v0.py
python -m pytest tests/test_tools_tests_list_smoke.py
```