### PR TITLE
docs(kaggle): add runtime evidence matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
 # PULSE — Artifact-Bound Release Authority for AI Release Decisions
 
+
+## 🚀 Runtime Evidence: Separating Execution from Release Authority
+
+### PULSEmech Runtime Evidence Matrix
+
+These public Kaggle runs demonstrate PULSEmech as an executable instrument, not
+only as a documentation pattern.
+
+They show that release authority can be represented as a measurable,
+artifact-bound pre-deployment state: recorded evidence is evaluated against
+declared policy, materialized gates are enforced, and the runtime exits through
+the authorized or fail-closed path.
+
+The system does not rely on assumptions or post-event logging; it validates the
+pre-deployment boundary directly in the runtime environment.
+
+Ordinary CI execution proves that commands ran.
+
+PULSEmech runtime evidence shows whether the pre-deployment authority boundary
+opened or remained closed under declared evidence and policy.
+
 - [PULSE Kaggle Run 0 Capture Smoke v0](https://www.kaggle.com/code/horvathkatalin/pulse-kaggle-run-0-capture-smoke-v0) — diagnostic capture smoke for SHA-256-bound, non-authoritative PULSEmech review artifacts.✨
 
 - [PULSEmech Explainable Evidence Transform Demo v0](https://www.kaggle.com/code/horvathkatalin/pulsemech-explainable-evidence-transform-demo-v0) — human-readable diagnostic demo of raw observations transformed into SHA-256-bound PULSEmech review artifacts.✨


### PR DESCRIPTION
## Summary

This PR adds a Kaggle runtime evidence matrix above the public Kaggle proof
surfaces.

The new section frames the Kaggle runs as executable PULSEmech proof surfaces:
they show that release authority can be represented as a measurable,
artifact-bound pre-deployment state while preserving the boundary between
runtime execution, diagnostic evidence, and release authority.

## What changed

- Added a runtime evidence introduction for the Kaggle proof surfaces.
- Clarified the distinction between ordinary CI execution and PULSEmech release
  authority.
- Added the core runtime boundary sentence:

```text
The system does not rely on assumptions or post-event logging; it validates the
pre-deployment boundary directly in the runtime environment.
```

- Documented the runtime transition:

```text
recorded evidence
→ declared policy
→ materialized gate check
→ deterministic exit state
→ reviewable artifact
```

- Preserved the PULSEmech authority path:

```text
recorded release evidence
→ status.json
→ declared gate policy
→ workflow-effective materialized required gate set
→ strict fail-closed CI enforcement
→ pre-deployment allow/block release decision
```

- Added / exposed the Kaggle runtime proof surfaces for:
  - Exit Code 0 — Authorized Path
  - Exit Code 1 — Fail-Closed Enforcement
  - Evidence Transform / Artifact Binding Path

## Boundary

This PR does not make Kaggle a release authority carrier.

The Kaggle runs are public runtime proof surfaces.

They demonstrate executable behavior and evidence transitions, but they do not
replace the PULSEmech authority path.

This PR preserves the boundary that:

```text
Kaggle run ≠ verifier
notebook output ≠ verified evidence
digest match ≠ relation satisfaction
metric score ≠ gate materialization
packet preview ≠ release authority
diagnostic artifact ≠ release authority
```

## Scope

Docs-only change.

This PR does not change:

```text
PULSEmech decision semantics
gate policy
required gate wiring
check_gates.py behavior
status schema
CI allow/block behavior
Quality Ledger renderer behavior
artifact provenance binding behavior
attestation workflow behavior
release tags
publication paths
```

This PR does not add:

```text
new release semantics
new gate policy behavior
new authority carrier
new PULSE capability
new CI behavior
new workflow behavior
```

## Link requirement

All Kaggle entries should use real public Kaggle run links.

No placeholder Kaggle links should remain in the published README or docs.

## Reason

The public Kaggle runs demonstrate PULSEmech as an executable instrument, not
only as a documentation pattern.

They show the practical separation between:

```text
ordinary execution
runtime evidence
diagnostic proof surface
release authority
```

This helps external readers see what the PULSE instrument does before evaluating
enterprise integration, onboarding, or deployment-specific wiring.

## Testing

Not run.

Docs-only change.

No code, schema, workflow, or CI behavior changed.