### PR TITLE
feat(ref): add public non-stubbed release-grade reference-run packaging

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1825,7 +1825,7 @@ jobs:
           print(f"Wrote {out}")
           PY
 
-      - name: qualify release-grade reference run
+      - name: Check release-grade reference run qualification (advisory)
         id: release_grade_reference_qualify
         if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') }}
         shell: bash

--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1835,16 +1835,39 @@ jobs:
           TOOL="${PACK_DIR}/tools/check_release_grade_reference_run_v0.py"
           STATUS="${PACK_DIR}/artifacts/status.json"
           MANIFEST="${PACK_DIR}/artifacts/release_authority_v0.json"
+          REPORT="${PACK_DIR}/artifacts/report_card.html"
+          AUDIT_BUNDLE="${PACK_DIR}/artifacts/release_authority_audit_bundle"
 
-          if python "$TOOL" --status "$STATUS" --manifest "$MANIFEST"; then
-            RESULT="Qualified"
-            echo "REFERENCE_RUN_QUALIFIED=true" >> "$GITHUB_ENV"
-            echo "qualified=true" >> "$GITHUB_OUTPUT"
-          else
+          set +e
+          python "$TOOL" \
+            --status "$STATUS" \
+            --manifest "$MANIFEST" \
+            --report "$REPORT" \
+            --audit-bundle-dir "$AUDIT_BUNDLE"
+          CHECK_RC=$?
+          set -e
+
+          if [[ "$CHECK_RC" -ne 0 ]]; then
             RESULT="Not qualified (advisory)"
+            echo "::warning::release-grade reference qualification failed; release outcome unchanged"
             echo "REFERENCE_RUN_QUALIFIED=false" >> "$GITHUB_ENV"
             echo "qualified=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Release-grade reference run"
+              echo
+              echo "| Field | Value |"
+              echo "|---|---|"
+              echo "| Workflow path | \`${GITHUB_REF}\` / \`${GITHUB_EVENT_NAME}\` |"
+              echo "| Active enforce set | \`required+release_required\` |"
+              echo "| Qualification | \`${RESULT}\` |"
+              echo "| Authority | Advisory / non-normative / non-blocking; release outcome unchanged |"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
+
+          RESULT="Qualified"
+          echo "REFERENCE_RUN_QUALIFIED=true" >> "$GITHUB_ENV"
+          echo "qualified=true" >> "$GITHUB_OUTPUT"
 
           {
             echo "### Release-grade reference run"
@@ -1854,7 +1877,7 @@ jobs:
             echo "| Workflow path | \`${GITHUB_REF}\` / \`${GITHUB_EVENT_NAME}\` |"
             echo "| Active enforce set | \`required+release_required\` |"
             echo "| Qualification | \`${RESULT}\` |"
-            echo "| Authority | Advisory only; does not replace \`check_gates.py\` |"
+            echo "| Authority | Advisory / non-normative / non-blocking; release outcome unchanged |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           exit 0

--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1826,35 +1826,25 @@ jobs:
           PY
 
       - name: qualify release-grade reference run
+        id: release_grade_reference_qualify
         if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') }}
         shell: bash
         run: |
           set -euo pipefail
 
-          CHECKER="${PACK_DIR}/tools/check_release_grade_reference_run_v0.py"
+          TOOL="${PACK_DIR}/tools/check_release_grade_reference_run_v0.py"
           STATUS="${PACK_DIR}/artifacts/status.json"
           MANIFEST="${PACK_DIR}/artifacts/release_authority_v0.json"
-          REPORT="${PACK_DIR}/artifacts/report_card.html"
-          AUDIT_BUNDLE="${PACK_DIR}/artifacts/release_authority_audit_bundle"
-          RESULT="Not qualified (advisory)"
-          CHECK_RC=0
 
-          set +e
-          python "${CHECKER}" \
-            --status "${STATUS}" \
-            --manifest "${MANIFEST}" \
-            --report "${REPORT}" \
-            --audit-bundle-dir "${AUDIT_BUNDLE}"
-          CHECK_RC=$?
-          set -e
-
-          if [[ "${CHECK_RC}" -eq 0 ]]; then
+          if python "$TOOL" --status "$STATUS" --manifest "$MANIFEST"; then
             RESULT="Qualified"
+            echo "REFERENCE_RUN_QUALIFIED=true" >> "$GITHUB_ENV"
+            echo "qualified=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::release-grade reference qualification failed; release outcome unchanged"
+            RESULT="Not qualified (advisory)"
+            echo "REFERENCE_RUN_QUALIFIED=false" >> "$GITHUB_ENV"
+            echo "qualified=false" >> "$GITHUB_OUTPUT"
           fi
-
-          echo "RELEASE_GRADE_REFERENCE_QUALIFICATION=${RESULT}" >> "${GITHUB_ENV}"
 
           {
             echo "### Release-grade reference run"
@@ -1862,56 +1852,81 @@ jobs:
             echo "| Field | Value |"
             echo "|---|---|"
             echo "| Workflow path | \`${GITHUB_REF}\` / \`${GITHUB_EVENT_NAME}\` |"
-            echo "| Active enforce set | \`${PULSE_POLICY_SET:-core_required}+release_required\` |"
-            echo "| Artifacts | \`release-grade-reference-run-v0\`, \`release-authority-audit-bundle\` |"
+            echo "| Active enforce set | \`required+release_required\` |"
             echo "| Qualification | \`${RESULT}\` |"
             echo "| Authority | Advisory only; does not replace \`check_gates.py\` |"
-          } >> "${GITHUB_STEP_SUMMARY}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
           exit 0
 
-      - name: assemble release-grade reference bundle
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') }}
+      - name: Quality Ledger / status parity
+        id: quality_ledger_parity
+        if: ${{ always() && steps.quality_ledger_final_render.outcome == 'success' }}
         shell: bash
         run: |
           set -euo pipefail
+          STATUS="${{ env.PACK_DIR }}/artifacts/status.json"
+          LEDGER="${{ env.PACK_DIR }}/artifacts/report_card.html"
+
+          python "${{ env.PACK_DIR }}/tools/check_quality_ledger_status_parity.py" \
+            --status "$STATUS" \
+            --ledger "$LEDGER"
+
+      - name: mark release-grade reference parity state
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          if [[ "${{ steps.quality_ledger_parity.outcome }}" == "success" ]]; then
+            echo "REFERENCE_LEDGER_PARITY_OK=true" >> "$GITHUB_ENV"
+          else
+            echo "REFERENCE_LEDGER_PARITY_OK=false" >> "$GITHUB_ENV"
+          fi
+      
+      - name: assemble release-grade reference bundle
+        if: ${{ (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true')) && env.REFERENCE_RUN_QUALIFIED == 'true' && env.REFERENCE_LEDGER_PARITY_OK == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
           BUNDLE_DIR="${RUNNER_TEMP}/release-grade-reference-run-v0"
-          rm -rf "${BUNDLE_DIR}"
-          mkdir -p "${BUNDLE_DIR}/artifacts"
-          mkdir -p "${BUNDLE_DIR}/reports"
+          rm -rf "$BUNDLE_DIR"
+          mkdir -p "$BUNDLE_DIR/artifacts" "$BUNDLE_DIR/reports"
 
-          cp "${PACK_DIR}/artifacts/status.json" "${BUNDLE_DIR}/artifacts/status.json"
-          cp "${PACK_DIR}/artifacts/report_card.html" "${BUNDLE_DIR}/artifacts/report_card.html"
-          cp "${PACK_DIR}/artifacts/release_authority_v0.json" "${BUNDLE_DIR}/artifacts/release_authority_v0.json"
+          cp "${PACK_DIR}/artifacts/status.json" "$BUNDLE_DIR/artifacts/status.json"
+          cp "${PACK_DIR}/artifacts/report_card.html" "$BUNDLE_DIR/artifacts/report_card.html"
+          cp "${PACK_DIR}/artifacts/release_authority_v0.json" "$BUNDLE_DIR/artifacts/release_authority_v0.json"
 
-          if [ -d "${PACK_DIR}/artifacts/release_authority_audit_bundle" ]; then
-            cp -a "${PACK_DIR}/artifacts/release_authority_audit_bundle" "${BUNDLE_DIR}/release-authority-audit-bundle"
-          elif [ -d "release-authority-audit-bundle" ]; then
-            cp -a "release-authority-audit-bundle" "${BUNDLE_DIR}/release-authority-audit-bundle"
+          if [ -d "release-authority-audit-bundle" ]; then
+            cp -a "release-authority-audit-bundle" "$BUNDLE_DIR/release-authority-audit-bundle"
+          elif [ -d "${PACK_DIR}/artifacts/release_authority_audit_bundle" ]; then
+            cp -a "${PACK_DIR}/artifacts/release_authority_audit_bundle" "$BUNDLE_DIR/release-authority-audit-bundle"
           fi
 
-          if compgen -G "${PACK_DIR}/artifacts/external/*_summary.json" > /dev/null; then
-            mkdir -p "${BUNDLE_DIR}/artifacts/external"
-            cp "${PACK_DIR}"/artifacts/external/*_summary.json "${BUNDLE_DIR}/artifacts/external/"
+          shopt -s nullglob
+          EXT_SUMMARIES=(
+            "${PACK_DIR}"/artifacts/external/*_summary.json
+            "${PACK_DIR}"/artifacts/external/*_summary.jsonl
+          )
+          if (( ${#EXT_SUMMARIES[@]} )); then
+            mkdir -p "$BUNDLE_DIR/artifacts/external"
+            cp "${EXT_SUMMARIES[@]}" "$BUNDLE_DIR/artifacts/external/"
           fi
+          shopt -u nullglob
 
           if [ -f "reports/junit.xml" ]; then
-            cp "reports/junit.xml" "${BUNDLE_DIR}/reports/junit.xml"
+            cp "reports/junit.xml" "$BUNDLE_DIR/reports/junit.xml"
           elif [ -f "${PACK_DIR}/artifacts/reports/junit.xml" ]; then
-            cp "${PACK_DIR}/artifacts/reports/junit.xml" "${BUNDLE_DIR}/reports/junit.xml"
+            cp "${PACK_DIR}/artifacts/reports/junit.xml" "$BUNDLE_DIR/reports/junit.xml"
           fi
 
-          if [ -f "reports/sarif.json" ]; then
-            cp "reports/sarif.json" "${BUNDLE_DIR}/reports/sarif.json"
-          elif [ -f "${PACK_DIR}/artifacts/reports/sarif.json" ]; then
-            cp "${PACK_DIR}/artifacts/reports/sarif.json" "${BUNDLE_DIR}/reports/sarif.json"
-          fi
+          # Do not copy pre-materialization SARIF into the reference bundle.
+          # Bundle SARIF only after a final-status release-grade SARIF export exists.
 
-          echo "REFERENCE_BUNDLE_DIR=${BUNDLE_DIR}" >> "${GITHUB_ENV}"
+          echo "REFERENCE_BUNDLE_DIR=${BUNDLE_DIR}" >> "$GITHUB_ENV"
 
       - name: upload release-grade reference bundle
-        if: ${{ env.REFERENCE_BUNDLE_DIR != '' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        if: ${{ env.REFERENCE_BUNDLE_DIR != '' && env.REFERENCE_RUN_QUALIFIED == 'true' && env.REFERENCE_LEDGER_PARITY_OK == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-grade-reference-run-v0
           path: ${{ env.REFERENCE_BUNDLE_DIR }}
@@ -1932,7 +1947,7 @@ jobs:
             --ledger "$LEDGER"
       
       - name: Upload artifacts
-        if: ${{ always() && steps.quality_ledger_final_render.outcome == 'success' && steps.quality_ledger_status_parity.outcome == 'success' }}
+        if: ${{ always() && steps.quality_ledger_final_render.outcome == 'success' && steps.quality_ledger_parity.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
         with:
           name: pulse-report

--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1898,7 +1898,7 @@ jobs:
           exit 0
 
       - name: Quality Ledger / status parity
-        id: quality_ledger_parity
+        id: quality_ledger_status_parity
         if: ${{ always() && steps.quality_ledger_final_render.outcome == 'success' }}
         shell: bash
         run: |
@@ -1914,7 +1914,7 @@ jobs:
         if: ${{ always() }}
         shell: bash
         run: |
-          if [[ "${{ steps.quality_ledger_parity.outcome }}" == "success" ]]; then
+         if [[ "${{ steps.quality_ledger_status_parity.outcome }}" == "success" ]]; then
             echo "REFERENCE_LEDGER_PARITY_OK=true" >> "$GITHUB_ENV"
           else
             echo "REFERENCE_LEDGER_PARITY_OK=false" >> "$GITHUB_ENV"
@@ -1975,7 +1975,7 @@ jobs:
           retention-days: 30
       
       - name: Upload artifacts
-        if: ${{ always() && steps.quality_ledger_final_render.outcome == 'success' && steps.quality_ledger_parity.outcome == 'success' }}
+        if: ${{ always() && steps.quality_ledger_final_render.outcome == 'success' && steps.quality_ledger_status_parity.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
         with:
           name: pulse-report

--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -47,7 +47,8 @@ jobs:
     
     env:
       PACK_DIR: ${{ github.workspace }}/PULSE_safe_pack_v0
-
+      REFERENCE_BUNDLE_DIR: ""
+ 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pinned
@@ -1010,74 +1011,6 @@ jobs:
             echo "| Workspace path | \`$BUNDLE\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Check release-grade reference run qualification (advisory)
-        if: always()
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          CHECKER="${{ env.PACK_DIR }}/tools/check_release_grade_reference_run_v0.py"
-          STATUS="${{ env.PACK_DIR }}/artifacts/status.json"
-          MANIFEST="${{ env.PACK_DIR }}/artifacts/release_authority_v0.json"
-          REPORT="${{ env.PACK_DIR }}/artifacts/report_card.html"
-          BUNDLE="${{ env.PACK_DIR }}/artifacts/release_authority_audit_bundle"
-
-          {
-            echo "### Release-grade reference qualification"
-            echo
-            echo "| Field | Value |"
-            echo "|---|---|"
-            echo "| Role | Advisory reference-run qualification |"
-            echo "| Authority | Non-normative / non-blocking |"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          if [[ "${PULSE_IS_RELEASE:-0}" != "1" ]]; then
-            {
-              echo "| Status | Skipped |"
-              echo "| Reason | Not a release-grade run |"
-              echo
-              echo "This check only qualifies release-grade runs as candidate reference runs."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          if [[ ! -f "$CHECKER" ]]; then
-            echo "::warning::release-grade reference checker not found at $CHECKER"
-            {
-              echo "| Status | Skipped |"
-              echo "| Reason | Checker missing |"
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          set +e
-          python "$CHECKER" \
-            --status "$STATUS" \
-            --manifest "$MANIFEST" \
-            --report "$REPORT" \
-            --audit-bundle-dir "$BUNDLE"
-
-          CHECK_RC=$?
-          set -e
-
-          if [[ "$CHECK_RC" -ne 0 ]]; then
-            echo "::warning::release-grade reference qualification failed; release outcome unchanged"
-            {
-              echo "| Status | Not qualified |"
-              echo "| Result | Checker returned $CHECK_RC |"
-              echo
-              echo "The run may still be evaluated by the normal release authority path. This qualification check is advisory and does not change release outcome."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          {
-            echo "| Status | Qualified |"
-            echo "| Result | Candidate release-grade reference run |"
-            echo
-            echo "This advisory check confirms the run satisfies the documented release-grade reference criteria."
-          } >> "$GITHUB_STEP_SUMMARY"
-
       - name: Upload release authority audit bundle (audit-only)
         if: always()
         continue-on-error: true
@@ -1892,6 +1825,99 @@ jobs:
           print(f"Wrote {out}")
           PY
 
+      - name: qualify release-grade reference run
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          CHECKER="${PACK_DIR}/tools/check_release_grade_reference_run_v0.py"
+          STATUS="${PACK_DIR}/artifacts/status.json"
+          MANIFEST="${PACK_DIR}/artifacts/release_authority_v0.json"
+          REPORT="${PACK_DIR}/artifacts/report_card.html"
+          AUDIT_BUNDLE="${PACK_DIR}/artifacts/release_authority_audit_bundle"
+          RESULT="Not qualified (advisory)"
+          CHECK_RC=0
+
+          set +e
+          python "${CHECKER}" \
+            --status "${STATUS}" \
+            --manifest "${MANIFEST}" \
+            --report "${REPORT}" \
+            --audit-bundle-dir "${AUDIT_BUNDLE}"
+          CHECK_RC=$?
+          set -e
+
+          if [[ "${CHECK_RC}" -eq 0 ]]; then
+            RESULT="Qualified"
+          else
+            echo "::warning::release-grade reference qualification failed; release outcome unchanged"
+          fi
+
+          echo "RELEASE_GRADE_REFERENCE_QUALIFICATION=${RESULT}" >> "${GITHUB_ENV}"
+
+          {
+            echo "### Release-grade reference run"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Workflow path | \`${GITHUB_REF}\` / \`${GITHUB_EVENT_NAME}\` |"
+            echo "| Active enforce set | \`${PULSE_POLICY_SET:-core_required}+release_required\` |"
+            echo "| Artifacts | \`release-grade-reference-run-v0\`, \`release-authority-audit-bundle\` |"
+            echo "| Qualification | \`${RESULT}\` |"
+            echo "| Authority | Advisory only; does not replace \`check_gates.py\` |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          exit 0
+
+      - name: assemble release-grade reference bundle
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          BUNDLE_DIR="${RUNNER_TEMP}/release-grade-reference-run-v0"
+          rm -rf "${BUNDLE_DIR}"
+          mkdir -p "${BUNDLE_DIR}/artifacts"
+          mkdir -p "${BUNDLE_DIR}/reports"
+
+          cp "${PACK_DIR}/artifacts/status.json" "${BUNDLE_DIR}/artifacts/status.json"
+          cp "${PACK_DIR}/artifacts/report_card.html" "${BUNDLE_DIR}/artifacts/report_card.html"
+          cp "${PACK_DIR}/artifacts/release_authority_v0.json" "${BUNDLE_DIR}/artifacts/release_authority_v0.json"
+
+          if [ -d "${PACK_DIR}/artifacts/release_authority_audit_bundle" ]; then
+            cp -a "${PACK_DIR}/artifacts/release_authority_audit_bundle" "${BUNDLE_DIR}/release-authority-audit-bundle"
+          elif [ -d "release-authority-audit-bundle" ]; then
+            cp -a "release-authority-audit-bundle" "${BUNDLE_DIR}/release-authority-audit-bundle"
+          fi
+
+          if compgen -G "${PACK_DIR}/artifacts/external/*_summary.json" > /dev/null; then
+            mkdir -p "${BUNDLE_DIR}/artifacts/external"
+            cp "${PACK_DIR}"/artifacts/external/*_summary.json "${BUNDLE_DIR}/artifacts/external/"
+          fi
+
+          if [ -f "reports/junit.xml" ]; then
+            cp "reports/junit.xml" "${BUNDLE_DIR}/reports/junit.xml"
+          elif [ -f "${PACK_DIR}/artifacts/reports/junit.xml" ]; then
+            cp "${PACK_DIR}/artifacts/reports/junit.xml" "${BUNDLE_DIR}/reports/junit.xml"
+          fi
+
+          if [ -f "reports/sarif.json" ]; then
+            cp "reports/sarif.json" "${BUNDLE_DIR}/reports/sarif.json"
+          elif [ -f "${PACK_DIR}/artifacts/reports/sarif.json" ]; then
+            cp "${PACK_DIR}/artifacts/reports/sarif.json" "${BUNDLE_DIR}/reports/sarif.json"
+          fi
+
+          echo "REFERENCE_BUNDLE_DIR=${BUNDLE_DIR}" >> "${GITHUB_ENV}"
+
+      - name: upload release-grade reference bundle
+        if: ${{ env.REFERENCE_BUNDLE_DIR != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        with:
+          name: release-grade-reference-run-v0
+          path: ${{ env.REFERENCE_BUNDLE_DIR }}
+          if-no-files-found: error
+          retention-days: 30
+      
       - name: Check Quality Ledger status parity before artifact upload
         id: quality_ledger_status_parity
         if: ${{ always() && steps.quality_ledger_final_render.outcome == 'success' }}

--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1798,6 +1798,21 @@ jobs:
             echo "::warning::Failed to derive SARIF gate list for policy set '${POLICY_SET}'; exporting all gates."
           fi
 
+          if [[ "${PULSE_IS_RELEASE:-0}" == "1" ]]; then
+            if RELEASE_REQ_STR="$(python tools/policy_to_require_args.py --policy pulse_gate_policy_v0.yml --set release_required --format space 2>/dev/null)"; then
+              if [[ -n "${RELEASE_REQ_STR}" ]]; then
+                read -r -a RELEASE_REQ <<< "$RELEASE_REQ_STR"
+                REQ+=("${RELEASE_REQ[@]}")
+              else
+                echo "::error::Derived release_required SARIF gate list is empty on a release-grade run."
+                exit 1
+              fi
+            else
+              echo "::error::Failed to derive release_required SARIF gate list."
+              exit 1
+            fi
+          fi
+
           if (( ${#REQ[@]} > 0 )); then
             python "${PACK_DIR}/tools/status_to_sarif.py" --require "${REQ[@]}"
           else
@@ -1942,8 +1957,11 @@ jobs:
             cp "${PACK_DIR}/artifacts/reports/junit.xml" "$BUNDLE_DIR/reports/junit.xml"
           fi
 
-          # Do not copy pre-materialization SARIF into the reference bundle.
-          # Bundle SARIF only after a final-status release-grade SARIF export exists.
+          if [ -f "${PACK_DIR}/artifacts/reports/sarif.json" ]; then
+            cp "${PACK_DIR}/artifacts/reports/sarif.json" "$BUNDLE_DIR/reports/sarif.json"
+          elif [ -f "reports/sarif.json" ]; then
+            cp "reports/sarif.json" "$BUNDLE_DIR/reports/sarif.json"
+          fi 
 
           echo "REFERENCE_BUNDLE_DIR=${BUNDLE_DIR}" >> "$GITHUB_ENV"
 
@@ -1955,19 +1973,6 @@ jobs:
           path: ${{ env.REFERENCE_BUNDLE_DIR }}
           if-no-files-found: error
           retention-days: 30
-      
-      - name: Check Quality Ledger status parity before artifact upload
-        id: quality_ledger_status_parity
-        if: ${{ always() && steps.quality_ledger_final_render.outcome == 'success' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          STATUS="${{ env.PACK_DIR }}/artifacts/status.json"
-          LEDGER="${{ env.PACK_DIR }}/artifacts/report_card.html"
-
-          python "${{ env.PACK_DIR }}/tools/check_quality_ledger_status_parity.py" \
-            --status "$STATUS" \
-            --ledger "$LEDGER"
       
       - name: Upload artifacts
         if: ${{ always() && steps.quality_ledger_final_render.outcome == 'success' && steps.quality_ledger_parity.outcome == 'success' }}

--- a/README.md
+++ b/README.md
@@ -186,6 +186,23 @@ status.json
 - Quality Ledger: https://hkati.github.io/pulse-release-gates-0.1/
 - Public Status JSON: https://hkati.github.io/pulse-release-gates-0.1/status.json
 
+## Release-grade reference run
+
+PULSE distinguishes between:
+
+- Core smoke surface = integration / visibility surface
+- Release-grade reference run = materialized evidence release-authority reference
+
+The first public non-stubbed release-grade reference run is documented in:
+
+- `docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md`
+- `docs/release_grade_reference_run_v0.md`
+
+The reference run remains review/documentation surface.
+Release authority still comes only from:
+
+`status.json + declared gate policy + workflow-effective required gate set + check_gates.py + primary CI workflow`
+
 ## Current verification checkpoint
 
 - PULSE-REF RA1 operating proof: `docs/PULSE_REF_RA1_OPERATING_PROOF_v0.md`

--- a/docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md
+++ b/docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md
@@ -1,0 +1,67 @@
+# Release-grade reference run note v0
+
+## Purpose
+
+This note records one public, non-stubbed release-grade PULSE reference run.
+
+It is a review and provenance note.
+It does not create release authority.
+Release authority remains the normal PULSE path:
+
+```text
+status.json
+→ declared gate policy
+→ workflow-effective required gate set
+→ check_gates.py
+→ primary CI workflow
+```
+
+## Run identity
+
+- date:
+- workflow path: version tag push / workflow_dispatch
+- ref:
+- git_sha:
+- run_key:
+- run_mode:
+- active policy set: required + release_required
+
+## Qualification summary
+
+- release-grade reference checker result:
+- stubbed/scaffolded evidence absent:
+- external evidence required:
+- external summaries present:
+- required gates evaluated fail-closed:
+- release authority manifest produced:
+- Quality Ledger produced:
+- audit bundle produced:
+
+## Public artifacts
+
+- status.json:
+- report_card.html:
+- release_authority_v0.json:
+- release-authority-audit-bundle:
+- external summaries:
+- junit:
+- sarif:
+
+## Boundary reminder
+
+This note documents a candidate reference run.
+It does not replace status.json.
+It does not replace check_gates.py.
+It does not create a second release-decision engine.
+It does not promote reader, dashboard, Pages, or shadow surfaces into authority.
+
+## Reviewer checklist
+
+- Which workflow path produced the run?
+- Was the run release-grade or only Core?
+- Was the effective enforce set required + release_required?
+- Was diagnostics.gates_stubbed absent/false?
+- Were external summaries present when required?
+- Was release_authority_v0.json produced?
+- Was the audit bundle uploaded?
+- Are all public reader surfaces clearly non-authoritative?

--- a/docs/release_grade_reference_run_v0.md
+++ b/docs/release_grade_reference_run_v0.md
@@ -508,17 +508,15 @@ Release-grade reference run = materialized evidence release-authority reference
 
 ---
 
-## Next implementation  steps 
+## Next implementation steps
 
 Suggested next steps:
 
-   * Use the recorded release-evidence verifier for detector materialization, canonical external summaries, and refusal-delta evidence.
-  * Only after verifier-admitted evidence is available, allow `--release-grade-materialized` to fold verified evidence into release-required gate booleans.
-  * The example package under `examples/release_grade_reference_run_v0/` still shows the expected artifact shape. A real non-stubbed release-grade reference run remains future work.
-- Produce one non-stubbed release-grade reference run.  
-- Archive its `status.json`, Quality Ledger, release authority manifest, and
-  audit bundle.  
-- Document the run in a short reference-run note.  
-- Link the reference run from the README or documentation index.  
-- Use the reference run as the baseline for future enterprise-grade release
-  governance examples.
+* Use the recorded release-evidence verifier for detector materialization, canonical external summaries, and refusal-delta evidence.
+* Only after verifier-admitted evidence is available, allow `--release-grade-materialized` to fold verified evidence into release-required gate booleans.
+* Add public reference-run packaging in the primary workflow for release-grade runs.
+* Produce one non-stubbed release-grade reference run.
+* Archive its `status.json`, Quality Ledger, release authority manifest, and audit bundle.
+* Document the run in a short reference-run note.
+* Link the reference run from the README or documentation index.
+* Use the reference run as the baseline for future enterprise-grade release governance examples.


### PR DESCRIPTION
## Summary

Add public packaging for a non-stubbed release-grade reference run.

This PR prepares the repository to produce and publish one
reviewable release-grade reference-run bundle from the primary
workflow. It adds release-grade qualification/packaging in CI,
a reference-run note template, and documentation/README links
for the public reference-run surface.

## Scope

- update `.github/workflows/pulse_ci.yml`
- add `docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md`
- update `docs/release_grade_reference_run_v0.md`
- update `README.md`

## Why

The strongest remaining gap is not another shadow layer or
publication surface. The strongest remaining gap is a public,
non-stubbed, reviewable release-grade reference run.

This PR addresses that gap by preparing the workflow and docs
needed to package and publish the reference-run artifact set.

## What this PR adds

- release-grade qualification in the primary workflow
- dedicated reference-run artifact packaging
- a reference-run note template for the first public run
- README/docs entrypoints for the reference-run surface

## Boundary

- no new gate set
- no new release policy
- no status.json semantics change
- no replacement for `check_gates.py`
- no second release-decision engine

The normative release path remains:

recorded release evidence
→ status.json
→ declared gate policy
→ workflow-effective required gate set
→ check_gates.py
→ primary CI allow/block decision

Release-grade qualification in this PR is review/documentation
surface, not independent release authority.

## Expected artifact set

The packaged reference-run surface is intended to include:

- `status.json`
- `report_card.html`
- `release_authority_v0.json`
- release-authority audit bundle
- optional external summaries
- optional junit / sarif outputs

## Post-merge operational step

This PR prepares the public reference-run path.

The first concrete public non-stubbed reference run will be
produced after merge by a controlled release-grade execution
(tag push or strict workflow dispatch), then documented in
`docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md`.

## Result

This PR closes the packaging/publication gap for the first
public release-grade reference run without changing the core
release-authority model.