### PR TITLE
fix(ref): bind evidence admission to canonical candidate replay

### DIFF
--- a/PULSE_safe_pack_v0/tools/build_recorded_release_candidates_v0.py
+++ b/PULSE_safe_pack_v0/tools/build_recorded_release_candidates_v0.py
@@ -2043,6 +2043,60 @@ def build_candidates(
     return envelopes, index, []
 
 
+def build_canonical_candidates_for_replay(
+    repo: Path,
+) -> tuple[
+    dict[str, dict[str, Any]] | None,
+    dict[str, Any] | None,
+    list[str],
+]:
+    """Recompute canonical candidate envelopes in memory.
+
+    This replay uses the same canonical inputs and producer
+    implementation as the normal candidate build.
+
+    It does not clear, replace, or write candidate outputs.
+    It does not materialize gates or create release authority.
+    """
+
+    return build_candidates(
+        repo=repo,
+        status_path=Path(
+            STATUS
+        ),
+        evidence_path=Path(
+            REQUIRED_EVIDENCE
+        ),
+        evidence_schema_path=Path(
+            REQUIRED_EVIDENCE_SCHEMA_PATH
+        ),
+        status_schema_path=Path(
+            STATUS_SCHEMA
+        ),
+        envelope_schema_path=Path(
+            ENVELOPE_SCHEMA_PATH
+        ),
+        policy_path=Path(
+            POLICY
+        ),
+        registry_path=Path(
+            REGISTRY
+        ),
+        thresholds_path=Path(
+            THRESHOLDS
+        ),
+        refusal_path=Path(
+            REFUSAL
+        ),
+        external_dir=Path(
+            EXTERNAL_DIR
+        ),
+        tool_path=Path(
+            TOOL
+        ),
+    )
+
+
 def canonical_output(
     repo: Path,
     supplied: Path,

--- a/PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py
+++ b/PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py
@@ -31,6 +31,15 @@ try:
 except Exception:  # pragma: no cover - fail-closed at runtime if unavailable
     yaml = None
 
+if __package__:
+    from .build_recorded_release_candidates_v0 import (
+        build_canonical_candidates_for_replay,
+    )
+else:  # pragma: no cover - direct CLI execution
+    from build_recorded_release_candidates_v0 import (
+        build_canonical_candidates_for_replay,
+    )
+
 REPORT_SCHEMA_VERSION = "recorded_release_evidence_verifier_v0"
 REPORT_VERSION = "0.2.0"
 INPUT_MANIFEST_SCHEMA_VERSION = "release_evidence_input_manifest_v0"
@@ -91,6 +100,28 @@ def _is_sha256(value: Any) -> bool:
 def _is_non_empty_text(value: Any) -> bool:
     return isinstance(value, str) and bool(value.strip())
 
+
+def _candidate_for_replay_comparison(
+    candidate: dict[str, Any],
+    label: str,
+    errors: list[str],
+) -> dict[str, Any] | None:
+    """Normalize only the non-authoritative creation timestamp."""
+
+    created_utc = candidate.get("created_utc")
+
+    if not _is_non_empty_text(created_utc):
+        errors.append(
+            f"{label}.created_utc must be a non-empty string"
+        )
+        return None
+
+    normalized = dict(candidate)
+    normalized["created_utc"] = (
+        "<normalized-created-utc>"
+    )
+
+    return normalized
 
 def _safe_report_digest(path: Path) -> str | None:
     try:
@@ -526,6 +557,99 @@ def check_recorded_release_evidence(
                 f"{sorted(missing_registry_ids)!r}"
             )
 
+    canonical_candidates: dict[
+        str,
+        dict[str, Any],
+    ] = {}
+
+    if not errors:
+        try:
+            (
+                replayed_candidates,
+                replayed_index,
+                replay_errors,
+            ) = build_canonical_candidates_for_replay(
+                repo_root
+            )
+
+        except Exception as exc:  # noqa: BLE001
+            errors.append(
+                "canonical candidate replay could not "
+                f"be completed: {exc}"
+            )
+
+        else:
+            if replay_errors:
+                errors.extend(
+                    "canonical candidate replay failed: "
+                    f"{error}"
+                    for error in replay_errors
+                )
+
+            if (
+                not replay_errors
+                and isinstance(
+                    replayed_candidates,
+                    dict,
+                )
+                and isinstance(
+                    replayed_index,
+                    dict,
+                )
+            ):
+                canonical_candidates = (
+                    replayed_candidates
+                )
+
+                canonical_candidate_ids = set(
+                    canonical_candidates
+                )
+                manifest_candidate_ids = set(
+                    candidate_evidence
+                )
+
+                missing_candidates = sorted(
+                    canonical_candidate_ids
+                    - manifest_candidate_ids
+                )
+                extra_candidates = sorted(
+                    manifest_candidate_ids
+                    - canonical_candidate_ids
+                )
+
+                if missing_candidates:
+                    errors.append(
+                        "manifest candidate set is missing "
+                        "canonical candidates: "
+                        f"{missing_candidates!r}"
+                    )
+
+                if extra_candidates:
+                    errors.append(
+                        "manifest candidate set contains "
+                        "non-canonical candidates: "
+                        f"{extra_candidates!r}"
+                    )
+
+                if (
+                    replayed_index.get(
+                        "candidate_ids"
+                    )
+                    != sorted(
+                        canonical_candidate_ids
+                    )
+                ):
+                    errors.append(
+                        "canonical candidate replay index "
+                        "candidate_ids mismatch"
+                    )
+
+            elif not replay_errors:
+                errors.append(
+                    "canonical candidate replay did not "
+                    "return candidate envelopes and index"
+                )
+    
     evidence_results: dict[str, Any] = {}
     verified_evidence_ids: set[str] = set()
     candidate_artifacts: dict[str, dict[str, Any]] = {}
@@ -715,14 +839,80 @@ def check_recorded_release_evidence(
             candidate_errors,
             f"candidate artifact {evidence_id}",
         )
-        if trusted_required:
-            if artifact_provenance.get("trusted_producer") is True:
-                result["trusted_producer_verified"] = True
-            else:
-                candidate_errors.append(
-                    f"candidate artifact {evidence_id}.provenance.trusted_producer must be true"
-                )
+        if (
+            trusted_required
+            and artifact_provenance.get(
+                "trusted_producer"
+            )
+            is not True
+        ):
+            candidate_errors.append(
+                f"candidate artifact {evidence_id}."
+                "provenance.trusted_producer "
+                "must be true"
+            )
 
+        canonical_artifact = (
+            canonical_candidates.get(
+                evidence_id
+            )
+        )
+
+        if not isinstance(
+            canonical_artifact,
+            dict,
+        ):
+            candidate_errors.append(
+                f"candidate artifact {evidence_id} "
+                "is missing from canonical "
+                "candidate replay"
+            )
+
+        else:
+            supplied_for_comparison = (
+                _candidate_for_replay_comparison(
+                    artifact,
+                    (
+                        "candidate artifact "
+                        f"{evidence_id}"
+                    ),
+                    candidate_errors,
+                )
+            )
+
+            replayed_for_comparison = (
+                _candidate_for_replay_comparison(
+                    canonical_artifact,
+                    (
+                        "canonical candidate replay "
+                        f"{evidence_id}"
+                    ),
+                    candidate_errors,
+                )
+            )
+
+            if (
+                supplied_for_comparison
+                is not None
+                and replayed_for_comparison
+                is not None
+            ):
+                if (
+                    supplied_for_comparison
+                    != replayed_for_comparison
+                ):
+                    candidate_errors.append(
+                        f"candidate artifact "
+                        f"{evidence_id} does not "
+                        "match canonical candidate "
+                        "replay"
+                    )
+
+                elif trusted_required:
+                    result[
+                        "trusted_producer_verified"
+                    ] = True
+      
         raw_binding = _section(
             artifact,
             "raw_evidence_binding",

--- a/PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py
+++ b/PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py
@@ -1214,7 +1214,9 @@ def check_recorded_release_evidence(
     return report
 
 
-def main() -> int:
+def main(
+    argv: list[str] | None = None,
+) -> int:
     parser = argparse.ArgumentParser(
         description=(
             "Verify recorded release evidence bindings for release-grade "
@@ -1236,7 +1238,7 @@ def main() -> int:
         default="PULSE_safe_pack_v0/artifacts/recorded_release_evidence_verifier_v0.json",
         help="Path to write the machine-readable verifier report.",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     manifest_path = Path(args.manifest)
     repo_root = Path(args.repo_root)

--- a/tests/test_check_recorded_release_evidence_v0.py
+++ b/tests/test_check_recorded_release_evidence_v0.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import contextlib
+import copy
 import hashlib
+import io
 import json
 import pathlib
 import subprocess
@@ -14,9 +17,18 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from PULSE_safe_pack_v0.tools.check_recorded_release_evidence_v0 import (
-    REPORT_SCHEMA_VERSION,
-    check_recorded_release_evidence,
+from PULSE_safe_pack_v0.tools import (
+    check_recorded_release_evidence_v0
+    as checker_module,
+)
+
+REPORT_SCHEMA_VERSION = (
+    checker_module.REPORT_SCHEMA_VERSION
+)
+
+check_recorded_release_evidence = (
+    checker_module
+    .check_recorded_release_evidence
 )
 
 CHECKER = (
@@ -25,6 +37,64 @@ CHECKER = (
 HEX40 = "a" * 40
 RUN_KEY = "run-prod-2026-01-01"
 COMMIT_SHA = HEX40
+_CANONICAL_CANDIDATES_BY_REPO: dict[
+    pathlib.Path,
+    dict[str, dict[str, Any]],
+] = {}
+
+
+@pytest.fixture(autouse=True)
+def _patch_canonical_candidate_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _CANONICAL_CANDIDATES_BY_REPO.clear()
+
+    def replay(
+        repo: pathlib.Path,
+    ) -> tuple[
+        dict[str, dict[str, Any]] | None,
+        dict[str, Any] | None,
+        list[str],
+    ]:
+        candidates = (
+            _CANONICAL_CANDIDATES_BY_REPO.get(
+                repo.resolve()
+            )
+        )
+
+        if candidates is None:
+            return (
+                None,
+                None,
+                [
+                    "unit-test canonical candidate "
+                    "fixture is not registered"
+                ],
+            )
+
+        replayed = copy.deepcopy(
+            candidates
+        )
+
+        return (
+            replayed,
+            {
+                "candidate_ids": sorted(
+                    replayed
+                ),
+            },
+            [],
+        )
+
+    monkeypatch.setattr(
+        checker_module,
+        (
+            "build_canonical_candidates_"
+            "for_replay"
+        ),
+        replay,
+    )
+
 
 POLICY_TEXT = """policy:
   id: pulse-gate-policy-v0
@@ -83,6 +153,9 @@ def _candidate_artifact(
     git_sha: str = COMMIT_SHA,
 ) -> dict[str, Any]:
     return {
+        "created_utc": (
+            "2026-01-01T00:00:00Z"
+        ),
         "schema_version": schema_version,
         "run_identity": {
             "git_sha": git_sha,
@@ -256,6 +329,10 @@ def _build_repo_fixture(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.P
     policy_sha = _write_text(tmp_path / "pulse_gate_policy_v0.yml", POLICY_TEXT)
     registry_sha = _write_text(tmp_path / "pulse_gate_registry_v0.yml", REGISTRY_TEXT)
     manifest = _manifest_template(policy_sha, registry_sha)
+    canonical_candidates: dict[
+        str,
+        dict[str, Any],
+    ] = {}
     for evidence_id, definition in EVIDENCE_DEFS.items():
         raw_path = tmp_path / definition["raw_path"]
         raw_sha = _write_text(raw_path, f"raw::{evidence_id}\n")
@@ -266,6 +343,11 @@ def _build_repo_fixture(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.P
             raw_sha256=raw_sha,
             policy_sha256=policy_sha,
         )
+        canonical_candidates[
+            evidence_id
+        ] = copy.deepcopy(
+            artifact_payload
+        )
         artifact_path = tmp_path / definition["artifact_path"]
         artifact_sha = _write_json(artifact_path, artifact_payload)
         manifest["candidate_evidence"][evidence_id]["expected_sha256"] = artifact_sha
@@ -274,6 +356,9 @@ def _build_repo_fixture(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.P
         tmp_path / "PULSE_safe_pack_v0" / "artifacts" / "release_evidence_input_manifest_v0.json"
     )
     _write_json(manifest_path, manifest)
+    _CANONICAL_CANDIDATES_BY_REPO[
+        tmp_path.resolve()
+    ] = canonical_candidates
     return tmp_path, manifest_path, manifest
 
 
@@ -282,21 +367,31 @@ def _run_cli(
     manifest_path: pathlib.Path,
     out_json: pathlib.Path,
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        [
-            sys.executable,
-            str(CHECKER),
-            "--manifest",
-            str(manifest_path),
-            "--repo-root",
-            str(repo_root),
-            "--out-json",
-            str(out_json),
-        ],
-        cwd=str(REPO_ROOT),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
+     args = [
+        "--manifest",
+        str(manifest_path),
+        "--repo-root",
+        str(repo_root),
+        "--out-json",
+        str(out_json),
+    ]
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    with (
+        contextlib.redirect_stdout(stdout),
+        contextlib.redirect_stderr(stderr),
+    ):
+        returncode = checker_module.main(
+            args
+        )
+
+    return subprocess.CompletedProcess(
+        args=args,
+        returncode=returncode,
+        stdout=stdout.getvalue(),
+        stderr=stderr.getvalue(),
     )
 
 

--- a/tests/test_check_recorded_release_evidence_v0.py
+++ b/tests/test_check_recorded_release_evidence_v0.py
@@ -666,5 +666,194 @@ def test_untrusted_producer_fails_when_required(tmp_path: pathlib.Path) -> None:
     )
 
 
+def test_self_declared_trust_cannot_replace_canonical_replay(
+    tmp_path: pathlib.Path,
+) -> None:
+    repo_root, manifest_path, manifest = (
+        _build_repo_fixture(tmp_path)
+    )
+
+    detector_path = (
+        repo_root
+        / EVIDENCE_DEFS[
+            "detector_report"
+        ][
+            "artifact_path"
+        ]
+    )
+
+    payload = _read_json(
+        detector_path
+    )
+
+    assert (
+        payload["provenance"][
+            "trusted_producer"
+        ]
+        is True
+    )
+
+    payload["provenance"][
+        "producer"
+    ] = "forged-producer"
+
+    forged_sha = _write_json(
+        detector_path,
+        payload,
+    )
+
+    manifest[
+        "candidate_evidence"
+    ][
+        "detector_report"
+    ][
+        "expected_sha256"
+    ] = forged_sha
+
+    _write_json(
+        manifest_path,
+        manifest,
+    )
+
+    report = (
+        check_recorded_release_evidence(
+            manifest_path,
+            repo_root,
+        )
+    )
+
+    assert report["status"] == "failed"
+
+    detector_result = report[
+        "evidence_results"
+    ][
+        "detector_report"
+    ]
+
+    assert (
+        detector_result["digest_match"]
+        is True
+    )
+
+    assert (
+        detector_result[
+            "trusted_producer_verified"
+        ]
+        is False
+    )
+
+    assert any(
+        (
+            "candidate artifact detector_report "
+            "does not match canonical candidate "
+            "replay"
+        )
+        in error
+        for error in report["errors"]
+    )
+
+
+def test_created_utc_difference_is_non_authoritative_for_replay(
+    tmp_path: pathlib.Path,
+) -> None:
+    repo_root, manifest_path, manifest = (
+        _build_repo_fixture(tmp_path)
+    )
+
+    detector_path = (
+        repo_root
+        / EVIDENCE_DEFS[
+            "detector_report"
+        ][
+            "artifact_path"
+        ]
+    )
+
+    payload = _read_json(
+        detector_path
+    )
+
+    payload["created_utc"] = (
+        "2030-12-31T23:59:59Z"
+    )
+
+    updated_sha = _write_json(
+        detector_path,
+        payload,
+    )
+
+    manifest[
+        "candidate_evidence"
+    ][
+        "detector_report"
+    ][
+        "expected_sha256"
+    ] = updated_sha
+
+    _write_json(
+        manifest_path,
+        manifest,
+    )
+
+    report = (
+        check_recorded_release_evidence(
+            manifest_path,
+            repo_root,
+        )
+    )
+
+    assert report["status"] == "verified"
+    assert report["errors"] == []
+
+    assert (
+        report[
+            "evidence_results"
+        ][
+            "detector_report"
+        ][
+            "trusted_producer_verified"
+        ]
+        is True
+    )
+
+
+def test_manifest_candidate_set_must_match_canonical_replay(
+    tmp_path: pathlib.Path,
+) -> None:
+    repo_root, manifest_path, manifest = (
+        _build_repo_fixture(tmp_path)
+    )
+
+    manifest[
+        "candidate_evidence"
+    ].pop(
+        "refusal_delta_summary"
+    )
+
+    _write_json(
+        manifest_path,
+        manifest,
+    )
+
+    report = (
+        check_recorded_release_evidence(
+            manifest_path,
+            repo_root,
+        )
+    )
+
+    assert report["status"] == "failed"
+
+    assert any(
+        (
+            "manifest candidate set is missing "
+            "canonical candidates: "
+            "['refusal_delta_summary']"
+        )
+        in error
+        for error in report["errors"]
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))

--- a/tests/test_check_recorded_release_evidence_v0.py
+++ b/tests/test_check_recorded_release_evidence_v0.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import pytest
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1] 
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 

--- a/tests/test_check_recorded_release_evidence_v0.py
+++ b/tests/test_check_recorded_release_evidence_v0.py
@@ -367,7 +367,7 @@ def _run_cli(
     manifest_path: pathlib.Path,
     out_json: pathlib.Path,
 ) -> subprocess.CompletedProcess[str]:
-     args = [
+    args = [
         "--manifest",
         str(manifest_path),
         "--repo-root",

--- a/tests/test_check_recorded_release_evidence_v0.py
+++ b/tests/test_check_recorded_release_evidence_v0.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from __future__ import annotations
+from __future__ import annotations    
 
 import contextlib
 import copy


### PR DESCRIPTION
## Summary

Replace self-declared candidate producer trust with a canonical in-memory
replay of the recorded-release candidate producer.

The verifier must not treat:

provenance.trusted_producer = true

as independent proof of producer trust.

Instead, candidate admission will be bound to envelopes recomputed from the
canonical current-run inputs by the existing candidate producer.

## Current change

Add:

build_canonical_candidates_for_replay(repo)

to:

PULSE_safe_pack_v0/tools/build_recorded_release_candidates_v0.py

The helper calls the existing build_candidates(...) implementation with the
canonical repository paths and returns the recomputed candidate envelopes
and index in memory.

It does not:

- clear existing candidate outputs
- write candidate envelopes
- replace the candidate index
- modify status.json
- materialize release_required gates
- create release authority
- replace check_gates.py

## Remaining work in this PR

- invoke canonical candidate replay from
  check_recorded_release_evidence_v0.py
- require the replayed candidate set to exactly match the manifest-declared
  and supplied candidate set
- compare each supplied candidate envelope with its canonical replay
- normalize only the non-authoritative created_utc representation where
  required for deterministic comparison
- derive trusted_producer_verified from canonical replay equality
- reject self-declared producer trust without canonical replay
- reject missing, extra, modified, or substituted candidate envelopes
- add verifier and complete-chain fail-closed regressions
- preserve the existing #2610 candidate-evidence golden path
- preserve the canonical Q4 evaluator

## Intended mechanical path

canonical current-run inputs
→ existing candidate producer logic
→ in-memory canonical candidate envelopes
→ supplied candidate-envelope comparison
→ verified producer trust
→ recorded-evidence admission

## Security effect

After the verifier wiring is complete, the following will no longer be
sufficient for evidence admission:

provenance.trusted_producer = true

Producer trust will require equality with the result recomputed by the
canonical checked-in producer from the current repository state and
current-run evidence.

## Boundary

- no gate-policy change
- no gate-registry change
- no status-schema change
- no materializer change
- no check_gates.py change
- no Q4 change
- no required-gate evaluator change
- no reader, audit, Pages, or publication authority change

## Required validation before merge

- candidate replay helper performs no repository writes
- canonical candidate replay succeeds on the complete #2610 evidence chain
- self-declared trusted_producer with modified producer metadata fails closed
- modified candidate-envelope contents fail closed
- missing or extra candidate envelopes fail closed
- negative underlying refusal or external evidence cannot replay as a
  passing candidate
- existing verifier regressions remain green
- candidate-evidence golden path remains green
- canonical Q4 regressions remain green
- PULSE CI and Tools smoke tests pass

Do not merge this PR until the verifier wiring and regressions are included.