### PR TITLE
test(ref): fix Kaggle HPC fixture contract whitespace v0

### DIFF
--- a/tests/test_hpc_evidence_bundle_v0_contract.py
+++ b/tests/test_hpc_evidence_bundle_v0_contract.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Smoke tests for hpc_evidence_bundle_v0 contract checker."""
 
-from __future__ import annotations 
+from __future__ import annotations
 
 import hashlib
 import json
@@ -14,8 +14,23 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 CHECKER = ROOT / "scripts" / "check_hpc_evidence_bundle_v0_contract.py"
-COMPLETE_FIXTURE = ROOT / "tests" / "fixtures" / "hpc_evidence_bundle_v0" / "complete.json"
-INCOMPLETE_FIXTURE = ROOT / "tests" / "fixtures" / "hpc_evidence_bundle_v0" / "incomplete.json"
+
+COMPLETE_FIXTURE = (
+    ROOT
+    / "tests"
+    / "fixtures"
+    / "hpc_evidence_bundle_v0"
+    / "complete.json"
+)
+
+INCOMPLETE_FIXTURE = (
+    ROOT
+    / "tests"
+    / "fixtures"
+    / "hpc_evidence_bundle_v0"
+    / "incomplete.json"
+)
+
 KAGGLE_HPC_MINIMAL_DIAGNOSTIC_FIXTURE = (
     ROOT
     / "tests"
@@ -72,11 +87,13 @@ def _walk_mapping_keys(value: Any) -> list[str]:
 
 def test_complete_fixture_is_valid() -> None:
     result = _run(COMPLETE_FIXTURE)
+
     assert result.returncode == 0, result.stderr + result.stdout
 
 
 def test_incomplete_fixture_is_valid_diagnostic_artifact() -> None:
     result = _run(INCOMPLETE_FIXTURE)
+
     assert result.returncode == 0, result.stderr + result.stdout
 
 
@@ -129,7 +146,7 @@ def test_folded_evidence_with_policy_route_is_valid() -> None:
     payload["evidence_items"][0]["folded_into_status"] = True
     payload["evidence_items"][0]["policy_route"] = {
         "policy_path": "pulse_gate_policy_v0.yml",
-        "gate_id": "external_all_pass"
+        "gate_id": "external_all_pass",
     }
 
     with tempfile.TemporaryDirectory() as td:
@@ -154,20 +171,9 @@ def test_creates_release_authority_true_is_rejected() -> None:
 
 
 def test_kaggle_hpc_minimal_diagnostic_fixture_contract_passes() -> None:
-    result = subprocess.run(
-        [
-            sys.executable,
-            str(CHECKER),
-            "--in",
-            str(KAGGLE_HPC_MINIMAL_DIAGNOSTIC_FIXTURE),
-        ],
-        cwd=str(ROOT),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    result = _run(KAGGLE_HPC_MINIMAL_DIAGNOSTIC_FIXTURE)
 
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 0, result.stderr + result.stdout
 
 
 def test_kaggle_hpc_minimal_diagnostic_fixture_is_non_authoritative() -> None:


### PR DESCRIPTION
## Summary

This PR adds a local minimal Kaggle / HPC diagnostic packet fixture.

The fixture uses the existing:

`hpc_evidence_bundle_v0`

surface.

## Scope

Fixture + test only.

Added files:

- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_minimal_diagnostic.json`
- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_input_manifest.demo.json`
- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_payload/demo_output.json`
- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_hpc_payload/demo_log.txt`

Changed file:

- `tests/test_hpc_evidence_bundle_v0_contract.py`

## Boundary

The fixture is diagnostic and non-authoritative.

```text
authority_status = diagnostic_non_normative
creates_release_authority = false
folded_into_status = false
```

What this proves

The fixture proves the local packet shape before any Kaggle notebook or Kaggle run is introduced.

It keeps:

Kaggle metadata as metadata only
input manifest digest separate from payload artifact digest
payload artifacts SHA-256-bound separately
all evidence items folded out of status by default
Digest boundary

input_manifest.sha256 is the digest of the input manifest file only.

Payload artifact digests are recorded separately under evidence_items[].sha256.

Non-goals

This PR does not change:

schemas
builders
checkers
workflows
check_gates.py
run_all.py
release policy
gate registry
CI authority path
--release-grade-materialized

This PR does not create or enable:

VERIFIED
trusted evidence
verified evidence
verified_artifacts
relation_bindings
relation satisfaction
gate materialization
status.json writing
release authority
Testing

GitHub Actions checks.

Expected targeted checks:


```text
python tests/test_hpc_evidence_bundle_v0_contract.py
python -m pytest tests/test_hpc_evidence_bundle_v0_contract.py
python -m pytest tests/test_build_hpc_evidence_bundle_v0.py
python -m pytest tests/test_tools_tests_list_smoke.py
```