### PR TITLE
test(ref): add inert Kaggle notebook skeleton fixture v0

### DIFF
--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/README.md
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/README.md
@@ -1,0 +1,70 @@
+# Inert Kaggle Notebook Skeleton Fixture v0
+
+Status: fixture-only  
+Normative status: non-normative diagnostic fixture  
+Scope: local, inert Kaggle notebook skeleton shape for future diagnostic / reproducibility artifacts
+
+## Boundary
+
+This fixture does not run Kaggle.
+
+This fixture does not fetch external state.
+
+This fixture does not use Kaggle credentials.
+
+This fixture does not write `status.json`.
+
+This fixture does not invoke or replace `check_gates.py`.
+
+This fixture does not change policy, registry, workflows, CI allow/block behavior, or release authority.
+
+The notebook skeleton and expected outputs are diagnostic only.
+
+## Packet compatibility
+
+The expected packet preview is shaped for:
+
+```text
+schema = hpc_evidence_bundle_v0
+authority_status = diagnostic_non_normative
+creates_release_authority = false
+```
+
+Every emitted evidence item remains:
+
+```text
+folded_into_status = false
+```
+
+## Digest boundary
+
+`input_manifest.sha256` is the digest of the input manifest file only.
+
+Payload artifact digests are recorded separately under `evidence_items[].sha256` or in the local digest manifest.
+
+The digest manifest records hashes for:
+
+- `notebook_skeleton.ipynb`
+- `expected/input_manifest.json`
+- `expected/diagnostic_output.json`
+- `expected/diagnostic_log.txt`
+- `expected/hpc_evidence_bundle_preview.json`
+
+The digest manifest does not self-hash.
+
+## Expected artifacts
+
+```text
+notebook_skeleton.ipynb
+expected/input_manifest.json
+expected/diagnostic_output.json
+expected/diagnostic_log.txt
+expected/digest_manifest.json
+expected/hpc_evidence_bundle_preview.json
+```
+
+## Mechanical anchor
+
+A Kaggle notebook skeleton can make a future external run reviewable.
+
+It cannot make an external run release-authoritative.

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_log.txt
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_log.txt
@@ -1,0 +1,5 @@
+local Kaggle notebook skeleton fixture
+no Kaggle run
+no HPC run
+no external state fetched
+no status.json written

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_output.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_output.json
@@ -1,0 +1,12 @@
+{
+  "diagnostic_metadata_only": true,
+  "hpc_run_performed": false,
+  "kaggle_run_performed": false,
+  "metric": {
+    "name": "demo_notebook_artifact_count",
+    "unit": "count",
+    "value": 2
+  },
+  "notes": "Local inert diagnostic output. Not a verifier.",
+  "schema": "kaggle_notebook_skeleton_diagnostic_output_v0"
+}

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/digest_manifest.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/digest_manifest.json
@@ -1,0 +1,31 @@
+{
+  "digests": [
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/notebook_skeleton.ipynb",
+      "role": "notebook_skeleton",
+      "sha256": "9da51a8ee59f66f7d8046f4606c7be059c5dbeccace9f198d6180c276ee7d4ff"
+    },
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/input_manifest.json",
+      "role": "input_manifest",
+      "sha256": "144f5309f0dd3fae9ef79c8e2d8a2526f11d07fc94334d39ade822f01ea3c28d"
+    },
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_output.json",
+      "role": "diagnostic_output",
+      "sha256": "befefe36844081d7291c0560157fe14aaa278a03751428dc2835e96635104caa"
+    },
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_log.txt",
+      "role": "diagnostic_log",
+      "sha256": "03b0a66ef1f43df824b3bb9fe957ae1cb04a052f8593366d1b26773637d315c6"
+    },
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/hpc_evidence_bundle_preview.json",
+      "role": "diagnostic_packet_preview",
+      "sha256": "1d31d94393edbafdd01f8dc103c667084c37d5598d1051d0e802c79b9409a668"
+    }
+  ],
+  "notes": "Digest records for the inert Kaggle notebook skeleton fixture. Diagnostic metadata only.",
+  "schema": "kaggle_notebook_skeleton_digest_manifest_v0"
+}

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/hpc_evidence_bundle_preview.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/hpc_evidence_bundle_preview.json
@@ -1,0 +1,103 @@
+{
+  "authority_status": "diagnostic_non_normative",
+  "code_identity": {
+    "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "notebook_path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/notebook_skeleton.ipynb",
+    "notebook_version": "kaggle_notebook_skeleton_v0",
+    "ref": "inert-notebook-skeleton-fixture",
+    "repository": "HKati/pulse-release-gates-0.1"
+  },
+  "creates_release_authority": false,
+  "environment": {
+    "accelerator_class": "none",
+    "determinism_note": "static deterministic fixture",
+    "external_state_note": "no external state fetched",
+    "node_count": 1,
+    "package_versions_note": "not a Kaggle or HPC runtime attestation",
+    "python_version": "metadata-only-local",
+    "runtime_surface": "local_notebook_skeleton",
+    "scheduler": "none",
+    "seed": 0
+  },
+  "evidence_items": [
+    {
+      "artifact_kind": "inert_notebook_skeleton",
+      "diagnostic_metadata_only": true,
+      "evidence_status": "present",
+      "folded_into_status": false,
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/notebook_skeleton.ipynb",
+      "role": "package_manifest",
+      "sha256": "9da51a8ee59f66f7d8046f4606c7be059c5dbeccace9f198d6180c276ee7d4ff"
+    },
+    {
+      "artifact_kind": "diagnostic_output",
+      "diagnostic_metadata_only": true,
+      "evidence_status": "present",
+      "folded_into_status": false,
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_output.json",
+      "role": "summary_metric",
+      "sha256": "befefe36844081d7291c0560157fe14aaa278a03751428dc2835e96635104caa"
+    },
+    {
+      "artifact_kind": "diagnostic_log",
+      "diagnostic_metadata_only": true,
+      "evidence_status": "present",
+      "folded_into_status": false,
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_log.txt",
+      "role": "raw_trace",
+      "sha256": "03b0a66ef1f43df824b3bb9fe957ae1cb04a052f8593366d1b26773637d315c6"
+    }
+  ],
+  "input_manifest": {
+    "dataset_identity": "kaggle-demo-dataset-metadata-only",
+    "kaggle": {
+      "availability_drift_note": "external state unavailable by design",
+      "competition_id": "metadata-only-demo",
+      "dataset_id": "metadata-only-demo",
+      "external_state_warning": "Kaggle state is not consulted by this inert fixture",
+      "license_terms_note": "metadata only; no Kaggle download or run in this fixture",
+      "notebook_id": "none-inert-fixture",
+      "notebook_version": "none-inert-fixture",
+      "observed_utc": "2026-06-12T00:00:00Z",
+      "producer_or_author": "metadata only",
+      "source_url": "metadata-only-not-recorded-evidence"
+    },
+    "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/input_manifest.json",
+    "sample_identity": "local-notebook-skeleton-sample",
+    "sha256": "144f5309f0dd3fae9ef79c8e2d8a2526f11d07fc94334d39ade822f01ea3c28d"
+  },
+  "notes": "This packet preview is diagnostic. This packet preview does not create release authority. It does not verify evidence. It does not satisfy relation bindings. It does not materialize gates. It does not write status.json. It does not affect check_gates.py.",
+  "provenance": {
+    "command": "inert notebook skeleton fixture only; no Kaggle run; no HPC run",
+    "external_state_note": "No external Kaggle state was fetched, trusted, verified, or folded into status authority.",
+    "notebook_execution_path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/notebook_skeleton.ipynb",
+    "seed": 0,
+    "source_url": "metadata only; not evidence"
+  },
+  "reconstruction": {
+    "instructions": [
+      "Verify the SHA-256 of the local input manifest file recorded in input_manifest.path.",
+      "Verify each present evidence_items[].path against its recorded evidence_items[].sha256.",
+      "Do not treat this notebook skeleton, packet preview, or digest match as verified evidence, relation satisfaction, gate materialization, status.json writing, or release authority."
+    ]
+  },
+  "result": "complete",
+  "run_identity": {
+    "packet_created_utc": "2026-06-12T00:00:00Z",
+    "packet_id": "kaggle-notebook-skeleton-local-001",
+    "packet_version": "kaggle_hpc_diagnostic_packet_v0",
+    "producer": "inert notebook skeleton fixture",
+    "purpose": "diagnostic reproducibility and review only",
+    "run_completed_utc": "2026-06-12T00:00:00Z",
+    "run_id": "kaggle-notebook-skeleton-local-001",
+    "run_mode": "local_notebook_skeleton",
+    "run_started_utc": "2026-06-12T00:00:00Z"
+  },
+  "schema": "hpc_evidence_bundle_v0",
+  "summary_metrics": {
+    "demo_notebook_artifact_count": 2,
+    "diagnostic_fixture": true,
+    "hpc_run_performed": false,
+    "kaggle_run_performed": false
+  }
+}

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/input_manifest.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/input_manifest.json
@@ -1,0 +1,16 @@
+{
+  "artifacts": [
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_output.json",
+      "role": "summary_metric"
+    },
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_log.txt",
+      "role": "raw_trace"
+    }
+  ],
+  "dataset_identity": "kaggle-demo-dataset-metadata-only",
+  "notes": "Local inert notebook skeleton. No Kaggle run. No external state fetched.",
+  "sample_identity": "local-notebook-skeleton-sample",
+  "schema": "kaggle_notebook_skeleton_input_manifest_v0"
+}

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/notebook_skeleton.ipynb
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/notebook_skeleton.ipynb
@@ -1,0 +1,242 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Boundary / non-authority banner\n",
+        "\n",
+        "This notebook and its packet outputs are diagnostic.\n",
+        "They do not create release authority.\n",
+        "They do not verify evidence.\n",
+        "They do not create trusted evidence or verified evidence.\n",
+        "They do not create VERIFIED.\n",
+        "They do not create verified_artifacts.\n",
+        "They do not create relation_bindings.\n",
+        "They do not satisfy relations.\n",
+        "They do not materialize gates.\n",
+        "They do not write status.json.\n",
+        "They do not change policy, registry, check_gates.py, workflows, CI allow/block behavior, or release authority.\n",
+        "All evidence_items are folded_into_status = false.\n",
+        "\n",
+        "This inert fixture does not fetch Kaggle state, does not use Kaggle credentials, and does not run Kaggle.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from __future__ import annotations\n",
+        "\n",
+        "RUN_IDENTITY = {\n",
+        "    \"packet_id\": \"kaggle-notebook-skeleton-local-001\",\n",
+        "    \"packet_version\": \"kaggle_hpc_diagnostic_packet_v0\",\n",
+        "    \"packet_created_utc\": \"2026-06-12T00:00:00Z\",\n",
+        "    \"producer\": \"inert notebook skeleton fixture\",\n",
+        "    \"purpose\": \"diagnostic reproducibility and review only\",\n",
+        "    \"run_id\": \"kaggle-notebook-skeleton-local-001\",\n",
+        "    \"run_mode\": \"local_notebook_skeleton\",\n",
+        "    \"run_started_utc\": \"2026-06-12T00:00:00Z\",\n",
+        "    \"run_completed_utc\": \"2026-06-12T00:00:00Z\",\n",
+        "}\n",
+        "RUN_IDENTITY\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "CODE_IDENTITY = {\n",
+        "    \"repository\": \"HKati/pulse-release-gates-0.1\",\n",
+        "    \"git_sha\": \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\n",
+        "    \"ref\": \"inert-notebook-skeleton-fixture\",\n",
+        "    \"notebook_path\": \"tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/notebook_skeleton.ipynb\",\n",
+        "    \"notebook_version\": \"kaggle_notebook_skeleton_v0\",\n",
+        "}\n",
+        "CODE_IDENTITY\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "KAGGLE_SOURCE_METADATA = {\n",
+        "    \"competition_id\": \"metadata-only-demo\",\n",
+        "    \"dataset_id\": \"metadata-only-demo\",\n",
+        "    \"notebook_id\": \"none-inert-fixture\",\n",
+        "    \"notebook_version\": \"none-inert-fixture\",\n",
+        "    \"source_url\": \"metadata-only-not-recorded-evidence\",\n",
+        "    \"observed_utc\": \"2026-06-12T00:00:00Z\",\n",
+        "    \"producer_or_author\": \"metadata only\",\n",
+        "    \"license_terms_note\": \"metadata only; no Kaggle download or run in this fixture\",\n",
+        "    \"external_state_warning\": \"Kaggle state is not consulted by this inert fixture\",\n",
+        "    \"availability_drift_note\": \"external state unavailable by design\",\n",
+        "}\n",
+        "KAGGLE_SOURCE_METADATA\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "ENVIRONMENT_METADATA = {\n",
+        "    \"runtime_surface\": \"local_notebook_skeleton\",\n",
+        "    \"scheduler\": \"none\",\n",
+        "    \"node_count\": 1,\n",
+        "    \"accelerator_class\": \"none\",\n",
+        "    \"python_version\": \"metadata-only-local\",\n",
+        "    \"package_versions_note\": \"not a Kaggle or HPC runtime attestation\",\n",
+        "    \"seed\": 0,\n",
+        "    \"determinism_note\": \"static deterministic fixture\",\n",
+        "    \"external_state_note\": \"no external state fetched\",\n",
+        "}\n",
+        "ENVIRONMENT_METADATA\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "INPUT_MANIFEST_PREVIEW = {\n",
+        "    \"schema\": \"kaggle_notebook_skeleton_input_manifest_v0\",\n",
+        "    \"dataset_identity\": \"kaggle-demo-dataset-metadata-only\",\n",
+        "    \"sample_identity\": \"local-notebook-skeleton-sample\",\n",
+        "    \"notes\": \"Local inert notebook skeleton. No Kaggle run. No external state fetched.\",\n",
+        "    \"artifacts\": [\n",
+        "        {\n",
+        "            \"path\": \"tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_output.json\",\n",
+        "            \"role\": \"summary_metric\",\n",
+        "        },\n",
+        "        {\n",
+        "            \"path\": \"tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_log.txt\",\n",
+        "            \"role\": \"raw_trace\",\n",
+        "        },\n",
+        "    ],\n",
+        "}\n",
+        "INPUT_MANIFEST_PREVIEW\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "DIAGNOSTIC_OUTPUT_PREVIEW = {\n",
+        "    \"schema\": \"kaggle_notebook_skeleton_diagnostic_output_v0\",\n",
+        "    \"diagnostic_metadata_only\": True,\n",
+        "    \"metric\": {\n",
+        "        \"name\": \"demo_notebook_artifact_count\",\n",
+        "        \"unit\": \"count\",\n",
+        "        \"value\": 2,\n",
+        "    },\n",
+        "    \"kaggle_run_performed\": False,\n",
+        "    \"hpc_run_performed\": False,\n",
+        "    \"notes\": \"Local inert diagnostic output. Not a verifier.\",\n",
+        "}\n",
+        "DIAGNOSTIC_OUTPUT_PREVIEW\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import hashlib\n",
+        "from pathlib import Path\n",
+        "\n",
+        "def sha256_file(path: Path) -> str:\n",
+        "    h = hashlib.sha256()\n",
+        "    with path.open(\"rb\") as f:\n",
+        "        for chunk in iter(lambda: f.read(65536), b\"\"):\n",
+        "            h.update(chunk)\n",
+        "    return h.hexdigest()\n",
+        "\n",
+        "# In this inert fixture, expected hashes are recorded in expected/digest_manifest.json.\n",
+        "# input_manifest.sha256 is the digest of the input manifest file only.\n",
+        "# Payload artifact hashes are recorded separately under evidence_items[].sha256.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "SUMMARY_METRICS_PREVIEW = {\n",
+        "    \"demo_notebook_artifact_count\": 2,\n",
+        "    \"diagnostic_fixture\": True,\n",
+        "    \"kaggle_run_performed\": False,\n",
+        "    \"hpc_run_performed\": False,\n",
+        "}\n",
+        "SUMMARY_METRICS_PREVIEW\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Reconstruction / replay instructions\n",
+        "\n",
+        "This inert notebook skeleton is a fixture-only artifact producer shape.\n",
+        "\n",
+        "Expected local artifacts are listed under `expected/`.\n",
+        "\n",
+        "Replay boundary:\n",
+        "\n",
+        "1. Do not fetch Kaggle state.\n",
+        "2. Do not use Kaggle credentials.\n",
+        "3. Do not write `status.json`.\n",
+        "4. Do not call or replace `check_gates.py`.\n",
+        "5. Verify local artifact SHA-256 values before using outputs as diagnostic evidence.\n",
+        "6. Keep every `evidence_items[].folded_into_status` value `false`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "HPC_EVIDENCE_BUNDLE_PREVIEW_BOUNDARY = {\n",
+        "    \"schema\": \"hpc_evidence_bundle_v0\",\n",
+        "    \"authority_status\": \"diagnostic_non_normative\",\n",
+        "    \"creates_release_authority\": False,\n",
+        "    \"evidence_items_default\": {\n",
+        "        \"folded_into_status\": False,\n",
+        "    },\n",
+        "    \"notes\": (\n",
+        "        \"This packet preview is diagnostic. It does not create release authority. \"\n",
+        "        \"It does not verify evidence, satisfy relation bindings, materialize gates, \"\n",
+        "        \"write status.json, or affect check_gates.py.\"\n",
+        "    ),\n",
+        "}\n",
+        "HPC_EVIDENCE_BUNDLE_PREVIEW_BOUNDARY\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.x"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

This PR adds an inert Kaggle notebook skeleton fixture.

The skeleton is a static diagnostic / reproducibility fixture. It does not run Kaggle and does not fetch external state.

## Scope

Fixture-only.

Added files:

- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/README.md`
- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/notebook_skeleton.ipynb`
- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/input_manifest.json`
- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_output.json`
- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_log.txt`
- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/digest_manifest.json`
- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/hpc_evidence_bundle_preview.json`

## Boundary

The skeleton is diagnostic only.

It does not create or enable:

- `VERIFIED`
- trusted evidence
- verified evidence
- `verified_artifacts`
- `relation_bindings`
- relation satisfaction
- gate materialization
- `status.json` writing
- policy changes
- registry changes
- `check_gates.py` changes
- workflow changes
- CI allow/block changes
- release authority

## Packet compatibility

The skeleton is shaped for future outputs compatible with:

```text
schema = hpc_evidence_bundle_v0
authority_status = diagnostic_non_normative
creates_release_authority = false
folded_into_status = false
```

Digest boundary

input_manifest.sha256 remains the digest of the input manifest file only.

Payload artifacts, notebook outputs, logs, tables, plots, and packet previews are digest-bound separately.

Non-goals

This PR does not add:

a real Kaggle run
Kaggle API calls
Kaggle credentials
Kaggle dataset downloads
a schema change
a builder change
a checker change
a workflow change
a policy or registry change
a release-authority path