### PR TITLE
docs(cleanup): normalize PULSE terminology boundary register

### DIFF
--- a/docs/PULSE_TERMINOLOGY_RISK_REGISTER_v0.md
+++ b/docs/PULSE_TERMINOLOGY_RISK_REGISTER_v0.md
@@ -2,23 +2,55 @@
 
 ## Purpose
 
-This document records terminology that can cause PULSE to be misread outside the PULSEmech category boundary.
+This document records terminology that can cause PULSE to be misread outside the
+PULSEmech category boundary.
 
 It is a terminology boundary-control document.
 
-It protects PULSE from being reframed as governance, compliance, dashboard, MLOps, adoption, maturity, or supply-chain tooling.
+It protects PULSE from being reframed as:
 
-It does not change release authority.
+```text
+governance
+compliance
+dashboard
+MLOps
+runtime guardrail
+adoption project
+maturity project
+enterprise platform
+supply-chain framework
+```
 
-This document does not prohibit controlled use of these terms.
+This document does not ban controlled use of these terms.
 
-It defines where these terms are allowed, and where they must not be used as PULSE identity descriptors.
+It defines where these terms are allowed, and where they must not be used as
+PULSE identity descriptors.
+
+This document does not change release authority.
+
+It does not change:
+
+```text
+PULSEmech decision semantics
+gate policy
+required gate wiring
+check_gates.py behavior
+status schema
+CI allow/block behavior
+Quality Ledger renderer behavior
+artifact provenance binding behavior
+attestation workflow behavior
+release tags
+DOI / Zenodo path
+publication paths
+```
 
 ## Canonical identity
 
-PULSEmech is an artifact-bound release-authority mechanism for AI release decisions.
+PULSEmech is an artifact-bound release-authority mechanism for AI release
+decisions.
 
-The authority path is:
+The PULSEmech authority path is:
 
 ```text
 recorded release evidence
@@ -29,36 +61,89 @@ recorded release evidence
 → pre-deployment allow/block release decision
 ```
 
-## Terms that require boundary control
+PULSE-facing identity text should resolve to:
 
-The following terms may appear only when their scope is explicit and they are not used as PULSE identity descriptors.
+```text
+PULSEmech = artifact-bound release-authority mechanism for AI release decisions
+```
+
+not to:
+
+```text
+governance framework
+compliance framework
+dashboard
+MLOps platform
+runtime guardrail
+supply-chain framework
+adoption maturity project
+enterprise maturity project
+```
+
+## Identity descriptor rule
+
+A term is unsafe as a PULSE identity descriptor when it causes the reader to
+classify PULSE primarily as:
+
+```text
+institutional governance
+legal compliance
+quality dashboard
+MLOps platform
+runtime guardrail
+supply-chain framework
+enterprise control plane
+adoption project
+maturity project
+```
+
+A term is acceptable when it is explicitly scoped as:
+
+```text
+external context
+supporting hardening layer
+reader surface
+review carrier
+trace carrier
+audit carrier
+legacy alias
+repository stewardship
+deployment context
+```
+
+The distinction must be explicit.
+
+## Terms that require boundary control
 
 | Term | Risk | Allowed use |
 |---|---|---|
-| governance | Can make PULSE appear to be an institutional control model | External AI-governance literature, repository stewardship, or legacy alias only |
+| governance | Can make PULSE appear to be an institutional control model | External AI-governance literature, repository stewardship, maintainer process, organizational adoption, or legacy alias only |
 | release governance | Can replace release authority with process language | Avoid in PULSE-facing identity text |
 | governance framework | Can make PULSE appear to be a compliance framework | Avoid for PULSE identity |
+| compliance | Can make PULSE appear to be a legal or regulatory compliance system | Use only as external adoption context |
 | control plane | Can make PULSE appear to be an enterprise platform | Use only with explicit release-authority boundary |
-| maturity | Can make repository hardening appear to define PULSE | Use only for external maturity or repository hardening |
-| supply-chain framework | Can make PULSE appear to be SLSA / in-toto / Sigstore equivalent | Use only as external hardening context |
-| dashboard | Can make reader surfaces appear authoritative | Use only for reader / publication surfaces |
+| enterprise platform | Can make PULSEmech appear to be an enterprise software product category | Use only when discussing deployment packaging or integration environment |
+| MLOps platform | Can make PULSE appear to be lifecycle orchestration tooling | Use only as external comparison or integration context |
+| dashboard | Can make reader surfaces appear authoritative | Use only for reader, publication, or diagnostic surfaces |
+| Quality Ledger | Can make PULSE appear to be a quality-assurance dashboard | Use only as a reader carrier over recorded `status.json`; never as release authority |
 | runtime guardrail | Can move PULSE away from pre-deployment release authority | Use only as contrast or external category |
-| compliance | Can make PULSE appear to be a legal compliance system | Use only as external adoption context |
-| adoption metrics | Can be misread as mechanical validity metrics | Use only as ecosystem visibility / uptake signals |
-| Quality Ledger | Can make PULSE appear to be a quality-assurance dashboard or evaluation report | Use only as a reader carrier over recorded `status.json`; never as release authority |
-| Safe & Useful AI | Can make PULSE appear to define safety or usefulness as a broad governance framework | Use only as release-domain wording; PULSE checks recorded release evidence, not general safety meaning |
+| supply-chain framework | Can make PULSE appear to be SLSA / Sigstore / in-toto equivalent | Use only as external hardening context |
+| hardening layer | Can be misread as PULSEmech definition | Use only as surrounding repository, security, artifact, verifier, or operational hardening |
+| maturity | Can make repository hardening appear to define PULSE | Use only for external maturity, repository hardening, or deployment readiness |
+| industrial maturity | Can make PULSEmech appear to be defined by enterprise adoption status | Use only as an external deployment or adoption dimension |
+| productization maturity | Can make PULSEmech appear to be measured as a plug-and-play product category | Use only for packaging, operational support, or deployment readiness around PULSEmech |
+| industrial standard | Can make PULSEmech appear to require broad market adoption before its mechanism can be evaluated | Use only for ecosystem/adoption status, not for mechanical validity |
+| adoption metrics | Can be misread as mechanical validity metrics | Use only as ecosystem visibility or uptake signal |
+| third-party integration / adoption | Can be misread as PULSEmech identity or mechanical maturity | Use only as deployment/adoption context around PULSEmech |
 | policy | Can be misread as organizational or management policy | In PULSE-facing text, use only as declared gate policy tied to materialized required gates |
 | evaluation / eval | Can make evidence producers appear to be the PULSE mechanism itself | Use only as evidence-producing or diagnostic context unless recorded, declared, materialized, and enforced |
-| ecosystem around PULSE | Can make surrounding dashboards, reports, evals, docs, or workflows appear to be PULSE identity | Use only as supporting context around the PULSEmech authority path |
-| industrial maturity | Can make PULSEmech appear to be defined by enterprise / production adoption status | Use only as an external deployment or adoption dimension; not as PULSEmech identity |
-| productization maturity | Can make PULSEmech appear to be measured as a plug-and-play product category | Use only for packaging, operational support, or deployment readiness around PULSEmech |
-| enterprise platform | Can make PULSEmech appear to be an enterprise software product category | Use only when discussing deployment packaging or integration environment, not the release-authority mechanism |
-| industrial standard | Can make PULSEmech appear to require broad market adoption before its mechanism can be evaluated | Use only for ecosystem/adoption status; not for mechanical validity |
+| external evidence presence | Can be misread as materialized release evidence | Use only as artifact/file presence unless mapped into the declared PULSEmech path |
 | release-grade lane eligibility | Can be misread as release permission or CI allow outcome | Use only as lane/materialization review status; never as release permission |
-| external evidence presence | Can be misread as materialized release evidence | Use only as artifact/file presence unless recorded, parseable, subject-bound, freshness-bound when required, mapped by declared rules, folded into status/gate state, and enforced when release-required |
 | publication exposure | Can be misread as release authority | Use only as public/private artifact classification; publication does not authorize release |
-| third-party integration / adoption | Can be misread as PULSEmech identity or mechanical maturity | Use only as deployment/adoption context around PULSEmech; not as PULSEmech identity |
-| hardening layer | Can be misread as PULSEmech definition | Use only as surrounding repository, security, artifact, verifier, or operational hardening; not as the PULSEmech mechanism definition |
+| ecosystem around PULSE | Can make surrounding dashboards, reports, evals, docs, or workflows appear to be PULSE identity | Use only as supporting context around the PULSEmech authority path |
+| Safe & Useful AI | Can make PULSE appear to define safety or usefulness as a broad governance framework | Use only as release-domain wording; PULSE checks recorded release evidence, not general safety meaning |
+| trace carrier | Can be misread as a second release-decision engine | Use only for reconstruction, audit, and review support |
+| audit carrier | Can be misread as a second release-decision engine | Use only for preservation and inspection support |
 
 ## Preferred PULSE-facing descriptors
 
@@ -77,6 +162,7 @@ carrier boundary
 reader carrier
 trace carrier
 binding carrier
+audit carrier
 external verification carrier
 ```
 
@@ -92,9 +178,11 @@ dashboard
 runtime guardrail
 supply-chain framework
 institutional governance model
+enterprise maturity platform
+adoption maturity project
 ```
 
-## Governance term boundary
+## Governance and compliance boundary
 
 The term `governance` is not banned.
 
@@ -105,7 +193,8 @@ external AI-governance literature
 repository stewardship
 maintainer process
 organizational adoption
-legacy filename or legacy workshop alias
+legacy filename
+legacy workshop alias
 ```
 
 It must not be used as the primary descriptor for PULSE identity.
@@ -128,97 +217,106 @@ Preferred PULSE-facing identity:
 PULSEmech is an artifact-bound release-authority mechanism.
 ```
 
-## Adoption boundary
-
-Adoption metrics are not mechanical validity metrics.
-
-Stars, forks, downloads, community uptake, and external usage may describe ecosystem visibility.
-
-They do not determine whether the PULSEmech release-authority path is mechanically valid.
-
-They also do not define PULSEmech identity.
-
-Boundary lock:
-
-```text
-third-party integration / adoption
-≠ PULSEmech identity
-```
-
-Correct classification:
-
-```text
-low adoption
-= adoption / ecosystem signal
-```
-
-Incorrect classification:
-
-```text
-low adoption
-= weak release-authority mechanism
-```
-## Industrial / productization maturity boundary
-
-Industrial maturity, productization maturity, enterprise platform status, and industrial standard status are external adoption or deployment dimensions.
-
-They do not define PULSEmech.
-
-PULSEmech remains an artifact-bound release-authority mechanism for AI release decisions.
-
-The PULSEmech authority path remains:
-
-```text
-recorded release evidence
-→ status.json
-→ declared gate policy
-→ workflow-effective materialized required gate set
-→ strict fail-closed CI enforcement
-→ pre-deployment allow/block release decision
-```
-
-Industrialization may add operational requirements around PULSEmech.
-
-It does not define the mechanism.
-
-## Release-grade lane eligibility boundary
-
-Release-grade lane eligibility is not release permission.
-
-A release-grade materialized lane may define whether a recorded run is
-structurally eligible for release-grade review.
-
-It does not authorize release.
-
-Release permission remains produced only by the PULSEmech authority path:
-
-```text
-recorded release evidence
-→ status.json
-→ declared gate policy
-→ workflow-effective materialized required gate set
-→ strict fail-closed CI enforcement
-→ pre-deployment allow/block release decision
-```
-
-Boundary lock:
-
-```text
-release-grade lane eligibility ≠ release permission
-```
+The term `compliance` is also not banned, but it must not define PULSE identity.
 
 Correct use:
 
 ```text
-release-grade lane eligibility as materialization review status
+Compliance teams may inspect PULSE artifacts as external review material.
 ```
 
 Incorrect use:
 
 ```text
-release-grade lane eligibility as release permission
-release-grade lane eligibility as CI allow outcome
-release-grade lane eligibility as a second release-decision engine
+PULSE is a compliance framework.
+```
+
+## Reader surface and Quality Ledger boundary
+
+Reader carriers may display, summarize, or explain recorded state.
+
+They do not create release authority.
+
+Examples of reader carriers:
+
+```text
+Quality Ledger
+Markdown summary
+JSON summary
+public Pages surface
+dashboard-style view
+rendered report
+badge
+```
+
+The Quality Ledger is a reader carrier.
+
+It displays or summarizes recorded release-state artifacts.
+
+It does not replace:
+
+```text
+status.json
+declared gate policy
+workflow-effective materialized required gate set
+strict fail-closed CI enforcement
+```
+
+Boundary lock:
+
+```text
+reader surface ≠ release authority
+Quality Ledger ≠ release authority
+dashboard ≠ release authority
+publication exposure ≠ release authority
+```
+
+Correct use:
+
+```text
+Quality Ledger reader surface over recorded status.json.
+```
+
+Incorrect use:
+
+```text
+Quality Ledger as the release authority.
+Quality Ledger as the source of release permission.
+Dashboard as the CI allow/block decision.
+Public Pages output as release authority.
+```
+
+## Publication exposure boundary
+
+Publication exposure is not release authority.
+
+A public artifact, public status surface, Pages output, report, badge, dashboard,
+or reader surface does not authorize release by being public.
+
+A public artifact may support review only when it is bound into the recorded
+release-state relation and its mechanical effect is defined through declared
+policy, materialized gates, and strict CI enforcement.
+
+Boundary lock:
+
+```text
+publication exposure ≠ release authority
+public visibility ≠ release authority
+public status visibility ≠ CI allow outcome
+```
+
+Correct use:
+
+```text
+public artifact as reader surface, recorded artifact, or review carrier
+```
+
+Incorrect use:
+
+```text
+public artifact as release permission
+public Pages output as release authority
+public status visibility as CI allow outcome
 ```
 
 ## External evidence materialization boundary
@@ -229,10 +327,18 @@ A detector output, external summary, metric key, report, external packet, or
 third-party review artifact may exist without becoming materialized release
 evidence.
 
-External evidence becomes release-relevant only when it is recorded, parseable,
-source-identified, subject-bound, freshness-bound when required, mapped by
-declared rules, folded into status or gate state deterministically, and enforced
-by strict CI when release-required.
+External evidence becomes release-relevant only when it is:
+
+```text
+recorded as release evidence
+parseable
+source-identified
+subject-bound
+freshness-bound when required
+mapped by declared rules
+folded into status or gate state deterministically
+enforced by strict CI when release-required
+```
 
 Presence alone does not satisfy release-required evidence.
 
@@ -240,6 +346,8 @@ Boundary lock:
 
 ```text
 external evidence presence ≠ materialization
+summary file presence ≠ release evidence
+aggregate pass ≠ release permission
 ```
 
 Correct use:
@@ -259,44 +367,200 @@ unknown summary file as release-grade evidence
 absence of known failures as release permission
 ```
 
-## Publication exposure boundary
+## Declared gate policy boundary
 
-Publication exposure is not release authority.
+In PULSE-facing text, `policy` means declared gate policy.
 
-A public artifact, public status surface, Pages output, report, badge, dashboard,
-or reader surface does not authorize release by being public.
-
-A public artifact may support review only when it is bound into the recorded
-release-state relation and its mechanical effect is defined through declared
-policy, materialized gates, and strict CI enforcement.
-
-Boundary lock:
+It does not mean:
 
 ```text
-publication exposure ≠ release authority
+organizational policy
+management policy
+compliance policy
+institutional governance
+human approval preference
 ```
+
+A declared gate policy is release-relevant only when it is used to materialize the
+required gate set enforced by strict fail-closed CI.
 
 Correct use:
 
 ```text
-public artifact as reader surface, recorded artifact, or review carrier
+declared gate policy
+→ workflow-effective materialized required gate set
+→ strict fail-closed CI enforcement
 ```
 
 Incorrect use:
 
 ```text
-public artifact as release permission
-public Pages output as release authority
-public status visibility as CI allow outcome
+policy as broad organizational governance
+policy as a management framework
+policy as human approval preference
 ```
 
-## Third-party integration / adoption boundary
+## Release-grade lane eligibility boundary
 
-Third-party integration / adoption is not PULSEmech identity.
+Release-grade lane eligibility is not release permission.
 
-External verifier tooling, onboarding, deployment packaging, example
-repositories, enterprise integration, third-party adoption, and productization
-support may exist around PULSEmech.
+A release-grade materialized lane may define whether a recorded run, artifact,
+workflow, or repository path is structurally eligible for release-grade review.
+
+It does not authorize release.
+
+Release permission exists only when the enforced PULSEmech authority path reaches
+a pre-deployment allow decision.
+
+Boundary lock:
+
+```text
+release-grade lane eligibility ≠ release permission
+release-grade lane eligibility ≠ CI allow outcome
+release-grade lane eligibility ≠ second release-decision engine
+```
+
+Correct use:
+
+```text
+release-grade lane eligibility as materialization review status
+```
+
+Incorrect use:
+
+```text
+release-grade lane eligibility as release permission
+release-grade lane eligibility as CI allow outcome
+release-grade lane eligibility as a second release-decision engine
+```
+
+## Runtime guardrail boundary
+
+PULSE acts at the release boundary before deployment.
+
+Runtime guardrails act during live interaction or runtime execution.
+
+Boundary lock:
+
+```text
+PULSEmech release boundary ≠ runtime interaction boundary
+```
+
+Correct use:
+
+```text
+runtime guardrail as an external contrast category
+```
+
+Incorrect use:
+
+```text
+PULSE as a runtime guardrail
+PULSEmech as prompt-level refusal routing
+PULSEmech as live interaction moderation
+```
+
+## Adoption and maturity boundary
+
+Adoption metrics are not mechanical validity metrics.
+
+Stars, forks, downloads, community uptake, third-party integration, and external
+usage may describe ecosystem visibility.
+
+They do not determine whether the PULSEmech release-authority path is
+mechanically valid.
+
+Industrial maturity, productization maturity, enterprise platform status, and
+industrial standard status are external adoption or deployment dimensions.
+
+They do not define PULSEmech.
+
+Boundary lock:
+
+```text
+third-party integration / adoption ≠ PULSEmech identity
+low adoption ≠ weak release-authority mechanism
+industrial maturity ≠ PULSEmech definition
+productization maturity ≠ PULSEmech definition
+enterprise platform status ≠ PULSEmech identity
+```
+
+Correct classification:
+
+```text
+low adoption = adoption / ecosystem signal
+```
+
+Incorrect classification:
+
+```text
+low adoption = weak release-authority mechanism
+enterprise integration as proof of mechanical validity
+onboarding maturity as release-authority definition
+```
+
+## Hardening and supply-chain boundary
+
+Repository hardening may strengthen the operating environment around PULSEmech.
+
+Examples:
+
+```text
+branch protection
+dependency locking
+dependency single truth
+packaging layout
+clean-install validation
+workflow hardening
+signing
+SLSA
+Sigstore
+in-toto
+artifact attestations
+provenance attestations
+public/private artifact classification
+verifier hardening
+publication-surface clarity
+```
+
+These layers are supporting layers.
+
+They do not define PULSEmech.
+
+PULSEmech is not a supply-chain framework.
+
+PULSEmech is a release-authority mechanism for AI release decisions.
+
+Boundary lock:
+
+```text
+hardening layer ≠ PULSE identity
+hardening layer ≠ PULSEmech definition
+supply-chain hardening ≠ PULSEmech definition
+SLSA / Sigstore / in-toto ≠ PULSE identity
+```
+
+Correct use:
+
+```text
+hardening layer as surrounding boundary, security, artifact, verifier, or
+operational strengthening
+```
+
+Incorrect use:
+
+```text
+hardening layer as PULSEmech identity
+maturity layer as PULSEmech definition
+deployment hardening as release-authority mechanism
+supply-chain framework as PULSE identity
+```
+
+## Third-party integration boundary
+
+External verifier tooling, onboarding, deployment packaging, example repositories,
+enterprise integration, third-party adoption, and productization support may
+exist around PULSEmech.
 
 They do not define PULSEmech.
 
@@ -320,239 +584,10 @@ enterprise integration as proof of mechanical validity
 onboarding maturity as release-authority definition
 ```
 
-## Hardening layer definition boundary
-
-A hardening layer is not PULSEmech definition.
-
-Security hardening, verifier hardening, artifact-boundary docs, public/private
-classification, external evidence materialization rules, dependency hardening,
-attestation, packaging, or operational maturity may strengthen the repository
-around PULSEmech.
-
-They do not redefine PULSEmech.
-
-Boundary lock:
-
-```text
-hardening layer ≠ PULSEmech definition
-```
-
-Correct use:
-
-```text
-hardening layer as surrounding boundary, security, artifact, or operational
-strengthening
-```
-
-Incorrect use:
-
-```text
-hardening layer as PULSEmech identity
-maturity layer as PULSEmech definition
-deployment hardening as release-authority mechanism
-```
-
-## Release-grade lane eligibility boundary
-
-Release-grade lane eligibility means that an artifact, workflow, or repository path is eligible to be evaluated under release-grade gates.
-
-It does not by itself grant release permission.
-
-Boundary lock:
-
-```text
-release-grade lane eligibility
-≠ release permission
-```
-
-Release permission exists only when the enforced PULSEmech authority path reaches a pre-deployment allow decision.
-
-## External evidence materialization boundary
-
-External evidence may exist before it is release-relevant.
-
-Presence alone does not mean the evidence has materialized into a required gate.
-
-Boundary lock:
-
-```text
-external evidence presence
-≠ materialization
-```
-
-External evidence becomes release-relevant only when it is:
-
-```text
-recorded as release evidence
-referenced by declared gate policy
-materialized as a required gate
-enforced through strict fail-closed CI
-```
-
-
-## Hardening boundary
-
-Repository hardening, branch protection, dependency locking, signing, SLSA, Sigstore, in-toto, and attestation may strengthen the operating environment around PULSEmech.
-
-They do not define PULSE.
-
-Hardening documents must keep this distinction explicit:
-
-```text
-hardening layer
-≠ PULSE identity
-hardening layer
-≠ PULSEmech definition
-```
-
-The PULSEmech identity remains:
-
-```text
-artifact-bound release-authority mechanism
-```
-
-## Public surface boundary
-
-Public Pages, Quality Ledger, summaries, dashboards, and rendered reports are reader or publication surfaces unless explicitly bound to recorded release-decision artifacts.
-
-They are not the PULSEmech authority path.
-
-Public visibility, publication, or exposure does not create release authority.
-
-Boundary lock:
-
-```text
-publication exposure
-≠ release authority
-```
-
-
-The PULSEmech authority path remains:
-
-```text
-status.json
-→ declared gate policy
-→ workflow-effective materialized required gate set
-→ strict fail-closed CI enforcement
-```
-
-## Supply-chain hardening boundary
-
-SLSA, Sigstore, in-toto, artifact attestations, signing, and provenance frameworks may strengthen external trust, reproducibility, and artifact verification around a release-grade path.
-
-They do not define PULSE.
-
-PULSEmech is not a supply-chain framework.
-
-PULSEmech is a release-authority mechanism for AI release decisions.
-
-## Reader carrier boundary
-
-Reader carriers may display, summarize, or explain recorded state.
-
-They do not create release authority.
-
-Examples of reader carriers:
-
-```text
-Quality Ledger
-summary Markdown
-summary JSON
-public Pages surface
-dashboard-style view
-rendered report
-```
-
-Reader carriers must not be described as the source of release authority.
-
-## Quality Ledger boundary
-
-The Quality Ledger is a reader carrier.
-
-It displays or summarizes recorded release-state artifacts.
-
-It does not create release authority.
-
-It does not replace:
-
-```text
-status.json
-declared gate policy
-workflow-effective materialized required gate set
-strict fail-closed CI enforcement
-```
-
-Correct use:
-
-```text
-Quality Ledger reader surface over recorded status.json
-```
-
-Incorrect use:
-
-```text
-Quality Ledger as the release authority
-Quality Ledger as the source of release permission
-Quality Ledger as a quality-assurance dashboard that decides release
-```
-
-## Safe & Useful AI boundary
-
-The phrase `Safe & Useful AI` names the release domain in which PULSE is applied.
-
-It does not mean that PULSE defines safety, usefulness, or general AI-governance policy.
-
-PULSE checks whether recorded release evidence satisfies declared gates.
-
-Correct use:
-
-```text
-PULSE applies artifact-bound release authority to Safe & Useful AI release decisions.
-```
-
-Incorrect use:
-
-```text
-PULSE is a general Safe & Useful AI governance framework.
-```
-
-The PULSEmech authority path remains:
-
-```text
-recorded release evidence
-→ status.json
-→ declared gate policy
-→ workflow-effective materialized required gate set
-→ strict fail-closed CI enforcement
-→ pre-deployment allow/block release decision
-```
-
-## Declared gate policy boundary
-
-In PULSE-facing text, `policy` means declared gate policy.
-
-It does not mean organizational policy, management policy, compliance policy, or institutional governance.
-
-A declared gate policy is release-relevant only when it is used to materialize the required gate set enforced by strict fail-closed CI.
-
-Correct use:
-
-```text
-declared gate policy
-→ workflow-effective materialized required gate set
-```
-
-Incorrect use:
-
-```text
-policy as broad organizational governance
-policy as a management framework
-policy as human approval preference
-```
-
 ## Ecosystem boundary
 
-Dashboards, reports, evals, external detectors, reader surfaces, docs, and review artifacts may exist around PULSE.
+Dashboards, reports, evals, external detectors, reader surfaces, docs, and
+review artifacts may exist around PULSE.
 
 They are not PULSE identity.
 
@@ -584,44 +619,51 @@ release_authority_v0.json
 audit bundle
 external verification packet
 normative/shadow inventory report
-artifact provenance binding review output
+artifact provenance binding
+review output
+publication snapshot
 ```
 
 These carriers support review.
 
 They do not replace the PULSEmech authority path.
 
-## Identity descriptor rule
-
-A term is unsafe as a PULSE identity descriptor when it causes the reader to classify PULSE primarily as:
+Boundary lock:
 
 ```text
-institutional governance
-compliance
-dashboard
-MLOps
-runtime guardrail
-supply-chain framework
-enterprise control plane
-adoption maturity project
+trace carrier ≠ release authority
+audit carrier ≠ release authority
+external review ≠ release authority
+publication snapshot ≠ release authority
 ```
 
-A term is acceptable when it is scoped as:
+## Safe & Useful AI boundary
+
+The phrase `Safe & Useful AI` names the release domain in which PULSE is applied.
+
+It does not mean that PULSE defines safety, usefulness, or general AI-governance
+policy.
+
+PULSE checks whether recorded release evidence satisfies declared gates.
+
+Correct use:
 
 ```text
-external context
-supporting hardening layer
-reader surface
-review carrier
-legacy alias
-repository stewardship
+PULSE applies artifact-bound release authority to Safe & Useful AI release
+decisions.
 ```
 
-The distinction must be explicit.
+Incorrect use:
+
+```text
+PULSE is a general Safe & Useful AI governance framework.
+```
 
 ## Boundary held by this document
 
-This document does not change:
+This document holds a terminology boundary only.
+
+It does not change:
 
 ```text
 PULSEmech decision semantics
@@ -635,6 +677,7 @@ artifact provenance binding behavior
 attestation workflow behavior
 release tags
 DOI / Zenodo path
+publication paths
 ```
 
 ## Final rule
@@ -655,4 +698,5 @@ MLOps platform
 runtime guardrail
 supply-chain framework
 adoption maturity project
+enterprise maturity project
 ```


### PR DESCRIPTION
## Summary

This PR normalizes `docs/PULSE_TERMINOLOGY_RISK_REGISTER_v0.md` as a clean
terminology boundary-control document.

It keeps the canonical PULSEmech identity centered:

```text
PULSEmech = artifact-bound release-authority mechanism for AI release decisions
```

and preserves the authority path:

```text
recorded release evidence
→ status.json
→ declared gate policy
→ workflow-effective materialized required gate set
→ strict fail-closed CI enforcement
→ pre-deployment allow/block release decision
```

## What changed

- Cleaned and normalized the terminology boundary register.
- Preserved controlled use of risky terms such as:
  - governance
  - compliance
  - dashboard
  - MLOps
  - runtime guardrail
  - adoption
  - maturity
  - supply-chain framework
- Clarified that those terms may be used only with explicit boundary scope.
- Clarified that those terms must not become PULSE identity descriptors.
- Clarified boundaries for:
  - reader surfaces
  - Quality Ledger
  - publication exposure
  - external evidence materialization
  - declared gate policy
  - release-grade lane eligibility
  - runtime guardrails
  - adoption and maturity
  - hardening and supply-chain context
  - third-party integration
  - trace and audit carriers
  - Safe & Useful AI wording

## Boundary

This is a docs-only terminology cleanup.

This PR does not change:

```text
PULSEmech decision semantics
gate policy
required gate wiring
check_gates.py behavior
status schema
CI allow/block behavior
Quality Ledger renderer behavior
artifact provenance binding behavior
attestation workflow behavior
release tags
DOI / Zenodo path
publication paths
```

## Reason

External readers and automated research or review tools can misclassify PULSE as
a governance framework, dashboard, MLOps platform, runtime guardrail, adoption
project, maturity project, enterprise platform, or supply-chain framework.

This document keeps those terms available for controlled context, but prevents
them from becoming PULSE identity descriptors.

The goal is to reduce category confusion without weakening or expanding the
PULSEmech authority path.

## Testing

Not run.

Docs-only change.

No code, schema, workflow, or CI behavior changed.