### PR TITLE
test(ref): add duplicate-key manifest regression for recorded release…

### DIFF
--- a/tests/test_check_recorded_release_evidence_v0.py
+++ b/tests/test_check_recorded_release_evidence_v0.py
@@ -468,6 +468,24 @@ def test_duplicate_json_keys_fail_closed(tmp_path: pathlib.Path) -> None:
     assert any("duplicate JSON key" in error for error in report["errors"])
 
 
+def test_duplicate_manifest_json_keys_fail_closed(tmp_path: pathlib.Path) -> None:
+    repo_root, manifest_path, manifest = _build_repo_fixture(tmp_path)
+    manifest_text = json.dumps(manifest, indent=2, sort_keys=True)
+    manifest_path.write_text(
+        manifest_text.replace(
+            '  "schema_version": "release_evidence_input_manifest_v0",',
+            '  "schema_version": "release_evidence_input_manifest_v0",\n'
+            '  "schema_version": "tampered",',
+            1,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    report = check_recorded_release_evidence(manifest_path, repo_root)
+    assert report["status"] == "failed"
+    assert any("duplicate JSON key" in error for error in report["errors"])
+
+
 def test_policy_and_registry_digest_mismatch_fail_closed(tmp_path: pathlib.Path) -> None:
     repo_root, manifest_path, manifest = _build_repo_fixture(tmp_path)
     manifest["policy_binding"]["policy_sha256"] = "d" * 64


### PR DESCRIPTION
## Summary

Adds regression coverage for duplicate JSON keys in the
release-evidence input manifest.

The new test injects a duplicate schema_version key into
the manifest and asserts that the recorded release-evidence
verifier fails closed with a duplicate JSON key error.

## Why

The verifier must reject ambiguous JSON inputs.

This follow-up locks in the duplicate-key fail-closed
behavior with an explicit regression test so the boundary
does not silently regress later.

## Scope

- update tests/test_check_recorded_release_evidence_v0.py

## Boundary

- test-only
- no release semantics change
- no status.json change
- no gate policy change
- no check_gates.py change

## Testing

- pytest -q tests/test_check_recorded_release_evidence_v0.py