### PR TITLE
fix(ref): bind release-required materialization to canonical verifier…

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -792,6 +792,8 @@ jobs:
           python "${PACK_DIR}/tools/materialize_release_required_from_verifier_v0.py" \
             --status "${PACK_DIR}/artifacts/status.json" \
             --verifier-report "${PACK_DIR}/artifacts/recorded_release_evidence_verifier_v0.json" \
+            --manifest "${PACK_DIR}/artifacts/release_evidence_input_manifest_v0.json" \
+            --repo-root "${GITHUB_WORKSPACE}" \
             --policy "${GITHUB_WORKSPACE}/pulse_gate_policy_v0.yml" \
             --registry "${GITHUB_WORKSPACE}/pulse_gate_registry_v0.yml" \
             --out "${PACK_DIR}/artifacts/status.json"

--- a/PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
+++ b/PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
@@ -286,9 +286,7 @@ def materialize_release_required_from_verifier(
     )
 
     if not repo_root.is_dir():
-        errors.append(
-            f"repo root must be a directory: {repo_root}"
-        )
+        errors.append(f"repo root must be a directory: {repo_root}")
         return None, [], errors
 
     try:
@@ -300,9 +298,7 @@ def materialize_release_required_from_verifier(
         )
 
     if not manifest_path.is_file():
-        errors.append(
-            f"release evidence input manifest not found: {manifest_path}"
-        )
+        errors.append(f"release evidence input manifest not found: {manifest_path}")
 
     if errors:
         return None, [], errors
@@ -317,7 +313,7 @@ def materialize_release_required_from_verifier(
         "recorded_release_evidence_verifier_v0.json",
         errors,
     )
-        policy_obj = _load_yaml(
+    policy_obj = _load_yaml(
         policy_path,
         "policy file",
         errors,
@@ -328,7 +324,7 @@ def materialize_release_required_from_verifier(
         errors,
     )
 
-        if (
+    if (
         status is None
         or supplied_verifier_report is None
         or policy_obj is None
@@ -337,11 +333,9 @@ def materialize_release_required_from_verifier(
         return None, [], errors
 
     try:
-        canonical_verifier_report = (
-            check_recorded_release_evidence(
-                manifest_path=manifest_path,
-                repo_root=repo_root,
-            )
+        canonical_verifier_report = check_recorded_release_evidence(
+            manifest_path=manifest_path,
+            repo_root=repo_root,
         )
     except Exception as exc:  # noqa: BLE001 - fail closed
         errors.append(
@@ -350,10 +344,7 @@ def materialize_release_required_from_verifier(
         )
         return None, [], errors
 
-    if (
-        canonical_verifier_report.get("status")
-        != EXPECTED_VERIFIER_STATUS
-    ):
+    if canonical_verifier_report.get("status") != EXPECTED_VERIFIER_STATUS:
         errors.append(
             "canonical verifier replay status must be "
             f"{EXPECTED_VERIFIER_STATUS!r} "
@@ -361,11 +352,8 @@ def materialize_release_required_from_verifier(
         )
 
     replay_errors = canonical_verifier_report.get("errors")
-
     if not isinstance(replay_errors, list):
-        errors.append(
-            "canonical verifier replay errors must be an array"
-        )
+        errors.append("canonical verifier replay errors must be an array")
     elif replay_errors:
         errors.append(
             "canonical verifier replay errors must be empty "
@@ -376,26 +364,16 @@ def materialize_release_required_from_verifier(
         "evidence_results",
         "relation_binding_results",
     ):
-        supplied_value = supplied_verifier_report.get(
-            field_name
-        )
-        replayed_value = canonical_verifier_report.get(
-            field_name
-        )
+        supplied_value = supplied_verifier_report.get(field_name)
+        replayed_value = canonical_verifier_report.get(field_name)
 
-        if (
-            not isinstance(supplied_value, dict)
-            or not supplied_value
-        ):
+        if not isinstance(supplied_value, dict) or not supplied_value:
             errors.append(
                 f"verifier report {field_name} "
                 "must be a non-empty object"
             )
 
-        if (
-            not isinstance(replayed_value, dict)
-            or not replayed_value
-        ):
+        if not isinstance(replayed_value, dict) or not replayed_value:
             errors.append(
                 f"canonical verifier replay {field_name} "
                 "must be a non-empty object"
@@ -410,8 +388,8 @@ def materialize_release_required_from_verifier(
     if errors:
         return None, [], errors
 
-    # All later admission checks consume the freshly replayed
-    # canonical report, never the standalone report file.
+    # All later admission checks consume the freshly replayed canonical report,
+    # never the standalone report file.
     verifier_report = canonical_verifier_report
 
     metrics = _require_object(status, "metrics", "status", errors)
@@ -424,14 +402,13 @@ def materialize_release_required_from_verifier(
         errors.append("status.diagnostics must be an object when present")
         diagnostics_obj = {}
 
-         status_gates = status.get("gates")
-
+    status_gates = status.get("gates")
     if not isinstance(status_gates, dict):
         errors.append("status.gates must be an object")
         gates: dict[str, Any] = {}
     else:
-        # Work on a detached copy. Failed admission must not
-        # partially mutate the loaded status object.
+        # Work on a detached copy. Failed admission must not partially mutate the
+        # loaded status object.
         gates = dict(status_gates)
 
     status_git_sha = metrics.get("git_sha")
@@ -582,7 +559,7 @@ def materialize_release_required_from_verifier(
                 f"policy.gates.release_required contains unknown registry gate id {gate_id!r}"
             )
 
-       preexisting_release_required = [
+    preexisting_release_required = [
         gate_id
         for gate_id in release_required_gates
         if gate_id in gates
@@ -601,7 +578,7 @@ def materialize_release_required_from_verifier(
         admissibility = {}
 
     if errors:
-        return None, materialized_gates, errors
+        return None, [], errors
 
     for gate_id in release_required_gates:
         entry = admissibility.get(gate_id)
@@ -643,13 +620,13 @@ def materialize_release_required_from_verifier(
         materialized_gates.append(gate_id)
 
     if errors:
-        return None, materialized_gates, errors
-
-    status["gates"] = gates
-    return None, [], errors
+        return None, [], errors
 
     for gate_id in materialized_gates:
         gates[gate_id] = True
+
+    status["gates"] = gates
+    return status, materialized_gates, errors
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -672,7 +649,7 @@ def main(argv: list[str] | None = None) -> int:
         ),
         help="Path to recorded_release_evidence_verifier_v0.json.",
     )
-   parser.add_argument(
+    parser.add_argument(
         "--manifest",
         required=True,
         help=(
@@ -708,9 +685,7 @@ def main(argv: list[str] | None = None) -> int:
     status, materialized_gates, errors = (
         materialize_release_required_from_verifier(
             status_path=Path(args.status),
-            verifier_report_path=Path(
-                args.verifier_report
-            ),
+            verifier_report_path=Path(args.verifier_report),
             manifest_path=Path(args.manifest),
             repo_root=Path(args.repo_root),
             policy_path=Path(args.policy),

--- a/PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
+++ b/PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
@@ -48,160 +48,323 @@ def _repo_root_from_tool() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def _json_object_no_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+def _json_object_no_duplicates(
+    pairs: list[tuple[str, Any]],
+) -> dict[str, Any]:
     result: dict[str, Any] = {}
+
     for key, value in pairs:
         if key in result:
-            raise ValueError(f"duplicate JSON key {key!r}")
+            raise ValueError(
+                f"duplicate JSON key {key!r}"
+            )
+
         result[key] = value
+
     return result
 
 
 def _yaml_loader_no_duplicates():
     if yaml is None:
-        raise RuntimeError("PyYAML is required for YAML verification")
+        raise RuntimeError(
+            "PyYAML is required for YAML verification"
+        )
 
     class Loader(yaml.SafeLoader):
         pass
 
-    def construct_mapping(loader: Any, node: Any, deep: bool = False) -> dict[str, Any]:
+    def construct_mapping(
+        loader: Any,
+        node: Any,
+        deep: bool = False,
+    ) -> dict[str, Any]:
         mapping: dict[str, Any] = {}
+
         for key_node, value_node in node.value:
-            key = loader.construct_object(key_node, deep=deep)
+            key = loader.construct_object(
+                key_node,
+                deep=deep,
+            )
+
             if key in mapping:
-                raise ValueError(f"duplicate YAML key {key!r}")
-            mapping[key] = loader.construct_object(value_node, deep=deep)
+                raise ValueError(
+                    f"duplicate YAML key {key!r}"
+                )
+
+            mapping[key] = loader.construct_object(
+                value_node,
+                deep=deep,
+            )
+
         return mapping
 
     Loader.add_constructor(
         yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
         construct_mapping,
     )
+
     return Loader
 
 
-def _is_non_empty_text(value: Any) -> bool:
-    return isinstance(value, str) and bool(value.strip())
-
-
-def _is_sha256(value: Any) -> bool:
-    return isinstance(value, str) and len(value) == 64 and all(
-        c in "0123456789abcdef" for c in value.lower()
+def _is_non_empty_text(
+    value: Any,
+) -> bool:
+    return (
+        isinstance(value, str)
+        and bool(value.strip())
     )
 
 
-def _is_git_sha(value: Any) -> bool:
-    return isinstance(value, str) and len(value) == 40 and all(
-        c in "0123456789abcdef" for c in value.lower()
+def _is_sha256(
+    value: Any,
+) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(
+            character in "0123456789abcdef"
+            for character in value.lower()
+        )
     )
 
 
-def _safe_read_text(path: Path, label: str, errors: list[str]) -> str | None:
+def _is_git_sha(
+    value: Any,
+) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 40
+        and all(
+            character in "0123456789abcdef"
+            for character in value.lower()
+        )
+    )
+
+
+def _safe_read_text(
+    path: Path,
+    label: str,
+    errors: list[str],
+) -> str | None:
     try:
         if not path.exists():
-            errors.append(f"{label} not found: {path}")
+            errors.append(
+                f"{label} not found: {path}"
+            )
             return None
+
         if not path.is_file():
-            errors.append(f"{label} must be a file: {path}")
+            errors.append(
+                f"{label} must be a file: {path}"
+            )
             return None
-        return path.read_text(encoding="utf-8")
+
+        return path.read_text(
+            encoding="utf-8",
+        )
+
     except OSError as exc:
-        errors.append(f"{label} could not be read: {exc}")
+        errors.append(
+            f"{label} could not be read: {exc}"
+        )
         return None
 
 
-def _load_json(path: Path, label: str, errors: list[str]) -> dict[str, Any] | None:
-    text = _safe_read_text(path, label, errors)
+def _load_json(
+    path: Path,
+    label: str,
+    errors: list[str],
+) -> dict[str, Any] | None:
+    text = _safe_read_text(
+        path,
+        label,
+        errors,
+    )
+
     if text is None:
         return None
+
     try:
-        data = json.loads(text, object_pairs_hook=_json_object_no_duplicates)
+        data = json.loads(
+            text,
+            object_pairs_hook=(
+                _json_object_no_duplicates
+            ),
+        )
+
     except Exception as exc:  # noqa: BLE001
-        errors.append(f"{label} is not valid JSON: {exc}")
+        errors.append(
+            f"{label} is not valid JSON: {exc}"
+        )
         return None
+
     if not isinstance(data, dict):
-        errors.append(f"{label} must be a JSON object")
+        errors.append(
+            f"{label} must be a JSON object"
+        )
         return None
+
     return data
 
 
-def _load_yaml(path: Path, label: str, errors: list[str]) -> dict[str, Any] | None:
+def _load_yaml(
+    path: Path,
+    label: str,
+    errors: list[str],
+) -> dict[str, Any] | None:
     if yaml is None:
-        errors.append(f"{label} could not be loaded: PyYAML is unavailable")
+        errors.append(
+            f"{label} could not be loaded: "
+            "PyYAML is unavailable"
+        )
         return None
-    text = _safe_read_text(path, label, errors)
+
+    text = _safe_read_text(
+        path,
+        label,
+        errors,
+    )
+
     if text is None:
         return None
+
     try:
         loader = _yaml_loader_no_duplicates()
-        data = yaml.load(text, Loader=loader)
+
+        data = yaml.load(
+            text,
+            Loader=loader,
+        )
+
     except Exception as exc:  # noqa: BLE001
-        errors.append(f"{label} is not valid YAML: {exc}")
+        errors.append(
+            f"{label} is not valid YAML: {exc}"
+        )
         return None
+
     if not isinstance(data, dict):
-        errors.append(f"{label} must be a YAML mapping")
+        errors.append(
+            f"{label} must be a YAML mapping"
+        )
         return None
+
     return data
 
 
-def _sha256_file(path: Path, label: str, errors: list[str]) -> str | None:
+def _sha256_file(
+    path: Path,
+    label: str,
+    errors: list[str],
+) -> str | None:
     try:
         if not path.exists():
-            errors.append(f"{label} not found: {path}")
+            errors.append(
+                f"{label} not found: {path}"
+            )
             return None
+
         if not path.is_file():
-            errors.append(f"{label} must be a file: {path}")
+            errors.append(
+                f"{label} must be a file: {path}"
+            )
             return None
+
     except OSError as exc:
-        errors.append(f"{label} path check failed: {exc}")
+        errors.append(
+            f"{label} path check failed: {exc}"
+        )
         return None
 
     digest = hashlib.sha256()
+
     try:
         with path.open("rb") as handle:
-            for chunk in iter(lambda: handle.read(65536), b""):
+            for chunk in iter(
+                lambda: handle.read(65536),
+                b"",
+            ):
                 digest.update(chunk)
+
     except OSError as exc:
-        errors.append(f"{label} could not be read: {exc}")
+        errors.append(
+            f"{label} could not be read: {exc}"
+        )
         return None
+
     return digest.hexdigest()
 
 
-def _require_object(parent: dict[str, Any], key: str, label: str, errors: list[str]) -> dict[str, Any]:
+def _require_object(
+    parent: dict[str, Any],
+    key: str,
+    label: str,
+    errors: list[str],
+) -> dict[str, Any]:
     value = parent.get(key)
+
     if not isinstance(value, dict):
-        errors.append(f"{label}.{key} must be an object")
+        errors.append(
+            f"{label}.{key} must be an object"
+        )
         return {}
+
     return value
 
 
-def _normalize_gate_list(value: Any, label: str, errors: list[str]) -> list[str]:
+def _normalize_gate_list(
+    value: Any,
+    label: str,
+    errors: list[str],
+) -> list[str]:
     if not isinstance(value, list):
-        errors.append(f"{label} must be an array")
+        errors.append(
+            f"{label} must be an array"
+        )
         return []
+
     if not value:
-        errors.append(f"{label} must not be empty")
+        errors.append(
+            f"{label} must not be empty"
+        )
         return []
 
     normalized: list[str] = []
     seen: set[str] = set()
+
     for item in value:
         if not _is_non_empty_text(item):
-            errors.append(f"{label} entries must be non-empty strings")
+            errors.append(
+                f"{label} entries must be "
+                "non-empty strings"
+            )
             continue
+
         gate_id = str(item).strip()
+
         if gate_id in seen:
-            errors.append(f"{label} contains duplicate gate id {gate_id!r}")
+            errors.append(
+                f"{label} contains duplicate "
+                f"gate id {gate_id!r}"
+            )
             continue
+
         seen.add(gate_id)
         normalized.append(gate_id)
+
     return normalized
 
 
-def _extract_release_required_gates(policy_obj: dict[str, Any], errors: list[str]) -> list[str]:
+def _extract_release_required_gates(
+    policy_obj: dict[str, Any],
+    errors: list[str],
+) -> list[str]:
     gates = policy_obj.get("gates")
+
     if not isinstance(gates, dict):
-        errors.append("policy file must contain top-level gates mapping")
+        errors.append(
+            "policy file must contain "
+            "top-level gates mapping"
+        )
         return []
 
     return _normalize_gate_list(
@@ -211,59 +374,185 @@ def _extract_release_required_gates(policy_obj: dict[str, Any], errors: list[str
     )
 
 
-def _extract_registry_gate_ids(registry_obj: dict[str, Any], errors: list[str]) -> set[str]:
+def _extract_registry_gate_ids(
+    registry_obj: dict[str, Any],
+    errors: list[str],
+) -> set[str]:
     gates = registry_obj.get("gates")
+
     if not isinstance(gates, dict):
-        errors.append("registry file must contain top-level gates mapping")
+        errors.append(
+            "registry file must contain "
+            "top-level gates mapping"
+        )
         return set()
 
     gate_ids: set[str] = set()
+
     for gate_id in gates:
         if not _is_non_empty_text(gate_id):
-            errors.append("registry gate ids must be non-empty strings")
+            errors.append(
+                "registry gate ids must be "
+                "non-empty strings"
+            )
             continue
+
         gate_ids.add(str(gate_id))
+
     if not gate_ids:
-        errors.append("registry file must declare at least one gate id")
+        errors.append(
+            "registry file must declare at least "
+            "one gate id"
+        )
+
     return gate_ids
 
 
-def _validate_git_sha(value: Any, label: str, errors: list[str]) -> bool:
+def _validate_git_sha(
+    value: Any,
+    label: str,
+    errors: list[str],
+) -> bool:
     if not _is_git_sha(value):
-        errors.append(f"{label} must be a 40-hex git sha")
+        errors.append(
+            f"{label} must be a 40-hex git sha"
+        )
         return False
+
     return True
 
 
-def _validate_run_key(value: Any, label: str, errors: list[str]) -> bool:
+def _validate_run_key(
+    value: Any,
+    label: str,
+    errors: list[str],
+) -> bool:
     if not _is_non_empty_text(value):
-        errors.append(f"{label} must be a non-empty string")
+        errors.append(
+            f"{label} must be a non-empty string"
+        )
         return False
+
     return True
 
 
-def _canonical_repo_path(path: Path, repo_root: Path) -> str:
+def _canonical_repo_path(
+    path: Path,
+    repo_root: Path,
+) -> str:
     try:
-        return str(path.resolve().relative_to(repo_root.resolve()))
+        return str(
+            path.resolve().relative_to(
+                repo_root.resolve()
+            )
+        )
+
     except Exception:  # noqa: BLE001
         return str(path)
 
 
-def _path_matches_recorded(value: Any, path: Path, repo_root: Path) -> bool:
+def _path_matches_recorded(
+    value: Any,
+    path: Path,
+    repo_root: Path,
+) -> bool:
     if not _is_non_empty_text(value):
         return False
+
     actual = str(value).strip()
+
     candidates = {
         str(path),
         str(path.resolve()),
-        _canonical_repo_path(path, repo_root),
+        _canonical_repo_path(
+            path,
+            repo_root,
+        ),
     }
+
     return actual in candidates
 
 
-def _write_json(path: Path, data: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+def _report_with_canonical_manifest_path(
+    report: dict[str, Any],
+    repo_root: Path,
+    label: str,
+    errors: list[str],
+) -> dict[str, Any] | None:
+    manifest = report.get("manifest")
+
+    if not isinstance(manifest, dict):
+        errors.append(
+            f"{label}.manifest must be an object"
+        )
+        return None
+
+    raw_path = manifest.get("path")
+
+    if not _is_non_empty_text(raw_path):
+        errors.append(
+            f"{label}.manifest.path must be "
+            "a non-empty string"
+        )
+        return None
+
+    reported_path = Path(
+        str(raw_path).strip()
+    )
+
+    resolved_path = (
+        reported_path.resolve()
+        if reported_path.is_absolute()
+        else (
+            repo_root
+            / reported_path
+        ).resolve()
+    )
+
+    try:
+        resolved_path.relative_to(
+            repo_root
+        )
+
+    except ValueError:
+        errors.append(
+            f"{label}.manifest.path must be "
+            "contained within repo root: "
+            f"{resolved_path}"
+        )
+        return None
+
+    normalized = dict(report)
+    normalized_manifest = dict(manifest)
+
+    normalized_manifest["path"] = str(
+        resolved_path
+    )
+    normalized["manifest"] = (
+        normalized_manifest
+    )
+
+    return normalized
+
+
+def _write_json(
+    path: Path,
+    data: dict[str, Any],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    path.write_text(
+        json.dumps(
+            data,
+            indent=2,
+            sort_keys=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 def materialize_release_required_from_verifier(
@@ -274,31 +563,50 @@ def materialize_release_required_from_verifier(
     repo_root: Path,
     policy_path: Path,
     registry_path: Path,
-) -> tuple[dict[str, Any] | None, list[str], list[str]]:
+) -> tuple[
+    dict[str, Any] | None,
+    list[str],
+    list[str],
+]:
     errors: list[str] = []
     materialized_gates: list[str] = []
 
     repo_root = repo_root.resolve()
+
     manifest_path = (
         manifest_path.resolve()
         if manifest_path.is_absolute()
-        else (repo_root / manifest_path).resolve()
+        else (
+            repo_root
+            / manifest_path
+        ).resolve()
     )
 
     if not repo_root.is_dir():
-        errors.append(f"repo root must be a directory: {repo_root}")
+        errors.append(
+            "repo root must be a directory: "
+            f"{repo_root}"
+        )
         return None, [], errors
 
     try:
-        manifest_path.relative_to(repo_root)
+        manifest_path.relative_to(
+            repo_root
+        )
+
     except ValueError:
         errors.append(
-            "manifest path must be contained within repo root "
-            f"(manifest={manifest_path}, repo_root={repo_root})"
+            "manifest path must be contained "
+            "within repo root "
+            f"(manifest={manifest_path}, "
+            f"repo_root={repo_root})"
         )
 
     if not manifest_path.is_file():
-        errors.append(f"release evidence input manifest not found: {manifest_path}")
+        errors.append(
+            "release evidence input manifest "
+            f"not found: {manifest_path}"
+        )
 
     if errors:
         return None, [], errors
@@ -308,16 +616,22 @@ def materialize_release_required_from_verifier(
         "status.json",
         errors,
     )
+
     supplied_verifier_report = _load_json(
         verifier_report_path,
-        "recorded_release_evidence_verifier_v0.json",
+        (
+            "recorded_release_evidence_"
+            "verifier_v0.json"
+        ),
         errors,
     )
+
     policy_obj = _load_yaml(
         policy_path,
         "policy file",
         errors,
     )
+
     registry_obj = _load_yaml(
         registry_path,
         "registry file",
@@ -333,230 +647,630 @@ def materialize_release_required_from_verifier(
         return None, [], errors
 
     try:
-        canonical_verifier_report = check_recorded_release_evidence(
-            manifest_path=manifest_path,
-            repo_root=repo_root,
+        canonical_verifier_report = (
+            check_recorded_release_evidence(
+                manifest_path=manifest_path,
+                repo_root=repo_root,
+            )
         )
-    except Exception as exc:  # noqa: BLE001 - fail closed
+
+    except Exception as exc:  # noqa: BLE001
         errors.append(
-            "canonical verifier replay could not be completed: "
-            f"{exc}"
+            "canonical verifier replay could "
+            f"not be completed: {exc}"
         )
         return None, [], errors
 
-    if canonical_verifier_report.get("status") != EXPECTED_VERIFIER_STATUS:
+    if (
+        canonical_verifier_report.get("status")
+        != EXPECTED_VERIFIER_STATUS
+    ):
         errors.append(
-            "canonical verifier replay status must be "
-            f"{EXPECTED_VERIFIER_STATUS!r} "
-            f"(got {canonical_verifier_report.get('status')!r})"
+            "canonical verifier replay status "
+            f"must be {EXPECTED_VERIFIER_STATUS!r} "
+            "(got "
+            f"{canonical_verifier_report.get('status')!r})"
         )
 
-    replay_errors = canonical_verifier_report.get("errors")
+    replay_errors = (
+        canonical_verifier_report.get(
+            "errors"
+        )
+    )
+
     if not isinstance(replay_errors, list):
-        errors.append("canonical verifier replay errors must be an array")
+        errors.append(
+            "canonical verifier replay errors "
+            "must be an array"
+        )
+
     elif replay_errors:
         errors.append(
-            "canonical verifier replay errors must be empty "
-            "before materialization"
+            "canonical verifier replay errors "
+            "must be empty before materialization"
         )
 
     for field_name in (
         "evidence_results",
         "relation_binding_results",
     ):
-        supplied_value = supplied_verifier_report.get(field_name)
-        replayed_value = canonical_verifier_report.get(field_name)
+        supplied_value = (
+            supplied_verifier_report.get(
+                field_name
+            )
+        )
 
-        if not isinstance(supplied_value, dict) or not supplied_value:
+        replayed_value = (
+            canonical_verifier_report.get(
+                field_name
+            )
+        )
+
+        if (
+            not isinstance(
+                supplied_value,
+                dict,
+            )
+            or not supplied_value
+        ):
             errors.append(
                 f"verifier report {field_name} "
                 "must be a non-empty object"
             )
 
-        if not isinstance(replayed_value, dict) or not replayed_value:
+        if (
+            not isinstance(
+                replayed_value,
+                dict,
+            )
+            or not replayed_value
+        ):
             errors.append(
-                f"canonical verifier replay {field_name} "
-                "must be a non-empty object"
+                "canonical verifier replay "
+                f"{field_name} must be a "
+                "non-empty object"
             )
 
-    if supplied_verifier_report != canonical_verifier_report:
+    supplied_for_comparison = (
+        _report_with_canonical_manifest_path(
+            supplied_verifier_report,
+            repo_root,
+            "verifier report",
+            errors,
+        )
+    )
+
+    replayed_for_comparison = (
+        _report_with_canonical_manifest_path(
+            canonical_verifier_report,
+            repo_root,
+            "canonical verifier replay",
+            errors,
+        )
+    )
+
+    expected_manifest_path = str(
+        manifest_path
+    )
+
+    if (
+        supplied_for_comparison is not None
+        and (
+            supplied_for_comparison[
+                "manifest"
+            ][
+                "path"
+            ]
+            != expected_manifest_path
+        )
+    ):
         errors.append(
-            "verifier report does not match canonical replay "
-            "from the supplied manifest and repo root"
+            "verifier report manifest.path "
+            "does not resolve to the supplied "
+            "manifest"
+        )
+
+    if (
+        replayed_for_comparison is not None
+        and (
+            replayed_for_comparison[
+                "manifest"
+            ][
+                "path"
+            ]
+            != expected_manifest_path
+        )
+    ):
+        errors.append(
+            "canonical verifier replay "
+            "manifest.path does not resolve "
+            "to the supplied manifest"
+        )
+
+    if (
+        supplied_for_comparison is not None
+        and replayed_for_comparison is not None
+        and (
+            supplied_for_comparison
+            != replayed_for_comparison
+        )
+    ):
+        errors.append(
+            "verifier report does not match "
+            "canonical replay from the supplied "
+            "manifest and repo root"
         )
 
     if errors:
         return None, [], errors
 
-    # All later admission checks consume the freshly replayed canonical report,
-    # never the standalone report file.
-    verifier_report = canonical_verifier_report
+    # All later admission checks consume the
+    # freshly replayed canonical report, never
+    # the standalone report file.
+    verifier_report = (
+        canonical_verifier_report
+    )
 
-    metrics = _require_object(status, "metrics", "status", errors)
-    diagnostics = status.get("diagnostics")
+    metrics = _require_object(
+        status,
+        "metrics",
+        "status",
+        errors,
+    )
+
+    diagnostics = status.get(
+        "diagnostics"
+    )
+
     if diagnostics is None:
         diagnostics_obj: dict[str, Any] = {}
+
     elif isinstance(diagnostics, dict):
         diagnostics_obj = diagnostics
+
     else:
-        errors.append("status.diagnostics must be an object when present")
+        errors.append(
+            "status.diagnostics must be an "
+            "object when present"
+        )
         diagnostics_obj = {}
 
     status_gates = status.get("gates")
+
     if not isinstance(status_gates, dict):
-        errors.append("status.gates must be an object")
+        errors.append(
+            "status.gates must be an object"
+        )
         gates: dict[str, Any] = {}
+
     else:
-        # Work on a detached copy. Failed admission must not partially mutate the
-        # loaded status object.
+        # Work on a detached copy. Failed
+        # admission must not partially mutate
+        # the loaded status object.
         gates = dict(status_gates)
 
-    status_git_sha = metrics.get("git_sha")
-    status_run_key = metrics.get("run_key")
-    status_run_mode = metrics.get("run_mode")
-    status_policy_path = metrics.get("gate_policy_path")
-    status_policy_sha = metrics.get("gate_policy_sha256")
+    status_git_sha = metrics.get(
+        "git_sha"
+    )
+    status_run_key = metrics.get(
+        "run_key"
+    )
+    status_run_mode = metrics.get(
+        "run_mode"
+    )
+    status_policy_path = metrics.get(
+        "gate_policy_path"
+    )
+    status_policy_sha = metrics.get(
+        "gate_policy_sha256"
+    )
 
-    _validate_git_sha(status_git_sha, "status.metrics.git_sha", errors)
-    _validate_run_key(status_run_key, "status.metrics.run_key", errors)
+    _validate_git_sha(
+        status_git_sha,
+        "status.metrics.git_sha",
+        errors,
+    )
+
+    _validate_run_key(
+        status_run_key,
+        "status.metrics.run_key",
+        errors,
+    )
 
     if status_run_mode != EXPECTED_RUN_MODE:
         errors.append(
-            "status.metrics.run_mode must be 'prod' for release-grade materialization "
+            "status.metrics.run_mode must be "
+            "'prod' for release-grade "
+            "materialization "
             f"(got {status_run_mode!r})"
         )
 
-    if diagnostics_obj.get("gates_stubbed") is True:
-        errors.append("status.diagnostics.gates_stubbed must not be true for release-grade materialization")
-    if diagnostics_obj.get("scaffold") is True:
-        errors.append("status.diagnostics.scaffold must not be true for release-grade materialization")
-
-    if not _is_non_empty_text(status_policy_path):
-        errors.append("status.metrics.gate_policy_path must be a non-empty string")
-    elif not _path_matches_recorded(status_policy_path, policy_path, repo_root):
+    if (
+        diagnostics_obj.get(
+            "gates_stubbed"
+        )
+        is True
+    ):
         errors.append(
-            "status.metrics.gate_policy_path does not match the current policy file "
-            f"(got {status_policy_path!r}, expected {_canonical_repo_path(policy_path, repo_root)!r})"
+            "status.diagnostics.gates_stubbed "
+            "must not be true for release-grade "
+            "materialization"
         )
 
-    if not _is_sha256(status_policy_sha):
-        errors.append("status.metrics.gate_policy_sha256 must be a 64-hex sha256")
-
-    if verifier_report.get("schema_version") != EXPECTED_VERIFIER_SCHEMA:
+    if (
+        diagnostics_obj.get(
+            "scaffold"
+        )
+        is True
+    ):
         errors.append(
-            "verifier report schema_version must be "
+            "status.diagnostics.scaffold must "
+            "not be true for release-grade "
+            "materialization"
+        )
+
+    if not _is_non_empty_text(
+        status_policy_path
+    ):
+        errors.append(
+            "status.metrics.gate_policy_path "
+            "must be a non-empty string"
+        )
+
+    elif not _path_matches_recorded(
+        status_policy_path,
+        policy_path,
+        repo_root,
+    ):
+        errors.append(
+            "status.metrics.gate_policy_path "
+            "does not match the current policy "
+            "file "
+            f"(got {status_policy_path!r}, "
+            "expected "
+            f"{_canonical_repo_path(policy_path, repo_root)!r})"
+        )
+
+    if not _is_sha256(
+        status_policy_sha
+    ):
+        errors.append(
+            "status.metrics.gate_policy_sha256 "
+            "must be a 64-hex sha256"
+        )
+
+    if (
+        verifier_report.get(
+            "schema_version"
+        )
+        != EXPECTED_VERIFIER_SCHEMA
+    ):
+        errors.append(
+            "verifier report schema_version "
+            "must be "
             f"{EXPECTED_VERIFIER_SCHEMA!r}"
         )
-    if verifier_report.get("status") != EXPECTED_VERIFIER_STATUS:
+
+    if (
+        verifier_report.get("status")
+        != EXPECTED_VERIFIER_STATUS
+    ):
         errors.append(
             "verifier report status must be "
-            f"{EXPECTED_VERIFIER_STATUS!r} (got {verifier_report.get('status')!r})"
+            f"{EXPECTED_VERIFIER_STATUS!r} "
+            "(got "
+            f"{verifier_report.get('status')!r})"
         )
 
-    verifier_errors = verifier_report.get("errors")
+    verifier_errors = verifier_report.get(
+        "errors"
+    )
+
     if verifier_errors is not None:
-        if not isinstance(verifier_errors, list):
-            errors.append("verifier_report.errors must be an array when present")
+        if not isinstance(
+            verifier_errors,
+            list,
+        ):
+            errors.append(
+                "verifier_report.errors must "
+                "be an array when present"
+            )
+
         elif verifier_errors:
-            errors.append("verifier_report.errors must be absent or empty before materialization")
+            errors.append(
+                "verifier_report.errors must "
+                "be absent or empty before "
+                "materialization"
+            )
 
-    policy_sha = _sha256_file(policy_path, "policy file", errors)
-    registry_sha = _sha256_file(registry_path, "registry file", errors)
+    policy_sha = _sha256_file(
+        policy_path,
+        "policy file",
+        errors,
+    )
 
-    if policy_sha is not None and status_policy_sha is not None and status_policy_sha != policy_sha:
+    registry_sha = _sha256_file(
+        registry_path,
+        "registry file",
+        errors,
+    )
+
+    if (
+        policy_sha is not None
+        and status_policy_sha is not None
+        and status_policy_sha != policy_sha
+    ):
         errors.append(
-            "status.metrics.gate_policy_sha256 does not match the current policy file "
-            f"(expected {policy_sha!r}, got {status_policy_sha!r})"
+            "status.metrics.gate_policy_sha256 "
+            "does not match the current policy "
+            "file "
+            f"(expected {policy_sha!r}, "
+            f"got {status_policy_sha!r})"
         )
 
-    run_identity = _require_object(verifier_report, "run_identity", "verifier_report", errors)
-    report_git_sha = run_identity.get("git_sha")
-    report_run_key = run_identity.get("run_key")
-    report_run_mode = run_identity.get("run_mode")
+    run_identity = _require_object(
+        verifier_report,
+        "run_identity",
+        "verifier_report",
+        errors,
+    )
 
-    _validate_git_sha(report_git_sha, "verifier_report.run_identity.git_sha", errors)
-    _validate_run_key(report_run_key, "verifier_report.run_identity.run_key", errors)
+    report_git_sha = run_identity.get(
+        "git_sha"
+    )
+    report_run_key = run_identity.get(
+        "run_key"
+    )
+    report_run_mode = run_identity.get(
+        "run_mode"
+    )
+
+    _validate_git_sha(
+        report_git_sha,
+        (
+            "verifier_report.run_identity."
+            "git_sha"
+        ),
+        errors,
+    )
+
+    _validate_run_key(
+        report_run_key,
+        (
+            "verifier_report.run_identity."
+            "run_key"
+        ),
+        errors,
+    )
+
     if report_run_mode != EXPECTED_RUN_MODE:
         errors.append(
-            "verifier_report.run_identity.run_mode must be 'prod' "
+            "verifier_report.run_identity."
+            "run_mode must be 'prod' "
             f"(got {report_run_mode!r})"
         )
 
     if status_git_sha != report_git_sha:
         errors.append(
-            "status.metrics.git_sha must match verifier_report.run_identity.git_sha "
-            f"(expected {report_git_sha!r}, got {status_git_sha!r})"
+            "status.metrics.git_sha must match "
+            "verifier_report.run_identity.git_sha "
+            f"(expected {report_git_sha!r}, "
+            f"got {status_git_sha!r})"
         )
+
     if status_run_key != report_run_key:
         errors.append(
-            "status.metrics.run_key must match verifier_report.run_identity.run_key "
-            f"(expected {report_run_key!r}, got {status_run_key!r})"
+            "status.metrics.run_key must match "
+            "verifier_report.run_identity.run_key "
+            f"(expected {report_run_key!r}, "
+            f"got {status_run_key!r})"
         )
 
-    verified_subjects = _require_object(verifier_report, "verified_subjects", "verifier_report", errors)
-    verified_subject_git_sha = verified_subjects.get("git_sha")
-    verified_subject_run_key = verified_subjects.get("run_key")
-    verified_subject_commit_sha = verified_subjects.get("commit_sha")
+    verified_subjects = _require_object(
+        verifier_report,
+        "verified_subjects",
+        "verifier_report",
+        errors,
+    )
 
-    _validate_git_sha(verified_subject_git_sha, "verifier_report.verified_subjects.git_sha", errors)
-    _validate_run_key(verified_subject_run_key, "verifier_report.verified_subjects.run_key", errors)
-    _validate_git_sha(verified_subject_commit_sha, "verifier_report.verified_subjects.commit_sha", errors)
+    verified_subject_git_sha = (
+        verified_subjects.get(
+            "git_sha"
+        )
+    )
+    verified_subject_run_key = (
+        verified_subjects.get(
+            "run_key"
+        )
+    )
+    verified_subject_commit_sha = (
+        verified_subjects.get(
+            "commit_sha"
+        )
+    )
 
-    if verified_subject_git_sha != status_git_sha:
+    _validate_git_sha(
+        verified_subject_git_sha,
+        (
+            "verifier_report."
+            "verified_subjects.git_sha"
+        ),
+        errors,
+    )
+
+    _validate_run_key(
+        verified_subject_run_key,
+        (
+            "verifier_report."
+            "verified_subjects.run_key"
+        ),
+        errors,
+    )
+
+    _validate_git_sha(
+        verified_subject_commit_sha,
+        (
+            "verifier_report."
+            "verified_subjects.commit_sha"
+        ),
+        errors,
+    )
+
+    if (
+        verified_subject_git_sha
+        != status_git_sha
+    ):
         errors.append(
-            "verifier_report.verified_subjects.git_sha must match status.metrics.git_sha "
-            f"(expected {status_git_sha!r}, got {verified_subject_git_sha!r})"
-        )
-    if verified_subject_run_key != status_run_key:
-        errors.append(
-            "verifier_report.verified_subjects.run_key must match status.metrics.run_key "
-            f"(expected {status_run_key!r}, got {verified_subject_run_key!r})"
-        )
-    if verified_subject_commit_sha != status_git_sha:
-        errors.append(
-            "verifier_report.verified_subjects.commit_sha must match status.metrics.git_sha "
-            f"(expected {status_git_sha!r}, got {verified_subject_commit_sha!r})"
+            "verifier_report.verified_subjects."
+            "git_sha must match "
+            "status.metrics.git_sha "
+            f"(expected {status_git_sha!r}, "
+            f"got {verified_subject_git_sha!r})"
         )
 
-    policy_binding = _require_object(verifier_report, "policy_binding", "verifier_report", errors)
-    report_policy_set = policy_binding.get("policy_set")
-    report_policy_sha = policy_binding.get("policy_sha256")
-
-    if report_policy_set != EXPECTED_POLICY_SET:
+    if (
+        verified_subject_run_key
+        != status_run_key
+    ):
         errors.append(
-            "verifier_report.policy_binding.policy_set must be "
-            f"{EXPECTED_POLICY_SET!r} (got {report_policy_set!r})"
-        )
-    if not _is_sha256(report_policy_sha):
-        errors.append("verifier_report.policy_binding.policy_sha256 must be a 64-hex sha256")
-
-    if policy_sha is not None and report_policy_sha != policy_sha:
-        errors.append(
-            "verifier_report.policy_binding.policy_sha256 does not match the current policy file "
-            f"(expected {policy_sha!r}, got {report_policy_sha!r})"
-        )
-    if status_policy_sha is not None and report_policy_sha != status_policy_sha:
-        errors.append(
-            "verifier_report.policy_binding.policy_sha256 must match status.metrics.gate_policy_sha256 "
-            f"(expected {status_policy_sha!r}, got {report_policy_sha!r})"
+            "verifier_report.verified_subjects."
+            "run_key must match "
+            "status.metrics.run_key "
+            f"(expected {status_run_key!r}, "
+            f"got {verified_subject_run_key!r})"
         )
 
-    registry_binding = _require_object(verifier_report, "registry_binding", "verifier_report", errors)
-    report_registry_sha = registry_binding.get("registry_sha256")
-    if not _is_sha256(report_registry_sha):
-        errors.append("verifier_report.registry_binding.registry_sha256 must be a 64-hex sha256")
-    if registry_sha is not None and report_registry_sha != registry_sha:
+    if (
+        verified_subject_commit_sha
+        != status_git_sha
+    ):
         errors.append(
-            "verifier_report.registry_binding.registry_sha256 does not match the current registry file "
-            f"(expected {registry_sha!r}, got {report_registry_sha!r})"
+            "verifier_report.verified_subjects."
+            "commit_sha must match "
+            "status.metrics.git_sha "
+            f"(expected {status_git_sha!r}, "
+            f"got {verified_subject_commit_sha!r})"
         )
 
-    release_required_gates = _extract_release_required_gates(policy_obj, errors)
-    registry_gate_ids = _extract_registry_gate_ids(registry_obj, errors)
+    policy_binding = _require_object(
+        verifier_report,
+        "policy_binding",
+        "verifier_report",
+        errors,
+    )
+
+    report_policy_set = (
+        policy_binding.get(
+            "policy_set"
+        )
+    )
+    report_policy_sha = (
+        policy_binding.get(
+            "policy_sha256"
+        )
+    )
+
+    if (
+        report_policy_set
+        != EXPECTED_POLICY_SET
+    ):
+        errors.append(
+            "verifier_report.policy_binding."
+            "policy_set must be "
+            f"{EXPECTED_POLICY_SET!r} "
+            f"(got {report_policy_set!r})"
+        )
+
+    if not _is_sha256(
+        report_policy_sha
+    ):
+        errors.append(
+            "verifier_report.policy_binding."
+            "policy_sha256 must be a "
+            "64-hex sha256"
+        )
+
+    if (
+        policy_sha is not None
+        and report_policy_sha != policy_sha
+    ):
+        errors.append(
+            "verifier_report.policy_binding."
+            "policy_sha256 does not match the "
+            "current policy file "
+            f"(expected {policy_sha!r}, "
+            f"got {report_policy_sha!r})"
+        )
+
+    if (
+        status_policy_sha is not None
+        and (
+            report_policy_sha
+            != status_policy_sha
+        )
+    ):
+        errors.append(
+            "verifier_report.policy_binding."
+            "policy_sha256 must match "
+            "status.metrics.gate_policy_sha256 "
+            f"(expected {status_policy_sha!r}, "
+            f"got {report_policy_sha!r})"
+        )
+
+    registry_binding = _require_object(
+        verifier_report,
+        "registry_binding",
+        "verifier_report",
+        errors,
+    )
+
+    report_registry_sha = (
+        registry_binding.get(
+            "registry_sha256"
+        )
+    )
+
+    if not _is_sha256(
+        report_registry_sha
+    ):
+        errors.append(
+            "verifier_report.registry_binding."
+            "registry_sha256 must be a "
+            "64-hex sha256"
+        )
+
+    if (
+        registry_sha is not None
+        and report_registry_sha != registry_sha
+    ):
+        errors.append(
+            "verifier_report.registry_binding."
+            "registry_sha256 does not match the "
+            "current registry file "
+            f"(expected {registry_sha!r}, "
+            f"got {report_registry_sha!r})"
+        )
+
+    release_required_gates = (
+        _extract_release_required_gates(
+            policy_obj,
+            errors,
+        )
+    )
+
+    registry_gate_ids = (
+        _extract_registry_gate_ids(
+            registry_obj,
+            errors,
+        )
+    )
+
     for gate_id in release_required_gates:
         if gate_id not in registry_gate_ids:
             errors.append(
-                f"policy.gates.release_required contains unknown registry gate id {gate_id!r}"
+                "policy.gates.release_required "
+                "contains unknown registry "
+                f"gate id {gate_id!r}"
             )
 
     preexisting_release_required = [
@@ -567,57 +1281,89 @@ def materialize_release_required_from_verifier(
 
     if preexisting_release_required:
         errors.append(
-            "status.gates must not contain release-required "
-            "gate entries before verifier materialization: "
+            "status.gates must not contain "
+            "release-required gate entries before "
+            "verifier materialization: "
             f"{preexisting_release_required!r}"
         )
 
-    admissibility = verifier_report.get("gate_materialization_admissibility")
+    admissibility = verifier_report.get(
+        "gate_materialization_admissibility"
+    )
+
     if not isinstance(admissibility, dict):
-        errors.append("verifier_report.gate_materialization_admissibility must be an object")
+        errors.append(
+            "verifier_report."
+            "gate_materialization_admissibility "
+            "must be an object"
+        )
         admissibility = {}
 
     if errors:
         return None, [], errors
 
     for gate_id in release_required_gates:
-        entry = admissibility.get(gate_id)
+        entry = admissibility.get(
+            gate_id
+        )
+
         if not isinstance(entry, dict):
             errors.append(
-                f"verifier_report.gate_materialization_admissibility.{gate_id} must be an object"
+                "verifier_report."
+                "gate_materialization_admissibility."
+                f"{gate_id} must be an object"
             )
             continue
 
         if entry.get("status") != "verified":
             errors.append(
-                "verifier_report.gate_materialization_admissibility."
-                f"{gate_id}.status must be 'verified' (got {entry.get('status')!r})"
+                "verifier_report."
+                "gate_materialization_admissibility."
+                f"{gate_id}.status must be "
+                "'verified' "
+                f"(got {entry.get('status')!r})"
             )
             continue
 
         if entry.get("admissible") is not True:
             errors.append(
-                "verifier_report.gate_materialization_admissibility."
-                f"{gate_id}.admissible must be literal true"
+                "verifier_report."
+                "gate_materialization_admissibility."
+                f"{gate_id}.admissible must be "
+                "literal true"
             )
             continue
 
-        entry_errors = entry.get("errors")
+        entry_errors = entry.get(
+            "errors"
+        )
+
         if entry_errors is not None:
-            if not isinstance(entry_errors, list):
+            if not isinstance(
+                entry_errors,
+                list,
+            ):
                 errors.append(
-                    "verifier_report.gate_materialization_admissibility."
-                    f"{gate_id}.errors must be an array when present"
-                )
-                continue
-            if entry_errors:
-                errors.append(
-                    "verifier_report.gate_materialization_admissibility."
-                    f"{gate_id}.errors must be absent or empty before materialization"
+                    "verifier_report."
+                    "gate_materialization_admissibility."
+                    f"{gate_id}.errors must be "
+                    "an array when present"
                 )
                 continue
 
-        materialized_gates.append(gate_id)
+            if entry_errors:
+                errors.append(
+                    "verifier_report."
+                    "gate_materialization_admissibility."
+                    f"{gate_id}.errors must be "
+                    "absent or empty before "
+                    "materialization"
+                )
+                continue
+
+        materialized_gates.append(
+            gate_id
+        )
 
     if errors:
         return None, [], errors
@@ -626,88 +1372,181 @@ def materialize_release_required_from_verifier(
         gates[gate_id] = True
 
     status["gates"] = gates
-    return status, materialized_gates, errors
+
+    return (
+        status,
+        materialized_gates,
+        errors,
+    )
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(
+    argv: list[str] | None = None,
+) -> int:
     root = _repo_root_from_tool()
+
     parser = argparse.ArgumentParser(
         description=(
-            "Materialize release-required gates into status.json from a verified "
-            "recorded release-evidence verifier report."
+            "Materialize release-required gates "
+            "into status.json from a verified "
+            "recorded release-evidence verifier "
+            "report."
         )
     )
+
     parser.add_argument(
         "--status",
-        default=str(root / "PULSE_safe_pack_v0" / "artifacts" / "status.json"),
-        help="Path to the input status.json.",
+        default=str(
+            root
+            / "PULSE_safe_pack_v0"
+            / "artifacts"
+            / "status.json"
+        ),
+        help=(
+            "Path to the input status.json."
+        ),
     )
+
     parser.add_argument(
         "--verifier-report",
         default=str(
-            root / "PULSE_safe_pack_v0" / "artifacts" / "recorded_release_evidence_verifier_v0.json"
+            root
+            / "PULSE_safe_pack_v0"
+            / "artifacts"
+            / (
+                "recorded_release_evidence_"
+                "verifier_v0.json"
+            )
         ),
-        help="Path to recorded_release_evidence_verifier_v0.json.",
+        help=(
+            "Path to "
+            "recorded_release_evidence_"
+            "verifier_v0.json."
+        ),
     )
+
     parser.add_argument(
         "--manifest",
         required=True,
         help=(
-            "Path to the release_evidence_input_manifest_v0.json "
+            "Path to the "
+            "release_evidence_input_manifest_v0.json "
             "used for canonical verifier replay."
         ),
     )
+
     parser.add_argument(
         "--repo-root",
         required=True,
         help=(
-            "Repository root used for canonical verifier replay "
-            "and evidence-path resolution."
+            "Repository root used for canonical "
+            "verifier replay and evidence-path "
+            "resolution."
         ),
     )
+
     parser.add_argument(
         "--policy",
-        default=str(root / "pulse_gate_policy_v0.yml"),
-        help="Path to pulse_gate_policy_v0.yml.",
+        default=str(
+            root
+            / "pulse_gate_policy_v0.yml"
+        ),
+        help=(
+            "Path to pulse_gate_policy_v0.yml."
+        ),
     )
+
     parser.add_argument(
         "--registry",
-        default=str(root / "pulse_gate_registry_v0.yml"),
-        help="Path to pulse_gate_registry_v0.yml.",
+        default=str(
+            root
+            / "pulse_gate_registry_v0.yml"
+        ),
+        help=(
+            "Path to pulse_gate_registry_v0.yml."
+        ),
     )
+
     parser.add_argument(
         "--out",
-        default=str(root / "PULSE_safe_pack_v0" / "artifacts" / "status.json"),
-        help="Path to write the materialized status.json.",
+        default=str(
+            root
+            / "PULSE_safe_pack_v0"
+            / "artifacts"
+            / "status.json"
+        ),
+        help=(
+            "Path to write the materialized "
+            "status.json."
+        ),
     )
-    args = parser.parse_args(argv)
 
-    status, materialized_gates, errors = (
-        materialize_release_required_from_verifier(
-            status_path=Path(args.status),
-            verifier_report_path=Path(args.verifier_report),
-            manifest_path=Path(args.manifest),
-            repo_root=Path(args.repo_root),
-            policy_path=Path(args.policy),
-            registry_path=Path(args.registry),
-        )
+    args = parser.parse_args(
+        argv
+    )
+
+    (
+        status,
+        materialized_gates,
+        errors,
+    ) = materialize_release_required_from_verifier(
+        status_path=Path(
+            args.status
+        ),
+        verifier_report_path=Path(
+            args.verifier_report
+        ),
+        manifest_path=Path(
+            args.manifest
+        ),
+        repo_root=Path(
+            args.repo_root
+        ),
+        policy_path=Path(
+            args.policy
+        ),
+        registry_path=Path(
+            args.registry
+        ),
     )
 
     if errors:
-        print("ERRORS (fail-closed):", file=sys.stderr)
+        print(
+            "ERRORS (fail-closed):",
+            file=sys.stderr,
+        )
+
         for error in errors:
-            print(f" - {error}", file=sys.stderr)
+            print(
+                f" - {error}",
+                file=sys.stderr,
+            )
+
         return 1
 
     assert status is not None
-    _write_json(Path(args.out), status)
-    print(
-        "OK: materialized release-required gates from verified recorded evidence: "
-        + ", ".join(materialized_gates)
+
+    _write_json(
+        Path(args.out),
+        status,
     )
-    print(f"Status written to {args.out}")
+
+    print(
+        "OK: materialized release-required "
+        "gates from verified recorded evidence: "
+        + ", ".join(
+            materialized_gates
+        )
+    )
+
+    print(
+        f"Status written to {args.out}"
+    )
+
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(
+        main()
+    )

--- a/PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
+++ b/PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
@@ -29,6 +29,15 @@ try:
 except Exception:  # pragma: no cover - fail closed at runtime if unavailable
     yaml = None
 
+if __package__:
+    from .check_recorded_release_evidence_v0 import (
+        check_recorded_release_evidence,
+    )
+else:  # pragma: no cover - direct CLI execution
+    from check_recorded_release_evidence_v0 import (
+        check_recorded_release_evidence,
+    )
+
 EXPECTED_VERIFIER_SCHEMA = "recorded_release_evidence_verifier_v0"
 EXPECTED_VERIFIER_STATUS = "verified"
 EXPECTED_POLICY_SET = "required+release_required"
@@ -261,24 +270,149 @@ def materialize_release_required_from_verifier(
     *,
     status_path: Path,
     verifier_report_path: Path,
+    manifest_path: Path,
+    repo_root: Path,
     policy_path: Path,
     registry_path: Path,
 ) -> tuple[dict[str, Any] | None, list[str], list[str]]:
     errors: list[str] = []
     materialized_gates: list[str] = []
-    repo_root = _repo_root_from_tool()
 
-    status = _load_json(status_path, "status.json", errors)
-    verifier_report = _load_json(
+    repo_root = repo_root.resolve()
+    manifest_path = (
+        manifest_path.resolve()
+        if manifest_path.is_absolute()
+        else (repo_root / manifest_path).resolve()
+    )
+
+    if not repo_root.is_dir():
+        errors.append(
+            f"repo root must be a directory: {repo_root}"
+        )
+        return None, [], errors
+
+    try:
+        manifest_path.relative_to(repo_root)
+    except ValueError:
+        errors.append(
+            "manifest path must be contained within repo root "
+            f"(manifest={manifest_path}, repo_root={repo_root})"
+        )
+
+    if not manifest_path.is_file():
+        errors.append(
+            f"release evidence input manifest not found: {manifest_path}"
+        )
+
+    if errors:
+        return None, [], errors
+
+    status = _load_json(
+        status_path,
+        "status.json",
+        errors,
+    )
+    supplied_verifier_report = _load_json(
         verifier_report_path,
         "recorded_release_evidence_verifier_v0.json",
         errors,
     )
-    policy_obj = _load_yaml(policy_path, "policy file", errors)
-    registry_obj = _load_yaml(registry_path, "registry file", errors)
+        policy_obj = _load_yaml(
+        policy_path,
+        "policy file",
+        errors,
+    )
+    registry_obj = _load_yaml(
+        registry_path,
+        "registry file",
+        errors,
+    )
 
-    if status is None or verifier_report is None or policy_obj is None or registry_obj is None:
-        return None, materialized_gates, errors
+        if (
+        status is None
+        or supplied_verifier_report is None
+        or policy_obj is None
+        or registry_obj is None
+    ):
+        return None, [], errors
+
+    try:
+        canonical_verifier_report = (
+            check_recorded_release_evidence(
+                manifest_path=manifest_path,
+                repo_root=repo_root,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 - fail closed
+        errors.append(
+            "canonical verifier replay could not be completed: "
+            f"{exc}"
+        )
+        return None, [], errors
+
+    if (
+        canonical_verifier_report.get("status")
+        != EXPECTED_VERIFIER_STATUS
+    ):
+        errors.append(
+            "canonical verifier replay status must be "
+            f"{EXPECTED_VERIFIER_STATUS!r} "
+            f"(got {canonical_verifier_report.get('status')!r})"
+        )
+
+    replay_errors = canonical_verifier_report.get("errors")
+
+    if not isinstance(replay_errors, list):
+        errors.append(
+            "canonical verifier replay errors must be an array"
+        )
+    elif replay_errors:
+        errors.append(
+            "canonical verifier replay errors must be empty "
+            "before materialization"
+        )
+
+    for field_name in (
+        "evidence_results",
+        "relation_binding_results",
+    ):
+        supplied_value = supplied_verifier_report.get(
+            field_name
+        )
+        replayed_value = canonical_verifier_report.get(
+            field_name
+        )
+
+        if (
+            not isinstance(supplied_value, dict)
+            or not supplied_value
+        ):
+            errors.append(
+                f"verifier report {field_name} "
+                "must be a non-empty object"
+            )
+
+        if (
+            not isinstance(replayed_value, dict)
+            or not replayed_value
+        ):
+            errors.append(
+                f"canonical verifier replay {field_name} "
+                "must be a non-empty object"
+            )
+
+    if supplied_verifier_report != canonical_verifier_report:
+        errors.append(
+            "verifier report does not match canonical replay "
+            "from the supplied manifest and repo root"
+        )
+
+    if errors:
+        return None, [], errors
+
+    # All later admission checks consume the freshly replayed
+    # canonical report, never the standalone report file.
+    verifier_report = canonical_verifier_report
 
     metrics = _require_object(status, "metrics", "status", errors)
     diagnostics = status.get("diagnostics")
@@ -290,10 +424,15 @@ def materialize_release_required_from_verifier(
         errors.append("status.diagnostics must be an object when present")
         diagnostics_obj = {}
 
-    gates = status.get("gates")
-    if not isinstance(gates, dict):
+         status_gates = status.get("gates")
+
+    if not isinstance(status_gates, dict):
         errors.append("status.gates must be an object")
-        gates = {}
+        gates: dict[str, Any] = {}
+    else:
+        # Work on a detached copy. Failed admission must not
+        # partially mutate the loaded status object.
+        gates = dict(status_gates)
 
     status_git_sha = metrics.get("git_sha")
     status_run_key = metrics.get("run_key")
@@ -443,6 +582,19 @@ def materialize_release_required_from_verifier(
                 f"policy.gates.release_required contains unknown registry gate id {gate_id!r}"
             )
 
+       preexisting_release_required = [
+        gate_id
+        for gate_id in release_required_gates
+        if gate_id in gates
+    ]
+
+    if preexisting_release_required:
+        errors.append(
+            "status.gates must not contain release-required "
+            "gate entries before verifier materialization: "
+            f"{preexisting_release_required!r}"
+        )
+
     admissibility = verifier_report.get("gate_materialization_admissibility")
     if not isinstance(admissibility, dict):
         errors.append("verifier_report.gate_materialization_admissibility must be an object")
@@ -488,14 +640,16 @@ def materialize_release_required_from_verifier(
                 )
                 continue
 
-        gates[gate_id] = True
         materialized_gates.append(gate_id)
 
     if errors:
         return None, materialized_gates, errors
 
     status["gates"] = gates
-    return status, materialized_gates, errors
+    return None, [], errors
+
+    for gate_id in materialized_gates:
+        gates[gate_id] = True
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -518,6 +672,22 @@ def main(argv: list[str] | None = None) -> int:
         ),
         help="Path to recorded_release_evidence_verifier_v0.json.",
     )
+   parser.add_argument(
+        "--manifest",
+        required=True,
+        help=(
+            "Path to the release_evidence_input_manifest_v0.json "
+            "used for canonical verifier replay."
+        ),
+    )
+    parser.add_argument(
+        "--repo-root",
+        required=True,
+        help=(
+            "Repository root used for canonical verifier replay "
+            "and evidence-path resolution."
+        ),
+    )
     parser.add_argument(
         "--policy",
         default=str(root / "pulse_gate_policy_v0.yml"),
@@ -535,11 +705,17 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    status, materialized_gates, errors = materialize_release_required_from_verifier(
-        status_path=Path(args.status),
-        verifier_report_path=Path(args.verifier_report),
-        policy_path=Path(args.policy),
-        registry_path=Path(args.registry),
+    status, materialized_gates, errors = (
+        materialize_release_required_from_verifier(
+            status_path=Path(args.status),
+            verifier_report_path=Path(
+                args.verifier_report
+            ),
+            manifest_path=Path(args.manifest),
+            repo_root=Path(args.repo_root),
+            policy_path=Path(args.policy),
+            registry_path=Path(args.registry),
+        )
     )
 
     if errors:

--- a/tests/test_materialize_release_required_from_verifier_v0.py
+++ b/tests/test_materialize_release_required_from_verifier_v0.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import pathlib
-import subprocess
 import sys
+from dataclasses import dataclass
 from typing import Any
 
 import pytest
@@ -14,15 +15,8 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from PULSE_safe_pack_v0.tools.materialize_release_required_from_verifier_v0 import (
-    materialize_release_required_from_verifier,
-)
-
-TOOL = (
-    REPO_ROOT
-    / "PULSE_safe_pack_v0"
-    / "tools"
-    / "materialize_release_required_from_verifier_v0.py"
+from PULSE_safe_pack_v0.tools import (
+    materialize_release_required_from_verifier_v0 as materializer_module,
 )
 
 COMMIT_SHA = "a" * 40
@@ -37,13 +31,6 @@ RELEASE_REQUIRED_GATES = [
 POLICY_TEXT = """policy:
   id: pulse-gate-policy-v0
   version: "0.1.5"
-  enforcement:
-    required_missing: FAIL
-    required_false: FAIL
-    advisory_missing: WARN
-    advisory_false: WARN
-    unknown_gate_in_status: WARN
-    external_detectors_default: ADVISORY
 
 gates:
   required:
@@ -74,6 +61,17 @@ gates:
 """
 
 
+@dataclass
+class Fixture:
+    repo_root: pathlib.Path
+    status_path: pathlib.Path
+    verifier_path: pathlib.Path
+    manifest_path: pathlib.Path
+    policy_path: pathlib.Path
+    registry_path: pathlib.Path
+    canonical_report: dict[str, Any]
+
+
 def _sha256_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
@@ -86,16 +84,27 @@ def _write_text(path: pathlib.Path, text: str) -> str:
 
 def _write_json(path: pathlib.Path, payload: dict[str, Any]) -> str:
     path.parent.mkdir(parents=True, exist_ok=True)
-    text = json.dumps(payload, indent=2, sort_keys=False) + "\n"
+    text = json.dumps(
+        payload,
+        indent=2,
+        sort_keys=False,
+        ensure_ascii=False,
+        allow_nan=False,
+    ) + "\n"
     path.write_text(text, encoding="utf-8")
     return _sha256_bytes(text.encode("utf-8"))
 
 
 def _read_json(path: pathlib.Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
 
 
-def _status_payload(policy_path: pathlib.Path, policy_sha: str) -> dict[str, Any]:
+def _status_payload(
+    policy_path: pathlib.Path,
+    policy_sha: str,
+) -> dict[str, Any]:
     return {
         "version": "1.0.0-prod",
         "created_utc": "2026-01-01T00:00:00Z",
@@ -116,16 +125,53 @@ def _status_payload(policy_path: pathlib.Path, policy_sha: str) -> dict[str, Any
     }
 
 
-def _verifier_payload(policy_sha: str, registry_sha: str) -> dict[str, Any]:
+def _verifier_payload(
+    *,
+    manifest_path: pathlib.Path,
+    manifest_sha: str,
+    policy_sha: str,
+    registry_sha: str,
+) -> dict[str, Any]:
+    relation_results: dict[str, Any] = {}
+    admissibility: dict[str, Any] = {}
+
+    for gate_id in RELEASE_REQUIRED_GATES:
+        relation_id = f"candidate_to_gate_{gate_id}"
+        relation_results[relation_id] = {
+            "status": "verified",
+            "binding_type": "artifact_to_gate",
+            "source_evidence_id": "candidate",
+            "expected_gate_id": gate_id,
+            "target": f"gate.{gate_id}",
+            "errors": [],
+        }
+        admissibility[gate_id] = {
+            "status": "verified",
+            "expected_value": True,
+            "candidate_evidence_ids": ["candidate"],
+            "relation_binding_ids": [relation_id],
+            "admissible": True,
+            "errors": [],
+        }
+
     return {
         "schema_version": "recorded_release_evidence_verifier_v0",
         "report_version": "0.2.0",
         "status": "verified",
-        "errors": [],
+        "manifest": {
+            "path": str(manifest_path.resolve()),
+            "sha256": manifest_sha,
+            "schema_version": "release_evidence_input_manifest_v0",
+        },
         "run_identity": {
             "git_sha": COMMIT_SHA,
             "run_key": RUN_KEY,
             "run_mode": "prod",
+        },
+        "subject": {
+            "repository": "HKati/pulse-release-gates-test",
+            "commit_sha": COMMIT_SHA,
+            "release_candidate": "v-test",
         },
         "verified_subjects": {
             "git_sha": COMMIT_SHA,
@@ -133,154 +179,257 @@ def _verifier_payload(policy_sha: str, registry_sha: str) -> dict[str, Any]:
             "commit_sha": COMMIT_SHA,
         },
         "policy_binding": {
+            "policy_path": "pulse_gate_policy_v0.yml",
             "policy_set": "required+release_required",
             "policy_sha256": policy_sha,
         },
         "registry_binding": {
+            "registry_path": "pulse_gate_registry_v0.yml",
             "registry_sha256": registry_sha,
         },
-        "gate_materialization_admissibility": {
-            gate_id: {
+        "evidence_results": {
+            "candidate": {
+                "path": "candidate.json",
+                "expected_sha256": "e" * 64,
+                "actual_sha256": "e" * 64,
+                "schema_version": "candidate_v0",
                 "status": "verified",
-                "admissible": True,
+                "digest_match": True,
+                "schema_version_match": True,
+                "run_identity_match": True,
+                "subject_binding_match": True,
+                "policy_binding_match": True,
+                "trusted_producer_verified": True,
+                "raw_evidence_verified": True,
+                "required_for_gates_match": True,
                 "errors": [],
             }
-            for gate_id in RELEASE_REQUIRED_GATES
         },
+        "relation_binding_results": relation_results,
+        "gate_materialization_admissibility": admissibility,
+        "errors": [],
     }
 
 
 def _build_fixture(
     tmp_path: pathlib.Path,
-) -> tuple[pathlib.Path, pathlib.Path, pathlib.Path, pathlib.Path]:
+    monkeypatch: pytest.MonkeyPatch,
+) -> Fixture:
     policy_path = tmp_path / "pulse_gate_policy_v0.yml"
     registry_path = tmp_path / "pulse_gate_registry_v0.yml"
     policy_sha = _write_text(policy_path, POLICY_TEXT)
     registry_sha = _write_text(registry_path, REGISTRY_TEXT)
 
-    status_path = tmp_path / "PULSE_safe_pack_v0" / "artifacts" / "status.json"
-    verifier_path = (
-        tmp_path
-        / "PULSE_safe_pack_v0"
-        / "artifacts"
-        / "recorded_release_evidence_verifier_v0.json"
+    artifact_dir = tmp_path / "PULSE_safe_pack_v0" / "artifacts"
+    status_path = artifact_dir / "status.json"
+    verifier_path = artifact_dir / "recorded_release_evidence_verifier_v0.json"
+    manifest_path = artifact_dir / "release_evidence_input_manifest_v0.json"
+
+    manifest_sha = _write_json(
+        manifest_path,
+        {
+            "schema_version": "release_evidence_input_manifest_v0",
+        },
     )
 
-    _write_json(status_path, _status_payload(policy_path, policy_sha))
-    _write_json(verifier_path, _verifier_payload(policy_sha, registry_sha))
-    return status_path, verifier_path, policy_path, registry_path
+    canonical_report = _verifier_payload(
+        manifest_path=manifest_path,
+        manifest_sha=manifest_sha,
+        policy_sha=policy_sha,
+        registry_sha=registry_sha,
+    )
 
+    _write_json(
+        status_path,
+        _status_payload(policy_path, policy_sha),
+    )
+    _write_json(verifier_path, canonical_report)
 
-def test_materializes_release_required_gates_from_verified_report(
-    tmp_path: pathlib.Path,
-) -> None:
-    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
+    def replay(
+        *,
+        manifest_path: pathlib.Path,
+        repo_root: pathlib.Path,
+    ) -> dict[str, Any]:
+        assert manifest_path.resolve() == (
+            artifact_dir / "release_evidence_input_manifest_v0.json"
+        ).resolve()
+        assert repo_root.resolve() == tmp_path.resolve()
+        return copy.deepcopy(canonical_report)
 
-    status, materialized_gates, errors = materialize_release_required_from_verifier(
+    monkeypatch.setattr(
+        materializer_module,
+        "check_recorded_release_evidence",
+        replay,
+    )
+
+    return Fixture(
+        repo_root=tmp_path,
         status_path=status_path,
-        verifier_report_path=verifier_path,
+        verifier_path=verifier_path,
+        manifest_path=manifest_path,
         policy_path=policy_path,
         registry_path=registry_path,
+        canonical_report=canonical_report,
     )
+
+
+def _materialize(
+    fixture: Fixture,
+) -> tuple[dict[str, Any] | None, list[str], list[str]]:
+    return materializer_module.materialize_release_required_from_verifier(
+        status_path=fixture.status_path,
+        verifier_report_path=fixture.verifier_path,
+        manifest_path=fixture.manifest_path,
+        repo_root=fixture.repo_root,
+        policy_path=fixture.policy_path,
+        registry_path=fixture.registry_path,
+    )
+
+
+def _main_args(
+    fixture: Fixture,
+    out_path: pathlib.Path,
+) -> list[str]:
+    return [
+        "--status",
+        str(fixture.status_path),
+        "--verifier-report",
+        str(fixture.verifier_path),
+        "--manifest",
+        str(fixture.manifest_path),
+        "--repo-root",
+        str(fixture.repo_root),
+        "--policy",
+        str(fixture.policy_path),
+        "--registry",
+        str(fixture.registry_path),
+        "--out",
+        str(out_path),
+    ]
+
+
+def test_materializes_release_required_gates_from_canonical_replay(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _build_fixture(tmp_path, monkeypatch)
+
+    status, materialized_gates, errors = _materialize(fixture)
 
     assert errors == []
     assert materialized_gates == RELEASE_REQUIRED_GATES
     assert status is not None
     assert status["gates"]["q1_grounded_ok"] is True
+
     for gate_id in RELEASE_REQUIRED_GATES:
         assert status["gates"][gate_id] is True
 
 
-def test_cli_writes_materialized_status(tmp_path: pathlib.Path) -> None:
-    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
-    out_path = tmp_path / "PULSE_safe_pack_v0" / "artifacts" / "status.materialized.json"
+def test_cli_writes_materialized_status(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _build_fixture(tmp_path, monkeypatch)
+    out_path = fixture.status_path.with_name("status.materialized.json")
 
-    result = subprocess.run(
-        [
-            sys.executable,
-            str(TOOL),
-            "--status",
-            str(status_path),
-            "--verifier-report",
-            str(verifier_path),
-            "--policy",
-            str(policy_path),
-            "--registry",
-            str(registry_path),
-            "--out",
-            str(out_path),
-        ],
-        cwd=str(REPO_ROOT),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
+    result = materializer_module.main(
+        _main_args(fixture, out_path)
     )
 
-    assert result.returncode == 0, result.stderr
+    assert result == 0
     written = _read_json(out_path)
+
     for gate_id in RELEASE_REQUIRED_GATES:
         assert written["gates"][gate_id] is True
 
 
-def test_rejects_status_report_identity_mismatch(tmp_path: pathlib.Path) -> None:
-    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
+@pytest.mark.parametrize(
+    "field_name",
+    ["evidence_results", "relation_binding_results"],
+)
+def test_rejects_report_missing_complete_proof_map(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field_name: str,
+) -> None:
+    fixture = _build_fixture(tmp_path, monkeypatch)
+    supplied = _read_json(fixture.verifier_path)
+    supplied.pop(field_name)
+    _write_json(fixture.verifier_path, supplied)
 
-    status = _read_json(status_path)
-    status["metrics"]["git_sha"] = "b" * 40
-    _write_json(status_path, status)
+    status, materialized_gates, errors = _materialize(fixture)
 
-    materialized, _, errors = materialize_release_required_from_verifier(
-        status_path=status_path,
-        verifier_report_path=verifier_path,
-        policy_path=policy_path,
-        registry_path=registry_path,
-    )
-
-    assert materialized is None
+    assert status is None
+    assert materialized_gates == []
     assert any(
-        "status.metrics.git_sha must match verifier_report.run_identity.git_sha" in error
+        f"verifier report {field_name} must be a non-empty object"
+        in error
+        for error in errors
+    )
+    assert any(
+        "verifier report does not match canonical replay" in error
         for error in errors
     )
 
 
-def test_rejects_status_policy_metadata_mismatch(tmp_path: pathlib.Path) -> None:
-    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
+def test_rejects_modified_admissibility_after_verification(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _build_fixture(tmp_path, monkeypatch)
+    supplied = _read_json(fixture.verifier_path)
+    supplied["gate_materialization_admissibility"][
+        "external_all_pass"
+    ]["candidate_evidence_ids"] = ["substituted-candidate"]
+    _write_json(fixture.verifier_path, supplied)
 
-    status = _read_json(status_path)
-    status["metrics"]["gate_policy_sha256"] = "d" * 64
-    _write_json(status_path, status)
+    status, materialized_gates, errors = _materialize(fixture)
 
-    materialized, _, errors = materialize_release_required_from_verifier(
-        status_path=status_path,
-        verifier_report_path=verifier_path,
-        policy_path=policy_path,
-        registry_path=registry_path,
-    )
-
-    assert materialized is None
+    assert status is None
+    assert materialized_gates == []
     assert any(
-        "status.metrics.gate_policy_sha256 does not match the current policy file" in error
+        "verifier report does not match canonical replay" in error
         for error in errors
     )
 
 
-def test_rejects_verified_report_with_top_level_errors(tmp_path: pathlib.Path) -> None:
-    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
+def test_rejects_substituted_report_with_matching_identity_metadata(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _build_fixture(tmp_path, monkeypatch)
+    supplied = _read_json(fixture.verifier_path)
+    supplied["evidence_results"]["candidate"][
+        "actual_sha256"
+    ] = "f" * 64
+    _write_json(fixture.verifier_path, supplied)
 
-    verifier = _read_json(verifier_path)
-    verifier["errors"] = ["unexpected-top-level-error"]
-    _write_json(verifier_path, verifier)
+    status, materialized_gates, errors = _materialize(fixture)
 
-    materialized, _, errors = materialize_release_required_from_verifier(
-        status_path=status_path,
-        verifier_report_path=verifier_path,
-        policy_path=policy_path,
-        registry_path=registry_path,
+    assert status is None
+    assert materialized_gates == []
+    assert any(
+        "verifier report does not match canonical replay" in error
+        for error in errors
     )
 
-    assert materialized is None
+
+def test_rejects_status_report_identity_mismatch(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _build_fixture(tmp_path, monkeypatch)
+    status_payload = _read_json(fixture.status_path)
+    status_payload["metrics"]["git_sha"] = "b" * 40
+    _write_json(fixture.status_path, status_payload)
+
+    status, materialized_gates, errors = _materialize(fixture)
+
+    assert status is None
+    assert materialized_gates == []
     assert any(
-        "verifier_report.errors must be absent or empty before materialization" in error
+        "status.metrics.git_sha must match "
+        "verifier_report.run_identity.git_sha" in error
         for error in errors
     )
 
@@ -288,55 +437,82 @@ def test_rejects_verified_report_with_top_level_errors(tmp_path: pathlib.Path) -
 @pytest.mark.parametrize("field_name", ["gates_stubbed", "scaffold"])
 def test_rejects_stubbed_or_scaffold_status(
     tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
     field_name: str,
 ) -> None:
-    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
+    fixture = _build_fixture(tmp_path, monkeypatch)
+    status_payload = _read_json(fixture.status_path)
+    status_payload["diagnostics"][field_name] = True
+    _write_json(fixture.status_path, status_payload)
 
-    status = _read_json(status_path)
-    status["diagnostics"][field_name] = True
-    _write_json(status_path, status)
+    status, materialized_gates, errors = _materialize(fixture)
 
-    materialized, _, errors = materialize_release_required_from_verifier(
-        status_path=status_path,
-        verifier_report_path=verifier_path,
-        policy_path=policy_path,
-        registry_path=registry_path,
-    )
-
-    assert materialized is None
+    assert status is None
+    assert materialized_gates == []
     assert any(
         f"status.diagnostics.{field_name} must not be true" in error
         for error in errors
     )
 
 
-def test_fails_when_policy_required_gate_is_missing_from_admissibility(
+def test_rejects_preexisting_false_release_required_without_overwrite(
     tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
+    fixture = _build_fixture(tmp_path, monkeypatch)
+    status_payload = _read_json(fixture.status_path)
+    status_payload["gates"]["external_all_pass"] = False
+    _write_json(fixture.status_path, status_payload)
+    before = fixture.status_path.read_bytes()
 
-    verifier = _read_json(verifier_path)
-    del verifier["gate_materialization_admissibility"]["external_all_pass"]
-    _write_json(verifier_path, verifier)
-
-    materialized, _, errors = materialize_release_required_from_verifier(
-        status_path=status_path,
-        verifier_report_path=verifier_path,
-        policy_path=policy_path,
-        registry_path=registry_path,
+    result = materializer_module.main(
+        _main_args(fixture, fixture.status_path)
     )
 
-    assert materialized is None
+    assert result == 1
+    assert fixture.status_path.read_bytes() == before
+    assert _read_json(fixture.status_path)["gates"][
+        "external_all_pass"
+    ] is False
+
+
+def test_failed_admission_does_not_partially_materialize_or_write(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _build_fixture(tmp_path, monkeypatch)
+    fixture.canonical_report["gate_materialization_admissibility"][
+        "refusal_delta_evidence_present"
+    ]["admissible"] = False
+    _write_json(
+        fixture.verifier_path,
+        fixture.canonical_report,
+    )
+    before = fixture.status_path.read_bytes()
+
+    status, materialized_gates, errors = _materialize(fixture)
+
+    assert status is None
+    assert materialized_gates == []
     assert any(
-        "verifier_report.gate_materialization_admissibility.external_all_pass must be an object"
-        in error
+        "refusal_delta_evidence_present.admissible "
+        "must be literal true" in error
         for error in errors
     )
 
+    result = materializer_module.main(
+        _main_args(fixture, fixture.status_path)
+    )
 
-def test_rejects_legacy_nested_policy_gates_shape(tmp_path: pathlib.Path) -> None:
-    status_path, verifier_path, policy_path, registry_path = _build_fixture(tmp_path)
+    assert result == 1
+    assert fixture.status_path.read_bytes() == before
 
+
+def test_rejects_legacy_nested_policy_gates_shape(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _build_fixture(tmp_path, monkeypatch)
     legacy_nested_policy = """policy:
   id: pulse-gate-policy-v0
   version: "0.1.5"
@@ -347,25 +523,32 @@ def test_rejects_legacy_nested_policy_gates_shape(tmp_path: pathlib.Path) -> Non
       - external_all_pass
       - refusal_delta_evidence_present
 """
-    policy_sha = _write_text(policy_path, legacy_nested_policy)
-
-    status = _read_json(status_path)
-    status["metrics"]["gate_policy_sha256"] = policy_sha
-    _write_json(status_path, status)
-
-    verifier = _read_json(verifier_path)
-    verifier["policy_binding"]["policy_sha256"] = policy_sha
-    _write_json(verifier_path, verifier)
-
-    materialized, _, errors = materialize_release_required_from_verifier(
-        status_path=status_path,
-        verifier_report_path=verifier_path,
-        policy_path=policy_path,
-        registry_path=registry_path,
+    policy_sha = _write_text(
+        fixture.policy_path,
+        legacy_nested_policy,
     )
 
-    assert materialized is None
+    status_payload = _read_json(fixture.status_path)
+    status_payload["metrics"]["gate_policy_sha256"] = policy_sha
+    _write_json(fixture.status_path, status_payload)
+
+    fixture.canonical_report["policy_binding"][
+        "policy_sha256"
+    ] = policy_sha
+    _write_json(
+        fixture.verifier_path,
+        fixture.canonical_report,
+    )
+
+    status, materialized_gates, errors = _materialize(fixture)
+
+    assert status is None
+    assert materialized_gates == []
     assert any(
         "policy file must contain top-level gates mapping" in error
         for error in errors
     )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_release_grade_candidate_evidence_path_v0.py
+++ b/tests/test_release_grade_candidate_evidence_path_v0.py
@@ -1362,10 +1362,12 @@ def test_synthetic_chain_verifies_and_materializes_release_required(
             "materialize_release_required_"
             "from_verifier_v0.py"
         ),
-        "--status",
-        str(status_path),
-        "--verifier-report",
+       "--verifier-report",
         str(report_path),
+        "--manifest",
+        str(manifest_path),
+        "--repo-root",
+        str(repo),
         "--policy",
         str(
             repo

--- a/tests/test_release_grade_candidate_evidence_path_v0.py
+++ b/tests/test_release_grade_candidate_evidence_path_v0.py
@@ -1362,7 +1362,9 @@ def test_synthetic_chain_verifies_and_materializes_release_required(
             "materialize_release_required_"
             "from_verifier_v0.py"
         ),
-       "--verifier-report",
+        "--status",
+        str(status_path),
+        "--verifier-report",
         str(report_path),
         "--manifest",
         str(manifest_path),


### PR DESCRIPTION
## Summary

Bind release-required gate materialization to a fresh canonical replay of
the recorded-release evidence verifier.

The materializer now requires the runtime evidence manifest and repository
root, recomputes the verifier report from those inputs, and permits
materialization only when the supplied report exactly matches the canonical
replay.

## Changes

- require `--manifest` and `--repo-root`
- replay `check_recorded_release_evidence(...)` before materialization
- require non-empty `evidence_results`
- require non-empty `relation_binding_results`
- reject a substituted or modified verifier report
- reject pre-existing `release_required` entries in candidate `status.json`
- materialize gates atomically only after all admission checks pass
- wire the canonical manifest and repository root through the primary workflow
- add forged-report, modified-report, and no-partial-write regressions
- preserve the canonical verified candidate-evidence golden path

## Security effect

This closes the standalone forged or substituted verifier-report path:

recorded evidence manifest
→ canonical verifier replay
→ exact supplied-report comparison
→ release-required materialization

A report that merely claims `verified` and `admissible=true` can no longer
materialize release-required gates.

## Boundary

- no gate-policy change
- no gate-registry change
- no `check_gates.py` change
- no status-schema change
- no Q4 change
- no required-gate evaluator change
- no reader, audit, or publication authority change

This PR closes the report-substitution boundary only. Independent producer
trust and underlying evidence semantic hardening remain separate follow-up work.

## Required validation before merge

- materializer compilation passes
- materializer regressions pass
- complete candidate-evidence chain passes
- forged and incomplete verifier reports fail closed
- failed admission leaves `status.json` unchanged
- existing Q4 regressions remain green