### PR TITLE
fix(ref): require canonical top-level gates for release-required mate…

### DIFF
--- a/PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
+++ b/PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
@@ -191,26 +191,15 @@ def _normalize_gate_list(value: Any, label: str, errors: list[str]) -> list[str]
 
 def _extract_release_required_gates(policy_obj: dict[str, Any], errors: list[str]) -> list[str]:
     gates = policy_obj.get("gates")
-    if isinstance(gates, dict):
+    if not isinstance(gates, dict):
+        errors.append("policy file must contain top-level gates mapping")
+        return []
+
         return _normalize_gate_list(
-            gates.get("release_required"),
-            "gates.release_required",
-            errors,
-        )
-
-    # Backward-compatible fallback if an older nested shape is ever seen.
-    policy = policy_obj.get("policy")
-    if isinstance(policy, dict):
-        nested_gates = policy.get("gates")
-        if isinstance(nested_gates, dict):
-            return _normalize_gate_list(
-                nested_gates.get("release_required"),
-                "policy.gates.release_required",
-                errors,
-            )
-
-    errors.append("policy file must contain top-level gates mapping")
-    return []
+        gates.get("release_required"),
+        "gates.release_required",
+        errors,
+    )
 
 
 def _extract_registry_gate_ids(registry_obj: dict[str, Any], errors: list[str]) -> set[str]:

--- a/PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
+++ b/PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
@@ -195,7 +195,7 @@ def _extract_release_required_gates(policy_obj: dict[str, Any], errors: list[str
         errors.append("policy file must contain top-level gates mapping")
         return []
 
-        return _normalize_gate_list(
+    return _normalize_gate_list(
         gates.get("release_required"),
         "gates.release_required",
         errors,

--- a/tests/test_materialize_release_required_from_verifier_v0.py
+++ b/tests/test_materialize_release_required_from_verifier_v0.py
@@ -332,3 +332,40 @@ def test_fails_when_policy_required_gate_is_missing_from_admissibility(
         in error
         for error in errors
     )
+
+
+def test_rejects_legacy_nested_policy_gates_shape(tmp_path: pathlib.Path) -> None:
+    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
+
+    legacy_nested_policy = """policy:
+  id: pulse-gate-policy-v0
+  version: "0.1.5"
+  gates:
+    release_required:
+      - detectors_materialized_ok
+      - external_summaries_present
+      - external_all_pass
+      - refusal_delta_evidence_present
+"""
+    policy_sha = _write_text(policy_path, legacy_nested_policy)
+
+    status = _read_json(status_path)
+    status["metrics"]["gate_policy_sha256"] = policy_sha
+    _write_json(status_path, status)
+
+    verifier = _read_json(verifier_path)
+    verifier["policy_binding"]["policy_sha256"] = policy_sha
+    _write_json(verifier_path, verifier)
+
+    materialized, _, errors = materialize_release_required_from_verifier(
+        status_path=status_path,
+        verifier_report_path=verifier_path,
+        policy_path=policy_path,
+        registry_path=registry_path,
+    )
+
+    assert materialized is None
+    assert any(
+        "policy file must contain top-level gates mapping" in error
+        for error in errors
+    )


### PR DESCRIPTION
Materialize release-required gates from the recorded
release-evidence verifier report.

This merge adds a fail-closed admission step that writes
policy-derived release_required gate booleans into status.json
only when the verifier report is verified, error-free,
identity-bound, policy-bound, non-stubbed, and explicitly
admissible for every required release-grade gate.

Final hardening included:
- require canonical top-level gates.release_required only
- remove legacy nested policy.gates fallback
- add regression coverage for the legacy nested policy shape

Included:
- materializer tool
- materializer tests
- tools smoke wiring
- release workflow wiring

Boundary:
- no status.json semantics change
- no gate-policy change
- no replacement for check_gates.py
- no second release-decision engine