### PR TITLE
feat(pages): bind PULSEmech name identity to the stable public root

### DIFF
--- a/.github/workflows/publish_report_pages.yml
+++ b/.github/workflows/publish_report_pages.yml
@@ -266,6 +266,15 @@ jobs:
             cp -a "_site/index.html" "_site/report_card.html"
           fi
 
+          # --- Stable public root: PULSEmech landing ---
+          if [ -f "docs/pulsemech_root_landing.html" ]; then
+            cp -f "docs/pulsemech_root_landing.html" "_site/index.html"
+            echo "OK: installed stable PULSEmech landing at _site/index.html"
+          else
+            echo "::error::Missing docs/pulsemech_root_landing.html"
+            exit 1
+          fi
+         
           # Ensure legacy /report_card.htm exists and points to /report_card.html.
           # Prefer the repo-maintained file if present; otherwise generate it.
           if [ -f "docs/report_card.htm" ]; then
@@ -577,9 +586,9 @@ jobs:
               print("OK: keeping artifact-provided _site/latest/index.html")
               raise SystemExit(0)
 
-          src = Path("_site/index.html")
+          src = Path("_site/report_card.html")
           if not src.is_file():
-              src = Path("_site/report_card.html")
+              src = Path("_site/index.html")
 
           if not src.is_file():
               raise SystemExit(

--- a/docs/pulsemech_root_landing.html
+++ b/docs/pulsemech_root_landing.html
@@ -1,0 +1,245 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>PULSEmech — Artifact-Bound Release Authority for AI</title>
+  <meta name="description" content="PULSEmech is the artifact-bound release-authority mechanism for AI: recorded evidence, status.json, declared policy, materialized required gates, and strict fail-closed CI allow/block before deployment.">
+  <link rel="canonical" href="https://hkati.github.io/pulse-release-gates-0.1/">
+
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="PULSEmech — Artifact-Bound Release Authority for AI">
+  <meta property="og:description" content="PULSEmech is the artifact-bound release-authority mechanism for AI: recorded evidence, status.json, declared policy, materialized required gates, and strict fail-closed CI allow/block before deployment.">
+  <meta property="og:url" content="https://hkati.github.io/pulse-release-gates-0.1/">
+  <meta property="og:image" content="https://raw.githubusercontent.com/HKati/pulse-release-gates-0.1/main/hero_dark_4k.png">
+  <meta property="og:image:alt" content="PULSEmech — artifact-bound release authority for AI">
+  <meta property="og:site_name" content="PULSEmech">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="PULSEmech — Artifact-Bound Release Authority for AI">
+  <meta name="twitter:description" content="PULSEmech is the artifact-bound release-authority mechanism for AI: recorded evidence, status.json, declared policy, materialized required gates, and strict fail-closed CI allow/block before deployment.">
+  <meta name="twitter:image" content="https://raw.githubusercontent.com/HKati/pulse-release-gates-0.1/main/hero_dark_4k.png">
+  <meta name="twitter:image:alt" content="PULSEmech — artifact-bound release authority for AI">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    "name": "PULSEmech",
+    "alternateName": "PULSE",
+    "codeRepository": "https://github.com/HKati/pulse-release-gates-0.1",
+    "url": "https://hkati.github.io/pulse-release-gates-0.1/",
+    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+    "programmingLanguage": "Python",
+    "description": "PULSEmech is the artifact-bound release-authority mechanism for AI: recorded evidence, status.json, declared policy, materialized required gates, and strict fail-closed CI allow/block before deployment.",
+    "author": {
+      "@type": "Organization",
+      "name": "EPLabsAI"
+    },
+    "sameAs": [
+      "https://github.com/HKati/pulse-release-gates-0.1",
+      "https://hkati.github.io/pulse-release-gates-0.1/",
+      "https://doi.org/10.5281/zenodo.17373002",
+      "https://doi.org/10.5281/zenodo.17214908",
+      "https://doi.org/10.5281/zenodo.17833583"
+    ]
+  }
+  </script>
+
+  <style>
+    :root {
+      --bg: #0b0b0c;
+      --fg: #eaeaea;
+      --muted: #a9b0b6;
+      --accent: #e73e2f;
+      --chip: #2b2f33;
+      --link: #8ab4f8;
+      --card: #15171a;
+    }
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg: #ffffff;
+        --fg: #111111;
+        --muted: #555555;
+        --chip: #f2f4f7;
+        --link: #1a73e8;
+        --card: #fafbfc;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font: 16px/1.6 system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--fg);
+    }
+    .wrap {
+      max-width: 980px;
+      margin: 40px auto;
+      padding: 0 16px;
+    }
+    header {
+      text-align: center;
+      margin-bottom: 28px;
+    }
+    .eyebrow {
+      display: inline-block;
+      padding: 6px 12px;
+      border-radius: 999px;
+      background: var(--chip);
+      color: var(--fg);
+      font-size: 13px;
+      margin-bottom: 14px;
+    }
+    h1 {
+      font-size: 36px;
+      line-height: 1.15;
+      margin: 0 0 10px;
+      letter-spacing: .2px;
+    }
+    .sub {
+      font-size: 18px;
+      color: var(--muted);
+      margin: 0 auto 18px;
+      max-width: 760px;
+    }
+    .lead {
+      max-width: 820px;
+      margin: 0 auto 22px;
+      color: var(--fg);
+    }
+    .btns {
+      display: flex;
+      gap: 12px;
+      justify-content: center;
+      flex-wrap: wrap;
+      margin: 18px 0 10px;
+    }
+    .btn {
+      appearance: none;
+      border: 0;
+      border-radius: 10px;
+      padding: 12px 18px;
+      text-decoration: none;
+      font-weight: 600;
+      background: var(--accent);
+      color: white;
+    }
+    .btn.secondary {
+      background: var(--chip);
+      color: var(--fg);
+    }
+    .chips {
+      display: flex;
+      gap: 10px;
+      justify-content: center;
+      flex-wrap: wrap;
+      margin: 14px 0 0;
+    }
+    .chip {
+      background: var(--chip);
+      padding: 6px 10px;
+      border-radius: 999px;
+      font-size: 13px;
+    }
+    section {
+      margin: 28px 0;
+      padding: 20px;
+      border-radius: 14px;
+      background: var(--card);
+    }
+    h2 {
+      font-size: 22px;
+      margin: 0 0 10px;
+    }
+    p {
+      margin: 0 0 10px;
+    }
+    code {
+      background: var(--chip);
+      padding: 2px 6px;
+      border-radius: 6px;
+    }
+    .path {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      background: var(--chip);
+      padding: 10px 12px;
+      border-radius: 10px;
+      display: inline-block;
+      margin-top: 8px;
+    }
+    a { color: var(--link); }
+    footer {
+      margin: 40px 0 20px;
+      color: var(--muted);
+      text-align: center;
+      font-size: 14px;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <div class="eyebrow">Stable public root</div>
+      <h1>PULSEmech</h1>
+      <p class="sub">Artifact-Bound Release Authority for AI</p>
+      <p class="lead">
+        PULSEmech is the mechanism: recorded release evidence is bound into
+        <code>status.json</code>, declared gate policy, materialized required gates,
+        and strict fail-closed CI allow/block release decisions before deployment.
+      </p>
+
+      <div class="btns">
+        <a class="btn" href="report_card.html">Open Quality Ledger</a>
+        <a class="btn secondary" href="latest/">Open /latest/ reader surface</a>
+        <a class="btn secondary" href="https://github.com/HKati/pulse-release-gates-0.1">View on GitHub</a>
+        <a class="btn secondary" href="https://doi.org/10.5281/zenodo.17373002">Zenodo DOI</a>
+      </div>
+
+      <div class="chips">
+        <span class="chip">PULSEmech-first root</span>
+        <span class="chip">reader surface kept separate</span>
+        <span class="chip">fail-closed authority path unchanged</span>
+      </div>
+    </header>
+
+    <section>
+      <h2>What this root means</h2>
+      <p>
+        This public root is the stable name entrypoint for <strong>PULSEmech</strong>.
+        It identifies the mechanism first.
+      </p>
+      <p>
+        The Quality Ledger remains a separate public reader surface at
+        <a href="report_card.html"><code>report_card.html</code></a>.
+      </p>
+    </section>
+
+    <section>
+      <h2>Authority boundary</h2>
+      <p>
+        PULSEmech does not derive release authority from dashboards, pages, reviews,
+        or public reader surfaces.
+      </p>
+      <div class="path">
+        recorded release evidence → status.json → declared gate policy →
+        materialized required gate set → strict fail-closed CI enforcement →
+        CI allow/block release decision
+      </div>
+    </section>
+
+    <section>
+      <h2>Public entrypoints</h2>
+      <p><a href="report_card.html">Quality Ledger</a> — human-readable reader surface.</p>
+      <p><a href="latest/">/latest/</a> — stable alias for the current public reader surface.</p>
+      <p><a href="diagnostics/">/diagnostics/</a> — auxiliary public diagnostics.</p>
+      <p><a href="paradox/core/v0/">/paradox/core/v0/</a> — published Paradox Core reviewer surface.</p>
+    </section>
+
+    <footer>
+      © EPLabsAI ·
+      <a href="https://github.com/HKati/pulse-release-gates-0.1/blob/main/LICENSE">Apache-2.0</a> ·
+      <a href="mailto:eplabsai@eplabsai.com">eplabsai@eplabsai.com</a>
+    </footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Bind the PULSEmech name identity to the stable public root.

This PR adds a stable PULSEmech landing page for the Pages root and keeps
the Quality Ledger as a separate public reader surface.

## Why

The current public Pages root is ledger-first.
The repository identity is already PULSEmech-first.

This PR connects the name field to the strongest public entrypoint so the
stable root identifies PULSEmech first, while the ledger remains available
at its own reader surface.

## Scope

- add `docs/pulsemech_root_landing.html`
- update `.github/workflows/publish_report_pages.yml`

## Boundary

- no release-authority semantics change
- no gate-policy change
- no CI decision-path change
- no `check_gates.py` change
- no `.zenodo.json` change
- no Zenodo ingestion-path change

## Result

- `/` becomes the stable PULSEmech-first public entrypoint
- `report_card.html` remains the Quality Ledger reader surface
- `/latest/` remains the stable reader-surface alias