### PR TITLE
docs(ref): record Kaggle notebook skeleton boundary v0

### DIFF
--- a/docs/PULSE_KAGGLE_NOTEBOOK_SKELETON_BOUNDARY_v0.md
+++ b/docs/PULSE_KAGGLE_NOTEBOOK_SKELETON_BOUNDARY_v0.md
@@ -287,7 +287,18 @@ evidence_items[].path
 evidence_items[].sha256
 evidence_items[].role
 evidence_items[].evidence_status
+evidence_items[].folded_into_status = false
 ```
+
+Every emitted `hpc_evidence_bundle_v0` evidence item must include `folded_into_status`.
+
+For current v0, notebook-produced evidence items must default to:
+
+```text
+folded_into_status = false
+```
+
+This keeps notebook-produced artifacts folded out of status authority unless a future separately reviewed policy path changes that.
 
 The digest cell does not verify evidence.
 

--- a/docs/PULSE_KAGGLE_NOTEBOOK_SKELETON_BOUNDARY_v0.md
+++ b/docs/PULSE_KAGGLE_NOTEBOOK_SKELETON_BOUNDARY_v0.md
@@ -1,0 +1,595 @@
+# Kaggle Notebook Skeleton Boundary v0
+
+- Status: notebook-skeleton boundary note
+- Normative status: non-normative clarification
+- Scope: future Kaggle notebook skeletons that may produce diagnostic / reproducibility artifacts for `hpc_evidence_bundle_v0`-compatible packets
+
+## Core statement
+
+A Kaggle notebook skeleton is a diagnostic reproducibility surface.
+
+It may produce reviewable artifacts, logs, metrics, digest records, and optional packet previews.
+
+It does not create release authority.
+
+It is not a verifier.
+
+It is not a gate.
+
+It does not produce trusted or verified evidence.
+
+## Core boundary
+
+```text
+Kaggle notebook skeleton ≠ trusted verifier
+Notebook output ≠ verified evidence
+Notebook pass ≠ relation satisfaction
+Notebook metric ≠ gate materialization
+Notebook packet preview ≠ release authority
+```
+
+A Kaggle notebook skeleton must not create or enable:
+
+- `VERIFIED`;
+- trusted evidence;
+- verified evidence;
+- `verified_artifacts`;
+- `relation_bindings`;
+- relation satisfaction;
+- gate materialization;
+- `status.json` writing;
+- policy changes;
+- registry changes;
+- `check_gates.py` changes;
+- workflow changes;
+- CI allow/block changes;
+- release authority.
+
+## Purpose
+
+The purpose of a future Kaggle notebook skeleton is to generate local diagnostic / reproducibility outputs that can later be reviewed, downloaded, digest-bound, and packaged into a non-authoritative `hpc_evidence_bundle_v0`-compatible diagnostic packet.
+
+The notebook skeleton may help produce:
+
+- diagnostic output JSON or CSV;
+- raw logs;
+- generated tables;
+- generated plots;
+- summary metrics;
+- environment metadata;
+- package-version metadata;
+- digest records;
+- reconstruction / replay instructions;
+- an optional diagnostic packet preview.
+
+These outputs are diagnostic artifacts.
+
+They are not release-authority artifacts.
+
+## Required notebook sections
+
+A safe future notebook skeleton should contain only sections that produce diagnostic metadata and reviewable artifacts.
+
+Recommended sections:
+
+1. Boundary / non-authority banner
+2. Run identity cell
+3. Code identity cell
+4. Kaggle / source metadata cell
+5. Environment metadata cell
+6. Input manifest cell
+7. Diagnostic execution cell
+8. Artifact digest cell
+9. Summary metrics cell
+10. Reconstruction / replay instructions cell
+11. Final diagnostic packet preview cell
+
+Each section must preserve the non-authority boundary.
+
+No section may run release gates, update policy, modify registry, write `status.json`, or affect CI allow/block behavior.
+
+## 1. Boundary / non-authority banner
+
+The notebook should begin with visible non-authority text.
+
+Required wording, or equivalent:
+
+```text
+This notebook and its packet outputs are diagnostic.
+They do not create release authority.
+They do not verify evidence.
+They do not create trusted evidence or verified evidence.
+They do not create VERIFIED.
+They do not create verified_artifacts.
+They do not create relation_bindings.
+They do not satisfy relations.
+They do not materialize gates.
+They do not write status.json.
+They do not change policy, registry, check_gates.py, workflows, CI allow/block behavior, or release authority.
+All evidence_items are folded_into_status = false unless a future separately reviewed policy path changes that.
+```
+
+This text is not decorative.
+
+It prevents the notebook from being misread as a verifier or decision engine.
+
+## 2. Run identity cell
+
+The run identity cell may define diagnostic packet identity metadata.
+
+Allowed fields:
+
+- `packet_id`;
+- `packet_version`;
+- `created_utc`;
+- `producer`;
+- `purpose`;
+- `run_id`;
+- `run_started_utc`;
+- `run_completed_utc`;
+- `run_mode`.
+
+Recommended values:
+
+```text
+packet_version = kaggle_hpc_diagnostic_packet_v0
+purpose = diagnostic reproducibility and review only
+```
+
+The run identity cell does not create trust.
+
+The producer field does not make the producer trusted.
+
+The packet ID does not create release authority.
+
+## 3. Code identity cell
+
+The code identity cell may record:
+
+- repository;
+- git SHA;
+- optional ref;
+- notebook file name or path;
+- optional notebook version metadata.
+
+Code identity is diagnostic metadata.
+
+Code identity is not trusted verifier identity.
+
+Code identity does not verify evidence.
+
+Code identity does not satisfy relation bindings.
+
+## 4. Kaggle / source metadata cell
+
+The Kaggle / source metadata cell may record:
+
+- Kaggle competition ID;
+- Kaggle dataset ID;
+- Kaggle notebook ID;
+- notebook version;
+- source URL;
+- observed timestamp;
+- producer / author metadata;
+- license / terms note;
+- external-state warning;
+- availability / drift note.
+
+These fields are metadata only.
+
+They do not create trust.
+
+They do not verify evidence.
+
+They do not satisfy relations.
+
+They do not materialize gates.
+
+A Kaggle public URL is not recorded evidence.
+
+A public score is not release authority.
+
+A screenshot is not artifact-bound evidence.
+
+## 5. Environment metadata cell
+
+The environment metadata cell may record:
+
+- runtime environment;
+- Python version;
+- package versions;
+- hardware / accelerator class;
+- notebook execution path;
+- seed / determinism note;
+- external-state note.
+
+Runtime metadata is not a trusted verifier.
+
+Accelerator class is not release authority.
+
+Notebook execution success is not verified evidence.
+
+A notebook pass is not release authority.
+
+## 6. Input manifest cell
+
+The input manifest cell may create or display a local input manifest file.
+
+The input manifest file should record local diagnostic input structure, not release authority.
+
+Required boundary:
+
+```text
+input_manifest.sha256 = SHA-256 of the input manifest file only
+```
+
+`input_manifest.sha256` must not be reused for:
+
+- Kaggle dataset payloads;
+- downloaded input payloads;
+- notebook outputs;
+- benchmark logs;
+- generated plots;
+- generated tables;
+- other artifact payloads.
+
+Payload artifacts must be digest-bound separately.
+
+The notebook should keep manifest identity separate from payload artifact identity.
+
+## 7. Diagnostic execution cell
+
+The diagnostic execution cell may run only diagnostic computations.
+
+Allowed outputs:
+
+- local diagnostic JSON;
+- local diagnostic CSV;
+- raw trace logs;
+- generated tables;
+- generated plots;
+- metric summaries.
+
+Forbidden outputs:
+
+- `status.json`;
+- `release_authority_v0.json`;
+- gate materialization output;
+- relation binding output;
+- verified artifact output;
+- release decision output.
+
+The diagnostic execution cell must not run or replace `check_gates.py`.
+
+It must not update declared policy.
+
+It must not update the gate registry.
+
+It must not affect CI allow/block behavior.
+
+## 8. Artifact digest cell
+
+The artifact digest cell should compute SHA-256 values for each present generated artifact.
+
+Required digest records:
+
+- SHA-256 of the input manifest file;
+- SHA-256 of each present output artifact;
+- SHA-256 of each present raw log;
+- SHA-256 of each present generated table;
+- SHA-256 of each present generated plot;
+- SHA-256 of any present diagnostic output file.
+
+Payload artifact digests should map to separate artifact records such as:
+
+```text
+evidence_items[].path
+evidence_items[].sha256
+evidence_items[].role
+evidence_items[].evidence_status
+```
+
+The digest cell does not verify evidence.
+
+Digest match does not create trusted evidence.
+
+Digest match does not satisfy relation bindings.
+
+Digest match does not materialize gates.
+
+## 9. Summary metrics cell
+
+The summary metrics cell may emit descriptive metrics.
+
+Allowed metric examples:
+
+- artifact count;
+- row count;
+- runtime duration;
+- diagnostic score;
+- benchmark value;
+- reproducibility flag;
+- warning count.
+
+Metrics are descriptive.
+
+Metric thresholds are diagnostic unless a later declared policy promotes them into workflow-effective materialized required gates and strict fail-closed CI enforcement.
+
+A metric threshold is not a declared gate by itself.
+
+A score is not release authority.
+
+A benchmark success does not materialize `detectors_materialized_ok`.
+
+## 10. Reconstruction / replay instructions cell
+
+The notebook should include reconstruction / replay instructions.
+
+Recommended content:
+
+- replay command or notebook replay steps;
+- environment reconstruction notes;
+- input acquisition notes;
+- expected input manifest path;
+- expected input manifest SHA-256;
+- expected payload artifact paths;
+- expected payload artifact SHA-256 values;
+- expected output files;
+- nondeterminism caveats;
+- external-state caveats.
+
+Replayable output is not a verified relation.
+
+A reproducibility packet is not release authority.
+
+Reproducibility supports review.
+
+Reproducibility does not replace the artifact-bound PULSEmech release-authority path.
+
+## 11. Final diagnostic packet preview cell
+
+The notebook may optionally assemble an in-memory or local preview object shaped like `hpc_evidence_bundle_v0`.
+
+If emitted, the preview must use:
+
+```text
+schema = hpc_evidence_bundle_v0
+authority_status = diagnostic_non_normative
+creates_release_authority = false
+```
+
+Every evidence item should default to:
+
+```text
+folded_into_status = false
+```
+
+The packet preview is diagnostic.
+
+The packet preview does not create release authority.
+
+The packet preview must not be written as `status.json`.
+
+The packet preview must not be used as gate materialization.
+
+The packet preview must not be used as relation satisfaction.
+
+## Expected diagnostic output artifacts
+
+A safe future notebook skeleton may produce:
+
+- `hpc_evidence_bundle_v0.json` or a diagnostic packet preview;
+- input manifest JSON;
+- diagnostic output JSON;
+- diagnostic output CSV;
+- raw log text;
+- generated plot files;
+- generated table files;
+- environment / package-version text;
+- digest manifest;
+- reconstruction instructions.
+
+All present artifacts should be local and SHA-256-bound before they are used as diagnostic evidence.
+
+External URLs alone are not recorded evidence.
+
+Screenshots alone are not artifact-bound evidence.
+
+Mutable Kaggle state must be marked as external / unavailable / unverified unless locally downloaded and hash-bound.
+
+## Required SHA-256 records
+
+A future notebook skeleton should record SHA-256 values for:
+
+1. the local input manifest file;
+2. each present downloaded input payload;
+3. each present notebook-generated output artifact;
+4. each present raw log;
+5. each present generated table;
+6. each present generated plot;
+7. each present diagnostic packet preview, if written.
+
+Boundary:
+
+```text
+input_manifest.sha256
+→ digest of the input manifest file only
+
+payload artifact sha256
+→ separate evidence_items[].sha256 or nested diagnostic metadata
+```
+
+Do not store dataset payload digests in `input_manifest.sha256`.
+
+## Metadata-only Kaggle fields
+
+The following fields must remain metadata-only in the skeleton:
+
+- competition ID;
+- dataset ID;
+- notebook ID;
+- notebook version;
+- source URL;
+- observed timestamp;
+- producer / author metadata;
+- license / terms note;
+- external-state warning;
+- notebook execution path;
+- availability / drift note.
+
+Metadata-only fields do not create trust.
+
+Metadata-only fields do not verify evidence.
+
+Metadata-only fields do not satisfy relations.
+
+Metadata-only fields do not materialize gates.
+
+## Compatibility with `hpc_evidence_bundle_v0`
+
+The skeleton should be designed to produce artifacts compatible with the existing `hpc_evidence_bundle_v0` surface.
+
+Current compatible non-authority values:
+
+```text
+schema = hpc_evidence_bundle_v0
+authority_status = diagnostic_non_normative
+creates_release_authority = false
+```
+
+Default evidence item value:
+
+```text
+folded_into_status = false
+```
+
+The notebook skeleton should not require a new schema.
+
+The notebook skeleton should not require a builder change.
+
+The notebook skeleton should not require a checker change.
+
+The notebook skeleton should not require a workflow change.
+
+## Unsafe current-v0 transitions
+
+The following transitions are forbidden in current v0:
+
+```text
+Kaggle notebook → verified_artifact
+Notebook output → verified evidence
+Notebook metric → gate materialization
+Benchmark success → detector_materialized_ok
+External run → trusted verifier
+Public result → release gate
+Diagnostic packet preview → status.json
+```
+
+The notebook skeleton must not currently:
+
+- add required gates;
+- change policy;
+- change registry;
+- materialize `detectors_materialized_ok`;
+- satisfy `external_summaries_present`;
+- satisfy `refusal_delta_evidence_present`;
+- affect `check_gates.py`;
+- affect CI allow/block decision.
+
+## Future hardening only
+
+Future work may evaluate:
+
+- producer identity;
+- artifact attestation;
+- notebook provenance;
+- dataset provenance;
+- environment capture;
+- reproducible run logs;
+- hash chains;
+- in-toto / SLSA-style evidence chains;
+- GitHub artifact attestations;
+- Kaggle external-state drift handling.
+
+These are staged hardening items.
+
+They are not current release authority.
+
+An attestation placeholder is not trusted evidence.
+
+A future provenance field is not release authority.
+
+## Recommended staged order
+
+```text
+1. notebook skeleton boundary note
+2. inert notebook skeleton or notebook fixture
+3. local diagnostic artifact generation
+4. local digest-record confirmation
+5. local hpc_evidence_bundle_v0-compatible packet preview
+6. Kaggle notebook skeleton
+7. Kaggle run
+8. downloaded/local artifacts with SHA-256
+9. non-authoritative HPC evidence bundle
+10. optional future candidate-evidence reference
+```
+
+The notebook skeleton should come after the local diagnostic packet fixture.
+
+The Kaggle run should come after the notebook skeleton and packet output shape are stable.
+
+The Kaggle run should not be treated as a verifier.
+
+## Non-goals
+
+This boundary note does not add:
+
+- a Kaggle notebook;
+- a Kaggle run;
+- a Kaggle artifact;
+- a schema change;
+- a builder change;
+- a checker change;
+- a workflow change;
+- a policy change;
+- a registry change;
+- a release-authority path.
+
+This boundary note does not create or enable:
+
+- `VERIFIED`;
+- trusted evidence;
+- verified evidence;
+- `verified_artifacts`;
+- `relation_bindings`;
+- relation satisfaction;
+- gate materialization;
+- `status.json` writing;
+- release authority.
+
+## Relation to the PULSEmech path
+
+Release authority remains only on the PULSEmech path:
+
+```text
+recorded release evidence
+→ status.json
+→ declared gate policy
+→ workflow-effective materialized required gate set
+→ strict fail-closed CI enforcement
+→ CI allow/block release decision
+```
+
+A Kaggle notebook output can later become release-relevant only if it is recorded, bound, checked, policy-routed, materialized as a required gate, and enforced by strict fail-closed CI.
+
+Until that path exists, notebook output remains diagnostic.
+
+## Mechanical anchor
+
+A Kaggle notebook skeleton can make an external run reviewable.
+
+It cannot make an external run release-authoritative.
+
+Current v0 accepts diagnostic visibility only.
+
+Current v0 does not accept release authority from Kaggle notebook material.


### PR DESCRIPTION
## Summary

This PR records the Kaggle notebook skeleton boundary for future Kaggle / HPC diagnostic reproducibility work.

The notebook skeleton is allowed to produce reviewable diagnostic artifacts such as:

- input manifest JSON
- diagnostic output JSON / CSV
- raw logs
- optional plots / tables
- environment metadata
- artifact digest records
- optional `hpc_evidence_bundle_v0` packet preview

It does not create release authority.

## Scope

Documentation-only.

Changed files:

- `docs/PULSE_KAGGLE_NOTEBOOK_SKELETON_BOUNDARY_v0.md`
- `docs/INDEX.md`

Optional link-only update:

- `docs/PULSE_KAGGLE_HPC_DIAGNOSTIC_PACKET_SHAPE_v0.md`

## Boundary

The notebook skeleton is diagnostic only.

It does not create or enable:

- `VERIFIED`
- trusted evidence
- verified evidence
- `verified_artifacts`
- `relation_bindings`
- relation satisfaction
- gate materialization
- `status.json` writing
- policy changes
- registry changes
- `check_gates.py` changes
- workflow changes
- CI allow/block changes
- release authority

## Required notebook sections

The document maps the safe skeleton sections:

- boundary / non-authority banner
- run identity
- code identity
- Kaggle/source metadata
- environment metadata
- input manifest
- diagnostic execution
- artifact digest records
- summary metrics
- reconstruction / replay instructions
- optional diagnostic packet preview

## Digest boundary

`input_manifest.sha256` remains the digest of the input manifest file only.

Payload, notebook output, logs, plots, tables, and generated artifacts must be digest-bound separately.

## Non-goals

This PR does not add:

- a Kaggle notebook
- a Kaggle run
- a Kaggle artifact
- a schema change
- a builder change
- a checker change
- a workflow change
- a policy or registry change
- a release-authority path

## Testing

Documentation-only change.

Expected checks:

```bash
git diff --check
```

```bash
python scripts/check_markdown_links.py \
  docs/PULSE_KAGGLE_NOTEBOOK_SKELETON_BOUNDARY_v0.md \
  docs/INDEX.md \
  docs/PULSE_KAGGLE_HPC_DIAGNOSTIC_PACKET_SHAPE_v0.md
```

```bash
python -m pytest tests/test_tools_tests_list_smoke.py
```