### PR TITLE
test(ref): fix inert Kaggle notebook digest manifest v0

### DIFF
--- a/docs/PULSE_COMPUTE_PRE_COMPARISON_ADMISSION_BOUNDARY_v0.md
+++ b/docs/PULSE_COMPUTE_PRE_COMPARISON_ADMISSION_BOUNDARY_v0.md
@@ -180,5 +180,3 @@ Without comparison, nothing may enter decision.
 PULSE-COMPUTE does not prevent the system from learning a wrong pattern.
 
 PULSE-COMPUTE prevents the wrong pattern from becoming a verified decision path.
-
-

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/digest_manifest.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/digest_manifest.json
@@ -18,12 +18,12 @@
     {
       "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/diagnostic_log.txt",
       "role": "diagnostic_log",
-      "sha256": "f5148bea1f251e3bbf0b1beae0b69d726921f531af4cb5ff285960fe1dae6640"
+      "sha256": "03b0a66ef1f43df824b3bb9fe957ae1cb04a052f8593366d1b26773637d315c6"
     },
     {
       "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/hpc_evidence_bundle_preview.json",
       "role": "diagnostic_packet_preview",
-      "sha256": "1d31d94393edbafdd01f8dc103c667084c37d5598d1051d0e802c79b9409a668"
+      "sha256": "f5148bea1f251e3bbf0b1beae0b69d726921f531af4cb5ff285960fe1dae6640"
     }
   ],
   "notes": "Digest records for the inert Kaggle notebook skeleton fixture. Diagnostic metadata only.",


### PR DESCRIPTION
## Summary

This PR fixes the digest manifest for the inert Kaggle notebook skeleton fixture.

The previous digest manifest had stale / swapped entries for:

- `expected/diagnostic_log.txt`
- `expected/hpc_evidence_bundle_preview.json`

## Fixed digests

```text
expected/diagnostic_log.txt
→ 03b0a66ef1f43df824b3bb9fe957ae1cb04a052f8593366d1b26773637d315c6
```

```text
expected/hpc_evidence_bundle_preview.json
→ f5148bea1f251e3bbf0b1beae0b69d726921f531af4cb5ff285960fe1dae6640
```

## Boundary

The fixture remains inert and diagnostic-only.

It does not run Kaggle.

It does not fetch external state.

It does not use Kaggle credentials.

It does not write `status.json`.

It does not invoke or replace `check_gates.py`.

It does not create release authority.

## Packet compatibility

The preview remains shaped for:

```text
schema = hpc_evidence_bundle_v0
authority_status = diagnostic_non_normative
creates_release_authority = false
folded_into_status = false
```

## Digest boundary

`input_manifest.sha256` remains the digest of the input manifest file only.

Payload artifact digests remain recorded separately under `evidence_items[].sha256`.

The digest manifest records local artifact hashes and does not self-hash.

## Non-goals

This PR does not change:

- schemas
- builders
- checkers
- workflows
- `check_gates.py`
- `run_all.py`
- release policy
- gate registry
- CI authority path
- `--release-grade-materialized`

This PR does not create or enable:

- `VERIFIED`
- trusted evidence
- verified evidence
- `verified_artifacts`
- `relation_bindings`
- relation satisfaction
- gate materialization
- `status.json` writing
- release authority

## Testing

Expected GitHub checks:

```bash
git show --check HEAD
```

```bash
python scripts/check_hpc_evidence_bundle_v0_contract.py \
  --in tests/fixtures/hpc_evidence_bundle_v0/kaggle_notebook_skeleton_v0/expected/hpc_evidence_bundle_preview.json
```

```bash
python -m pytest tests/test_hpc_evidence_bundle_v0_contract.py
```

```bash
python -m pytest tests/test_build_hpc_evidence_bundle_v0.py
```

```bash
python -m pytest tests/test_tools_tests_list_smoke.py
```