### PR TITLE
fix(ci): pin pulse-report upload artifact action

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1885,7 +1885,7 @@ jobs:
       
       - name: Upload artifacts
         if: ${{ always() && steps.quality_ledger_final_render.outcome == 'success' && steps.quality_ledger_status_parity.outcome == 'success' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
         with:
           name: pulse-report
           if-no-files-found: warn


### PR DESCRIPTION
Fixed the remaining post-merge verification finding.

The public `pulse-report` upload step now pins `actions/upload-artifact`
to the repo-standard full SHA used by surrounding upload-artifact steps:

`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`

The parity-gated upload condition is unchanged:

- final Quality Ledger render must succeed,
- Quality Ledger/status parity must succeed,
- normal gate-failure diagnostics remain uploadable when parity succeeds.

Boundary unchanged: reader-surface hardening only; no release-authority semantics change.