### PR TITLE
test(ref): add Kaggle Run 0 diagnostic capture artifacts v0

### DIFF
--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/kaggle_run_0_capture_v0/outputs/diagnostic_log.txt
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/kaggle_run_0_capture_v0/outputs/diagnostic_log.txt
@@ -1,0 +1,12 @@
+PULSE Kaggle Run 0 capture smoke
+created_utc=2026-06-14T22:01:30Z
+diagnostic_only=true
+kaggle_api_used=false
+kaggle_credentials_used=false
+external_fetch_performed=false
+status_json_written=false
+check_gates_invoked=false
+verified_artifacts_created=false
+relation_bindings_created=false
+gate_materialization_created=false
+release_authority_created=false

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/kaggle_run_0_capture_v0/outputs/diagnostic_output.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/kaggle_run_0_capture_v0/outputs/diagnostic_output.json
@@ -1,0 +1,15 @@
+{
+  "capture_smoke": true,
+  "creates_release_authority": false,
+  "diagnostic_metadata_only": true,
+  "hpc_run_performed": false,
+  "kaggle_run_performed": true,
+  "metric": {
+    "name": "run_0_artifact_count",
+    "unit": "count",
+    "value": 4
+  },
+  "notes": "This is a diagnostic capture output. It is not verified evidence, not relation satisfaction, not gate materialization, and not release authority.",
+  "schema": "kaggle_run_0_diagnostic_output_v0",
+  "verifier": false
+}

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/kaggle_run_0_capture_v0/outputs/digest_manifest.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/kaggle_run_0_capture_v0/outputs/digest_manifest.json
@@ -1,0 +1,37 @@
+{
+  "created_utc": "2026-06-14T22:01:30Z",
+  "digests": [
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/outputs/input_manifest.json",
+      "role": "input_manifest",
+      "sha256": "4ef010dfd4a16650d2932f6c3f1043c627edc5d8e4359a44300c5effe846e4c9"
+    },
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/outputs/diagnostic_output.json",
+      "role": "diagnostic_output",
+      "sha256": "99f4362a20c119a020205f1ed066d9e3ce8bd571d2c705b72cabb344429aeb9b"
+    },
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/outputs/diagnostic_log.txt",
+      "role": "diagnostic_log",
+      "sha256": "1f5c86573ef97883f68ce246678cf9dee80a4c6e9fa7f61ef8f731ebeb3d5efe"
+    },
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/outputs/environment.json",
+      "role": "environment_metadata",
+      "sha256": "5124abb5ee3914638022474de5bc791a7165a0155307584b301547f36401a176"
+    },
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/outputs/reconstruction_instructions.md",
+      "role": "reconstruction_instructions",
+      "sha256": "c59aaf0de7180c8dcc218dbcca87bee031c9adefa1eeb8924ef1a974de9c1bfc"
+    },
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/outputs/hpc_evidence_bundle_preview.json",
+      "role": "diagnostic_packet_preview",
+      "sha256": "443444c48b609e419aeb9484c80835c6691a2ac5f4683cb731b76fc09df8a2b3"
+    }
+  ],
+  "notes": "Digest records for Kaggle Run 0 capture smoke. Diagnostic metadata only. This manifest does not self-hash.",
+  "schema": "kaggle_run_0_digest_manifest_v0"
+}

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/kaggle_run_0_capture_v0/outputs/environment.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/kaggle_run_0_capture_v0/outputs/environment.json
@@ -1,0 +1,14 @@
+{
+  "accelerator_class": "metadata-only",
+  "created_utc": "2026-06-14T22:01:30Z",
+  "determinism_note": "Run 0 capture smoke; output artifacts are locally generated and hash-bound.",
+  "external_state_note": "No Kaggle API, credential, dataset download, or external fetch is used by this notebook.",
+  "node_count": 1,
+  "package_versions_note": "Package metadata is diagnostic only and is not a verifier identity.",
+  "platform": "Linux-6.6.122+-x86_64-with-glibc2.35",
+  "python_executable": "/usr/bin/python3",
+  "python_version": "3.12.13 (main, Mar  4 2026, 09:23:07) [GCC 11.4.0]",
+  "runtime_surface": "compute_scale",
+  "scheduler": "kaggle",
+  "schema": "kaggle_run_0_environment_v0"
+}

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/kaggle_run_0_capture_v0/outputs/hpc_evidence_bundle_preview.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/kaggle_run_0_capture_v0/outputs/hpc_evidence_bundle_preview.json
@@ -1,0 +1,114 @@
+{
+  "authority_status": "diagnostic_non_normative",
+  "code_identity": {
+    "git_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "notebook_path": "Kaggle notebook / kaggle_run_0_capture_notebook_v0",
+    "notebook_version": "kaggle_run_0_capture_notebook_v0",
+    "ref": "kaggle-run-0-capture-smoke-v0",
+    "repository": "HKati/pulse-release-gates-0.1"
+  },
+  "creates_release_authority": false,
+  "environment": {
+    "accelerator_class": "metadata-only",
+    "external_state_note": "No Kaggle API, credential, dataset download, or external fetch is used by this notebook.",
+    "node_count": 1,
+    "package_versions_note": "Package metadata is diagnostic only and is not a verifier identity.",
+    "platform": "Linux-6.6.122+-x86_64-with-glibc2.35",
+    "python_version": "3.12.13 (main, Mar  4 2026, 09:23:07) [GCC 11.4.0]",
+    "runtime_surface": "compute_scale",
+    "scheduler": "kaggle"
+  },
+  "evidence_items": [
+    {
+      "artifact_kind": "diagnostic_output",
+      "diagnostic_metadata_only": true,
+      "evidence_status": "present",
+      "folded_into_status": false,
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/outputs/diagnostic_output.json",
+      "role": "summary_metric",
+      "sha256": "99f4362a20c119a020205f1ed066d9e3ce8bd571d2c705b72cabb344429aeb9b"
+    },
+    {
+      "artifact_kind": "diagnostic_log",
+      "diagnostic_metadata_only": true,
+      "evidence_status": "present",
+      "folded_into_status": false,
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/outputs/diagnostic_log.txt",
+      "role": "raw_trace",
+      "sha256": "1f5c86573ef97883f68ce246678cf9dee80a4c6e9fa7f61ef8f731ebeb3d5efe"
+    },
+    {
+      "artifact_kind": "environment_metadata",
+      "diagnostic_metadata_only": true,
+      "evidence_status": "present",
+      "folded_into_status": false,
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/outputs/environment.json",
+      "role": "package_manifest",
+      "sha256": "5124abb5ee3914638022474de5bc791a7165a0155307584b301547f36401a176"
+    },
+    {
+      "artifact_kind": "reconstruction_instructions",
+      "diagnostic_metadata_only": true,
+      "evidence_status": "present",
+      "folded_into_status": false,
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/outputs/reconstruction_instructions.md",
+      "role": "package_manifest",
+      "sha256": "c59aaf0de7180c8dcc218dbcca87bee031c9adefa1eeb8924ef1a974de9c1bfc"
+    }
+  ],
+  "input_manifest": {
+    "dataset_identity": "metadata-only-kaggle-run-0-dataset",
+    "kaggle": {
+      "availability_drift_note": "Public Kaggle state may be mutable or unavailable; this Run 0 packet uses only local generated artifacts as diagnostic evidence.",
+      "competition_id": "metadata-only-run-0",
+      "dataset_id": "metadata-only-run-0",
+      "external_state_warning": "Kaggle state is not treated as evidence unless locally captured and SHA-256-bound.",
+      "license_terms_note": "metadata only; no credential or external fetch in this capture smoke",
+      "notebook_id": "metadata-only-run-0",
+      "notebook_version": "capture-smoke-v0",
+      "observed_utc": "2026-06-14T22:01:30Z",
+      "producer_or_author": "metadata only",
+      "source_url": "metadata-only-not-recorded-evidence"
+    },
+    "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/outputs/input_manifest.json",
+    "sample_identity": "kaggle-run-0-capture-smoke-sample",
+    "sha256": "4ef010dfd4a16650d2932f6c3f1043c627edc5d8e4359a44300c5effe846e4c9"
+  },
+  "notes": "This packet preview is diagnostic. This packet preview does not create release authority. It does not verify evidence. It does not satisfy relation bindings. It does not materialize gates. It does not write status.json. It does not affect check_gates.py.",
+  "provenance": {
+    "command": "Run all cells in Kaggle Run 0 capture smoke notebook.",
+    "external_state_note": "No Kaggle API, credential, dataset download, or external fetch is used. Kaggle-specific identifiers are metadata only.",
+    "notebook_execution_path": "Kaggle notebook / kaggle_run_0_capture_notebook_v0",
+    "seed": 0,
+    "source_url": "metadata only; not evidence"
+  },
+  "reconstruction": {
+    "instructions": [
+      "Download kaggle_run_0_capture_v0.zip from the Kaggle notebook output.",
+      "Verify outputs/input_manifest.json against input_manifest.sha256.",
+      "Verify each present evidence_items[].path against its evidence_items[].sha256.",
+      "Verify outputs/digest_manifest.json against local files; the digest manifest does not self-hash.",
+      "Do not treat this packet preview as verified evidence, relation satisfaction, gate materialization, status.json writing, or release authority."
+    ]
+  },
+  "result": "complete",
+  "run_identity": {
+    "packet_created_utc": "2026-06-14T22:01:30Z",
+    "packet_id": "kaggle-run-0-capture-smoke-001",
+    "packet_version": "kaggle_hpc_diagnostic_packet_v0",
+    "producer": "Kaggle Run 0 capture smoke notebook",
+    "purpose": "diagnostic reproducibility and review only",
+    "run_completed_utc": "2026-06-14T22:01:30Z",
+    "run_id": "kaggle-run-0-capture-smoke-001",
+    "run_mode": "compute_scale",
+    "run_started_utc": "2026-06-14T22:01:30Z"
+  },
+  "schema": "hpc_evidence_bundle_v0",
+  "summary_metrics": {
+    "artifact_count": 4,
+    "creates_release_authority": false,
+    "hpc_run_performed": false,
+    "kaggle_run_performed": true,
+    "run_0_capture_smoke": true
+  }
+}

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/kaggle_run_0_capture_v0/outputs/input_manifest.json
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/kaggle_run_0_capture_v0/outputs/input_manifest.json
@@ -1,0 +1,36 @@
+{
+  "artifacts": [
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/outputs/diagnostic_output.json",
+      "role": "summary_metric"
+    },
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/outputs/diagnostic_log.txt",
+      "role": "raw_trace"
+    },
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/outputs/environment.json",
+      "role": "package_manifest"
+    },
+    {
+      "path": "tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/outputs/reconstruction_instructions.md",
+      "role": "package_manifest"
+    }
+  ],
+  "dataset_identity": "metadata-only-kaggle-run-0-dataset",
+  "kaggle": {
+    "availability_drift_note": "Public Kaggle state may be mutable or unavailable; this Run 0 packet uses only local generated artifacts as diagnostic evidence.",
+    "competition_id": "metadata-only-run-0",
+    "dataset_id": "metadata-only-run-0",
+    "external_state_warning": "Kaggle state is not treated as evidence unless locally captured and SHA-256-bound.",
+    "license_terms_note": "metadata only; no credential or external fetch in this capture smoke",
+    "notebook_id": "metadata-only-run-0",
+    "notebook_version": "capture-smoke-v0",
+    "observed_utc": "2026-06-14T22:01:30Z",
+    "producer_or_author": "metadata only",
+    "source_url": "metadata-only-not-recorded-evidence"
+  },
+  "notes": "Kaggle Run 0 input manifest. Diagnostic only. input_manifest.sha256 must be the digest of this file only. Payload artifact digests are recorded separately.",
+  "sample_identity": "kaggle-run-0-capture-smoke-sample",
+  "schema": "kaggle_run_0_input_manifest_v0"
+}

--- a/tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/kaggle_run_0_capture_v0/outputs/reconstruction_instructions.md
+++ b/tests/fixtures/hpc_evidence_bundle_v0/kaggle_run_0_capture_v0/kaggle_run_0_capture_v0/outputs/reconstruction_instructions.md
@@ -1,0 +1,34 @@
+# Kaggle Run 0 Reconstruction Instructions v0
+
+This packet is diagnostic.
+
+It does not create release authority.
+
+## Replay boundary
+
+1. Run the Kaggle notebook cells in order.
+2. Do not fetch external Kaggle state.
+3. Do not use Kaggle credentials.
+4. Do not write status.json.
+5. Do not invoke or replace check_gates.py.
+6. Download the generated kaggle_run_0_capture_v0.zip artifact.
+7. Verify SHA-256 digests against outputs/digest_manifest.json.
+8. Validate outputs/hpc_evidence_bundle_preview.json with the existing hpc_evidence_bundle_v0 contract checker after committing the artifact packet to the repository.
+
+## Digest boundary
+
+input_manifest.sha256 is the digest of outputs/input_manifest.json only.
+
+Payload artifacts have separate digests under evidence_items[].sha256 and outputs/digest_manifest.json.
+
+## Non-authority boundary
+
+Kaggle run ≠ verifier.
+
+Notebook output ≠ verified evidence.
+
+Digest match ≠ relation satisfaction.
+
+Metric score ≠ gate materialization.
+
+Packet preview ≠ release authority.


### PR DESCRIPTION
Add Kaggle Run 0 diagnostic capture artifacts.

The artifact packet was produced by the Kaggle Run 0 capture smoke notebook and contains local, downloadable, SHA-256-bound diagnostic outputs plus an hpc_evidence_bundle_v0-compatible packet preview.

The packet remains non-authoritative: it is not a verifier, does not verify evidence, does not satisfy relation bindings, does not materialize gates, does not write status.json, does not invoke check_gates.py, and does not create release authority.

Fixture-only. No schema, builder, checker, workflow, policy, registry, CI authority path, or release-grade materialization behavior is changed.

<!-- PULSE PR Template v1.0 — keep sections; fill what applies. -->

## Summary
<!-- Short: what changes and why? -->

## What’s included
- [ ] Code
- [ ] Docs
- [ ] CI / workflow
- Paths / files touched:

## CI usage
```yaml
# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json
```

## Impact
- Additive / backwards-compatible
- Breaking change — details:
- Performance / SLO impact:
- Security considerations:

What’s included
 Code
 Docs
 CI / workflow

Paths / files touched:

CI usage

# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json

Impact
Additive / backwards-compatible

Breaking change — details:

Performance / SLO impact:

Security considerations:

### Security Intake (v0) — dependency / external code (if applicable)
**Intake v0:** PASS | REVIEW | HARD STOP  
**Isolation used (if REVIEW):** yes / no  

**Reasons (1–3 bullets):**
- 
- 
- 

**Checks**
- [ ] No password-protected ZIP / random binary download involved
- [ ] Repo age ≥ 12 months and maintainer history looks real
- [ ] No postinstall/preinstall scripts (or justified + reviewed)
- [ ] No obfuscation / base64 blobs / runtime-downloaded binaries
- [ ] No instructions like “disable Defender/AV”
- [ ] First run done in VM/container (if REVIEW)

> If any HIGH-risk signal appears → mark **HARD STOP** and do not merge.

Notes

Follow-ups:

Risks / mitigations:

PULSE checklist (release authority)
 PULSE CI is green on this PR
 Quality Ledger link (if enabled)
 Badges updated (PASS / RDSI / Q-Ledger)


## Notes
- Follow-ups:
- Risks / mitigations:

## PULSE checklist (release authority)
- [ ] PULSE CI is green on this PR
- [ ] Quality Ledger link (if enabled)
- [ ] Badges updated (PASS / RDSI / Q‑Ledger)
