### PR TITLE
feat(ref): add fail-closed recorded release-evidence verifier v0

### DIFF
--- a/PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py
+++ b/PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+"""Verify recorded release evidence bindings for release-grade prerequisites.
+
+This checker validates that candidate detector materialization artifacts,
+canonical external summaries, and refusal-delta evidence are bound to:
+
+- the declared run identity
+- the declared policy context
+- the declared subject binding
+- trusted provenance expectations
+- the declared raw evidence digest
+- the manifest-declared gate materialization relations
+
+The checker is prerequisite-only.
+It does not compute release authority.
+It does not replace check_gates.py.
+It does not change status.json semantics, gate policy, or CI allow/block logic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPORT_SCHEMA_VERSION = "recorded_release_evidence_verifier_v0"
+REPORT_VERSION = "0.1.0"
+INPUT_MANIFEST_SCHEMA_VERSION = "release_evidence_input_manifest_v0"
+VERIFIED = "verified"
+FAILED = "failed"
+
+
+REQUIRED_BINDING_KEYS = ("git_sha", "run_key")
+
+
+def _load_json(path: Path, label: str, errors: list[str]) -> dict[str, Any] | None:
+    if not path.exists():
+        errors.append(f"{label} not found: {path}")
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - CLI should report parse errors clearly
+        errors.append(f"{label} is not valid JSON: {exc}")
+        return None
+    if not isinstance(data, dict):
+        errors.append(f"{label} must be a JSON object")
+        return None
+    return data
+
+
+def _section(
+    obj: dict[str, Any],
+    key: str,
+    errors: list[str],
+    label: str,
+) -> dict[str, Any]:
+    value = obj.get(key)
+    if not isinstance(value, dict):
+        errors.append(f"{label}.{key} must be an object")
+        return {}
+    return value
+
+
+def _list_section(
+    obj: dict[str, Any],
+    key: str,
+    errors: list[str],
+    label: str,
+) -> list[Any]:
+    value = obj.get(key)
+    if not isinstance(value, list):
+        errors.append(f"{label}.{key} must be an array")
+        return []
+    return value
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _hex_digest(value: Any) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(
+        c in "0123456789abcdef" for c in value.lower()
+    )
+
+
+def _normalize_gate_list(value: Any) -> set[str]:
+    if not isinstance(value, list):
+        return set()
+    return {str(item) for item in value}
+
+
+def _binding_matches(
+    actual: dict[str, Any],
+    expected: dict[str, Any],
+    label: str,
+    errors: list[str],
+) -> bool:
+    ok = True
+    for key in REQUIRED_BINDING_KEYS:
+        expected_value = expected.get(key)
+        actual_value = actual.get(key)
+        if actual_value != expected_value:
+            errors.append(
+                f"{label}.{key} mismatch: expected {expected_value!r}, got {actual_value!r}"
+            )
+            ok = False
+    return ok
+
+
+def _policy_binding_matches(
+    actual: dict[str, Any],
+    expected: dict[str, Any],
+    label: str,
+    errors: list[str],
+) -> bool:
+    ok = True
+    for key in ("policy_set", "policy_sha256"):
+        expected_value = expected.get(key)
+        actual_value = actual.get(key)
+        if actual_value != expected_value:
+            errors.append(
+                f"{label}.{key} mismatch: expected {expected_value!r}, got {actual_value!r}"
+            )
+            ok = False
+    return ok
+
+
+def _build_empty_report(
+    manifest_path: Path,
+    manifest_sha256: str | None,
+    manifest: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "report_version": REPORT_VERSION,
+        "status": FAILED,
+        "manifest": {
+            "path": str(manifest_path),
+            "sha256": manifest_sha256,
+            "schema_version": None if manifest is None else manifest.get("schema_version"),
+        },
+        "run_identity": None if manifest is None else manifest.get("run_identity"),
+        "subject": None if manifest is None else manifest.get("subject"),
+        "policy_binding": None if manifest is None else manifest.get("policy_binding"),
+        "registry_binding": None if manifest is None else manifest.get("registry_binding"),
+        "verified_subjects": {},
+        "evidence_results": {},
+        "relation_binding_results": {},
+        "gate_materialization_admissibility": {},
+        "errors": [],
+    }
+
+
+def check_recorded_release_evidence(
+    manifest_path: Path,
+    repo_root: Path,
+) -> dict[str, Any]:
+    errors: list[str] = []
+    manifest = _load_json(manifest_path, "release_evidence_input_manifest_v0.json", errors)
+    manifest_sha256 = _sha256_file(manifest_path) if manifest_path.exists() else None
+    report = _build_empty_report(manifest_path, manifest_sha256, manifest)
+    if manifest is None:
+        report["errors"] = errors
+        return report
+
+    if manifest.get("schema_version") != INPUT_MANIFEST_SCHEMA_VERSION:
+        errors.append(
+            "manifest.schema_version must be "
+            f"{INPUT_MANIFEST_SCHEMA_VERSION!r}"
+        )
+
+    run_identity = _section(manifest, "run_identity", errors, "manifest")
+    subject = _section(manifest, "subject", errors, "manifest")
+    policy_binding = _section(manifest, "policy_binding", errors, "manifest")
+    candidate_evidence = _section(manifest, "candidate_evidence", errors, "manifest")
+    expected_relation_bindings = _section(
+        manifest,
+        "expected_relation_bindings",
+        errors,
+        "manifest",
+    )
+    expected_gate_materialization = _section(
+        manifest,
+        "expected_gate_materialization",
+        errors,
+        "manifest",
+    )
+
+    report["run_identity"] = run_identity
+    report["subject"] = subject
+    report["policy_binding"] = policy_binding
+    report["registry_binding"] = manifest.get("registry_binding")
+    report["verified_subjects"] = {
+        "git_sha": run_identity.get("git_sha"),
+        "run_key": run_identity.get("run_key"),
+        "commit_sha": subject.get("commit_sha"),
+    }
+
+    if run_identity.get("run_mode") != "prod":
+        errors.append(
+            "manifest.run_identity.run_mode must be 'prod' for recorded "
+            f"release-evidence verification (got {run_identity.get('run_mode')!r})"
+        )
+    if policy_binding.get("policy_set") != "required+release_required":
+        errors.append(
+            "manifest.policy_binding.policy_set must be 'required+release_required' "
+            f"(got {policy_binding.get('policy_set')!r})"
+        )
+    if not _hex_digest(policy_binding.get("policy_sha256")):
+        errors.append("manifest.policy_binding.policy_sha256 must be a 64-hex sha256")
+
+    evidence_results: dict[str, Any] = {}
+    verified_evidence_ids: set[str] = set()
+    candidate_artifacts: dict[str, dict[str, Any]] = {}
+
+    for evidence_id, candidate in candidate_evidence.items():
+        candidate_errors: list[str] = []
+        result: dict[str, Any] = {
+            "path": None,
+            "expected_sha256": None,
+            "actual_sha256": None,
+            "schema_version": None,
+            "status": FAILED,
+            "digest_match": False,
+            "schema_version_match": False,
+            "run_identity_match": False,
+            "subject_binding_match": False,
+            "policy_binding_match": False,
+            "trusted_producer_verified": False,
+            "raw_evidence_verified": False,
+            "required_for_gates_match": False,
+            "errors": candidate_errors,
+        }
+        evidence_results[evidence_id] = result
+
+        if not isinstance(candidate, dict):
+            errors.append(f"manifest.candidate_evidence.{evidence_id} must be an object")
+            candidate_errors.append("candidate manifest entry must be an object")
+            continue
+
+        path_value = candidate.get("path")
+        result["path"] = path_value
+        expected_sha256 = candidate.get("expected_sha256")
+        result["expected_sha256"] = expected_sha256
+        expected_schema_version = candidate.get("schema_version")
+        expected_binding = _section(
+            candidate,
+            "subject_binding",
+            candidate_errors,
+            f"manifest.candidate_evidence.{evidence_id}",
+        )
+        expected_required_gates = _normalize_gate_list(candidate.get("required_for_gates"))
+        trusted_required = (
+            _section(
+                candidate,
+                "provenance_expectations",
+                candidate_errors,
+                f"manifest.candidate_evidence.{evidence_id}",
+            ).get("trusted_producer_required")
+            is True
+        )
+
+        if candidate.get("verification_required") is not True:
+            candidate_errors.append(
+                "candidate evidence verification_required must be literal true"
+            )
+
+        if not isinstance(path_value, str) or not path_value:
+            candidate_errors.append("candidate evidence path must be a non-empty string")
+            continue
+
+        artifact_path = repo_root / path_value
+        if not artifact_path.exists():
+            candidate_errors.append(f"candidate artifact not found: {artifact_path}")
+            continue
+
+        actual_sha256 = _sha256_file(artifact_path)
+        result["actual_sha256"] = actual_sha256
+        if actual_sha256 == expected_sha256:
+            result["digest_match"] = True
+        else:
+            candidate_errors.append(
+                f"candidate artifact sha256 mismatch: expected {expected_sha256!r}, got {actual_sha256!r}"
+            )
+
+        artifact = _load_json(artifact_path, f"candidate artifact {evidence_id}", candidate_errors)
+        if artifact is None:
+            continue
+        candidate_artifacts[evidence_id] = artifact
+        result["schema_version"] = artifact.get("schema_version")
+
+        if artifact.get("schema_version") == expected_schema_version:
+            result["schema_version_match"] = True
+        else:
+            candidate_errors.append(
+                f"candidate artifact schema_version mismatch: expected {expected_schema_version!r}, got {artifact.get('schema_version')!r}"
+            )
+
+        artifact_run_identity = _section(
+            artifact,
+            "run_identity",
+            candidate_errors,
+            f"candidate artifact {evidence_id}",
+        )
+        if _binding_matches(
+            artifact_run_identity,
+            run_identity,
+            f"candidate artifact {evidence_id}.run_identity",
+            candidate_errors,
+        ) and artifact_run_identity.get("run_mode") == run_identity.get("run_mode"):
+            result["run_identity_match"] = True
+        else:
+            if artifact_run_identity.get("run_mode") != run_identity.get("run_mode"):
+                candidate_errors.append(
+                    "candidate artifact "
+                    f"{evidence_id}.run_identity.run_mode mismatch: expected {run_identity.get('run_mode')!r}, got {artifact_run_identity.get('run_mode')!r}"
+                )
+
+        artifact_subject_binding = _section(
+            artifact,
+            "subject_binding",
+            candidate_errors,
+            f"candidate artifact {evidence_id}",
+        )
+        subject_expected_ok = _binding_matches(
+            artifact_subject_binding,
+            expected_binding,
+            f"candidate artifact {evidence_id}.subject_binding",
+            candidate_errors,
+        )
+        commit_sha = subject.get("commit_sha")
+        if commit_sha is not None and artifact_subject_binding.get("git_sha") != commit_sha:
+            candidate_errors.append(
+                f"candidate artifact {evidence_id}.subject_binding.git_sha must also match manifest.subject.commit_sha {commit_sha!r}"
+            )
+            subject_expected_ok = False
+        if subject_expected_ok:
+            result["subject_binding_match"] = True
+
+        artifact_policy_binding = _section(
+            artifact,
+            "policy_binding",
+            candidate_errors,
+            f"candidate artifact {evidence_id}",
+        )
+        if _policy_binding_matches(
+            artifact_policy_binding,
+            policy_binding,
+            f"candidate artifact {evidence_id}.policy_binding",
+            candidate_errors,
+        ):
+            result["policy_binding_match"] = True
+
+        artifact_provenance = _section(
+            artifact,
+            "provenance",
+            candidate_errors,
+            f"candidate artifact {evidence_id}",
+        )
+        if trusted_required:
+            if artifact_provenance.get("trusted_producer") is True:
+                result["trusted_producer_verified"] = True
+            else:
+                candidate_errors.append(
+                    f"candidate artifact {evidence_id}.provenance.trusted_producer must be true"
+                )
+        else:
+            result["trusted_producer_verified"] = True
+
+        raw_binding = _section(
+            artifact,
+            "raw_evidence_binding",
+            candidate_errors,
+            f"candidate artifact {evidence_id}",
+        )
+        raw_path_value = raw_binding.get("path")
+        raw_sha_value = raw_binding.get("sha256")
+        if not isinstance(raw_path_value, str) or not raw_path_value:
+            candidate_errors.append(
+                f"candidate artifact {evidence_id}.raw_evidence_binding.path must be a non-empty string"
+            )
+        elif not _hex_digest(raw_sha_value):
+            candidate_errors.append(
+                f"candidate artifact {evidence_id}.raw_evidence_binding.sha256 must be a 64-hex sha256"
+            )
+        else:
+            raw_path = repo_root / raw_path_value
+            if not raw_path.exists():
+                candidate_errors.append(f"raw evidence not found: {raw_path}")
+            else:
+                actual_raw_sha = _sha256_file(raw_path)
+                if actual_raw_sha == raw_sha_value:
+                    result["raw_evidence_verified"] = True
+                else:
+                    candidate_errors.append(
+                        f"raw evidence sha256 mismatch for {evidence_id}: expected {raw_sha_value!r}, got {actual_raw_sha!r}"
+                    )
+
+        artifact_required_gates = _normalize_gate_list(artifact.get("required_for_gates"))
+        if artifact_required_gates == expected_required_gates:
+            result["required_for_gates_match"] = True
+        else:
+            candidate_errors.append(
+                "candidate artifact required_for_gates mismatch: expected "
+                f"{sorted(expected_required_gates)!r}, got {sorted(artifact_required_gates)!r}"
+            )
+
+        if not candidate_errors:
+            result["status"] = VERIFIED
+            verified_evidence_ids.add(evidence_id)
+
+    relation_binding_results: dict[str, Any] = {}
+    satisfied_relation_ids: set[str] = set()
+    for relation_id, relation in expected_relation_bindings.items():
+        relation_errors: list[str] = []
+        result = {
+            "status": FAILED,
+            "binding_type": None,
+            "source_evidence_id": None,
+            "expected_gate_id": None,
+            "target": None,
+            "errors": relation_errors,
+        }
+        relation_binding_results[relation_id] = result
+
+        if not isinstance(relation, dict):
+            relation_errors.append("relation binding entry must be an object")
+            continue
+
+        binding_type = relation.get("binding_type")
+        source_evidence_id = relation.get("source_evidence_id")
+        expected_gate_id = relation.get("expected_gate_id")
+        target = relation.get("target")
+        result["binding_type"] = binding_type
+        result["source_evidence_id"] = source_evidence_id
+        result["expected_gate_id"] = expected_gate_id
+        result["target"] = target
+
+        if source_evidence_id not in candidate_artifacts:
+            relation_errors.append(
+                f"relation binding source evidence missing: {source_evidence_id!r}"
+            )
+            continue
+        if source_evidence_id not in verified_evidence_ids:
+            relation_errors.append(
+                f"relation binding source evidence not verified: {source_evidence_id!r}"
+            )
+            continue
+        if expected_gate_id not in expected_gate_materialization:
+            relation_errors.append(
+                f"relation binding expected gate missing from manifest: {expected_gate_id!r}"
+            )
+            continue
+
+        artifact = candidate_artifacts[source_evidence_id]
+        artifact_required_gates = _normalize_gate_list(artifact.get("required_for_gates"))
+        artifact_subject_binding = artifact.get("subject_binding")
+        if not isinstance(artifact_subject_binding, dict):
+            relation_errors.append(
+                f"candidate artifact {source_evidence_id}.subject_binding must be an object"
+            )
+            continue
+
+        if binding_type == "artifact_to_subject":
+            commit_sha = subject.get("commit_sha")
+            if artifact_subject_binding.get("git_sha") != commit_sha:
+                relation_errors.append(
+                    f"artifact_to_subject relation requires git_sha {commit_sha!r}"
+                )
+            elif target != "subject.commit_sha":
+                relation_errors.append(
+                    f"artifact_to_subject relation target must be 'subject.commit_sha' (got {target!r})"
+                )
+        elif binding_type == "artifact_to_gate":
+            if expected_gate_id not in artifact_required_gates:
+                relation_errors.append(
+                    f"artifact_to_gate relation requires {source_evidence_id!r} to target gate {expected_gate_id!r}"
+                )
+            elif target != f"gate.{expected_gate_id}":
+                relation_errors.append(
+                    f"artifact_to_gate relation target must be 'gate.{expected_gate_id}' (got {target!r})"
+                )
+        else:
+            relation_errors.append(f"unsupported binding_type: {binding_type!r}")
+
+        if not relation_errors:
+            result["status"] = VERIFIED
+            satisfied_relation_ids.add(relation_id)
+
+    gate_materialization_admissibility: dict[str, Any] = {}
+    for gate_id, materialization in expected_gate_materialization.items():
+        gate_errors: list[str] = []
+        result = {
+            "status": FAILED,
+            "expected_value": None,
+            "candidate_evidence_ids": [],
+            "relation_binding_ids": [],
+            "admissible": False,
+            "errors": gate_errors,
+        }
+        gate_materialization_admissibility[gate_id] = result
+
+        if not isinstance(materialization, dict):
+            gate_errors.append("gate materialization entry must be an object")
+            continue
+
+        result["expected_value"] = materialization.get("expected_value")
+        candidate_ids = materialization.get("candidate_evidence_ids")
+        relation_ids = materialization.get("relation_binding_ids")
+        result["candidate_evidence_ids"] = candidate_ids if isinstance(candidate_ids, list) else []
+        result["relation_binding_ids"] = relation_ids if isinstance(relation_ids, list) else []
+
+        if materialization.get("expected_value") is not True:
+            gate_errors.append(f"gate {gate_id} expected_value must be literal true")
+        if materialization.get("policy_relation") != "release_required":
+            gate_errors.append(
+                f"gate {gate_id} policy_relation must be 'release_required'"
+            )
+        if materialization.get("materialization_allowed_without_verifier") is not False:
+            gate_errors.append(
+                f"gate {gate_id} materialization_allowed_without_verifier must be false"
+            )
+        if not isinstance(candidate_ids, list):
+            gate_errors.append(f"gate {gate_id} candidate_evidence_ids must be an array")
+            candidate_ids = []
+        if not isinstance(relation_ids, list):
+            gate_errors.append(f"gate {gate_id} relation_binding_ids must be an array")
+            relation_ids = []
+
+        for evidence_id in candidate_ids:
+            if evidence_id not in verified_evidence_ids:
+                gate_errors.append(
+                    f"gate {gate_id} candidate evidence not verified: {evidence_id!r}"
+                )
+        for relation_id in relation_ids:
+            if relation_id not in satisfied_relation_ids:
+                gate_errors.append(
+                    f"gate {gate_id} relation binding not satisfied: {relation_id!r}"
+                )
+
+        if not gate_errors:
+            result["status"] = VERIFIED
+            result["admissible"] = True
+
+    report["evidence_results"] = evidence_results
+    report["relation_binding_results"] = relation_binding_results
+    report["gate_materialization_admissibility"] = gate_materialization_admissibility
+    report["errors"] = errors + [
+        f"{evidence_id}: {message}"
+        for evidence_id, result in evidence_results.items()
+        for message in result["errors"]
+    ] + [
+        f"{relation_id}: {message}"
+        for relation_id, result in relation_binding_results.items()
+        for message in result["errors"]
+    ] + [
+        f"{gate_id}: {message}"
+        for gate_id, result in gate_materialization_admissibility.items()
+        for message in result["errors"]
+    ]
+
+    if not report["errors"]:
+        report["status"] = VERIFIED
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify recorded release evidence bindings for release-grade "
+            "materialization prerequisites."
+        )
+    )
+    parser.add_argument(
+        "--manifest",
+        default="PULSE_safe_pack_v0/artifacts/release_evidence_input_manifest_v0.json",
+        help="Path to release_evidence_input_manifest_v0.json.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root used to resolve candidate and raw evidence paths.",
+    )
+    parser.add_argument(
+        "--out-json",
+        default="PULSE_safe_pack_v0/artifacts/recorded_release_evidence_verifier_v0.json",
+        help="Path to write the machine-readable verifier report.",
+    )
+    args = parser.parse_args()
+
+    manifest_path = Path(args.manifest)
+    repo_root = Path(args.repo_root)
+    out_json = Path(args.out_json)
+
+    report = check_recorded_release_evidence(manifest_path=manifest_path, repo_root=repo_root)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+
+    if report["status"] != VERIFIED:
+        print("ERRORS (fail-closed):", file=sys.stderr)
+        for error in report["errors"]:
+            print(f" - {error}", file=sys.stderr)
+        print(
+            f"Verifier report written to {out_json}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("OK: recorded release-evidence verification satisfied")
+    print(f"Verifier report written to {out_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py
+++ b/PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py
@@ -26,22 +26,126 @@ import sys
 from pathlib import Path
 from typing import Any
 
+try:
+    import yaml
+except Exception:  # pragma: no cover - fail-closed at runtime if unavailable
+    yaml = None
+
 REPORT_SCHEMA_VERSION = "recorded_release_evidence_verifier_v0"
-REPORT_VERSION = "0.1.0"
+REPORT_VERSION = "0.2.0"
 INPUT_MANIFEST_SCHEMA_VERSION = "release_evidence_input_manifest_v0"
 VERIFIED = "verified"
 FAILED = "failed"
-
+EXPECTED_POLICY_SET = "required+release_required"
+EXPECTED_RUN_MODE = "prod"
 
 REQUIRED_BINDING_KEYS = ("git_sha", "run_key")
 
 
-def _load_json(path: Path, label: str, errors: list[str]) -> dict[str, Any] | None:
-    if not path.exists():
-        errors.append(f"{label} not found: {path}")
-        return None
+def _json_object_no_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def _yaml_loader_no_duplicates():
+    if yaml is None:
+        raise RuntimeError("PyYAML is required for policy/registry verification")
+
+    class Loader(yaml.SafeLoader):
+        pass
+
+    def construct_mapping(loader: Any, node: Any, deep: bool = False) -> dict[str, Any]:
+        mapping: dict[str, Any] = {}
+        for key_node, value_node in node.value:
+            key = loader.construct_object(key_node, deep=deep)
+            if key in mapping:
+                raise ValueError(f"duplicate YAML key {key!r}")
+            mapping[key] = loader.construct_object(value_node, deep=deep)
+        return mapping
+
+    Loader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        construct_mapping,
+    )
+    return Loader
+
+
+def _is_hex_digest(value: Any, length: int) -> bool:
+    return isinstance(value, str) and len(value) == length and all(
+        c in "0123456789abcdef" for c in value.lower()
+    )
+
+
+def _is_git_sha(value: Any) -> bool:
+    return _is_hex_digest(value, 40)
+
+
+def _is_sha256(value: Any) -> bool:
+    return _is_hex_digest(value, 64)
+
+
+def _is_non_empty_text(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _safe_report_digest(path: Path) -> str | None:
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
+        if not path.is_file():
+            return None
+    except OSError:
+        return None
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(65536), b""):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return digest.hexdigest()
+
+
+def _sha256_file(path: Path, label: str, errors: list[str]) -> str | None:
+    try:
+        if not path.exists():
+            errors.append(f"{label} not found: {path}")
+            return None
+        if not path.is_file():
+            errors.append(f"{label} must be a file: {path}")
+            return None
+    except OSError as exc:
+        errors.append(f"{label} path check failed: {exc}")
+        return None
+
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(65536), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        errors.append(f"{label} could not be read: {exc}")
+        return None
+    return digest.hexdigest()
+
+
+def _load_json(path: Path, label: str, errors: list[str]) -> dict[str, Any] | None:
+    try:
+        if not path.exists():
+            errors.append(f"{label} not found: {path}")
+            return None
+        if not path.is_file():
+            errors.append(f"{label} must be a file: {path}")
+            return None
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"{label} could not be read: {exc}")
+        return None
+
+    try:
+        data = json.loads(text, object_pairs_hook=_json_object_no_duplicates)
     except Exception as exc:  # noqa: BLE001 - CLI should report parse errors clearly
         errors.append(f"{label} is not valid JSON: {exc}")
         return None
@@ -51,50 +155,71 @@ def _load_json(path: Path, label: str, errors: list[str]) -> dict[str, Any] | No
     return data
 
 
+def _load_yaml(path: Path, label: str, errors: list[str]) -> dict[str, Any] | None:
+    if yaml is None:
+        errors.append(f"{label} could not be loaded: PyYAML is unavailable")
+        return None
+
+    try:
+        if not path.exists():
+            errors.append(f"{label} not found: {path}")
+            return None
+        if not path.is_file():
+            errors.append(f"{label} must be a file: {path}")
+            return None
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"{label} could not be read: {exc}")
+        return None
+
+    try:
+        loader = _yaml_loader_no_duplicates()
+        data = yaml.load(text, Loader=loader)
+    except Exception as exc:  # noqa: BLE001 - fail-closed parse reporting
+        errors.append(f"{label} is not valid YAML: {exc}")
+        return None
+    if not isinstance(data, dict):
+        errors.append(f"{label} must be a YAML mapping")
+        return None
+    return data
+
+
 def _section(
     obj: dict[str, Any],
     key: str,
     errors: list[str],
     label: str,
+    *,
+    require_non_empty: bool = False,
 ) -> dict[str, Any]:
     value = obj.get(key)
     if not isinstance(value, dict):
         errors.append(f"{label}.{key} must be an object")
         return {}
+    if require_non_empty and not value:
+        errors.append(f"{label}.{key} must not be empty")
     return value
 
 
-def _list_section(
-    obj: dict[str, Any],
-    key: str,
-    errors: list[str],
-    label: str,
-) -> list[Any]:
-    value = obj.get(key)
-    if not isinstance(value, list):
-        errors.append(f"{label}.{key} must be an array")
-        return []
-    return value
+def _validate_git_sha(value: Any, label: str, errors: list[str]) -> bool:
+    if not _is_git_sha(value):
+        errors.append(f"{label} must be a 40-hex git sha")
+        return False
+    return True
 
 
-def _sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(65536), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
+def _validate_run_key(value: Any, label: str, errors: list[str]) -> bool:
+    if not _is_non_empty_text(value):
+        errors.append(f"{label} must be a non-empty string")
+        return False
+    return True
 
 
-def _hex_digest(value: Any) -> bool:
-    return isinstance(value, str) and len(value) == 64 and all(
-        c in "0123456789abcdef" for c in value.lower()
-    )
-
-
-def _normalize_gate_list(value: Any) -> set[str]:
-    if not isinstance(value, list):
-        return set()
-    return {str(item) for item in value}
+def _validate_binding_identity(binding: dict[str, Any], label: str, errors: list[str]) -> bool:
+    ok = True
+    ok = _validate_git_sha(binding.get("git_sha"), f"{label}.git_sha", errors) and ok
+    ok = _validate_run_key(binding.get("run_key"), f"{label}.run_key", errors) and ok
+    return ok
 
 
 def _binding_matches(
@@ -104,6 +229,8 @@ def _binding_matches(
     errors: list[str],
 ) -> bool:
     ok = True
+    ok = _validate_binding_identity(expected, f"{label}.expected", errors) and ok
+    ok = _validate_binding_identity(actual, f"{label}.actual", errors) and ok
     for key in REQUIRED_BINDING_KEYS:
         expected_value = expected.get(key)
         actual_value = actual.get(key)
@@ -112,6 +239,29 @@ def _binding_matches(
                 f"{label}.{key} mismatch: expected {expected_value!r}, got {actual_value!r}"
             )
             ok = False
+    return ok
+
+
+def _run_identity_matches(
+    actual: dict[str, Any],
+    expected: dict[str, Any],
+    label: str,
+    errors: list[str],
+) -> bool:
+    ok = _binding_matches(actual, expected, label, errors)
+    actual_run_mode = actual.get("run_mode")
+    expected_run_mode = expected.get("run_mode")
+    if not _is_non_empty_text(expected_run_mode):
+        errors.append(f"{label}.expected.run_mode must be a non-empty string")
+        ok = False
+    if not _is_non_empty_text(actual_run_mode):
+        errors.append(f"{label}.actual.run_mode must be a non-empty string")
+        ok = False
+    if actual_run_mode != expected_run_mode:
+        errors.append(
+            f"{label}.run_mode mismatch: expected {expected_run_mode!r}, got {actual_run_mode!r}"
+        )
+        ok = False
     return ok
 
 
@@ -125,9 +275,96 @@ def _policy_binding_matches(
     for key in ("policy_set", "policy_sha256"):
         expected_value = expected.get(key)
         actual_value = actual.get(key)
+        if key == "policy_sha256":
+            if not _is_sha256(expected_value):
+                errors.append(f"{label}.expected.policy_sha256 must be a 64-hex sha256")
+                ok = False
+            if not _is_sha256(actual_value):
+                errors.append(f"{label}.actual.policy_sha256 must be a 64-hex sha256")
+                ok = False
+        else:
+            if not _is_non_empty_text(expected_value):
+                errors.append(f"{label}.expected.policy_set must be a non-empty string")
+                ok = False
+            if not _is_non_empty_text(actual_value):
+                errors.append(f"{label}.actual.policy_set must be a non-empty string")
+                ok = False
         if actual_value != expected_value:
             errors.append(
                 f"{label}.{key} mismatch: expected {expected_value!r}, got {actual_value!r}"
+            )
+            ok = False
+    return ok
+
+
+def _normalize_gate_list(value: Any, label: str, errors: list[str]) -> set[str]:
+    if not isinstance(value, list):
+        errors.append(f"{label} must be an array")
+        return set()
+    if not value:
+        errors.append(f"{label} must not be empty")
+        return set()
+    result: set[str] = set()
+    for item in value:
+        if not _is_non_empty_text(item):
+            errors.append(f"{label} entries must be non-empty strings")
+            continue
+        if item in result:
+            errors.append(f"{label} contains duplicate gate id {item!r}")
+            continue
+        result.add(item)
+    return result
+
+
+def _extract_release_required_gates(policy_obj: dict[str, Any], errors: list[str]) -> set[str]:
+    policy = policy_obj.get("policy")
+    if not isinstance(policy, dict):
+        errors.append("policy file must contain top-level policy mapping")
+        return set()
+    gates = policy.get("gates")
+    if not isinstance(gates, dict):
+        errors.append("policy file must contain policy.gates mapping")
+        return set()
+    return _normalize_gate_list(
+        gates.get("release_required"),
+        "policy.gates.release_required",
+        errors,
+    )
+
+
+def _extract_registry_gate_ids(registry_obj: dict[str, Any], errors: list[str]) -> set[str]:
+    gates = registry_obj.get("gates")
+    if not isinstance(gates, dict):
+        errors.append("registry file must contain top-level gates mapping")
+        return set()
+    result: set[str] = set()
+    for gate_id in gates:
+        if not _is_non_empty_text(gate_id):
+            errors.append("registry gate ids must be non-empty strings")
+            continue
+        result.add(gate_id)
+    if not result:
+        errors.append("registry file must declare at least one gate id")
+    return result
+
+
+def _validate_gate_membership(
+    gate_ids: set[str],
+    label: str,
+    release_required_gates: set[str],
+    registry_gate_ids: set[str],
+    errors: list[str],
+) -> bool:
+    ok = True
+    for gate_id in sorted(gate_ids):
+        if gate_id not in release_required_gates:
+            errors.append(
+                f"{label} contains gate {gate_id!r} which is not declared in policy.gates.release_required"
+            )
+            ok = False
+        if gate_id not in registry_gate_ids:
+            errors.append(
+                f"{label} contains gate {gate_id!r} which is not declared in the gate registry"
             )
             ok = False
     return ok
@@ -165,7 +402,7 @@ def check_recorded_release_evidence(
 ) -> dict[str, Any]:
     errors: list[str] = []
     manifest = _load_json(manifest_path, "release_evidence_input_manifest_v0.json", errors)
-    manifest_sha256 = _sha256_file(manifest_path) if manifest_path.exists() else None
+    manifest_sha256 = _safe_report_digest(manifest_path)
     report = _build_empty_report(manifest_path, manifest_sha256, manifest)
     if manifest is None:
         report["errors"] = errors
@@ -180,46 +417,120 @@ def check_recorded_release_evidence(
     run_identity = _section(manifest, "run_identity", errors, "manifest")
     subject = _section(manifest, "subject", errors, "manifest")
     policy_binding = _section(manifest, "policy_binding", errors, "manifest")
-    candidate_evidence = _section(manifest, "candidate_evidence", errors, "manifest")
+    registry_binding = _section(manifest, "registry_binding", errors, "manifest")
+    candidate_evidence = _section(
+        manifest,
+        "candidate_evidence",
+        errors,
+        "manifest",
+        require_non_empty=True,
+    )
     expected_relation_bindings = _section(
         manifest,
         "expected_relation_bindings",
         errors,
         "manifest",
+        require_non_empty=True,
     )
     expected_gate_materialization = _section(
         manifest,
         "expected_gate_materialization",
         errors,
         "manifest",
+        require_non_empty=True,
     )
 
     report["run_identity"] = run_identity
     report["subject"] = subject
     report["policy_binding"] = policy_binding
-    report["registry_binding"] = manifest.get("registry_binding")
+    report["registry_binding"] = registry_binding
     report["verified_subjects"] = {
         "git_sha": run_identity.get("git_sha"),
         "run_key": run_identity.get("run_key"),
         "commit_sha": subject.get("commit_sha"),
     }
 
-    if run_identity.get("run_mode") != "prod":
+    run_identity_ok = _validate_binding_identity(run_identity, "manifest.run_identity", errors)
+    if not _is_non_empty_text(run_identity.get("run_mode")):
+        errors.append("manifest.run_identity.run_mode must be a non-empty string")
+        run_identity_ok = False
+    if run_identity.get("run_mode") != EXPECTED_RUN_MODE:
         errors.append(
             "manifest.run_identity.run_mode must be 'prod' for recorded "
             f"release-evidence verification (got {run_identity.get('run_mode')!r})"
         )
-    if policy_binding.get("policy_set") != "required+release_required":
+        run_identity_ok = False
+
+    if not _validate_git_sha(subject.get("commit_sha"), "manifest.subject.commit_sha", errors):
+        pass
+    elif subject.get("commit_sha") != run_identity.get("git_sha"):
+        errors.append(
+            "manifest.subject.commit_sha must match manifest.run_identity.git_sha "
+            f"(expected {run_identity.get('git_sha')!r}, got {subject.get('commit_sha')!r})"
+        )
+
+    if policy_binding.get("policy_set") != EXPECTED_POLICY_SET:
         errors.append(
             "manifest.policy_binding.policy_set must be 'required+release_required' "
             f"(got {policy_binding.get('policy_set')!r})"
         )
-    if not _hex_digest(policy_binding.get("policy_sha256")):
+    if not _is_sha256(policy_binding.get("policy_sha256")):
         errors.append("manifest.policy_binding.policy_sha256 must be a 64-hex sha256")
+    if not _is_non_empty_text(policy_binding.get("policy_path")):
+        errors.append("manifest.policy_binding.policy_path must be a non-empty string")
+
+    if not _is_non_empty_text(registry_binding.get("registry_path")):
+        errors.append("manifest.registry_binding.registry_path must be a non-empty string")
+    if not _is_sha256(registry_binding.get("registry_sha256")):
+        errors.append("manifest.registry_binding.registry_sha256 must be a 64-hex sha256")
+
+    release_required_gates: set[str] = set()
+    registry_gate_ids: set[str] = set()
+
+    policy_path_value = policy_binding.get("policy_path")
+    if _is_non_empty_text(policy_path_value) and _is_sha256(policy_binding.get("policy_sha256")):
+        policy_path = repo_root / str(policy_path_value)
+        actual_policy_sha = _sha256_file(policy_path, "policy file", errors)
+        if actual_policy_sha is not None:
+            if actual_policy_sha != policy_binding.get("policy_sha256"):
+                errors.append(
+                    "policy file sha256 mismatch: expected "
+                    f"{policy_binding.get('policy_sha256')!r}, got {actual_policy_sha!r}"
+                )
+            policy_obj = _load_yaml(policy_path, "policy file", errors)
+            if policy_obj is not None:
+                release_required_gates = _extract_release_required_gates(policy_obj, errors)
+
+    registry_path_value = registry_binding.get("registry_path")
+    if _is_non_empty_text(registry_path_value) and _is_sha256(registry_binding.get("registry_sha256")):
+        registry_path = repo_root / str(registry_path_value)
+        actual_registry_sha = _sha256_file(registry_path, "registry file", errors)
+        if actual_registry_sha is not None:
+            if actual_registry_sha != registry_binding.get("registry_sha256"):
+                errors.append(
+                    "registry file sha256 mismatch: expected "
+                    f"{registry_binding.get('registry_sha256')!r}, got {actual_registry_sha!r}"
+                )
+            registry_obj = _load_yaml(registry_path, "registry file", errors)
+            if registry_obj is not None:
+                registry_gate_ids = _extract_registry_gate_ids(registry_obj, errors)
+
+    if release_required_gates and registry_gate_ids:
+        missing_registry_ids = release_required_gates - registry_gate_ids
+        if missing_registry_ids:
+            errors.append(
+                "policy.gates.release_required contains unknown registry gate ids: "
+                f"{sorted(missing_registry_ids)!r}"
+            )
 
     evidence_results: dict[str, Any] = {}
     verified_evidence_ids: set[str] = set()
     candidate_artifacts: dict[str, dict[str, Any]] = {}
+
+    manifest_binding_expected = {
+        "git_sha": run_identity.get("git_sha"),
+        "run_key": run_identity.get("run_key"),
+    }
 
     for evidence_id, candidate in candidate_evidence.items():
         candidate_errors: list[str] = []
@@ -257,23 +568,52 @@ def check_recorded_release_evidence(
             candidate_errors,
             f"manifest.candidate_evidence.{evidence_id}",
         )
-        expected_required_gates = _normalize_gate_list(candidate.get("required_for_gates"))
-        trusted_required = (
-            _section(
-                candidate,
-                "provenance_expectations",
-                candidate_errors,
-                f"manifest.candidate_evidence.{evidence_id}",
-            ).get("trusted_producer_required")
-            is True
+        expected_required_gates = _normalize_gate_list(
+            candidate.get("required_for_gates"),
+            f"manifest.candidate_evidence.{evidence_id}.required_for_gates",
+            candidate_errors,
         )
+        provenance_expectations = _section(
+            candidate,
+            "provenance_expectations",
+            candidate_errors,
+            f"manifest.candidate_evidence.{evidence_id}",
+        )
+        trusted_required_value = provenance_expectations.get("trusted_producer_required")
+        trusted_required = trusted_required_value is True
+        if trusted_required_value is not True:
+            candidate_errors.append(
+                "manifest.candidate_evidence."
+                f"{evidence_id}.provenance_expectations.trusted_producer_required must be literal true"
+            )
 
         if candidate.get("verification_required") is not True:
             candidate_errors.append(
                 "candidate evidence verification_required must be literal true"
             )
+        if not _is_sha256(expected_sha256):
+            candidate_errors.append("candidate evidence expected_sha256 must be a 64-hex sha256")
+        if not _is_non_empty_text(expected_schema_version):
+            candidate_errors.append("candidate evidence schema_version must be a non-empty string")
 
-        if not isinstance(path_value, str) or not path_value:
+        if _binding_matches(
+            expected_binding,
+            manifest_binding_expected,
+            f"manifest.candidate_evidence.{evidence_id}.subject_binding",
+            candidate_errors,
+        ) and subject.get("commit_sha") == run_identity.get("git_sha"):
+            pass
+
+        if release_required_gates and registry_gate_ids:
+            _validate_gate_membership(
+                expected_required_gates,
+                f"manifest.candidate_evidence.{evidence_id}.required_for_gates",
+                release_required_gates,
+                registry_gate_ids,
+                candidate_errors,
+            )
+
+        if not isinstance(path_value, str) or not path_value.strip():
             candidate_errors.append("candidate evidence path must be a non-empty string")
             continue
 
@@ -281,12 +621,15 @@ def check_recorded_release_evidence(
         if not artifact_path.exists():
             candidate_errors.append(f"candidate artifact not found: {artifact_path}")
             continue
+        if not artifact_path.is_file():
+            candidate_errors.append(f"candidate artifact must be a file: {artifact_path}")
+            continue
 
-        actual_sha256 = _sha256_file(artifact_path)
+        actual_sha256 = _sha256_file(artifact_path, f"candidate artifact {evidence_id}", candidate_errors)
         result["actual_sha256"] = actual_sha256
-        if actual_sha256 == expected_sha256:
+        if actual_sha256 is not None and actual_sha256 == expected_sha256:
             result["digest_match"] = True
-        else:
+        elif actual_sha256 is not None:
             candidate_errors.append(
                 f"candidate artifact sha256 mismatch: expected {expected_sha256!r}, got {actual_sha256!r}"
             )
@@ -301,7 +644,8 @@ def check_recorded_release_evidence(
             result["schema_version_match"] = True
         else:
             candidate_errors.append(
-                f"candidate artifact schema_version mismatch: expected {expected_schema_version!r}, got {artifact.get('schema_version')!r}"
+                "candidate artifact schema_version mismatch: expected "
+                f"{expected_schema_version!r}, got {artifact.get('schema_version')!r}"
             )
 
         artifact_run_identity = _section(
@@ -310,19 +654,13 @@ def check_recorded_release_evidence(
             candidate_errors,
             f"candidate artifact {evidence_id}",
         )
-        if _binding_matches(
+        if _run_identity_matches(
             artifact_run_identity,
             run_identity,
             f"candidate artifact {evidence_id}.run_identity",
             candidate_errors,
-        ) and artifact_run_identity.get("run_mode") == run_identity.get("run_mode"):
+        ):
             result["run_identity_match"] = True
-        else:
-            if artifact_run_identity.get("run_mode") != run_identity.get("run_mode"):
-                candidate_errors.append(
-                    "candidate artifact "
-                    f"{evidence_id}.run_identity.run_mode mismatch: expected {run_identity.get('run_mode')!r}, got {artifact_run_identity.get('run_mode')!r}"
-                )
 
         artifact_subject_binding = _section(
             artifact,
@@ -336,13 +674,19 @@ def check_recorded_release_evidence(
             f"candidate artifact {evidence_id}.subject_binding",
             candidate_errors,
         )
+        subject_run_ok = _binding_matches(
+            artifact_subject_binding,
+            manifest_binding_expected,
+            f"candidate artifact {evidence_id}.subject_binding_to_run_identity",
+            candidate_errors,
+        )
         commit_sha = subject.get("commit_sha")
-        if commit_sha is not None and artifact_subject_binding.get("git_sha") != commit_sha:
+        if _is_git_sha(commit_sha) and artifact_subject_binding.get("git_sha") != commit_sha:
             candidate_errors.append(
                 f"candidate artifact {evidence_id}.subject_binding.git_sha must also match manifest.subject.commit_sha {commit_sha!r}"
             )
             subject_expected_ok = False
-        if subject_expected_ok:
+        if subject_expected_ok and subject_run_ok:
             result["subject_binding_match"] = True
 
         artifact_policy_binding = _section(
@@ -353,7 +697,10 @@ def check_recorded_release_evidence(
         )
         if _policy_binding_matches(
             artifact_policy_binding,
-            policy_binding,
+            {
+                "policy_set": policy_binding.get("policy_set"),
+                "policy_sha256": policy_binding.get("policy_sha256"),
+            },
             f"candidate artifact {evidence_id}.policy_binding",
             candidate_errors,
         ):
@@ -372,8 +719,6 @@ def check_recorded_release_evidence(
                 candidate_errors.append(
                     f"candidate artifact {evidence_id}.provenance.trusted_producer must be true"
                 )
-        else:
-            result["trusted_producer_verified"] = True
 
         raw_binding = _section(
             artifact,
@@ -383,11 +728,11 @@ def check_recorded_release_evidence(
         )
         raw_path_value = raw_binding.get("path")
         raw_sha_value = raw_binding.get("sha256")
-        if not isinstance(raw_path_value, str) or not raw_path_value:
+        if not isinstance(raw_path_value, str) or not raw_path_value.strip():
             candidate_errors.append(
                 f"candidate artifact {evidence_id}.raw_evidence_binding.path must be a non-empty string"
             )
-        elif not _hex_digest(raw_sha_value):
+        elif not _is_sha256(raw_sha_value):
             candidate_errors.append(
                 f"candidate artifact {evidence_id}.raw_evidence_binding.sha256 must be a 64-hex sha256"
             )
@@ -395,16 +740,34 @@ def check_recorded_release_evidence(
             raw_path = repo_root / raw_path_value
             if not raw_path.exists():
                 candidate_errors.append(f"raw evidence not found: {raw_path}")
+            elif not raw_path.is_file():
+                candidate_errors.append(f"raw evidence must be a file: {raw_path}")
             else:
-                actual_raw_sha = _sha256_file(raw_path)
-                if actual_raw_sha == raw_sha_value:
+                actual_raw_sha = _sha256_file(
+                    raw_path,
+                    f"raw evidence for {evidence_id}",
+                    candidate_errors,
+                )
+                if actual_raw_sha is not None and actual_raw_sha == raw_sha_value:
                     result["raw_evidence_verified"] = True
-                else:
+                elif actual_raw_sha is not None:
                     candidate_errors.append(
                         f"raw evidence sha256 mismatch for {evidence_id}: expected {raw_sha_value!r}, got {actual_raw_sha!r}"
                     )
 
-        artifact_required_gates = _normalize_gate_list(artifact.get("required_for_gates"))
+        artifact_required_gates = _normalize_gate_list(
+            artifact.get("required_for_gates"),
+            f"candidate artifact {evidence_id}.required_for_gates",
+            candidate_errors,
+        )
+        if release_required_gates and registry_gate_ids:
+            _validate_gate_membership(
+                artifact_required_gates,
+                f"candidate artifact {evidence_id}.required_for_gates",
+                release_required_gates,
+                registry_gate_ids,
+                candidate_errors,
+            )
         if artifact_required_gates == expected_required_gates:
             result["required_for_gates_match"] = True
         else:
@@ -444,6 +807,28 @@ def check_recorded_release_evidence(
         result["expected_gate_id"] = expected_gate_id
         result["target"] = target
 
+        if binding_type not in {"artifact_to_subject", "artifact_to_gate"}:
+            relation_errors.append(f"unsupported binding_type: {binding_type!r}")
+            continue
+        if not _is_non_empty_text(source_evidence_id):
+            relation_errors.append("relation binding source_evidence_id must be a non-empty string")
+            continue
+        if not _is_non_empty_text(expected_gate_id):
+            relation_errors.append("relation binding expected_gate_id must be a non-empty string")
+            continue
+        if not _is_non_empty_text(target):
+            relation_errors.append("relation binding target must be a non-empty string")
+            continue
+
+        if release_required_gates and registry_gate_ids:
+            _validate_gate_membership(
+                {str(expected_gate_id)},
+                f"relation binding {relation_id}.expected_gate_id",
+                release_required_gates,
+                registry_gate_ids,
+                relation_errors,
+            )
+
         if source_evidence_id not in candidate_artifacts:
             relation_errors.append(
                 f"relation binding source evidence missing: {source_evidence_id!r}"
@@ -461,7 +846,11 @@ def check_recorded_release_evidence(
             continue
 
         artifact = candidate_artifacts[source_evidence_id]
-        artifact_required_gates = _normalize_gate_list(artifact.get("required_for_gates"))
+        artifact_required_gates = _normalize_gate_list(
+            artifact.get("required_for_gates"),
+            f"candidate artifact {source_evidence_id}.required_for_gates",
+            relation_errors,
+        )
         artifact_subject_binding = artifact.get("subject_binding")
         if not isinstance(artifact_subject_binding, dict):
             relation_errors.append(
@@ -470,26 +859,26 @@ def check_recorded_release_evidence(
             continue
 
         if binding_type == "artifact_to_subject":
-            commit_sha = subject.get("commit_sha")
-            if artifact_subject_binding.get("git_sha") != commit_sha:
-                relation_errors.append(
-                    f"artifact_to_subject relation requires git_sha {commit_sha!r}"
-                )
-            elif target != "subject.commit_sha":
+            if not _binding_matches(
+                artifact_subject_binding,
+                manifest_binding_expected,
+                f"relation binding {relation_id}.subject_binding_to_run_identity",
+                relation_errors,
+            ):
+                pass
+            if target != "subject.commit_sha":
                 relation_errors.append(
                     f"artifact_to_subject relation target must be 'subject.commit_sha' (got {target!r})"
                 )
-        elif binding_type == "artifact_to_gate":
+        else:
             if expected_gate_id not in artifact_required_gates:
                 relation_errors.append(
                     f"artifact_to_gate relation requires {source_evidence_id!r} to target gate {expected_gate_id!r}"
                 )
-            elif target != f"gate.{expected_gate_id}":
+            if target != f"gate.{expected_gate_id}":
                 relation_errors.append(
                     f"artifact_to_gate relation target must be 'gate.{expected_gate_id}' (got {target!r})"
                 )
-        else:
-            relation_errors.append(f"unsupported binding_type: {binding_type!r}")
 
         if not relation_errors:
             result["status"] = VERIFIED
@@ -518,6 +907,15 @@ def check_recorded_release_evidence(
         result["candidate_evidence_ids"] = candidate_ids if isinstance(candidate_ids, list) else []
         result["relation_binding_ids"] = relation_ids if isinstance(relation_ids, list) else []
 
+        if release_required_gates and registry_gate_ids:
+            _validate_gate_membership(
+                {gate_id},
+                f"manifest.expected_gate_materialization[{gate_id!r}]",
+                release_required_gates,
+                registry_gate_ids,
+                gate_errors,
+            )
+
         if materialization.get("expected_value") is not True:
             gate_errors.append(f"gate {gate_id} expected_value must be literal true")
         if materialization.get("policy_relation") != "release_required":
@@ -528,11 +926,11 @@ def check_recorded_release_evidence(
             gate_errors.append(
                 f"gate {gate_id} materialization_allowed_without_verifier must be false"
             )
-        if not isinstance(candidate_ids, list):
-            gate_errors.append(f"gate {gate_id} candidate_evidence_ids must be an array")
+        if not isinstance(candidate_ids, list) or not candidate_ids:
+            gate_errors.append(f"gate {gate_id} candidate_evidence_ids must be a non-empty array")
             candidate_ids = []
-        if not isinstance(relation_ids, list):
-            gate_errors.append(f"gate {gate_id} relation_binding_ids must be an array")
+        if not isinstance(relation_ids, list) or not relation_ids:
+            gate_errors.append(f"gate {gate_id} relation_binding_ids must be a non-empty array")
             relation_ids = []
 
         for evidence_id in candidate_ids:
@@ -540,10 +938,61 @@ def check_recorded_release_evidence(
                 gate_errors.append(
                     f"gate {gate_id} candidate evidence not verified: {evidence_id!r}"
                 )
+
+        gate_target_relation_sources: set[str] = set()
         for relation_id in relation_ids:
+            relation_result = relation_binding_results.get(relation_id)
+            relation = expected_relation_bindings.get(relation_id)
             if relation_id not in satisfied_relation_ids:
                 gate_errors.append(
                     f"gate {gate_id} relation binding not satisfied: {relation_id!r}"
+                )
+                continue
+            if not isinstance(relation, dict):
+                gate_errors.append(
+                    f"gate {gate_id} relation binding definition missing: {relation_id!r}"
+                )
+                continue
+
+            relation_source = relation.get("source_evidence_id")
+            relation_binding_type = relation.get("binding_type")
+            relation_expected_gate = relation.get("expected_gate_id")
+            relation_target = relation.get("target")
+
+            if relation_source not in candidate_ids:
+                gate_errors.append(
+                    f"gate {gate_id} relation binding source must be listed candidate evidence: {relation_id!r}"
+                )
+
+            if relation_binding_type == "artifact_to_subject":
+                if relation_target != "subject.commit_sha":
+                    gate_errors.append(
+                        f"gate {gate_id} subject relation target must be 'subject.commit_sha' (got {relation_target!r})"
+                    )
+            elif relation_binding_type == "artifact_to_gate":
+                if relation_expected_gate != gate_id:
+                    gate_errors.append(
+                        f"gate {gate_id} relation {relation_id!r} must target expected_gate_id {gate_id!r}"
+                    )
+                if relation_target != f"gate.{gate_id}":
+                    gate_errors.append(
+                        f"gate {gate_id} relation {relation_id!r} must target 'gate.{gate_id}'"
+                    )
+                if relation_expected_gate == gate_id and relation_target == f"gate.{gate_id}":
+                    gate_target_relation_sources.add(str(relation_source))
+            else:
+                gate_errors.append(
+                    f"gate {gate_id} has unsupported relation binding type in {relation_id!r}: {relation_binding_type!r}"
+                )
+
+        if not gate_target_relation_sources:
+            gate_errors.append(
+                f"gate {gate_id} must include at least one satisfied artifact_to_gate relation targeting gate.{gate_id}"
+            )
+        for evidence_id in candidate_ids:
+            if evidence_id not in gate_target_relation_sources:
+                gate_errors.append(
+                    f"gate {gate_id} is missing a gate-targeted relation for candidate evidence {evidence_id!r}"
                 )
 
         if not gate_errors:

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -35,6 +35,7 @@ tests/test_authority_boundary_repro_smoke.py
 tests/test_operator_handoff_smoke.py
 tests/test_check_release_authority_manifest_v0.py
 tests/test_check_release_evidence_verifier_report_v0.py
+tests/test_check_recorded_release_evidence_v0.py
 tests/test_build_release_authority_manifest_v0.py
 tests/test_release_authority_manifest_non_interference.py
 tests/test_release_decision_v0_smoke.py

--- a/docs/recorded_release_evidence_verifier_v0.md
+++ b/docs/recorded_release_evidence_verifier_v0.md
@@ -1,0 +1,193 @@
+# Recorded release-evidence verifier v0
+
+## Purpose
+
+This document defines the recorded release-evidence verifier prerequisite surface for release-grade materialization.
+
+The verifier checks whether candidate detector materialization artifacts, canonical external summaries, and refusal-delta evidence are sufficiently bound to:
+
+    run identity
+    → subject binding
+    → declared policy context
+    → trusted provenance expectations
+    → raw evidence digest
+    → expected gate materialization relations
+
+The verifier is prerequisite-only.
+
+It does not compute release authority.
+It does not replace `check_gates.py`.
+It does not change `status.json` semantics.
+It does not promote diagnostic or reader surfaces into release authority.
+
+## Status
+
+- stage: implemented prerequisite checker
+- normative: false
+- authority role: prerequisite evidence-binding checker
+- tool: `PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py`
+- test coverage: `tests/test_check_recorded_release_evidence_v0.py`
+- tools-test coverage: `ci/tools-tests.list`
+- output artifact: `PULSE_safe_pack_v0/artifacts/recorded_release_evidence_verifier_v0.json`
+- release-required fold-in status: not enabled in this step
+
+## Why this exists
+
+`--release-grade-materialized` must remain fail-closed until release-required detector materialization, canonical external summary, and refusal-delta artifacts are verified rather than merely declared.
+
+Local JSON files can exist and still be wrong.
+
+The missing step was not another dashboard or summary.
+The missing step was a machine-readable verifier that proves candidate artifacts are:
+
+- present
+- digest-bound
+- subject-bound
+- run-bound
+- policy-bound
+- provenance-checked
+- raw-evidence-bound
+- relation-bound to the declared release-required gates
+
+## Inputs
+
+The verifier consumes:
+
+- `release_evidence_input_manifest_v0.json`
+- repository-relative candidate artifact paths declared in that manifest
+- repository-relative raw evidence paths declared inside those candidate artifacts
+
+The manifest remains the declaration surface.
+The verifier answers whether those declarations are actually satisfied.
+
+## Candidate artifact minimum shape
+
+Each candidate artifact is expected to provide at least:
+
+- `schema_version`
+- `run_identity.git_sha`
+- `run_identity.run_key`
+- `run_identity.run_mode`
+- `subject_binding.git_sha`
+- `subject_binding.run_key`
+- `policy_binding.policy_set`
+- `policy_binding.policy_sha256`
+- `provenance.trusted_producer`
+- `raw_evidence_binding.path`
+- `raw_evidence_binding.sha256`
+- `required_for_gates[]`
+
+The verifier reads the candidate artifact itself.
+It does not trust the manifest alone.
+
+## Verification path
+
+For every candidate evidence item marked `verification_required=true`, the verifier checks:
+
+1. artifact presence
+2. artifact sha256 against `expected_sha256`
+3. `schema_version` match
+4. `run_identity` match
+5. `subject_binding` match
+6. `policy_binding` match
+7. trusted producer requirement when declared
+8. raw evidence presence
+9. raw evidence sha256 match
+10. `required_for_gates` match
+
+Then it checks the declared relation bindings:
+
+- `artifact_to_subject`
+- `artifact_to_gate`
+
+Then it checks gate materialization admissibility:
+
+- candidate evidence IDs are verified
+- relation binding IDs are satisfied
+- `expected_value=true`
+- `policy_relation=release_required`
+- `materialization_allowed_without_verifier=false`
+
+## Output artifact
+
+The verifier writes:
+
+    PULSE_safe_pack_v0/artifacts/recorded_release_evidence_verifier_v0.json
+
+Minimum output contents:
+
+- report schema/version
+- verifier status: `verified | failed`
+- manifest path/digest/schema version
+- run identity
+- subject
+- policy binding
+- registry binding when present
+- per-evidence verification results
+- per-relation verification results
+- per-gate admissibility results
+- verified subject summary
+- fail-closed error list
+
+## Authority boundary
+
+The verifier is not release authority.
+
+Its role is:
+
+    candidate detector/external/refusal artifact
+    → recorded evidence verification
+    → admissibility report
+    → later release-grade materialization input
+
+The normative release decision remains:
+
+    recorded release evidence
+    → status.json
+    → declared gate policy
+    → workflow-effective required gate set
+    → check_gates.py
+    → primary CI allow/block decision
+
+## CLI
+
+Example:
+
+```bash
+python PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py \
+  --manifest PULSE_safe_pack_v0/artifacts/release_evidence_input_manifest_v0.json \
+  --repo-root . \
+  --out-json PULSE_safe_pack_v0/artifacts/recorded_release_evidence_verifier_v0.json
+```
+
+Success output:
+
+    OK: recorded release-evidence verification satisfied
+
+Failure output:
+
+    ERRORS (fail-closed):
+      - ...
+
+## Non-goals
+
+This verifier is not:
+
+- a new release gate
+- a replacement for `check_gates.py`
+- a replacement for `status.json`
+- a second release-decision engine
+- automatic promotion of detector/external/refusal artifacts into release-required truth values
+- a policy override
+
+## Follow-up
+
+A later PR may allow `--release-grade-materialized` to fold only verifier-admitted evidence into release-required gate booleans.
+
+That later step must remain:
+
+- policy-derived
+- explicit
+- fail-closed
+- non-shadow
+- non-reader-authoritative

--- a/docs/release_grade_reference_run_v0.md
+++ b/docs/release_grade_reference_run_v0.md
@@ -29,25 +29,22 @@ authority.
 
 ## Status
 
-- stage: reference definition + qualification checker implemented  
-- normative: false  
-- target lane: release-grade  
-- authority role: documentation / operational guidance  
-- checker: PULSE_safe_pack_v0/tools/check_release_grade_reference_run_v0.py  
-- test coverage: tests/test_check_release_grade_reference_run_v0.py  
-- tools-test coverage: ci/tools-tests.list  
-- primary workflow advisory qualification: present  
-- primary workflow authority role: non-normative / non-blocking  
-- hotfix status: `--release-grade-materialized` is intentionally fail-closed until a real recorded release-evidence verifier is implemented
+  * stage: reference definition + qualification checker implemented + recorded release-evidence verifier prerequisite implemented
+  * normative: false
+  * target lane: release-grade
+  * authority role: documentation / operational guidance
+  * checker: `PULSE_safe_pack_v0/tools/check_release_grade_reference_run_v0.py`
+  * recorded evidence verifier: `PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py`
+  * test coverage: `tests/test_check_release_grade_reference_run_v0.py`
+  * recorded evidence verifier test coverage: `tests/test_check_recorded_release_evidence_v0.py`
+  * tools-test coverage: `ci/tools-tests.list`
+  * primary workflow advisory qualification: present
+  * primary workflow authority role: non-normative / non-blocking
+  * fold-in status: `--release-grade-materialized` remains intentionally fail-closed for release-required evidence fold-in until a follow-up PR admits only verifier-validated evidence
 
-Security hotfix note: local `detector_materialization_v0.json`, external summary
-files, and `refusal_delta_summary.json` are treated as self-declared artifacts.
-They may be useful diagnostics, but they must not set release-required gates to
-`true` unless a verifier binds identity, provenance, policy, and raw evidence.
+Security boundary note: detector materialization artifacts, canonical external summaries, and `refusal_delta_summary.json` are no longer treated as sufficient merely because they exist locally. They must now pass the recorded release-evidence verifier, which binds identity, provenance, policy, subject, and raw evidence before later release-grade materialization can admit them.
 
-The reference run definition describes how to produce and review a release-grade
-PULSE run. It does not create a new gate and does not promote any diagnostic
-surface into release authority.
+The reference run definition describes how to produce and review a release-grade PULSE run. It does not create a new gate and does not promote any diagnostic surface into release authority.
 
 ---
 
@@ -511,17 +508,13 @@ Release-grade reference run = materialized evidence release-authority reference
 
 ---
 
-## Next implementation steps
+## Next implementation  steps 
 
 Suggested next steps:
 
-- Implement the real recorded release-evidence verifier for detector
-  materialization, canonical external summaries, and refusal-delta evidence.
-- Only after that verifier exists, allow `--release-grade-materialized` to fold
-  verified evidence into release-required gate booleans.
-- The example package under `examples/release_grade_reference_run_v0/` now
-  shows the expected artifact shape. A real non-stubbed release-grade
-  reference run remains future work.  
+   * Use the recorded release-evidence verifier for detector materialization, canonical external summaries, and refusal-delta evidence.
+  * Only after verifier-admitted evidence is available, allow `--release-grade-materialized` to fold verified evidence into release-required gate booleans.
+  * The example package under `examples/release_grade_reference_run_v0/` still shows the expected artifact shape. A real non-stubbed release-grade reference run remains future work.
 - Produce one non-stubbed release-grade reference run.  
 - Archive its `status.json`, Quality Ledger, release authority manifest, and
   audit bundle.  

--- a/tests/test_check_recorded_release_evidence_v0.py
+++ b/tests/test_check_recorded_release_evidence_v0.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from PULSE_safe_pack_v0.tools.check_recorded_release_evidence_v0 import (
+    REPORT_SCHEMA_VERSION,
+    check_recorded_release_evidence,
+)
+
+CHECKER = (
+    REPO_ROOT / "PULSE_safe_pack_v0" / "tools" / "check_recorded_release_evidence_v0.py"
+)
+HEX40 = "a" * 40
+HEX64_POLICY = "b" * 64
+RUN_KEY = "run-prod-2026-01-01"
+COMMIT_SHA = HEX40
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _write_json(path: pathlib.Path, payload: dict[str, Any]) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    path.write_text(text, encoding="utf-8")
+    return _sha256_bytes(text.encode("utf-8"))
+
+
+def _write_text(path: pathlib.Path, text: str) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return _sha256_bytes(text.encode("utf-8"))
+
+
+def _candidate_artifact(
+    *,
+    schema_version: str,
+    required_for_gates: list[str],
+    raw_path: str,
+    raw_sha256: str,
+    trusted_producer: bool = True,
+    policy_sha256: str = HEX64_POLICY,
+    run_key: str = RUN_KEY,
+    git_sha: str = COMMIT_SHA,
+) -> dict[str, Any]:
+    return {
+        "schema_version": schema_version,
+        "run_identity": {
+            "git_sha": git_sha,
+            "run_key": run_key,
+            "run_mode": "prod",
+        },
+        "subject_binding": {
+            "git_sha": git_sha,
+            "run_key": run_key,
+        },
+        "policy_binding": {
+            "policy_set": "required+release_required",
+            "policy_sha256": policy_sha256,
+        },
+        "provenance": {
+            "trusted_producer": trusted_producer,
+            "producer": "pulse_ci",
+        },
+        "raw_evidence_binding": {
+            "path": raw_path,
+            "sha256": raw_sha256,
+        },
+        "required_for_gates": required_for_gates,
+    }
+
+
+EVIDENCE_DEFS = {
+    "detector_report": {
+        "schema_version": "detector_report_v0",
+        "artifact_path": "artifacts/detectors/detector_report.json",
+        "raw_path": "artifacts/raw/detector_report.raw.json",
+        "required_for_gates": ["detectors_materialized_ok"],
+    },
+    "external_summary": {
+        "schema_version": "external_summary_v0",
+        "artifact_path": "PULSE_safe_pack_v0/artifacts/external/gpt_summary.json",
+        "raw_path": "artifacts/raw/gpt_summary.raw.json",
+        "required_for_gates": ["external_summaries_present", "external_all_pass"],
+    },
+    "refusal_delta_summary": {
+        "schema_version": "refusal_delta_summary_v0",
+        "artifact_path": "PULSE_safe_pack_v0/artifacts/refusal/refusal_delta_summary.json",
+        "raw_path": "artifacts/raw/refusal_delta.raw.json",
+        "required_for_gates": ["refusal_delta_evidence_present"],
+    },
+}
+
+
+def _manifest_template() -> dict[str, Any]:
+    candidate_evidence: dict[str, Any] = {}
+    expected_relation_bindings: dict[str, Any] = {}
+    expected_gate_materialization: dict[str, Any] = {
+        "detectors_materialized_ok": {
+            "candidate_evidence_ids": ["detector_report"],
+            "expected_value": True,
+            "materialization_allowed_without_verifier": False,
+            "policy_relation": "release_required",
+            "relation_binding_ids": [
+                "detector_report_to_subject_commit",
+                "detector_report_to_gate",
+            ],
+        },
+        "external_summaries_present": {
+            "candidate_evidence_ids": ["external_summary"],
+            "expected_value": True,
+            "materialization_allowed_without_verifier": False,
+            "policy_relation": "release_required",
+            "relation_binding_ids": [
+                "external_summary_to_subject_commit",
+                "external_summary_to_gate_external_summaries_present",
+            ],
+        },
+        "external_all_pass": {
+            "candidate_evidence_ids": ["external_summary"],
+            "expected_value": True,
+            "materialization_allowed_without_verifier": False,
+            "policy_relation": "release_required",
+            "relation_binding_ids": [
+                "external_summary_to_subject_commit",
+                "external_summary_to_gate_external_all_pass",
+            ],
+        },
+        "refusal_delta_evidence_present": {
+            "candidate_evidence_ids": ["refusal_delta_summary"],
+            "expected_value": True,
+            "materialization_allowed_without_verifier": False,
+            "policy_relation": "release_required",
+            "relation_binding_ids": [
+                "refusal_delta_summary_to_subject_commit",
+                "refusal_delta_summary_to_gate",
+            ],
+        },
+    }
+
+    for evidence_id, definition in EVIDENCE_DEFS.items():
+        candidate_evidence[evidence_id] = {
+            "expected_sha256": None,
+            "kind": "recorded_release_evidence",
+            "path": definition["artifact_path"],
+            "provenance_expectations": {
+                "trusted_producer_required": True,
+            },
+            "required_for_gates": definition["required_for_gates"],
+            "schema_version": definition["schema_version"],
+            "subject_binding": {
+                "git_sha": COMMIT_SHA,
+                "run_key": RUN_KEY,
+            },
+            "verification_required": True,
+        }
+        expected_relation_bindings[f"{evidence_id}_to_subject_commit"] = {
+            "binding_type": "artifact_to_subject",
+            "expected_gate_id": definition["required_for_gates"][0],
+            "failure_if_missing": "candidate evidence is not bound to subject commit",
+            "required": True,
+            "source_evidence_id": evidence_id,
+            "target": "subject.commit_sha",
+        }
+        for gate_id in definition["required_for_gates"]:
+            if evidence_id == "external_summary":
+                relation_id = f"{evidence_id}_to_gate_{gate_id}"
+            else:
+                relation_id = f"{evidence_id}_to_gate"
+            expected_relation_bindings[relation_id] = {
+                "binding_type": "artifact_to_gate",
+                "expected_gate_id": gate_id,
+                "failure_if_missing": "candidate evidence is not bound to expected gate",
+                "required": True,
+                "source_evidence_id": evidence_id,
+                "target": f"gate.{gate_id}",
+            }
+
+    return {
+        "schema_version": "release_evidence_input_manifest_v0",
+        "manifest_id": "release_evidence_input_manifest_v0",
+        "manifest_version": "0.1.0",
+        "created_utc": "2026-01-01T00:00:00Z",
+        "run_identity": {
+            "git_sha": COMMIT_SHA,
+            "run_key": RUN_KEY,
+            "run_mode": "prod",
+        },
+        "subject": {
+            "commit_sha": COMMIT_SHA,
+            "release_candidate": "v0.0.0-test",
+            "repository": "HKati/pulse-release-gates-0.1",
+        },
+        "policy_binding": {
+            "policy_path": "pulse_gate_policy_v0.yml",
+            "policy_set": "required+release_required",
+            "policy_sha256": HEX64_POLICY,
+        },
+        "registry_binding": {
+            "registry_path": "pulse_gate_registry_v0.yml",
+            "registry_sha256": "c" * 64,
+        },
+        "candidate_evidence": candidate_evidence,
+        "expected_relation_bindings": expected_relation_bindings,
+        "expected_gate_materialization": expected_gate_materialization,
+        "fail_closed_requirements": [
+            "missing candidate evidence fails closed",
+            "missing expected relation binding fails closed",
+            "candidate evidence cannot materialize a gate without verifier output",
+        ],
+        "warnings": [],
+    }
+
+
+def _build_repo_fixture(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path, dict[str, Any]]:
+    manifest = _manifest_template()
+    for evidence_id, definition in EVIDENCE_DEFS.items():
+        raw_path = tmp_path / definition["raw_path"]
+        raw_sha = _write_text(raw_path, f"raw::{evidence_id}\n")
+        artifact_payload = _candidate_artifact(
+            schema_version=definition["schema_version"],
+            required_for_gates=definition["required_for_gates"],
+            raw_path=definition["raw_path"],
+            raw_sha256=raw_sha,
+        )
+        artifact_path = tmp_path / definition["artifact_path"]
+        artifact_sha = _write_json(artifact_path, artifact_payload)
+        manifest["candidate_evidence"][evidence_id]["expected_sha256"] = artifact_sha
+
+    manifest_path = tmp_path / "PULSE_safe_pack_v0" / "artifacts" / "release_evidence_input_manifest_v0.json"
+    _write_json(manifest_path, manifest)
+    return tmp_path, manifest_path, manifest
+
+
+def _run_cli(
+    repo_root: pathlib.Path,
+    manifest_path: pathlib.Path,
+    out_json: pathlib.Path,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--manifest",
+            str(manifest_path),
+            "--repo-root",
+            str(repo_root),
+            "--out-json",
+            str(out_json),
+        ],
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def test_valid_recorded_release_evidence_passes(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, _ = _build_repo_fixture(tmp_path)
+    report = check_recorded_release_evidence(manifest_path, repo_root)
+    assert report["schema_version"] == REPORT_SCHEMA_VERSION
+    assert report["status"] == "verified"
+    assert report["errors"] == []
+    assert report["gate_materialization_admissibility"]["detectors_materialized_ok"][
+        "admissible"
+    ] is True
+
+
+def test_cli_writes_report_and_passes(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, _ = _build_repo_fixture(tmp_path)
+    out_json = tmp_path / "PULSE_safe_pack_v0" / "artifacts" / "recorded_release_evidence_verifier_v0.json"
+    result = _run_cli(repo_root, manifest_path, out_json)
+    assert result.returncode == 0, result.stderr
+    assert "OK: recorded release-evidence verification satisfied" in result.stdout
+    report = json.loads(out_json.read_text(encoding="utf-8"))
+    assert report["status"] == "verified"
+
+
+def test_candidate_digest_mismatch_fails_closed(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, manifest = _build_repo_fixture(tmp_path)
+    detector_path = repo_root / EVIDENCE_DEFS["detector_report"]["artifact_path"]
+    payload = json.loads(detector_path.read_text(encoding="utf-8"))
+    payload["provenance"]["producer"] = "tampered"
+    _write_json(detector_path, payload)
+    report = check_recorded_release_evidence(manifest_path, repo_root)
+    assert report["status"] == "failed"
+    assert any("candidate artifact sha256 mismatch" in error for error in report["errors"])
+
+
+def test_run_identity_mismatch_fails_closed(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, _ = _build_repo_fixture(tmp_path)
+    detector_path = repo_root / EVIDENCE_DEFS["detector_report"]["artifact_path"]
+    payload = json.loads(detector_path.read_text(encoding="utf-8"))
+    payload["run_identity"]["run_key"] = "wrong-run-key"
+    _write_json(detector_path, payload)
+    report = check_recorded_release_evidence(manifest_path, repo_root)
+    assert report["status"] == "failed"
+    assert any("run_identity.run_key mismatch" in error for error in report["errors"])
+
+
+def test_policy_binding_mismatch_fails_closed(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, _ = _build_repo_fixture(tmp_path)
+    external_path = repo_root / EVIDENCE_DEFS["external_summary"]["artifact_path"]
+    payload = json.loads(external_path.read_text(encoding="utf-8"))
+    payload["policy_binding"]["policy_sha256"] = "d" * 64
+    _write_json(external_path, payload)
+    report = check_recorded_release_evidence(manifest_path, repo_root)
+    assert report["status"] == "failed"
+    assert any("policy_binding.policy_sha256 mismatch" in error for error in report["errors"])
+
+
+def test_missing_raw_evidence_fails_closed(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, _ = _build_repo_fixture(tmp_path)
+    raw_path = repo_root / EVIDENCE_DEFS["refusal_delta_summary"]["raw_path"]
+    raw_path.unlink()
+    report = check_recorded_release_evidence(manifest_path, repo_root)
+    assert report["status"] == "failed"
+    assert any("raw evidence not found" in error for error in report["errors"])
+
+
+def test_untrusted_producer_fails_when_required(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, _ = _build_repo_fixture(tmp_path)
+    detector_path = repo_root / EVIDENCE_DEFS["detector_report"]["artifact_path"]
+    payload = json.loads(detector_path.read_text(encoding="utf-8"))
+    payload["provenance"]["trusted_producer"] = False
+    _write_json(detector_path, payload)
+    report = check_recorded_release_evidence(manifest_path, repo_root)
+    assert report["status"] == "failed"
+    assert any("provenance.trusted_producer must be true" in error for error in report["errors"])
+
+
+def test_relation_and_gate_admissibility_fail_when_gate_target_missing(
+    tmp_path: pathlib.Path,
+) -> None:
+    repo_root, manifest_path, _ = _build_repo_fixture(tmp_path)
+    external_path = repo_root / EVIDENCE_DEFS["external_summary"]["artifact_path"]
+    payload = json.loads(external_path.read_text(encoding="utf-8"))
+    payload["required_for_gates"] = ["external_summaries_present"]
+    _write_json(external_path, payload)
+    report = check_recorded_release_evidence(manifest_path, repo_root)
+    assert report["status"] == "failed"
+    assert report["relation_binding_results"][
+        "external_summary_to_gate_external_all_pass"
+    ]["status"] == "failed"
+    assert report["gate_materialization_admissibility"]["external_all_pass"][
+        "admissible"
+    ] is False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_check_recorded_release_evidence_v0.py
+++ b/tests/test_check_recorded_release_evidence_v0.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import copy
 import hashlib
 import json
 import pathlib
@@ -24,9 +23,31 @@ CHECKER = (
     REPO_ROOT / "PULSE_safe_pack_v0" / "tools" / "check_recorded_release_evidence_v0.py"
 )
 HEX40 = "a" * 40
-HEX64_POLICY = "b" * 64
 RUN_KEY = "run-prod-2026-01-01"
 COMMIT_SHA = HEX40
+
+POLICY_TEXT = """policy:
+  id: pulse-gate-policy-v0
+  version: "0.1.5"
+  gates:
+    release_required:
+      - detectors_materialized_ok
+      - external_summaries_present
+      - external_all_pass
+      - refusal_delta_evidence_present
+"""
+
+REGISTRY_TEXT = """version: gate_registry_v0
+gates:
+  detectors_materialized_ok:
+    category: controls
+  external_summaries_present:
+    category: external
+  external_all_pass:
+    category: external
+  refusal_delta_evidence_present:
+    category: controls
+"""
 
 
 def _sha256_bytes(data: bytes) -> str:
@@ -46,6 +67,10 @@ def _write_text(path: pathlib.Path, text: str) -> str:
     return _sha256_bytes(text.encode("utf-8"))
 
 
+def _read_json(path: pathlib.Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 def _candidate_artifact(
     *,
     schema_version: str,
@@ -53,7 +78,7 @@ def _candidate_artifact(
     raw_path: str,
     raw_sha256: str,
     trusted_producer: bool = True,
-    policy_sha256: str = HEX64_POLICY,
+    policy_sha256: str,
     run_key: str = RUN_KEY,
     git_sha: str = COMMIT_SHA,
 ) -> dict[str, Any]:
@@ -106,7 +131,7 @@ EVIDENCE_DEFS = {
 }
 
 
-def _manifest_template() -> dict[str, Any]:
+def _manifest_template(policy_sha256: str, registry_sha256: str) -> dict[str, Any]:
     candidate_evidence: dict[str, Any] = {}
     expected_relation_bindings: dict[str, Any] = {}
     expected_gate_materialization: dict[str, Any] = {
@@ -177,10 +202,11 @@ def _manifest_template() -> dict[str, Any]:
             "target": "subject.commit_sha",
         }
         for gate_id in definition["required_for_gates"]:
-            if evidence_id == "external_summary":
-                relation_id = f"{evidence_id}_to_gate_{gate_id}"
-            else:
-                relation_id = f"{evidence_id}_to_gate"
+            relation_id = (
+                f"{evidence_id}_to_gate_{gate_id}"
+                if evidence_id == "external_summary"
+                else f"{evidence_id}_to_gate"
+            )
             expected_relation_bindings[relation_id] = {
                 "binding_type": "artifact_to_gate",
                 "expected_gate_id": gate_id,
@@ -208,11 +234,11 @@ def _manifest_template() -> dict[str, Any]:
         "policy_binding": {
             "policy_path": "pulse_gate_policy_v0.yml",
             "policy_set": "required+release_required",
-            "policy_sha256": HEX64_POLICY,
+            "policy_sha256": policy_sha256,
         },
         "registry_binding": {
             "registry_path": "pulse_gate_registry_v0.yml",
-            "registry_sha256": "c" * 64,
+            "registry_sha256": registry_sha256,
         },
         "candidate_evidence": candidate_evidence,
         "expected_relation_bindings": expected_relation_bindings,
@@ -227,7 +253,9 @@ def _manifest_template() -> dict[str, Any]:
 
 
 def _build_repo_fixture(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path, dict[str, Any]]:
-    manifest = _manifest_template()
+    policy_sha = _write_text(tmp_path / "pulse_gate_policy_v0.yml", POLICY_TEXT)
+    registry_sha = _write_text(tmp_path / "pulse_gate_registry_v0.yml", REGISTRY_TEXT)
+    manifest = _manifest_template(policy_sha, registry_sha)
     for evidence_id, definition in EVIDENCE_DEFS.items():
         raw_path = tmp_path / definition["raw_path"]
         raw_sha = _write_text(raw_path, f"raw::{evidence_id}\n")
@@ -236,12 +264,15 @@ def _build_repo_fixture(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.P
             required_for_gates=definition["required_for_gates"],
             raw_path=definition["raw_path"],
             raw_sha256=raw_sha,
+            policy_sha256=policy_sha,
         )
         artifact_path = tmp_path / definition["artifact_path"]
         artifact_sha = _write_json(artifact_path, artifact_payload)
         manifest["candidate_evidence"][evidence_id]["expected_sha256"] = artifact_sha
 
-    manifest_path = tmp_path / "PULSE_safe_pack_v0" / "artifacts" / "release_evidence_input_manifest_v0.json"
+    manifest_path = (
+        tmp_path / "PULSE_safe_pack_v0" / "artifacts" / "release_evidence_input_manifest_v0.json"
+    )
     _write_json(manifest_path, manifest)
     return tmp_path, manifest_path, manifest
 
@@ -282,18 +313,60 @@ def test_valid_recorded_release_evidence_passes(tmp_path: pathlib.Path) -> None:
 
 def test_cli_writes_report_and_passes(tmp_path: pathlib.Path) -> None:
     repo_root, manifest_path, _ = _build_repo_fixture(tmp_path)
-    out_json = tmp_path / "PULSE_safe_pack_v0" / "artifacts" / "recorded_release_evidence_verifier_v0.json"
+    out_json = (
+        tmp_path
+        / "PULSE_safe_pack_v0"
+        / "artifacts"
+        / "recorded_release_evidence_verifier_v0.json"
+    )
     result = _run_cli(repo_root, manifest_path, out_json)
     assert result.returncode == 0, result.stderr
     assert "OK: recorded release-evidence verification satisfied" in result.stdout
-    report = json.loads(out_json.read_text(encoding="utf-8"))
+    report = _read_json(out_json)
     assert report["status"] == "verified"
 
 
+def test_empty_manifest_sections_fail_closed(tmp_path: pathlib.Path) -> None:
+    policy_sha = _write_text(tmp_path / "pulse_gate_policy_v0.yml", POLICY_TEXT)
+    registry_sha = _write_text(tmp_path / "pulse_gate_registry_v0.yml", REGISTRY_TEXT)
+    manifest = {
+        "schema_version": "release_evidence_input_manifest_v0",
+        "run_identity": {"git_sha": COMMIT_SHA, "run_key": RUN_KEY, "run_mode": "prod"},
+        "subject": {"commit_sha": COMMIT_SHA},
+        "policy_binding": {
+            "policy_path": "pulse_gate_policy_v0.yml",
+            "policy_set": "required+release_required",
+            "policy_sha256": policy_sha,
+        },
+        "registry_binding": {
+            "registry_path": "pulse_gate_registry_v0.yml",
+            "registry_sha256": registry_sha,
+        },
+        "candidate_evidence": {},
+        "expected_relation_bindings": {},
+        "expected_gate_materialization": {},
+    }
+    manifest_path = (
+        tmp_path / "PULSE_safe_pack_v0" / "artifacts" / "release_evidence_input_manifest_v0.json"
+    )
+    _write_json(manifest_path, manifest)
+    report = check_recorded_release_evidence(manifest_path, tmp_path)
+    assert report["status"] == "failed"
+    assert any("manifest.candidate_evidence must not be empty" in error for error in report["errors"])
+    assert any(
+        "manifest.expected_relation_bindings must not be empty" in error
+        for error in report["errors"]
+    )
+    assert any(
+        "manifest.expected_gate_materialization must not be empty" in error
+        for error in report["errors"]
+    )
+
+
 def test_candidate_digest_mismatch_fails_closed(tmp_path: pathlib.Path) -> None:
-    repo_root, manifest_path, manifest = _build_repo_fixture(tmp_path)
+    repo_root, manifest_path, _ = _build_repo_fixture(tmp_path)
     detector_path = repo_root / EVIDENCE_DEFS["detector_report"]["artifact_path"]
-    payload = json.loads(detector_path.read_text(encoding="utf-8"))
+    payload = _read_json(detector_path)
     payload["provenance"]["producer"] = "tampered"
     _write_json(detector_path, payload)
     report = check_recorded_release_evidence(manifest_path, repo_root)
@@ -304,7 +377,7 @@ def test_candidate_digest_mismatch_fails_closed(tmp_path: pathlib.Path) -> None:
 def test_run_identity_mismatch_fails_closed(tmp_path: pathlib.Path) -> None:
     repo_root, manifest_path, _ = _build_repo_fixture(tmp_path)
     detector_path = repo_root / EVIDENCE_DEFS["detector_report"]["artifact_path"]
-    payload = json.loads(detector_path.read_text(encoding="utf-8"))
+    payload = _read_json(detector_path)
     payload["run_identity"]["run_key"] = "wrong-run-key"
     _write_json(detector_path, payload)
     report = check_recorded_release_evidence(manifest_path, repo_root)
@@ -315,7 +388,7 @@ def test_run_identity_mismatch_fails_closed(tmp_path: pathlib.Path) -> None:
 def test_policy_binding_mismatch_fails_closed(tmp_path: pathlib.Path) -> None:
     repo_root, manifest_path, _ = _build_repo_fixture(tmp_path)
     external_path = repo_root / EVIDENCE_DEFS["external_summary"]["artifact_path"]
-    payload = json.loads(external_path.read_text(encoding="utf-8"))
+    payload = _read_json(external_path)
     payload["policy_binding"]["policy_sha256"] = "d" * 64
     _write_json(external_path, payload)
     report = check_recorded_release_evidence(manifest_path, repo_root)
@@ -332,33 +405,152 @@ def test_missing_raw_evidence_fails_closed(tmp_path: pathlib.Path) -> None:
     assert any("raw evidence not found" in error for error in report["errors"])
 
 
+def test_candidate_subject_must_bind_back_to_run_identity(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, _ = _build_repo_fixture(tmp_path)
+    manifest = _read_json(manifest_path)
+    manifest["subject"]["commit_sha"] = "b" * 40
+    _write_json(manifest_path, manifest)
+    detector_path = repo_root / EVIDENCE_DEFS["detector_report"]["artifact_path"]
+    payload = _read_json(detector_path)
+    payload["subject_binding"]["git_sha"] = "b" * 40
+    _write_json(detector_path, payload)
+    report = check_recorded_release_evidence(manifest_path, repo_root)
+    assert report["status"] == "failed"
+    assert any(
+        "manifest.subject.commit_sha must match manifest.run_identity.git_sha" in error
+        for error in report["errors"]
+    )
+    assert any("subject_binding_to_run_identity.git_sha mismatch" in error for error in report["errors"])
+
+
+def test_gate_relation_must_match_current_gate(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, manifest = _build_repo_fixture(tmp_path)
+    manifest["expected_gate_materialization"]["external_all_pass"]["relation_binding_ids"] = [
+        "external_summary_to_subject_commit",
+        "external_summary_to_gate_external_summaries_present",
+    ]
+    _write_json(manifest_path, manifest)
+    report = check_recorded_release_evidence(manifest_path, repo_root)
+    assert report["status"] == "failed"
+    assert any(
+        "relation 'external_summary_to_gate_external_summaries_present' must target expected_gate_id 'external_all_pass'"
+        in error
+        or "gate external_all_pass relation 'external_summary_to_gate_external_summaries_present'" in error
+        for error in report["errors"]
+    )
+    assert report["gate_materialization_admissibility"]["external_all_pass"]["admissible"] is False
+
+
+def test_duplicate_json_keys_fail_closed(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, _ = _build_repo_fixture(tmp_path)
+    manifest = _read_json(manifest_path)
+    detector_path = repo_root / EVIDENCE_DEFS["detector_report"]["artifact_path"]
+    detector_path.write_text(
+        "\n".join(
+            [
+                "{",
+                '  "schema_version": "detector_report_v0",',
+                '  "schema_version": "tampered",',
+                '  "run_identity": {"git_sha": "' + COMMIT_SHA + '", "run_key": "' + RUN_KEY + '", "run_mode": "prod"},',
+                '  "subject_binding": {"git_sha": "' + COMMIT_SHA + '", "run_key": "' + RUN_KEY + '"},',
+                '  "policy_binding": {"policy_set": "required+release_required", "policy_sha256": "' + manifest["policy_binding"]["policy_sha256"] + '"},',
+                '  "provenance": {"trusted_producer": true},',
+                '  "raw_evidence_binding": {"path": "artifacts/raw/detector_report.raw.json", "sha256": "' + _sha256_bytes(b"raw::detector_report\n") + '"},',
+                '  "required_for_gates": ["detectors_materialized_ok"]',
+                "}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    report = check_recorded_release_evidence(manifest_path, repo_root)
+    assert report["status"] == "failed"
+    assert any("duplicate JSON key" in error for error in report["errors"])
+
+
+def test_policy_and_registry_digest_mismatch_fail_closed(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, manifest = _build_repo_fixture(tmp_path)
+    manifest["policy_binding"]["policy_sha256"] = "d" * 64
+    manifest["registry_binding"]["registry_sha256"] = "e" * 64
+    _write_json(manifest_path, manifest)
+    report = check_recorded_release_evidence(manifest_path, repo_root)
+    assert report["status"] == "failed"
+    assert any("policy file sha256 mismatch" in error for error in report["errors"])
+    assert any("registry file sha256 mismatch" in error for error in report["errors"])
+
+
+def test_unknown_release_required_gate_fails_closed(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, manifest = _build_repo_fixture(tmp_path)
+    manifest["expected_gate_materialization"]["totally_unknown_gate"] = {
+        "candidate_evidence_ids": ["detector_report"],
+        "expected_value": True,
+        "materialization_allowed_without_verifier": False,
+        "policy_relation": "release_required",
+        "relation_binding_ids": ["detector_report_to_subject_commit", "detector_report_to_gate"],
+    }
+    _write_json(manifest_path, manifest)
+    report = check_recorded_release_evidence(manifest_path, repo_root)
+    assert report["status"] == "failed"
+    assert any("not declared in policy.gates.release_required" in error for error in report["errors"])
+
+
+def test_directory_candidate_path_fails_closed_with_report(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, manifest = _build_repo_fixture(tmp_path)
+    bad_dir = repo_root / "artifacts" / "detectors" / "directory_artifact"
+    bad_dir.mkdir(parents=True, exist_ok=True)
+    manifest["candidate_evidence"]["detector_report"]["path"] = "artifacts/detectors/directory_artifact"
+    _write_json(manifest_path, manifest)
+    out_json = (
+        tmp_path
+        / "PULSE_safe_pack_v0"
+        / "artifacts"
+        / "recorded_release_evidence_verifier_v0.json"
+    )
+    result = _run_cli(repo_root, manifest_path, out_json)
+    assert result.returncode == 1
+    report = _read_json(out_json)
+    assert report["status"] == "failed"
+    assert any("candidate artifact must be a file" in error for error in report["errors"])
+
+
+def test_missing_concrete_run_identity_fails_closed(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, manifest = _build_repo_fixture(tmp_path)
+    manifest["run_identity"]["git_sha"] = "not-a-sha"
+    manifest["run_identity"]["run_key"] = ""
+    _write_json(manifest_path, manifest)
+    report = check_recorded_release_evidence(manifest_path, repo_root)
+    assert report["status"] == "failed"
+    assert any(
+        "manifest.run_identity.git_sha must be a 40-hex git sha" in error
+        for error in report["errors"]
+    )
+    assert any(
+        "manifest.run_identity.run_key must be a non-empty string" in error
+        for error in report["errors"]
+    )
+
+
+def test_trusted_producer_expectation_must_be_explicit(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, manifest = _build_repo_fixture(tmp_path)
+    del manifest["candidate_evidence"]["detector_report"]["provenance_expectations"]["trusted_producer_required"]
+    _write_json(manifest_path, manifest)
+    report = check_recorded_release_evidence(manifest_path, repo_root)
+    assert report["status"] == "failed"
+    assert any("trusted_producer_required must be literal true" in error for error in report["errors"])
+
+
 def test_untrusted_producer_fails_when_required(tmp_path: pathlib.Path) -> None:
     repo_root, manifest_path, _ = _build_repo_fixture(tmp_path)
     detector_path = repo_root / EVIDENCE_DEFS["detector_report"]["artifact_path"]
-    payload = json.loads(detector_path.read_text(encoding="utf-8"))
+    payload = _read_json(detector_path)
     payload["provenance"]["trusted_producer"] = False
     _write_json(detector_path, payload)
     report = check_recorded_release_evidence(manifest_path, repo_root)
     assert report["status"] == "failed"
-    assert any("provenance.trusted_producer must be true" in error for error in report["errors"])
-
-
-def test_relation_and_gate_admissibility_fail_when_gate_target_missing(
-    tmp_path: pathlib.Path,
-) -> None:
-    repo_root, manifest_path, _ = _build_repo_fixture(tmp_path)
-    external_path = repo_root / EVIDENCE_DEFS["external_summary"]["artifact_path"]
-    payload = json.loads(external_path.read_text(encoding="utf-8"))
-    payload["required_for_gates"] = ["external_summaries_present"]
-    _write_json(external_path, payload)
-    report = check_recorded_release_evidence(manifest_path, repo_root)
-    assert report["status"] == "failed"
-    assert report["relation_binding_results"][
-        "external_summary_to_gate_external_all_pass"
-    ]["status"] == "failed"
-    assert report["gate_materialization_admissibility"]["external_all_pass"][
-        "admissible"
-    ] is False
+    assert any(
+        "candidate artifact detector_report.provenance.trusted_producer must be true" in error
+        for error in report["errors"]
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a fail-closed recorded release-evidence verifier for release-grade materialization prerequisites.

The verifier checks whether detector materialization artifacts, canonical external summaries, and refusal-delta evidence are sufficiently bound to:

- run identity
- subject binding
- declared policy context
- trusted provenance expectations
- raw evidence digests
- expected relation bindings
- release-required gate admissibility

This PR is prerequisite-only. It does not create release authority and does not change the normative release path.

## Why

`--release-grade-materialized` is intentionally fail-closed today because local detector materialization artifacts, canonical external summaries, and refusal-delta summaries can exist as self-declared files without proving identity, provenance, policy, subject, or raw-evidence binding.

The missing step was a machine-readable verifier that proves those bindings before later release-grade materialization can admit them.

## What this PR adds

- `PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py`
- `tests/test_check_recorded_release_evidence_v0.py`
- `docs/recorded_release_evidence_verifier_v0.md`
- `ci/tools-tests.list` coverage wiring
- `docs/release_grade_reference_run_v0.md` status/follow-up update

## Boundary

The recorded release-evidence verifier is a prerequisite evidence-binding checker.

It is not:
- a new release gate
- a replacement for `check_gates.py`
- a replacement for `status.json`
- a second release-decision engine
- a policy override
- a fold-in of verified evidence into `--release-grade-materialized` in this PR

The normative release decision remains:

recorded release evidence
→ `status.json`
→ declared gate policy
→ workflow-effective required gate set
→ `check_gates.py`
→ primary CI allow/block decision

## Testing

Run:

```bash
pytest -q tests/test_check_recorded_release_evidence_v0.py
```

## Result

This PR adds the missing verifier prerequisite and keeps release-grade fold-in intentionally fail-closed until a later PR admits only verifier-validated evidence.