### PR TITLE
feat(ref): materialize release-required gates from verifier report

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -701,6 +701,28 @@ jobs:
 
           "${AUGMENT_CMD[@]}"
 
+      - name: release-grade verify recorded release evidence
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python "${PACK_DIR}/tools/check_recorded_release_evidence_v0.py" \
+            --manifest "${PACK_DIR}/artifacts/release_evidence_input_manifest_v0.json" \
+            --repo-root "${GITHUB_WORKSPACE}" \
+            --out-json "${PACK_DIR}/artifacts/recorded_release_evidence_verifier_v0.json"
+
+      - name: release-grade materialize release-required from verifier
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python "${PACK_DIR}/tools/materialize_release_required_from_verifier_v0.py" \
+            --status "${PACK_DIR}/artifacts/status.json" \
+            --verifier-report "${PACK_DIR}/artifacts/recorded_release_evidence_verifier_v0.json" \
+            --policy "${GITHUB_WORKSPACE}/pulse_gate_policy_v0.yml" \
+            --registry "${GITHUB_WORKSPACE}/pulse_gate_registry_v0.yml" \
+            --out "${PACK_DIR}/artifacts/status.json"
+      
       - name: "ci: schema validate status.json (status_v1)"
         shell: bash
         run: |

--- a/PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
+++ b/PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Materialize release-required gates from a verified recorded-evidence report.
+
+This tool is a prerequisite/admission step only.
+
+It does not replace check_gates.py.
+It does not redefine status.json semantics.
+It does not change gate policy.
+It does not create independent release authority.
+
+Role:
+verified recorded release-evidence report
+-> policy-derived release_required gate set
+-> literal true materialization into status["gates"]
+-> existing check_gates.py path
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - fail closed at runtime if unavailable
+    yaml = None
+
+EXPECTED_VERIFIER_SCHEMA = "recorded_release_evidence_verifier_v0"
+EXPECTED_VERIFIER_STATUS = "verified"
+EXPECTED_POLICY_SET = "required+release_required"
+EXPECTED_RUN_MODE = "prod"
+
+
+def _repo_root_from_tool() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _json_object_no_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def _yaml_loader_no_duplicates():
+    if yaml is None:
+        raise RuntimeError("PyYAML is required for YAML verification")
+
+    class Loader(yaml.SafeLoader):
+        pass
+
+    def construct_mapping(loader: Any, node: Any, deep: bool = False) -> dict[str, Any]:
+        mapping: dict[str, Any] = {}
+        for key_node, value_node in node.value:
+            key = loader.construct_object(key_node, deep=deep)
+            if key in mapping:
+                raise ValueError(f"duplicate YAML key {key!r}")
+            mapping[key] = loader.construct_object(value_node, deep=deep)
+        return mapping
+
+    Loader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        construct_mapping,
+    )
+    return Loader
+
+
+def _is_non_empty_text(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _is_sha256(value: Any) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(
+        c in "0123456789abcdef" for c in value.lower()
+    )
+
+
+def _load_json(path: Path, label: str, errors: list[str]) -> dict[str, Any] | None:
+    try:
+        if not path.exists():
+            errors.append(f"{label} not found: {path}")
+            return None
+        if not path.is_file():
+            errors.append(f"{label} must be a file: {path}")
+            return None
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"{label} could not be read: {exc}")
+        return None
+
+    try:
+        data = json.loads(text, object_pairs_hook=_json_object_no_duplicates)
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"{label} is not valid JSON: {exc}")
+        return None
+    if not isinstance(data, dict):
+        errors.append(f"{label} must be a JSON object")
+        return None
+    return data
+
+
+def _load_yaml(path: Path, label: str, errors: list[str]) -> dict[str, Any] | None:
+    if yaml is None:
+        errors.append(f"{label} could not be loaded: PyYAML is unavailable")
+        return None
+
+    try:
+        if not path.exists():
+            errors.append(f"{label} not found: {path}")
+            return None
+        if not path.is_file():
+            errors.append(f"{label} must be a file: {path}")
+            return None
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"{label} could not be read: {exc}")
+        return None
+
+    try:
+        loader = _yaml_loader_no_duplicates()
+        data = yaml.load(text, Loader=loader)
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"{label} is not valid YAML: {exc}")
+        return None
+    if not isinstance(data, dict):
+        errors.append(f"{label} must be a YAML mapping")
+        return None
+    return data
+
+
+def _sha256_file(path: Path, label: str, errors: list[str]) -> str | None:
+    try:
+        if not path.exists():
+            errors.append(f"{label} not found: {path}")
+            return None
+        if not path.is_file():
+            errors.append(f"{label} must be a file: {path}")
+            return None
+    except OSError as exc:
+        errors.append(f"{label} path check failed: {exc}")
+        return None
+
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(65536), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        errors.append(f"{label} could not be read: {exc}")
+        return None
+    return digest.hexdigest()
+
+
+def _normalize_gate_list(value: Any, label: str, errors: list[str]) -> list[str]:
+    if not isinstance(value, list):
+        errors.append(f"{label} must be an array")
+        return []
+    if not value:
+        errors.append(f"{label} must not be empty")
+        return []
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        if not _is_non_empty_text(item):
+            errors.append(f"{label} entries must be non-empty strings")
+            continue
+        gate_id = str(item).strip()
+        if gate_id in seen:
+            errors.append(f"{label} contains duplicate gate id {gate_id!r}")
+            continue
+        seen.add(gate_id)
+        normalized.append(gate_id)
+    return normalized
+
+
+def _extract_release_required_gates(policy_obj: dict[str, Any], errors: list[str]) -> list[str]:
+    policy = policy_obj.get("policy")
+    if not isinstance(policy, dict):
+        errors.append("policy file must contain top-level policy mapping")
+        return []
+    gates = policy.get("gates")
+    if not isinstance(gates, dict):
+        errors.append("policy file must contain policy.gates mapping")
+        return []
+    return _normalize_gate_list(
+        gates.get("release_required"),
+        "policy.gates.release_required",
+        errors,
+    )
+
+
+def _extract_registry_gate_ids(registry_obj: dict[str, Any], errors: list[str]) -> set[str]:
+    gates = registry_obj.get("gates")
+    if not isinstance(gates, dict):
+        errors.append("registry file must contain top-level gates mapping")
+        return set()
+    gate_ids: set[str] = set()
+    for gate_id in gates:
+        if not _is_non_empty_text(gate_id):
+            errors.append("registry gate ids must be non-empty strings")
+            continue
+        gate_ids.add(str(gate_id))
+    if not gate_ids:
+        errors.append("registry file must declare at least one gate id")
+    return gate_ids
+
+
+def _require_object(parent: dict[str, Any], key: str, label: str, errors: list[str]) -> dict[str, Any]:
+    value = parent.get(key)
+    if not isinstance(value, dict):
+        errors.append(f"{label}.{key} must be an object")
+        return {}
+    return value
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def materialize_release_required_from_verifier(
+    *,
+    status_path: Path,
+    verifier_report_path: Path,
+    policy_path: Path,
+    registry_path: Path,
+    out_path: Path,
+) -> tuple[dict[str, Any] | None, list[str], list[str]]:
+    errors: list[str] = []
+    materialized_gates: list[str] = []
+
+    status = _load_json(status_path, "status.json", errors)
+    verifier_report = _load_json(
+        verifier_report_path,
+        "recorded_release_evidence_verifier_v0.json",
+        errors,
+    )
+    policy_obj = _load_yaml(policy_path, "policy file", errors)
+    registry_obj = _load_yaml(registry_path, "registry file", errors)
+
+    if status is None or verifier_report is None or policy_obj is None or registry_obj is None:
+        return None, materialized_gates, errors
+
+    metrics = _require_object(status, "metrics", "status", errors)
+    if metrics.get("run_mode") != EXPECTED_RUN_MODE:
+        errors.append(
+            "status.metrics.run_mode must be 'prod' for release-grade materialization "
+            f"(got {metrics.get('run_mode')!r})"
+        )
+
+    gates = status.get("gates")
+    if not isinstance(gates, dict):
+        errors.append("status.gates must be an object")
+        gates = {}
+
+    if verifier_report.get("schema_version") != EXPECTED_VERIFIER_SCHEMA:
+        errors.append(
+            "verifier report schema_version must be "
+            f"{EXPECTED_VERIFIER_SCHEMA!r}"
+        )
+    if verifier_report.get("status") != EXPECTED_VERIFIER_STATUS:
+        errors.append(
+            "verifier report status must be "
+            f"{EXPECTED_VERIFIER_STATUS!r} (got {verifier_report.get('status')!r})"
+        )
+
+    policy_sha = _sha256_file(policy_path, "policy file", errors)
+    registry_sha = _sha256_file(registry_path, "registry file", errors)
+
+    policy_binding = _require_object(verifier_report, "policy_binding", "verifier_report", errors)
+    if policy_binding.get("policy_set") != EXPECTED_POLICY_SET:
+        errors.append(
+            "verifier_report.policy_binding.policy_set must be "
+            f"{EXPECTED_POLICY_SET!r} (got {policy_binding.get('policy_set')!r})"
+        )
+    if not _is_sha256(policy_binding.get("policy_sha256")):
+        errors.append("verifier_report.policy_binding.policy_sha256 must be a 64-hex sha256")
+    if policy_sha is not None and policy_binding.get("policy_sha256") != policy_sha:
+        errors.append(
+            "verifier_report.policy_binding.policy_sha256 does not match the current policy file "
+            f"(expected {policy_sha!r}, got {policy_binding.get('policy_sha256')!r})"
+        )
+
+    registry_binding = _require_object(verifier_report, "registry_binding", "verifier_report", errors)
+    if not _is_sha256(registry_binding.get("registry_sha256")):
+        errors.append("verifier_report.registry_binding.registry_sha256 must be a 64-hex sha256")
+    if registry_sha is not None and registry_binding.get("registry_sha256") != registry_sha:
+        errors.append(
+            "verifier_report.registry_binding.registry_sha256 does not match the current registry file "
+            f"(expected {registry_sha!r}, got {registry_binding.get('registry_sha256')!r})"
+        )
+
+    release_required_gates = _extract_release_required_gates(policy_obj, errors)
+    registry_gate_ids = _extract_registry_gate_ids(registry_obj, errors)
+
+    for gate_id in release_required_gates:
+        if gate_id not in registry_gate_ids:
+            errors.append(
+                f"policy.gates.release_required contains unknown registry gate id {gate_id!r}"
+            )
+
+    admissibility = verifier_report.get("gate_materialization_admissibility")
+    if not isinstance(admissibility, dict):
+        errors.append("verifier_report.gate_materialization_admissibility must be an object")
+        admissibility = {}
+
+    if errors:
+        return None, materialized_gates, errors
+
+    for gate_id in release_required_gates:
+        entry = admissibility.get(gate_id)
+        if not isinstance(entry, dict):
+            errors.append(
+                f"verifier_report.gate_materialization_admissibility.{gate_id} must be an object"
+            )
+            continue
+        if entry.get("status") != "verified":
+            errors.append(
+                "verifier_report.gate_materialization_admissibility."
+                f"{gate_id}.status must be 'verified' (got {entry.get('status')!r})"
+            )
+            continue
+        if entry.get("admissible") is not True:
+            errors.append(
+                "verifier_report.gate_materialization_admissibility."
+                f"{gate_id}.admissible must be literal true"
+            )
+            continue
+
+        gates[gate_id] = True
+        materialized_gates.append(gate_id)
+
+    if errors:
+        return None, materialized_gates, errors
+
+    status["gates"] = gates
+    return status, materialized_gates, errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    root = _repo_root_from_tool()
+    parser = argparse.ArgumentParser(
+        description=(
+            "Materialize release-required gates into status.json from a verified "
+            "recorded release-evidence verifier report."
+        )
+    )
+    parser.add_argument(
+        "--status",
+        default=str(root / "PULSE_safe_pack_v0" / "artifacts" / "status.json"),
+        help="Path to the input status.json.",
+    )
+    parser.add_argument(
+        "--verifier-report",
+        default=str(
+            root / "PULSE_safe_pack_v0" / "artifacts" / "recorded_release_evidence_verifier_v0.json"
+        ),
+        help="Path to recorded_release_evidence_verifier_v0.json.",
+    )
+    parser.add_argument(
+        "--policy",
+        default=str(root / "pulse_gate_policy_v0.yml"),
+        help="Path to pulse_gate_policy_v0.yml.",
+    )
+    parser.add_argument(
+        "--registry",
+        default=str(root / "pulse_gate_registry_v0.yml"),
+        help="Path to pulse_gate_registry_v0.yml.",
+    )
+    parser.add_argument(
+        "--out",
+        default=str(root / "PULSE_safe_pack_v0" / "artifacts" / "status.json"),
+        help="Path to write the materialized status.json.",
+    )
+    args = parser.parse_args(argv)
+
+    status, materialized_gates, errors = materialize_release_required_from_verifier(
+        status_path=Path(args.status),
+        verifier_report_path=Path(args.verifier_report),
+        policy_path=Path(args.policy),
+        registry_path=Path(args.registry),
+        out_path=Path(args.out),
+    )
+
+    if errors:
+        print("ERRORS (fail-closed):", file=sys.stderr)
+        for error in errors:
+            print(f" - {error}", file=sys.stderr)
+        return 1
+
+    assert status is not None  # for type checkers
+    _write_json(Path(args.out), status)
+    print(
+        "OK: materialized release-required gates from verified recorded evidence: "
+        + ", ".join(materialized_gates)
+    )
+    print(f"Status written to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
+++ b/PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
@@ -81,7 +81,13 @@ def _is_sha256(value: Any) -> bool:
     )
 
 
-def _load_json(path: Path, label: str, errors: list[str]) -> dict[str, Any] | None:
+def _is_git_sha(value: Any) -> bool:
+    return isinstance(value, str) and len(value) == 40 and all(
+        c in "0123456789abcdef" for c in value.lower()
+    )
+
+
+def _safe_read_text(path: Path, label: str, errors: list[str]) -> str | None:
     try:
         if not path.exists():
             errors.append(f"{label} not found: {path}")
@@ -89,11 +95,16 @@ def _load_json(path: Path, label: str, errors: list[str]) -> dict[str, Any] | No
         if not path.is_file():
             errors.append(f"{label} must be a file: {path}")
             return None
-        text = path.read_text(encoding="utf-8")
+        return path.read_text(encoding="utf-8")
     except OSError as exc:
         errors.append(f"{label} could not be read: {exc}")
         return None
 
+
+def _load_json(path: Path, label: str, errors: list[str]) -> dict[str, Any] | None:
+    text = _safe_read_text(path, label, errors)
+    if text is None:
+        return None
     try:
         data = json.loads(text, object_pairs_hook=_json_object_no_duplicates)
     except Exception as exc:  # noqa: BLE001
@@ -109,19 +120,9 @@ def _load_yaml(path: Path, label: str, errors: list[str]) -> dict[str, Any] | No
     if yaml is None:
         errors.append(f"{label} could not be loaded: PyYAML is unavailable")
         return None
-
-    try:
-        if not path.exists():
-            errors.append(f"{label} not found: {path}")
-            return None
-        if not path.is_file():
-            errors.append(f"{label} must be a file: {path}")
-            return None
-        text = path.read_text(encoding="utf-8")
-    except OSError as exc:
-        errors.append(f"{label} could not be read: {exc}")
+    text = _safe_read_text(path, label, errors)
+    if text is None:
         return None
-
     try:
         loader = _yaml_loader_no_duplicates()
         data = yaml.load(text, Loader=loader)
@@ -157,6 +158,14 @@ def _sha256_file(path: Path, label: str, errors: list[str]) -> str | None:
     return digest.hexdigest()
 
 
+def _require_object(parent: dict[str, Any], key: str, label: str, errors: list[str]) -> dict[str, Any]:
+    value = parent.get(key)
+    if not isinstance(value, dict):
+        errors.append(f"{label}.{key} must be an object")
+        return {}
+    return value
+
+
 def _normalize_gate_list(value: Any, label: str, errors: list[str]) -> list[str]:
     if not isinstance(value, list):
         errors.append(f"{label} must be an array")
@@ -164,6 +173,7 @@ def _normalize_gate_list(value: Any, label: str, errors: list[str]) -> list[str]
     if not value:
         errors.append(f"{label} must not be empty")
         return []
+
     normalized: list[str] = []
     seen: set[str] = set()
     for item in value:
@@ -180,19 +190,27 @@ def _normalize_gate_list(value: Any, label: str, errors: list[str]) -> list[str]
 
 
 def _extract_release_required_gates(policy_obj: dict[str, Any], errors: list[str]) -> list[str]:
+    gates = policy_obj.get("gates")
+    if isinstance(gates, dict):
+        return _normalize_gate_list(
+            gates.get("release_required"),
+            "gates.release_required",
+            errors,
+        )
+
+    # Backward-compatible fallback if an older nested shape is ever seen.
     policy = policy_obj.get("policy")
-    if not isinstance(policy, dict):
-        errors.append("policy file must contain top-level policy mapping")
-        return []
-    gates = policy.get("gates")
-    if not isinstance(gates, dict):
-        errors.append("policy file must contain policy.gates mapping")
-        return []
-    return _normalize_gate_list(
-        gates.get("release_required"),
-        "policy.gates.release_required",
-        errors,
-    )
+    if isinstance(policy, dict):
+        nested_gates = policy.get("gates")
+        if isinstance(nested_gates, dict):
+            return _normalize_gate_list(
+                nested_gates.get("release_required"),
+                "policy.gates.release_required",
+                errors,
+            )
+
+    errors.append("policy file must contain top-level gates mapping")
+    return []
 
 
 def _extract_registry_gate_ids(registry_obj: dict[str, Any], errors: list[str]) -> set[str]:
@@ -200,6 +218,7 @@ def _extract_registry_gate_ids(registry_obj: dict[str, Any], errors: list[str]) 
     if not isinstance(gates, dict):
         errors.append("registry file must contain top-level gates mapping")
         return set()
+
     gate_ids: set[str] = set()
     for gate_id in gates:
         if not _is_non_empty_text(gate_id):
@@ -211,12 +230,37 @@ def _extract_registry_gate_ids(registry_obj: dict[str, Any], errors: list[str]) 
     return gate_ids
 
 
-def _require_object(parent: dict[str, Any], key: str, label: str, errors: list[str]) -> dict[str, Any]:
-    value = parent.get(key)
-    if not isinstance(value, dict):
-        errors.append(f"{label}.{key} must be an object")
-        return {}
-    return value
+def _validate_git_sha(value: Any, label: str, errors: list[str]) -> bool:
+    if not _is_git_sha(value):
+        errors.append(f"{label} must be a 40-hex git sha")
+        return False
+    return True
+
+
+def _validate_run_key(value: Any, label: str, errors: list[str]) -> bool:
+    if not _is_non_empty_text(value):
+        errors.append(f"{label} must be a non-empty string")
+        return False
+    return True
+
+
+def _canonical_repo_path(path: Path, repo_root: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(repo_root.resolve()))
+    except Exception:  # noqa: BLE001
+        return str(path)
+
+
+def _path_matches_recorded(value: Any, path: Path, repo_root: Path) -> bool:
+    if not _is_non_empty_text(value):
+        return False
+    actual = str(value).strip()
+    candidates = {
+        str(path),
+        str(path.resolve()),
+        _canonical_repo_path(path, repo_root),
+    }
+    return actual in candidates
 
 
 def _write_json(path: Path, data: dict[str, Any]) -> None:
@@ -230,10 +274,10 @@ def materialize_release_required_from_verifier(
     verifier_report_path: Path,
     policy_path: Path,
     registry_path: Path,
-    out_path: Path,
 ) -> tuple[dict[str, Any] | None, list[str], list[str]]:
     errors: list[str] = []
     materialized_gates: list[str] = []
+    repo_root = _repo_root_from_tool()
 
     status = _load_json(status_path, "status.json", errors)
     verifier_report = _load_json(
@@ -248,16 +292,50 @@ def materialize_release_required_from_verifier(
         return None, materialized_gates, errors
 
     metrics = _require_object(status, "metrics", "status", errors)
-    if metrics.get("run_mode") != EXPECTED_RUN_MODE:
-        errors.append(
-            "status.metrics.run_mode must be 'prod' for release-grade materialization "
-            f"(got {metrics.get('run_mode')!r})"
-        )
+    diagnostics = status.get("diagnostics")
+    if diagnostics is None:
+        diagnostics_obj: dict[str, Any] = {}
+    elif isinstance(diagnostics, dict):
+        diagnostics_obj = diagnostics
+    else:
+        errors.append("status.diagnostics must be an object when present")
+        diagnostics_obj = {}
 
     gates = status.get("gates")
     if not isinstance(gates, dict):
         errors.append("status.gates must be an object")
         gates = {}
+
+    status_git_sha = metrics.get("git_sha")
+    status_run_key = metrics.get("run_key")
+    status_run_mode = metrics.get("run_mode")
+    status_policy_path = metrics.get("gate_policy_path")
+    status_policy_sha = metrics.get("gate_policy_sha256")
+
+    _validate_git_sha(status_git_sha, "status.metrics.git_sha", errors)
+    _validate_run_key(status_run_key, "status.metrics.run_key", errors)
+
+    if status_run_mode != EXPECTED_RUN_MODE:
+        errors.append(
+            "status.metrics.run_mode must be 'prod' for release-grade materialization "
+            f"(got {status_run_mode!r})"
+        )
+
+    if diagnostics_obj.get("gates_stubbed") is True:
+        errors.append("status.diagnostics.gates_stubbed must not be true for release-grade materialization")
+    if diagnostics_obj.get("scaffold") is True:
+        errors.append("status.diagnostics.scaffold must not be true for release-grade materialization")
+
+    if not _is_non_empty_text(status_policy_path):
+        errors.append("status.metrics.gate_policy_path must be a non-empty string")
+    elif not _path_matches_recorded(status_policy_path, policy_path, repo_root):
+        errors.append(
+            "status.metrics.gate_policy_path does not match the current policy file "
+            f"(got {status_policy_path!r}, expected {_canonical_repo_path(policy_path, repo_root)!r})"
+        )
+
+    if not _is_sha256(status_policy_sha):
+        errors.append("status.metrics.gate_policy_sha256 must be a 64-hex sha256")
 
     if verifier_report.get("schema_version") != EXPECTED_VERIFIER_SCHEMA:
         errors.append(
@@ -270,35 +348,106 @@ def materialize_release_required_from_verifier(
             f"{EXPECTED_VERIFIER_STATUS!r} (got {verifier_report.get('status')!r})"
         )
 
+    verifier_errors = verifier_report.get("errors")
+    if verifier_errors is not None:
+        if not isinstance(verifier_errors, list):
+            errors.append("verifier_report.errors must be an array when present")
+        elif verifier_errors:
+            errors.append("verifier_report.errors must be absent or empty before materialization")
+
     policy_sha = _sha256_file(policy_path, "policy file", errors)
     registry_sha = _sha256_file(registry_path, "registry file", errors)
 
+    if policy_sha is not None and status_policy_sha is not None and status_policy_sha != policy_sha:
+        errors.append(
+            "status.metrics.gate_policy_sha256 does not match the current policy file "
+            f"(expected {policy_sha!r}, got {status_policy_sha!r})"
+        )
+
+    run_identity = _require_object(verifier_report, "run_identity", "verifier_report", errors)
+    report_git_sha = run_identity.get("git_sha")
+    report_run_key = run_identity.get("run_key")
+    report_run_mode = run_identity.get("run_mode")
+
+    _validate_git_sha(report_git_sha, "verifier_report.run_identity.git_sha", errors)
+    _validate_run_key(report_run_key, "verifier_report.run_identity.run_key", errors)
+    if report_run_mode != EXPECTED_RUN_MODE:
+        errors.append(
+            "verifier_report.run_identity.run_mode must be 'prod' "
+            f"(got {report_run_mode!r})"
+        )
+
+    if status_git_sha != report_git_sha:
+        errors.append(
+            "status.metrics.git_sha must match verifier_report.run_identity.git_sha "
+            f"(expected {report_git_sha!r}, got {status_git_sha!r})"
+        )
+    if status_run_key != report_run_key:
+        errors.append(
+            "status.metrics.run_key must match verifier_report.run_identity.run_key "
+            f"(expected {report_run_key!r}, got {status_run_key!r})"
+        )
+
+    verified_subjects = _require_object(verifier_report, "verified_subjects", "verifier_report", errors)
+    verified_subject_git_sha = verified_subjects.get("git_sha")
+    verified_subject_run_key = verified_subjects.get("run_key")
+    verified_subject_commit_sha = verified_subjects.get("commit_sha")
+
+    _validate_git_sha(verified_subject_git_sha, "verifier_report.verified_subjects.git_sha", errors)
+    _validate_run_key(verified_subject_run_key, "verifier_report.verified_subjects.run_key", errors)
+    _validate_git_sha(verified_subject_commit_sha, "verifier_report.verified_subjects.commit_sha", errors)
+
+    if verified_subject_git_sha != status_git_sha:
+        errors.append(
+            "verifier_report.verified_subjects.git_sha must match status.metrics.git_sha "
+            f"(expected {status_git_sha!r}, got {verified_subject_git_sha!r})"
+        )
+    if verified_subject_run_key != status_run_key:
+        errors.append(
+            "verifier_report.verified_subjects.run_key must match status.metrics.run_key "
+            f"(expected {status_run_key!r}, got {verified_subject_run_key!r})"
+        )
+    if verified_subject_commit_sha != status_git_sha:
+        errors.append(
+            "verifier_report.verified_subjects.commit_sha must match status.metrics.git_sha "
+            f"(expected {status_git_sha!r}, got {verified_subject_commit_sha!r})"
+        )
+
     policy_binding = _require_object(verifier_report, "policy_binding", "verifier_report", errors)
-    if policy_binding.get("policy_set") != EXPECTED_POLICY_SET:
+    report_policy_set = policy_binding.get("policy_set")
+    report_policy_sha = policy_binding.get("policy_sha256")
+
+    if report_policy_set != EXPECTED_POLICY_SET:
         errors.append(
             "verifier_report.policy_binding.policy_set must be "
-            f"{EXPECTED_POLICY_SET!r} (got {policy_binding.get('policy_set')!r})"
+            f"{EXPECTED_POLICY_SET!r} (got {report_policy_set!r})"
         )
-    if not _is_sha256(policy_binding.get("policy_sha256")):
+    if not _is_sha256(report_policy_sha):
         errors.append("verifier_report.policy_binding.policy_sha256 must be a 64-hex sha256")
-    if policy_sha is not None and policy_binding.get("policy_sha256") != policy_sha:
+
+    if policy_sha is not None and report_policy_sha != policy_sha:
         errors.append(
             "verifier_report.policy_binding.policy_sha256 does not match the current policy file "
-            f"(expected {policy_sha!r}, got {policy_binding.get('policy_sha256')!r})"
+            f"(expected {policy_sha!r}, got {report_policy_sha!r})"
+        )
+    if status_policy_sha is not None and report_policy_sha != status_policy_sha:
+        errors.append(
+            "verifier_report.policy_binding.policy_sha256 must match status.metrics.gate_policy_sha256 "
+            f"(expected {status_policy_sha!r}, got {report_policy_sha!r})"
         )
 
     registry_binding = _require_object(verifier_report, "registry_binding", "verifier_report", errors)
-    if not _is_sha256(registry_binding.get("registry_sha256")):
+    report_registry_sha = registry_binding.get("registry_sha256")
+    if not _is_sha256(report_registry_sha):
         errors.append("verifier_report.registry_binding.registry_sha256 must be a 64-hex sha256")
-    if registry_sha is not None and registry_binding.get("registry_sha256") != registry_sha:
+    if registry_sha is not None and report_registry_sha != registry_sha:
         errors.append(
             "verifier_report.registry_binding.registry_sha256 does not match the current registry file "
-            f"(expected {registry_sha!r}, got {registry_binding.get('registry_sha256')!r})"
+            f"(expected {registry_sha!r}, got {report_registry_sha!r})"
         )
 
     release_required_gates = _extract_release_required_gates(policy_obj, errors)
     registry_gate_ids = _extract_registry_gate_ids(registry_obj, errors)
-
     for gate_id in release_required_gates:
         if gate_id not in registry_gate_ids:
             errors.append(
@@ -320,18 +469,35 @@ def materialize_release_required_from_verifier(
                 f"verifier_report.gate_materialization_admissibility.{gate_id} must be an object"
             )
             continue
+
         if entry.get("status") != "verified":
             errors.append(
                 "verifier_report.gate_materialization_admissibility."
                 f"{gate_id}.status must be 'verified' (got {entry.get('status')!r})"
             )
             continue
+
         if entry.get("admissible") is not True:
             errors.append(
                 "verifier_report.gate_materialization_admissibility."
                 f"{gate_id}.admissible must be literal true"
             )
             continue
+
+        entry_errors = entry.get("errors")
+        if entry_errors is not None:
+            if not isinstance(entry_errors, list):
+                errors.append(
+                    "verifier_report.gate_materialization_admissibility."
+                    f"{gate_id}.errors must be an array when present"
+                )
+                continue
+            if entry_errors:
+                errors.append(
+                    "verifier_report.gate_materialization_admissibility."
+                    f"{gate_id}.errors must be absent or empty before materialization"
+                )
+                continue
 
         gates[gate_id] = True
         materialized_gates.append(gate_id)
@@ -385,7 +551,6 @@ def main(argv: list[str] | None = None) -> int:
         verifier_report_path=Path(args.verifier_report),
         policy_path=Path(args.policy),
         registry_path=Path(args.registry),
-        out_path=Path(args.out),
     )
 
     if errors:
@@ -394,7 +559,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f" - {error}", file=sys.stderr)
         return 1
 
-    assert status is not None  # for type checkers
+    assert status is not None
     _write_json(Path(args.out), status)
     print(
         "OK: materialized release-required gates from verified recorded evidence: "

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -36,6 +36,7 @@ tests/test_operator_handoff_smoke.py
 tests/test_check_release_authority_manifest_v0.py
 tests/test_check_release_evidence_verifier_report_v0.py
 tests/test_check_recorded_release_evidence_v0.py
+tests/test_materialize_release_required_from_verifier_v0.py
 tests/test_build_release_authority_manifest_v0.py
 tests/test_release_authority_manifest_non_interference.py
 tests/test_release_decision_v0_smoke.py

--- a/tests/test_materialize_release_required_from_verifier_v0.py
+++ b/tests/test_materialize_release_required_from_verifier_v0.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from PULSE_safe_pack_v0.tools.materialize_release_required_from_verifier_v0 import (
+    materialize_release_required_from_verifier,
+)
+
+TOOL = (
+    REPO_ROOT
+    / "PULSE_safe_pack_v0"
+    / "tools"
+    / "materialize_release_required_from_verifier_v0.py"
+)
+
+COMMIT_SHA = "a" * 40
+RUN_KEY = "run-prod-2026-01-01"
+RELEASE_REQUIRED_GATES = [
+    "detectors_materialized_ok",
+    "external_summaries_present",
+    "external_all_pass",
+    "refusal_delta_evidence_present",
+]
+
+POLICY_TEXT = """policy:
+  id: pulse-gate-policy-v0
+  version: "0.1.5"
+  enforcement:
+    required_missing: FAIL
+    required_false: FAIL
+    advisory_missing: WARN
+    advisory_false: WARN
+    unknown_gate_in_status: WARN
+    external_detectors_default: ADVISORY
+
+gates:
+  required:
+    - q1_grounded_ok
+  core_required:
+    - q1_grounded_ok
+  release_required:
+    - detectors_materialized_ok
+    - external_summaries_present
+    - external_all_pass
+    - refusal_delta_evidence_present
+  advisory:
+    - external_summaries_present
+"""
+
+REGISTRY_TEXT = """version: gate_registry_v0
+gates:
+  q1_grounded_ok:
+    category: quality
+  detectors_materialized_ok:
+    category: controls
+  external_summaries_present:
+    category: external
+  external_all_pass:
+    category: external
+  refusal_delta_evidence_present:
+    category: controls
+"""
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _write_text(path: pathlib.Path, text: str) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return _sha256_bytes(text.encode("utf-8"))
+
+
+def _write_json(path: pathlib.Path, payload: dict[str, Any]) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=False) + "\n"
+    path.write_text(text, encoding="utf-8")
+    return _sha256_bytes(text.encode("utf-8"))
+
+
+def _read_json(path: pathlib.Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _status_payload(policy_path: pathlib.Path, policy_sha: str) -> dict[str, Any]:
+    return {
+        "version": "1.0.0-prod",
+        "created_utc": "2026-01-01T00:00:00Z",
+        "metrics": {
+            "run_mode": "prod",
+            "git_sha": COMMIT_SHA,
+            "run_key": RUN_KEY,
+            "gate_policy_path": str(policy_path.resolve()),
+            "gate_policy_sha256": policy_sha,
+        },
+        "diagnostics": {
+            "gates_stubbed": False,
+            "scaffold": False,
+        },
+        "gates": {
+            "q1_grounded_ok": True,
+        },
+    }
+
+
+def _verifier_payload(policy_sha: str, registry_sha: str) -> dict[str, Any]:
+    return {
+        "schema_version": "recorded_release_evidence_verifier_v0",
+        "report_version": "0.2.0",
+        "status": "verified",
+        "errors": [],
+        "run_identity": {
+            "git_sha": COMMIT_SHA,
+            "run_key": RUN_KEY,
+            "run_mode": "prod",
+        },
+        "verified_subjects": {
+            "git_sha": COMMIT_SHA,
+            "run_key": RUN_KEY,
+            "commit_sha": COMMIT_SHA,
+        },
+        "policy_binding": {
+            "policy_set": "required+release_required",
+            "policy_sha256": policy_sha,
+        },
+        "registry_binding": {
+            "registry_sha256": registry_sha,
+        },
+        "gate_materialization_admissibility": {
+            gate_id: {
+                "status": "verified",
+                "admissible": True,
+                "errors": [],
+            }
+            for gate_id in RELEASE_REQUIRED_GATES
+        },
+    }
+
+
+def _build_fixture(
+    tmp_path: pathlib.Path,
+) -> tuple[pathlib.Path, pathlib.Path, pathlib.Path, pathlib.Path]:
+    policy_path = tmp_path / "pulse_gate_policy_v0.yml"
+    registry_path = tmp_path / "pulse_gate_registry_v0.yml"
+    policy_sha = _write_text(policy_path, POLICY_TEXT)
+    registry_sha = _write_text(registry_path, REGISTRY_TEXT)
+
+    status_path = tmp_path / "PULSE_safe_pack_v0" / "artifacts" / "status.json"
+    verifier_path = (
+        tmp_path
+        / "PULSE_safe_pack_v0"
+        / "artifacts"
+        / "recorded_release_evidence_verifier_v0.json"
+    )
+
+    _write_json(status_path, _status_payload(policy_path, policy_sha))
+    _write_json(verifier_path, _verifier_payload(policy_sha, registry_sha))
+    return status_path, verifier_path, policy_path, registry_path
+
+
+def test_materializes_release_required_gates_from_verified_report(
+    tmp_path: pathlib.Path,
+) -> None:
+    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
+
+    status, materialized_gates, errors = materialize_release_required_from_verifier(
+        status_path=status_path,
+        verifier_report_path=verifier_path,
+        policy_path=policy_path,
+        registry_path=registry_path,
+    )
+
+    assert errors == []
+    assert materialized_gates == RELEASE_REQUIRED_GATES
+    assert status is not None
+    assert status["gates"]["q1_grounded_ok"] is True
+    for gate_id in RELEASE_REQUIRED_GATES:
+        assert status["gates"][gate_id] is True
+
+
+def test_cli_writes_materialized_status(tmp_path: pathlib.Path) -> None:
+    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
+    out_path = tmp_path / "PULSE_safe_pack_v0" / "artifacts" / "status.materialized.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(TOOL),
+            "--status",
+            str(status_path),
+            "--verifier-report",
+            str(verifier_path),
+            "--policy",
+            str(policy_path),
+            "--registry",
+            str(registry_path),
+            "--out",
+            str(out_path),
+        ],
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    written = _read_json(out_path)
+    for gate_id in RELEASE_REQUIRED_GATES:
+        assert written["gates"][gate_id] is True
+
+
+def test_rejects_status_report_identity_mismatch(tmp_path: pathlib.Path) -> None:
+    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
+
+    status = _read_json(status_path)
+    status["metrics"]["git_sha"] = "b" * 40
+    _write_json(status_path, status)
+
+    materialized, _, errors = materialize_release_required_from_verifier(
+        status_path=status_path,
+        verifier_report_path=verifier_path,
+        policy_path=policy_path,
+        registry_path=registry_path,
+    )
+
+    assert materialized is None
+    assert any(
+        "status.metrics.git_sha must match verifier_report.run_identity.git_sha" in error
+        for error in errors
+    )
+
+
+def test_rejects_status_policy_metadata_mismatch(tmp_path: pathlib.Path) -> None:
+    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
+
+    status = _read_json(status_path)
+    status["metrics"]["gate_policy_sha256"] = "d" * 64
+    _write_json(status_path, status)
+
+    materialized, _, errors = materialize_release_required_from_verifier(
+        status_path=status_path,
+        verifier_report_path=verifier_path,
+        policy_path=policy_path,
+        registry_path=registry_path,
+    )
+
+    assert materialized is None
+    assert any(
+        "status.metrics.gate_policy_sha256 does not match the current policy file" in error
+        for error in errors
+    )
+
+
+def test_rejects_verified_report_with_top_level_errors(tmp_path: pathlib.Path) -> None:
+    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
+
+    verifier = _read_json(verifier_path)
+    verifier["errors"] = ["unexpected-top-level-error"]
+    _write_json(verifier_path, verifier)
+
+    materialized, _, errors = materialize_release_required_from_verifier(
+        status_path=status_path,
+        verifier_report_path=verifier_path,
+        policy_path=policy_path,
+        registry_path=registry_path,
+    )
+
+    assert materialized is None
+    assert any(
+        "verifier_report.errors must be absent or empty before materialization" in error
+        for error in errors
+    )
+
+
+@pytest.mark.parametrize("field_name", ["gates_stubbed", "scaffold"])
+def test_rejects_stubbed_or_scaffold_status(
+    tmp_path: pathlib.Path,
+    field_name: str,
+) -> None:
+    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
+
+    status = _read_json(status_path)
+    status["diagnostics"][field_name] = True
+    _write_json(status_path, status)
+
+    materialized, _, errors = materialize_release_required_from_verifier(
+        status_path=status_path,
+        verifier_report_path=verifier_path,
+        policy_path=policy_path,
+        registry_path=registry_path,
+    )
+
+    assert materialized is None
+    assert any(
+        f"status.diagnostics.{field_name} must not be true" in error
+        for error in errors
+    )
+
+
+def test_fails_when_policy_required_gate_is_missing_from_admissibility(
+    tmp_path: pathlib.Path,
+) -> None:
+    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
+
+    verifier = _read_json(verifier_path)
+    del verifier["gate_materialization_admissibility"]["external_all_pass"]
+    _write_json(verifier_path, verifier)
+
+    materialized, _, errors = materialize_release_required_from_verifier(
+        status_path=status_path,
+        verifier_report_path=verifier_path,
+        policy_path=policy_path,
+        registry_path=registry_path,
+    )
+
+    assert materialized is None
+    assert any(
+        "verifier_report.gate_materialization_admissibility.external_all_pass must be an object"
+        in error
+        for error in errors
+    )


### PR DESCRIPTION
## Summary

Materialize release-required gates from the recorded
release-evidence verifier report.

This PR adds a fail-closed admission step for release-grade
materialization. It reads the verifier report and only writes
release-required gate booleans into `status.json` when the
verifier result is `verified` and every policy-derived
release-required gate is explicitly admissible.

## Scope

- add `PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py`
- add `tests/test_materialize_release_required_from_verifier_v0.py`
- wire the materialization step into the release-grade workflow path

## Why

The verifier already proves whether detector materialization,
canonical external summaries, and refusal-delta evidence are
admissible.

The missing mechanical step is to admit only that
verifier-validated evidence into release-grade gate
materialization before the existing `check_gates.py` path.

## Boundary

- no new gate set
- no new release policy
- no status.json semantics change
- no replacement for `check_gates.py`
- no second release-decision engine

The normative release path remains:

recorded release evidence
→ status.json
→ declared gate policy
→ workflow-effective required gate set
→ check_gates.py
→ CI allow/block decision

## Fail-closed behavior

The new step fails closed when:
- the verifier report is missing
- the verifier report is not `verified`
- policy or registry bindings do not match the current files
- a policy-derived release-required gate is missing from the
  verifier admissibility surface
- a policy-derived release-required gate is not explicitly
  admissible

## Testing

- pytest -q tests/test_materialize_release_required_from_verifier_v0.py