### PR TITLE
test(ref): fix inert Kaggle notebook skeleton fixture contract v0

### DIFF
--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/README.md
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/README.md
@@ -1,8 +1,8 @@
 # Inert Kaggle Notebook Skeleton Fixture v0
 
-Status: fixture-only  
-Normative status: non-normative diagnostic fixture  
-Scope: local, inert Kaggle notebook skeleton shape for future diagnostic / reproducibility artifacts
+- Status: fixture-only
+- Normative status: non-normative diagnostic fixture
+- Scope: local, inert Kaggle notebook skeleton shape for future diagnostic / reproducibility artifacts
 
 ## Boundary
 

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/digest_manifest.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/digest_manifest.json
@@ -18,7 +18,7 @@
     {
       "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_log.txt",
       "role": "diagnostic_log",
-      "sha256": "03b0a66ef1f43df824b3bb9fe957ae1cb04a052f8593366d1b26773637d315c6"
+      "sha256": "f5148bea1f251e3bbf0b1beae0b69d726921f531af4cb5ff285960fe1dae6640"
     },
     {
       "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/hpc_evidence_bundle_preview.json",

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/hpc_evidence_bundle_preview.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/hpc_evidence_bundle_preview.json
@@ -15,7 +15,7 @@
     "node_count": 1,
     "package_versions_note": "not a Kaggle or HPC runtime attestation",
     "python_version": "metadata-only-local",
-    "runtime_surface": "local_notebook_skeleton",
+    "runtime_surface": "local_hpc_sim",
     "scheduler": "none",
     "seed": 0
   },
@@ -90,7 +90,7 @@
     "purpose": "diagnostic reproducibility and review only",
     "run_completed_utc": "2026-06-12T00:00:00Z",
     "run_id": "kaggle-notebook-skeleton-local-001",
-    "run_mode": "local_notebook_skeleton",
+    "run_mode": "local_hpc_sim",
     "run_started_utc": "2026-06-12T00:00:00Z"
   },
   "schema": "hpc_evidence_bundle_v0",


### PR DESCRIPTION
## Summary

This PR fixes the inert Kaggle notebook skeleton fixture contract.

It addresses two review blockers:

- removes trailing whitespace from the fixture README metadata lines
- updates the `hpc_evidence_bundle_v0` preview fixture to use the currently accepted local runtime enum value:

```text
local_hpc_sim
```

for:

```text
environment.runtime_surface
run_identity.run_mode
```

The digest manifest is updated to match the corrected preview artifact.

## Scope

Fixture-only cleanup.

Changed files:

- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/README.md`
- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/hpc_evidence_bundle_preview.json`
- `tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/digest_manifest.json`

## Boundary

The inert Kaggle notebook skeleton fixture remains diagnostic-only.

It does not run Kaggle.

It does not fetch external state.

It does not use Kaggle credentials.

It does not write `status.json`.

It does not invoke or replace `check_gates.py`.

It does not create release authority.

## Packet compatibility

The preview remains shaped for:

```text
schema = hpc_evidence_bundle_v0
authority_status = diagnostic_non_normative
creates_release_authority = false
folded_into_status = false
```

The local runtime values now match the current accepted `hpc_evidence_bundle_v0` contract:

```text
environment.runtime_surface = local_hpc_sim
run_identity.run_mode = local_hpc_sim
```

## Digest boundary

`input_manifest.sha256` remains the digest of the input manifest file only.

Payload artifact digests remain recorded separately under `evidence_items[].sha256`.

The digest manifest records local artifact hashes and does not self-hash.

## Non-goals

This PR does not change:

- schemas
- builders
- checkers
- workflows
- `check_gates.py`
- `run_all.py`
- release policy
- gate registry
- CI authority path
- `--release-grade-materialized`

This PR does not create or enable:

- `VERIFIED`
- trusted evidence
- verified evidence
- `verified_artifacts`
- `relation_bindings`
- relation satisfaction
- gate materialization
- `status.json` writing
- release authority

## Testing

Expected GitHub checks:

```bash
git show --check HEAD
```

```bash
python scripts/check_hpc_evidence_bundle_v0_contract.py \
  --in tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/hpc_evidence_bundle_preview.json
```

```bash
python -m pytest tests/test_hpc_evidence_bundle_v0_contract.py
```

```bash
python -m pytest tests/test_build_hpc_evidence_bundle_v0.py
```

```bash
python -m pytest tests/test_tools_tests_list_smoke.py
```