### PR TITLE
fix(public-surface): close Quality Ledger parity fail-closed gaps v0

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -728,6 +728,8 @@ jobs:
             --max-errors 20
       
       - name: Re-render Quality Ledger from final status
+        id: quality_ledger_final_render
+        if: ${{ always() }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1870,6 +1872,7 @@ jobs:
 
       - name: Check Quality Ledger status parity before artifact upload
         id: quality_ledger_status_parity
+        if: ${{ always() && steps.quality_ledger_final_render.outcome == 'success' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1881,8 +1884,8 @@ jobs:
             --ledger "$LEDGER"
       
       - name: Upload artifacts
-                if: ${{ success() && steps.quality_ledger_status_parity.outcome == 'success' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        if: ${{ always() && steps.quality_ledger_final_render.outcome == 'success' && steps.quality_ledger_status_parity.outcome == 'success' }}
+        uses: actions/upload-artifact@v4
         with:
           name: pulse-report
           if-no-files-found: warn

--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1869,6 +1869,7 @@ jobs:
           PY
 
       - name: Check Quality Ledger status parity before artifact upload
+        id: quality_ledger_status_parity
         shell: bash
         run: |
           set -euo pipefail
@@ -1880,7 +1881,7 @@ jobs:
             --ledger "$LEDGER"
       
       - name: Upload artifacts
-        if: always()
+                if: ${{ success() && steps.quality_ledger_status_parity.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
         with:
           name: pulse-report

--- a/PULSE_safe_pack_v0/tools/check_quality_ledger_status_parity.py
+++ b/PULSE_safe_pack_v0/tools/check_quality_ledger_status_parity.py
@@ -8,6 +8,9 @@ already-rendered Quality Ledger reflects the provided status.json artefact.
 Gate truth rule:
     expected ledger status = PASS iff status["gates"][gate_id] is True
     expected ledger status = FAIL otherwise
+
+The checker intentionally scopes gate extraction to explicitly marked
+renderer gate tables. Gate-like diagnostic tables are not authoritative.
 """
 
 from __future__ import annotations
@@ -23,6 +26,17 @@ from typing import Any, DefaultDict, Dict, List, Mapping, Sequence
 
 
 PASS_FAIL = {"PASS", "FAIL"}
+TABLE_MARKER_ATTR = "data-pulse-ledger-table"
+GATE_TABLE_MARKER = "gate-status"
+TRACEABILITY_TABLE_MARKER = "traceability"
+
+_AUTHORITATIVE_GATE_SECTIONS = {
+    "safety gates",
+    "quality gates",
+    "other gates",
+    "stability / auxiliary gates",
+    "stability/auxiliary gates",
+}
 
 
 def _collapse_ws(value: Any) -> str:
@@ -39,12 +53,12 @@ def _clean_key(value: str) -> str:
 @dataclass(frozen=True)
 class _HtmlTable:
     section: str
-    attrs: Dict[str, str]
     rows: List[List[str]]
+    attrs: Dict[str, str]
 
 
 class _QualityLedgerHTMLParser(HTMLParser):
-    """Dependency-free table extractor with section context."""
+    """Dependency-free table extractor with section context and attrs."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -56,8 +70,9 @@ class _QualityLedgerHTMLParser(HTMLParser):
 
         self._in_table = False
         self._table_section = ""
-        self._table_rows: List[List[str]] = []
         self._table_attrs: Dict[str, str] = {}
+        self._table_rows: List[List[str]] = []
+
         self._in_row = False
         self._row: List[str] = []
 
@@ -80,8 +95,8 @@ class _QualityLedgerHTMLParser(HTMLParser):
             self._in_table = True
             self._table_section = self._current_section
             self._table_attrs = {
-                _collapse_ws(name).lower(): _collapse_ws(value or "")
-                for name, value in attrs
+                str(key).lower(): value or ""
+                for key, value in attrs
             }
             self._table_rows = []
             return
@@ -126,14 +141,14 @@ class _QualityLedgerHTMLParser(HTMLParser):
             self.tables.append(
                 _HtmlTable(
                     section=self._table_section,
-                    attrs=dict(self._table_attrs),
                     rows=list(self._table_rows),
+                    attrs=dict(self._table_attrs),
                 )
             )
             self._in_table = False
             self._table_section = ""
-            self._table_rows = []
             self._table_attrs = {}
+            self._table_rows = []
             self._in_row = False
             self._row = []
             self._in_cell = False
@@ -179,32 +194,26 @@ def _has_header(
     return False
 
 
-GATE_TABLE_SECTIONS = {
-    "Safety gates",
-    "Quality gates",
-    "Other gates",
-    "Stability / auxiliary gates",
-}
-
-
 def _table_marker(table: _HtmlTable) -> str:
-    return _collapse_ws(table.attrs.get("data-pulse-ledger-table", ""))
+    return _collapse_ws(
+        table.attrs.get(TABLE_MARKER_ATTR, "")
+    ).lower()
 
 
 def _is_gate_table(table: _HtmlTable) -> bool:
-    section = _collapse_ws(table.section)
+    section = _collapse_ws(table.section).lower()
     return (
-        _table_marker(table) == "gate-status"
-        and section in GATE_TABLE_SECTIONS
+        _table_marker(table) == GATE_TABLE_MARKER
+        and section in _AUTHORITATIVE_GATE_SECTIONS
         and _has_header(table, ["Gate", "Status"])
     )
 
 
 def _is_traceability_table(table: _HtmlTable) -> bool:
-    section = _collapse_ws(table.section)
+    section = _collapse_ws(table.section).lower()
     return (
-        _table_marker(table) == "traceability"
-        and section == "Traceability"
+        _table_marker(table) == TRACEABILITY_TABLE_MARKER
+        and section == "traceability"
         and _has_header(table, ["Field", "Value"])
     )
 
@@ -228,7 +237,7 @@ def _gate_status_values(
             if key == "Gate" and value == "Status":
                 continue
 
-           if key:
+            if key:
                 values[key].append(value)
 
     return values
@@ -289,14 +298,22 @@ def parity_errors(status: Mapping[str, Any], ledger_html: str) -> List[str]:
     metrics = metrics_raw if isinstance(metrics_raw, dict) else {}
 
     tables = _extract_tables(ledger_html)
+    gate_tables = [table for table in tables if _is_gate_table(table)]
+    trace_tables = [table for table in tables if _is_traceability_table(table)]
+
     gate_values = _gate_status_values(tables)
     trace_values = _traceability_values(tables)
 
-    if not any(_is_gate_table(table) for table in tables):
-        errors.append("no Gate/Status table found in Quality Ledger HTML")
+    if not gate_tables:
+        errors.append(
+            "no authoritative Gate/Status table found in Quality Ledger HTML"
+        )
 
-    if not any(_is_traceability_table(table) for table in tables):
-        errors.append("no Traceability Field/Value table found in Quality Ledger HTML")
+    if not trace_tables:
+        errors.append(
+            "no authoritative Traceability Field/Value table found in "
+            "Quality Ledger HTML"
+        )
 
     status_gate_ids = set(status_gates)
     ledger_gate_ids = set(gate_values)
@@ -313,7 +330,8 @@ def parity_errors(status: Mapping[str, Any], ledger_html: str) -> List[str]:
 
         if not actual_values:
             errors.append(
-                f"gate row missing: {gate_id} (expected {expected})"
+                f"gate row missing or has no visible status: {gate_id} "
+                f"(expected {expected})"
             )
             continue
 
@@ -328,9 +346,11 @@ def parity_errors(status: Mapping[str, Any], ledger_html: str) -> List[str]:
         if actual not in PASS_FAIL:
             errors.append(
                 f"gate row has invalid visible status: {gate_id} "
-                f"(ledger={actual!r}, expected PASS or FAIL)"
+                f"(ledger={actual!r}, expected PASS or FAIL; "
+                f"status.gates expected {expected})"
             )
             continue
+
         if actual != expected:
             errors.append(
                 f"gate status mismatch: {gate_id} "

--- a/PULSE_safe_pack_v0/tools/check_quality_ledger_status_parity.py
+++ b/PULSE_safe_pack_v0/tools/check_quality_ledger_status_parity.py
@@ -39,6 +39,7 @@ def _clean_key(value: str) -> str:
 @dataclass(frozen=True)
 class _HtmlTable:
     section: str
+    attrs: Dict[str, str]
     rows: List[List[str]]
 
 
@@ -56,7 +57,7 @@ class _QualityLedgerHTMLParser(HTMLParser):
         self._in_table = False
         self._table_section = ""
         self._table_rows: List[List[str]] = []
-
+        self._table_attrs: Dict[str, str] = 
         self._in_row = False
         self._row: List[str] = []
 
@@ -68,7 +69,6 @@ class _QualityLedgerHTMLParser(HTMLParser):
         tag: str,
         attrs: Sequence[tuple[str, str | None]],
     ) -> None:
-        del attrs
         tag = tag.lower()
 
         if tag in {"h2", "h3"}:
@@ -79,6 +79,10 @@ class _QualityLedgerHTMLParser(HTMLParser):
         if tag == "table":
             self._in_table = True
             self._table_section = self._current_section
+            self._table_attrs = {
+                _collapse_ws(name).lower(): _collapse_ws(value or "")
+                for name, value in attrs
+            }
             self._table_rows = []
             return
 
@@ -122,12 +126,14 @@ class _QualityLedgerHTMLParser(HTMLParser):
             self.tables.append(
                 _HtmlTable(
                     section=self._table_section,
+                    attrs=dict(self._table_attrs),
                     rows=list(self._table_rows),
                 )
             )
             self._in_table = False
             self._table_section = ""
             self._table_rows = []
+            self._table_attrs = {}
             self._in_row = False
             self._row = []
             self._in_cell = False
@@ -173,14 +179,34 @@ def _has_header(
     return False
 
 
+GATE_TABLE_SECTIONS = {
+    "Safety gates",
+    "Quality gates",
+    "Other gates",
+    "Stability / auxiliary gates",
+}
+
+
+def _table_marker(table: _HtmlTable) -> str:
+    return _collapse_ws(table.attrs.get("data-pulse-ledger-table", ""))
+
+
 def _is_gate_table(table: _HtmlTable) -> bool:
-    section = _collapse_ws(table.section).lower()
-    return "gates" in section and _has_header(table, ["Gate", "Status"])
+    section = _collapse_ws(table.section)
+    return (
+        _table_marker(table) == "gate-status"
+        and section in GATE_TABLE_SECTIONS
+        and _has_header(table, ["Gate", "Status"])
+    )
 
 
 def _is_traceability_table(table: _HtmlTable) -> bool:
-    section = _collapse_ws(table.section).lower()
-    return section == "traceability" and _has_header(table, ["Field", "Value"])
+    section = _collapse_ws(table.section)
+    return (
+        _table_marker(table) == "traceability"
+        and section == "Traceability"
+        and _has_header(table, ["Field", "Value"])
+    )
 
 
 def _gate_status_values(
@@ -202,7 +228,7 @@ def _gate_status_values(
             if key == "Gate" and value == "Status":
                 continue
 
-            if key and value in PASS_FAIL:
+           if key:
                 values[key].append(value)
 
     return values
@@ -287,8 +313,7 @@ def parity_errors(status: Mapping[str, Any], ledger_html: str) -> List[str]:
 
         if not actual_values:
             errors.append(
-                f"gate row missing or has no PASS/FAIL status: {gate_id} "
-                f"(expected {expected})"
+                f"gate row missing: {gate_id} (expected {expected})"
             )
             continue
 
@@ -300,6 +325,12 @@ def parity_errors(status: Mapping[str, Any], ledger_html: str) -> List[str]:
             continue
 
         actual = actual_values[0]
+        if actual not in PASS_FAIL:
+            errors.append(
+                f"gate row has invalid visible status: {gate_id} "
+                f"(ledger={actual!r}, expected PASS or FAIL)"
+            )
+            continue
         if actual != expected:
             errors.append(
                 f"gate status mismatch: {gate_id} "

--- a/PULSE_safe_pack_v0/tools/check_quality_ledger_status_parity.py
+++ b/PULSE_safe_pack_v0/tools/check_quality_ledger_status_parity.py
@@ -57,7 +57,7 @@ class _QualityLedgerHTMLParser(HTMLParser):
         self._in_table = False
         self._table_section = ""
         self._table_rows: List[List[str]] = []
-        self._table_attrs: Dict[str, str] = 
+        self._table_attrs: Dict[str, str] = {}
         self._in_row = False
         self._row: List[str] = []
 

--- a/PULSE_safe_pack_v0/tools/render_quality_ledger.py
+++ b/PULSE_safe_pack_v0/tools/render_quality_ledger.py
@@ -428,7 +428,7 @@ def render_gate_table(title: str, rows: List[Tuple[str, bool]]) -> str:
     return (
         f"<section class='panel'>"
         f"<h2>{escape(title)}</h2>"
-        "<table class='ledger-table'>"
+        "<table class='ledger-table' data-pulse-ledger-table='gate-status'>"
         "<thead><tr><th>Gate</th><th>Status</th></tr></thead>"
         f"<tbody>{''.join(body)}</tbody>"
         "</table>"
@@ -664,7 +664,7 @@ def render_traceability(status_path: Path, status: Dict[str, Any]) -> str:
     return (
         "<section class='panel'>"
         "<h2>Traceability</h2>"
-        "<table class='ledger-table'>"
+        "<table class='ledger-table' data-pulse-ledger-table='traceability'>"
         "<thead><tr><th>Field</th><th>Value</th></tr></thead>"
         f"<tbody>{body}</tbody>"
         "</table>"

--- a/tests/test_quality_ledger_status_parity_v0.py
+++ b/tests/test_quality_ledger_status_parity_v0.py
@@ -49,20 +49,26 @@ def minimal_ledger_html(
     *,
     refusal_gate_status: str = "PASS",
     git_sha: str | None = None,
+    include_gate_table: bool = True,
     include_refusal_gate: bool = True,
-    extra_gate_rows: str = "",
-    diagnostics_rows: str = "",
-    duplicate_identity_rows: str = "",
-    gate_table_attrs: str = " data-pulse-ledger-table=\"gate-status\"",
-    traceability_table_attrs: str = " data-pulse-ledger-table=\"traceability\"",
     gate_section_title: str = "Other gates",
+    gate_table_attrs: str | None = None,
+    extra_gate_rows: str = "",
     diagnostics_title: str = "Diagnostics",
-    diagnostics_table_attrs: str = "",
     diagnostics_header: str = "<tr><th>Field</th><th>Value</th></tr>",
+    diagnostics_rows: str = "",
+    traceability_table_attrs: str | None = None,
+    duplicate_identity_rows: str = "",
 ) -> str:
     status = status_payload()
     if git_sha is None:
         git_sha = status["metrics"]["git_sha"]
+
+    if gate_table_attrs is None:
+        gate_table_attrs = ' data-pulse-ledger-table="gate-status"'
+
+    if traceability_table_attrs is None:
+        traceability_table_attrs = ' data-pulse-ledger-table="traceability"'
 
     refusal_row = ""
     if include_refusal_gate:
@@ -73,15 +79,11 @@ def minimal_ledger_html(
         </tr>
         """
 
-    return f"""
-<!doctype html>
-<html>
-<body>
-<h1>PULSE Quality Ledger</h1>
-
+    gate_table = ""
+    if include_gate_table:
+        gate_table = f"""
 <h2>{gate_section_title}</h2>
 <table{gate_table_attrs}>
-<table>
   <thead>
     <tr><th>Gate</th><th>Status</th></tr>
   </thead>
@@ -98,11 +100,20 @@ def minimal_ledger_html(
     {extra_gate_rows}
   </tbody>
 </table>
+"""
+
+    return f"""
+<!doctype html>
+<html>
+<body>
+<h1>PULSE Quality Ledger</h1>
+
+{gate_table}
 
 <h2>{diagnostics_title}</h2>
-<table{diagnostics_table_attrs}>
-  <thead> 
-  {diagnostics_header}  
+<table>
+  <thead>
+    {diagnostics_header}
   </thead>
   <tbody>
     {diagnostics_rows}
@@ -134,28 +145,6 @@ def minimal_ledger_html(
 </html>
 """
 
-
-def test_quality_ledger_renderer_output_has_explicit_table_markers(
-    tmp_path: Path,
-) -> None:
-    status_path = tmp_path / "status.json"
-    ledger_path = tmp_path / "report_card.html"
-    status = status_payload()
-
-    write_json(status_path, status)
-    write_quality_ledger(status_path, ledger_path)
-
-    html = ledger_path.read_text(encoding="utf-8")
-
-    assert (
-        'data-pulse-ledger-table="gate-status"' in html
-        or "data-pulse-ledger-table='gate-status'" in html
-    )
-    assert (
-        'data-pulse-ledger-table="traceability"' in html
-        or "data-pulse-ledger-table='traceability'" in html
-    )
-    assert parity_errors(status, html) == []
 
 def test_quality_ledger_parity_passes_for_renderer_output(
     tmp_path: Path,
@@ -323,10 +312,18 @@ def test_quality_ledger_parity_cli_fails_closed_on_mismatch(
 def test_quality_ledger_parity_diagnostics_gates_section_cannot_satisfy_missing_gate() -> None:
     status = status_payload()
     html = minimal_ledger_html(
-        include_refusal_gate=False,
+        include_gate_table=False,
         diagnostics_title="Diagnostics gates",
         diagnostics_header="<tr><th>Gate</th><th>Status</th></tr>",
         diagnostics_rows="""
+        <tr>
+          <td><code>detectors_materialized_ok</code></td>
+          <td>FAIL</td>
+        </tr>
+        <tr>
+          <td><code>q1_grounded_ok</code></td>
+          <td>PASS</td>
+        </tr>
         <tr>
           <td><code>refusal_delta_evidence_present</code></td>
           <td>PASS</td>
@@ -337,7 +334,12 @@ def test_quality_ledger_parity_diagnostics_gates_section_cannot_satisfy_missing_
     errors = parity_errors(status, html)
 
     assert any(
-        "gate row missing" in err and "refusal_delta_evidence_present" in err
+        "no authoritative Gate/Status table found" in err
+        for err in errors
+    )
+    assert any(
+        "gate row missing" in err
+        and "refusal_delta_evidence_present" in err
         for err in errors
     )
 
@@ -361,28 +363,40 @@ def test_quality_ledger_parity_diagnostics_gates_section_cannot_conflict_with_re
 
 def test_quality_ledger_parity_rejects_stale_gate_row_with_unknown() -> None:
     status = status_payload()
-    html = minimal_ledger_html(extra_gate_rows="""
-        <tr><td><code>old_removed_gate</code></td><td>UNKNOWN</td></tr>
-    """)
+    html = minimal_ledger_html(
+        extra_gate_rows="""
+        <tr>
+          <td><code>old_removed_gate</code></td>
+          <td>UNKNOWN</td>
+        </tr>
+        """,
+    )
 
     errors = parity_errors(status, html)
 
     assert any(
-        "stale gate row present in ledger" in err and "old_removed_gate" in err
+        "stale gate row present in ledger" in err
+        and "old_removed_gate" in err
         for err in errors
     )
 
 
 def test_quality_ledger_parity_rejects_stale_gate_row_with_pending() -> None:
     status = status_payload()
-    html = minimal_ledger_html(extra_gate_rows="""
-        <tr><td><code>old_removed_gate</code></td><td>PENDING</td></tr>
-    """)
+    html = minimal_ledger_html(
+        extra_gate_rows="""
+        <tr>
+          <td><code>old_removed_gate</code></td>
+          <td>PENDING</td>
+        </tr>
+        """,
+    )
 
     errors = parity_errors(status, html)
 
     assert any(
-        "stale gate row present in ledger" in err and "old_removed_gate" in err
+        "stale gate row present in ledger" in err
+        and "old_removed_gate" in err
         for err in errors
     )
 
@@ -394,7 +408,8 @@ def test_quality_ledger_parity_rejects_current_gate_row_with_unknown() -> None:
     errors = parity_errors(status, html)
 
     assert any(
-        "invalid visible status" in err and "refusal_delta_evidence_present" in err
+        "invalid visible status" in err
+        and "refusal_delta_evidence_present" in err
         for err in errors
     )
 
@@ -406,7 +421,8 @@ def test_quality_ledger_parity_rejects_current_gate_row_with_blank_status() -> N
     errors = parity_errors(status, html)
 
     assert any(
-        "invalid visible status" in err and "refusal_delta_evidence_present" in err
+        "invalid visible status" in err
+        and "refusal_delta_evidence_present" in err
         for err in errors
     )
 
@@ -417,8 +433,10 @@ def test_quality_ledger_parity_requires_authoritative_gate_table_marker() -> Non
 
     errors = parity_errors(status, html)
 
-    assert any("no Gate/Status table found" in err for err in errors)
-    assert any("gate row missing" in err for err in errors)
+    assert any(
+        "no authoritative Gate/Status table found" in err
+        for err in errors
+    )
 
 
 def test_quality_ledger_parity_requires_traceability_table_marker() -> None:
@@ -427,26 +445,43 @@ def test_quality_ledger_parity_requires_traceability_table_marker() -> None:
 
     errors = parity_errors(status, html)
 
-    assert any("no Traceability Field/Value table found" in err for err in errors)
+    assert any(
+        "no authoritative Traceability Field/Value table found" in err
+        for err in errors
+    )
 
 
-def _pulse_ci_workflow_text() -> str:
-    return (REPO_ROOT / ".github" / "workflows" / "pulse_ci.yml").read_text(
-        encoding="utf-8"
+def test_quality_ledger_parity_rejects_gate_like_table_in_unknown_gate_section() -> None:
+    status = status_payload()
+    html = minimal_ledger_html(
+        gate_section_title="Diagnostics gates",
+        refusal_gate_status="PASS",
+    )
+
+    errors = parity_errors(status, html)
+
+    assert any(
+        "no authoritative Gate/Status table found" in err
+        for err in errors
     )
 
 
 def test_pulse_report_upload_is_gated_on_quality_ledger_parity_success() -> None:
-    workflow = _pulse_ci_workflow_text()
-    parity_idx = workflow.index("Check Quality Ledger status parity before artifact upload")
-    upload_idx = workflow.index("name: Upload artifacts", parity_idx)
-    upload_block_end = workflow.find("\n\n  ", upload_idx)
-    if upload_block_end == -1:
-        upload_block_end = len(workflow)
-    parity_block = workflow[parity_idx:upload_idx]
-    upload_block = workflow[upload_idx:upload_block_end]
+    workflow = (
+        REPO_ROOT
+        / ".github"
+        / "workflows"
+        / "pulse_ci.yml"
+    ).read_text(encoding="utf-8")
 
-    assert "id: quality_ledger_status_parity" in parity_block
-    assert "name: pulse-report" in upload_block
+    assert "id: quality_ledger_final_render" in workflow
+    assert "id: quality_ledger_status_parity" in workflow
+    assert "steps.quality_ledger_status_parity.outcome == 'success'" in workflow
+    assert "steps.quality_ledger_final_render.outcome == 'success'" in workflow
+
+    upload_pos = workflow.find("- name: Upload artifacts")
+    assert upload_pos != -1
+
+    upload_block = workflow[upload_pos: workflow.find("\n      - name:", upload_pos + 1)]
     assert "if: always()" not in upload_block
     assert "steps.quality_ledger_status_parity.outcome == 'success'" in upload_block

--- a/tests/test_quality_ledger_status_parity_v0.py
+++ b/tests/test_quality_ledger_status_parity_v0.py
@@ -53,6 +53,12 @@ def minimal_ledger_html(
     extra_gate_rows: str = "",
     diagnostics_rows: str = "",
     duplicate_identity_rows: str = "",
+    gate_table_attrs: str = " data-pulse-ledger-table=\"gate-status\"",
+    traceability_table_attrs: str = " data-pulse-ledger-table=\"traceability\"",
+    gate_section_title: str = "Other gates",
+    diagnostics_title: str = "Diagnostics",
+    diagnostics_table_attrs: str = "",
+    diagnostics_header: str = "<tr><th>Field</th><th>Value</th></tr>",
 ) -> str:
     status = status_payload()
     if git_sha is None:
@@ -73,7 +79,8 @@ def minimal_ledger_html(
 <body>
 <h1>PULSE Quality Ledger</h1>
 
-<h2>Other gates</h2>
+<h2>{gate_section_title}</h2>
+<table{gate_table_attrs}>
 <table>
   <thead>
     <tr><th>Gate</th><th>Status</th></tr>
@@ -92,10 +99,10 @@ def minimal_ledger_html(
   </tbody>
 </table>
 
-<h2>Diagnostics</h2>
-<table>
-  <thead>
-    <tr><th>Field</th><th>Value</th></tr>
+<h2>{diagnostics_title}</h2>
+<table{diagnostics_table_attrs}>
+  <thead> 
+  {diagnostics_header}  
   </thead>
   <tbody>
     {diagnostics_rows}
@@ -103,7 +110,7 @@ def minimal_ledger_html(
 </table>
 
 <h2>Traceability</h2>
-<table>
+<table{traceability_table_attrs}>
   <thead>
     <tr><th>Field</th><th>Value</th></tr>
   </thead>
@@ -127,6 +134,28 @@ def minimal_ledger_html(
 </html>
 """
 
+
+def test_quality_ledger_renderer_output_has_explicit_table_markers(
+    tmp_path: Path,
+) -> None:
+    status_path = tmp_path / "status.json"
+    ledger_path = tmp_path / "report_card.html"
+    status = status_payload()
+
+    write_json(status_path, status)
+    write_quality_ledger(status_path, ledger_path)
+
+    html = ledger_path.read_text(encoding="utf-8")
+
+    assert (
+        'data-pulse-ledger-table="gate-status"' in html
+        or "data-pulse-ledger-table='gate-status'" in html
+    )
+    assert (
+        'data-pulse-ledger-table="traceability"' in html
+        or "data-pulse-ledger-table='traceability'" in html
+    )
+    assert parity_errors(status, html) == []
 
 def test_quality_ledger_parity_passes_for_renderer_output(
     tmp_path: Path,
@@ -289,3 +318,135 @@ def test_quality_ledger_parity_cli_fails_closed_on_mismatch(
     assert result.returncode == 1
     assert "Quality Ledger status parity failed" in result.stdout
     assert "refusal_delta_evidence_present" in result.stdout
+
+
+def test_quality_ledger_parity_diagnostics_gates_section_cannot_satisfy_missing_gate() -> None:
+    status = status_payload()
+    html = minimal_ledger_html(
+        include_refusal_gate=False,
+        diagnostics_title="Diagnostics gates",
+        diagnostics_header="<tr><th>Gate</th><th>Status</th></tr>",
+        diagnostics_rows="""
+        <tr>
+          <td><code>refusal_delta_evidence_present</code></td>
+          <td>PASS</td>
+        </tr>
+        """,
+    )
+
+    errors = parity_errors(status, html)
+
+    assert any(
+        "gate row missing" in err and "refusal_delta_evidence_present" in err
+        for err in errors
+    )
+
+
+def test_quality_ledger_parity_diagnostics_gates_section_cannot_conflict_with_real_gate_table() -> None:
+    status = status_payload()
+    html = minimal_ledger_html(
+        refusal_gate_status="PASS",
+        diagnostics_title="Diagnostics gates",
+        diagnostics_header="<tr><th>Gate</th><th>Status</th></tr>",
+        diagnostics_rows="""
+        <tr>
+          <td><code>refusal_delta_evidence_present</code></td>
+          <td>FAIL</td>
+        </tr>
+        """,
+    )
+
+    assert parity_errors(status, html) == []
+
+
+def test_quality_ledger_parity_rejects_stale_gate_row_with_unknown() -> None:
+    status = status_payload()
+    html = minimal_ledger_html(extra_gate_rows="""
+        <tr><td><code>old_removed_gate</code></td><td>UNKNOWN</td></tr>
+    """)
+
+    errors = parity_errors(status, html)
+
+    assert any(
+        "stale gate row present in ledger" in err and "old_removed_gate" in err
+        for err in errors
+    )
+
+
+def test_quality_ledger_parity_rejects_stale_gate_row_with_pending() -> None:
+    status = status_payload()
+    html = minimal_ledger_html(extra_gate_rows="""
+        <tr><td><code>old_removed_gate</code></td><td>PENDING</td></tr>
+    """)
+
+    errors = parity_errors(status, html)
+
+    assert any(
+        "stale gate row present in ledger" in err and "old_removed_gate" in err
+        for err in errors
+    )
+
+
+def test_quality_ledger_parity_rejects_current_gate_row_with_unknown() -> None:
+    status = status_payload()
+    html = minimal_ledger_html(refusal_gate_status="UNKNOWN")
+
+    errors = parity_errors(status, html)
+
+    assert any(
+        "invalid visible status" in err and "refusal_delta_evidence_present" in err
+        for err in errors
+    )
+
+
+def test_quality_ledger_parity_rejects_current_gate_row_with_blank_status() -> None:
+    status = status_payload()
+    html = minimal_ledger_html(refusal_gate_status="")
+
+    errors = parity_errors(status, html)
+
+    assert any(
+        "invalid visible status" in err and "refusal_delta_evidence_present" in err
+        for err in errors
+    )
+
+
+def test_quality_ledger_parity_requires_authoritative_gate_table_marker() -> None:
+    status = status_payload()
+    html = minimal_ledger_html(gate_table_attrs="")
+
+    errors = parity_errors(status, html)
+
+    assert any("no Gate/Status table found" in err for err in errors)
+    assert any("gate row missing" in err for err in errors)
+
+
+def test_quality_ledger_parity_requires_traceability_table_marker() -> None:
+    status = status_payload()
+    html = minimal_ledger_html(traceability_table_attrs="")
+
+    errors = parity_errors(status, html)
+
+    assert any("no Traceability Field/Value table found" in err for err in errors)
+
+
+def _pulse_ci_workflow_text() -> str:
+    return (REPO_ROOT / ".github" / "workflows" / "pulse_ci.yml").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_pulse_report_upload_is_gated_on_quality_ledger_parity_success() -> None:
+    workflow = _pulse_ci_workflow_text()
+    parity_idx = workflow.index("Check Quality Ledger status parity before artifact upload")
+    upload_idx = workflow.index("name: Upload artifacts", parity_idx)
+    upload_block_end = workflow.find("\n\n  ", upload_idx)
+    if upload_block_end == -1:
+        upload_block_end = len(workflow)
+    parity_block = workflow[parity_idx:upload_idx]
+    upload_block = workflow[upload_idx:upload_block_end]
+
+    assert "id: quality_ledger_status_parity" in parity_block
+    assert "name: pulse-report" in upload_block
+    assert "if: always()" not in upload_block
+    assert "steps.quality_ledger_status_parity.outcome == 'success'" in upload_block


### PR DESCRIPTION
## Summary

Closes follow-up fail-closed gaps in the Quality Ledger/status parity guard.

This PR strengthens the public reader-surface parity path so that:

- spoofed gate-like diagnostic tables cannot satisfy gate parity,
- stale gate rows fail closed even with invalid visible statuses,
- public `pulse-report` upload is blocked if Quality Ledger parity fails.

This is a narrow PR-1b hotfix. It does not start the publication snapshot work.

## Changes

- Add explicit renderer markers to authoritative Quality Ledger gate-status tables.
- Add an explicit renderer marker to the Traceability table.
- Preserve HTML table attributes in the parity checker.
- Require explicit `data-pulse-ledger-table` markers for authoritative table detection.
- Restrict authoritative gate tables to the renderer’s actual gate sections.
- Collect all authoritative gate rows by gate id, including rows with invalid visible statuses.
- Fail closed on:
  - stale gate rows absent from final `status.json["gates"]`,
  - missing current gate rows,
  - duplicate current gate rows,
  - current gate rows with non-`PASS` / non-`FAIL` visible statuses,
  - missing authoritative gate markers,
  - missing Traceability marker,
  - duplicate or conflicting Traceability identity rows.
- Gate public `pulse-report` artifact upload on Quality Ledger parity success.
- Add regression coverage for spoofed Diagnostics gate tables, stale `UNKNOWN` / `PENDING` rows, invalid current statuses, required markers, and workflow upload gating.

## Authority boundary

Reader-surface hardening only.

This PR does not:

- change release-authority semantics,
- add new gates,
- change declared gate policy,
- change the gate registry,
- change `check_gates.py`,
- promote Quality Ledger into release authority,
- promote Pages into release authority,
- add Sigstore / SLSA / in-toto / signing,
- create a second release-decision engine.

The primary release-authority path remains unchanged:

```text
recorded release evidence
→ status artifact
→ declared gate policy
→ workflow-effective materialized required gates
→ strict fail-closed CI
→ allow/block release decision