### PR TITLE
docs(ref): align release-grade reference with implemented path

### DIFF
--- a/docs/release_grade_reference_run_v0.md
+++ b/docs/release_grade_reference_run_v0.md
@@ -7,19 +7,25 @@ This document defines what counts as a PULSE release-grade reference run.
 A release-grade reference run is a documented, reproducible run that exercises
 the release-grade evidence path rather than the minimal Core smoke path.
 
-Its purpose is to show the full release-authority chain with materialized
-evidence:
+Its purpose is to demonstrate the complete release-grade evidence-to-decision path:
 
 ```text
-recorded release evidence
-→ status.json
-→ declared gate policy
-→ workflow-effective required gate set
-→ check_gates.py
-→ Quality Ledger
-→ release_authority_v0.json
-→ release-authority-audit-bundle
+recorded current-run release evidence
+→ non-stubbed candidate release state
+→ canonical candidate production
+→ canonical candidate replay
+→ recorded release-evidence verification
+→ canonical verifier replay
+→ policy-derived release-required gate materialization
+→ final status.json
+→ workflow-effective materialized required gate set
+→ PULSE_safe_pack_v0/tools/check_gates.py
+→ primary CI allow/block release decision
 ```
+
+The Quality Ledger, `release_authority_v0.json`, audit bundles, reference-run notes, Pages, dashboards, and publication artifacts preserve review, provenance, trace, or publication state.
+
+They do not independently produce release authority.
 
 This document is an operational reference.
 
@@ -29,22 +35,44 @@ authority.
 
 ## Status
 
-  * stage: reference definition + qualification checker implemented + recorded release-evidence verifier prerequisite implemented
-  * normative: false
-  * target lane: release-grade
-  * authority role: documentation / operational guidance
-  * checker: `PULSE_safe_pack_v0/tools/check_release_grade_reference_run_v0.py`
-  * recorded evidence verifier: `PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py`
-  * test coverage: `tests/test_check_release_grade_reference_run_v0.py`
-  * recorded evidence verifier test coverage: `tests/test_check_recorded_release_evidence_v0.py`
-  * tools-test coverage: `ci/tools-tests.list`
-  * primary workflow advisory qualification: present
-  * primary workflow authority role: non-normative / non-blocking
-  * fold-in status: `--release-grade-materialized` remains intentionally fail-closed for release-required evidence fold-in until a follow-up PR admits only verifier-validated evidence
+- stage: implemented release-grade evidence path; first completed public reference run pending
+- normative: false
+- target lane: release-grade
+- authority role: documentation / operational guidance
+- current-run required-gate evidence production: implemented
+- non-stubbed release candidate status production: implemented
+- canonical recorded-release candidate production: implemented
+- canonical candidate replay: implemented
+- recorded release-evidence verifier: implemented
+- canonical verifier replay before materialization: implemented
+- policy-derived release-required materialization: implemented
+- external-summary schema validation: implemented
+- external-summary semantic validation: implemented
+- signer-policy admission: implemented
+- cryptographic GitHub attestation verification: implemented
+- exact operational release-grade signer identity: pending
+- current-run attested external-evidence production lane: pending
+- first completed public non-stubbed release-grade run record: pending
+- qualification checker: `PULSE_safe_pack_v0/tools/check_release_grade_reference_run_v0.py`
+- recorded evidence verifier: `PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py`
+- release-required materializer: `PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py`
+- release evaluator: `PULSE_safe_pack_v0/tools/check_gates.py`
+- primary workflow advisory qualification: present
+- qualification authority role: non-normative / non-blocking
 
-Security boundary note: detector materialization artifacts, canonical external summaries, and `refusal_delta_summary.json` are no longer treated as sufficient merely because they exist locally. They must now pass the recorded release-evidence verifier, which binds identity, provenance, policy, subject, and raw evidence before later release-grade materialization can admit them.
+The verifier-backed fold-in path is implemented.
 
-The reference run definition describes how to produce and review a release-grade PULSE run. It does not create a new gate and does not promote any diagnostic surface into release authority.
+Candidate evidence cannot authorize itself through local presence, a trusted-producer declaration, or a supplied verifier report.
+
+The implemented admission path requires canonical candidate replay, recorded-evidence verification, canonical verifier replay, and atomic policy-derived release-required materialization before final gate enforcement.
+
+External release-grade evidence must pass canonical schema and semantic validation, signer-policy admission, subject and digest binding, and cryptographic attestation verification.
+
+The remaining operational objective is to produce current-run attested external evidence under an exact signer identity and execute the first completed public non-stubbed release-grade reference run.
+
+The reference-run definition does not create a new gate and does not promote any verifier, materializer, diagnostic, reader, audit, or publication surface into independent release authority.
+
+---
 
 ---
 
@@ -135,19 +163,37 @@ release-grade reference run.
 
 ---
 
-### 2. External summaries
+### 2. Verified external evidence
 
-When strict external evidence is active, external detector summaries must be
-present and folded into the release evidence surface.
+When strict external evidence is active, release-grade external evidence must be present and admitted through the canonical verification path.
 
-Expected release-grade evidence:
+Each contributing external summary must satisfy:
 
-```
+- canonical `external_summary_v1` schema validation;
+- detector-specific metric identity;
+- declared threshold reference and comparator semantics;
+- literal `result.passed = true`;
+- repository, subject, commit, run, and release-candidate binding;
+- canonical repo-relative evidence paths;
+- raw-evidence and summary digest binding;
+- exact release-grade signer-policy admission;
+- a cryptographic attestation bundle;
+- successful independent attestation verification;
+- canonical candidate replay;
+- recorded release-evidence verification.
+
+Expected release-grade gate state:
+
+```text
 external_summaries_present = true
 external_all_pass = true
 ```
 
-when those gates are part of the active release-required set.
+when those gates are part of the active `release_required` set.
+
+Canonical filename, JSON parseability, generic metric presence, self-declared verification, or digest recording alone do not establish release-grade external evidence.
+
+Unsigned, unverified, stale, malformed, substituted, or mismatched external evidence must fail closed.
 
 ---
 
@@ -238,167 +284,249 @@ The bundle is a review and traceability package, not a release-decision engine.
 
 ## Expected artifact set
 
-A release-grade reference run should archive at least:
+A completed release-grade reference run should archive the complete reviewable evidence-to-decision chain.
 
+### Current-run evidence and candidate state
+
+```text
+PULSE_safe_pack_v0/artifacts/required_gate_evidence_v0.json
+PULSE_safe_pack_v0/artifacts/status.json
+PULSE_safe_pack_v0/artifacts/recorded_release_candidates/
+PULSE_safe_pack_v0/artifacts/recorded_release_candidate_index_v0.json
 ```
+
+### Verification and materialization inputs
+
+```text
+PULSE_safe_pack_v0/artifacts/release_evidence_input_manifest_v0.json
+PULSE_safe_pack_v0/artifacts/recorded_release_evidence_verifier_v0.json
+```
+
+### External evidence, when required
+
+```text
+PULSE_safe_pack_v0/artifacts/external/*_summary.json
+PULSE_safe_pack_v0/artifacts/external/*_summary.envelope.json
+PULSE_safe_pack_v0/artifacts/external/*_summary.bundle.json
+```
+
+### Final release and review surfaces
+
+```text
 PULSE_safe_pack_v0/artifacts/status.json
 PULSE_safe_pack_v0/artifacts/report_card.html
 PULSE_safe_pack_v0/artifacts/release_authority_v0.json
+release-authority-audit-bundle
+release-grade-reference-run-v0
 ```
 
-and, when present:
+### Optional CI exports
 
-```
-PULSE_safe_pack_v0/artifacts/external/*_summary.json
+```text
 reports/junit.xml
 reports/sarif.json
-release-authority-v0
-release-authority-audit-bundle
 ```
 
 Recommended review order:
 
-1. status.json  
-2. materialized required gate set  
-3. check_gates.py result  
-4. release_authority_v0.json  
-5. Quality Ledger  
-6. release-authority-audit-bundle  
+1. current-run evidence and run identity;
+2. candidate status and required-gate evidence;
+3. canonical candidate set and candidate replay;
+4. release-evidence input manifest;
+5. recorded release-evidence verifier result;
+6. canonical verifier replay and materialization result;
+7. final `status.json`;
+8. workflow-effective materialized required gate set;
+9. `PULSE_safe_pack_v0/tools/check_gates.py` result;
+10. primary CI allow/block decision;
+11. release-authority manifest;
+12. Quality Ledger;
+13. release-authority audit and reference bundles.
 
 ---
 
 ## Release authority boundary
 
-The release-grade reference run must preserve the PULSE authority boundary.
+A release-grade reference run must preserve the complete PULSEmech authority boundary.
 
 ### Normative path
 
+```text
+recorded release evidence
+→ final status.json
+→ declared gate policy
+→ workflow-effective materialized required gate set
+→ PULSE_safe_pack_v0/tools/check_gates.py
+→ primary CI workflow
+→ primary CI allow/block release decision
 ```
-status.json
-+ declared gate policy
-+ workflow-effective required gate set
-+ check_gates.py
-+ primary CI workflow
-= release authority
+
+### Evidence-admission and materialization layers
+
+```text
+candidate production
+→ canonical candidate replay
+→ recorded release-evidence verification
+→ canonical verifier replay
+→ release-required materialization
 ```
 
-### Audit / review surfaces
+These layers determine whether candidate evidence may enter final release state.
 
-- Quality Ledger  
-- release_authority_v0.json  
-- Step Summary  
-- release-authority-v0 artifact  
-- release-authority-audit-bundle  
-- Pages / dashboards  
+They do not independently produce the release decision.
 
-These surfaces explain, publish, or preserve the decision chain.
+### Audit, review, and publication surfaces
 
-They must not recompute, replace, or silently reinterpret release authority.
+- Quality Ledger
+- verifier reports
+- attestation reports
+- `release_authority_v0.json`
+- GitHub Step Summary
+- release-authority artifacts
+- audit bundles
+- reference-run notes
+- Pages and dashboards
+
+These surfaces explain, verify, publish, preserve, or reconstruct the decision chain.
+
+They must not recompute, replace, override, or silently reinterpret release authority.
 
 ---
 
 ## Acceptance criteria
 
-A run can be called a release-grade reference run only if the following are true:
+A run can be called a completed release-grade reference run only if all of the following are true:
 
-- The run uses a release-grade workflow path.  
-- The active enforce set is `required + release_required`, or the documented
-  release-grade equivalent.  
-- `metrics.run_mode` reflects the release-grade lane.  
-- Required gates are evaluated fail-closed.  
-- Stubbed gate output is rejected or absent.  
-- External summaries are present when strict external evidence is required.  
-- The final `status.json` is archived.  
-- The Quality Ledger is archived.  
-- `release_authority_v0.json` is produced and validated.  
-- The release authority audit bundle is produced.  
-- Diagnostic / shadow / publication surfaces remain non-normative unless
-  explicitly promoted by policy.  
+- the run uses a declared release-grade workflow path;
+- `metrics.run_mode = "prod"`;
+- the active policy set is `required + release_required`;
+- the workflow-effective materialized required gate set is derived from declared policy;
+- current-run required-gate evidence is present and identity-bound;
+- the candidate release state is non-stubbed;
+- stale candidate outputs were cleared before production;
+- canonical candidate production succeeded;
+- the supplied candidate set exactly matches canonical candidate replay;
+- recorded release-evidence verification succeeded;
+- the supplied verifier report exactly matches canonical verifier replay;
+- release-required gates were materialized atomically from verifier-admitted evidence;
+- the final `status.json` validates against the committed release-grade status contract;
+- every workflow-effective required gate is present and literal `true`;
+- `PULSE_safe_pack_v0/tools/check_gates.py` completed strict fail-closed enforcement;
+- the primary CI allow/block result is recorded;
+- required external evidence is present;
+- required external evidence passed schema, semantic, signer, digest, subject, and cryptographic attestation verification;
+- `release_authority_v0.json` was produced and validated;
+- the Quality Ledger was generated from the final `status.json`;
+- Quality Ledger / status parity passed;
+- the release-authority audit bundle was produced;
+- the release-grade reference bundle was produced;
+- all diagnostic, verifier, audit, reader, and publication surfaces remained non-authoritative;
+- the concrete run identity and artifact references were recorded in `docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md`.
 
 ---
 
 ## Qualification checker
 
-The release-grade reference run criteria are supported by a checker:
+The release-grade reference-run criteria are evaluated by:
 
 ```text
 PULSE_safe_pack_v0/tools/check_release_grade_reference_run_v0.py
 ```
 
-The checker qualifies candidate runs for operational review. It is not a
-release-decision engine and does not replace check_gates.py.
+The checker determines whether a produced run satisfies the documented release-grade reference-run criteria.
 
-It checks, among other things:
+It evaluates reference suitability.
 
-- `status.metrics.run_mode = "prod"`  
-- no stubbed gate surface  
-- materialized detector evidence  
-- external summary presence and pass gates  
-- release authority manifest presence  
-- `required + release_required` policy-set representation  
-- successful manifest decision state  
-- optional Quality Ledger presence  
-- optional audit bundle contents  
+It does not create or replace release authority.
 
-The checker is covered by:
+The checker examines, among other things:
+
+- `status.metrics.run_mode = "prod"`;
+- absence of stubbed or scaffolded release evidence;
+- materialized detector evidence;
+- external-summary presence and pass gates when required;
+- `required + release_required` policy-set representation;
+- release-authority manifest presence and validation state;
+- successful recorded decision state;
+- optional Quality Ledger presence;
+- optional audit-bundle contents.
+
+The checker does not:
+
+- produce current-run candidate evidence;
+- admit candidate evidence;
+- establish producer trust by declaration;
+- replace canonical candidate replay;
+- replace recorded release-evidence verification;
+- replace canonical verifier replay;
+- materialize `release_required` gates;
+- replace `PULSE_safe_pack_v0/tools/check_gates.py`;
+- change the primary CI allow/block release decision;
+- promote verifier, reader, audit, or publication surfaces into authority.
+
+Test coverage includes:
 
 ```text
 tests/test_check_release_grade_reference_run_v0.py
+tests/test_release_grade_reference_example_package.py
+tests/test_release_grade_reference_qualification_advisory_boundary_v0.py
 ```
 
-and is wired into:
+The checker is registered in:
 
 ```text
 ci/tools-tests.list
 ```
 
-Authority rule:
+### Workflow role
+
+In the primary workflow, release-grade reference qualification is:
+
+- advisory;
+- non-normative;
+- non-blocking;
+- release-grade only.
+
+A failed qualification may classify a run as unsuitable for use as the public reference run.
+
+It does not reinterpret or override the underlying release decision.
+
+### Authority rule
+
+The normative release decision remains:
 
 ```text
-check_gates.py = release authority evaluator
-check_release_grade_reference_run_v0.py = release-grade reference qualification checker
+recorded release evidence
+→ final status.json
+→ declared gate policy
+→ workflow-effective materialized required gate set
+→ PULSE_safe_pack_v0/tools/check_gates.py
+→ primary CI workflow
+→ primary CI allow/block release decision
 ```
 
-The checker can reject a candidate reference run as insufficient for reference
-purposes without redefining the underlying release decision.
-
----
-## Example package
-
-A minimal example package is available at:
+The qualification role is:
 
 ```text
-examples/release_grade_reference_run_v0/
+PULSE_safe_pack_v0/tools/check_release_grade_reference_run_v0.py
+= non-authoritative release-grade reference qualification checker
 ```
 
-It contains:
+The qualification checker answers:
 
 ```text
-README.md
-status.release_grade.pass.example.json
-release_authority_v0.release_grade.pass.example.json
+Does this produced run satisfy the documented release-grade reference-run criteria?
 ```
 
-The package shows the expected artifact shape for a non-stubbed,
-materialized-evidence release-grade reference run.
-
-From the repository root, the example can be inspected with:
+It does not answer:
 
 ```text
-python PULSE_safe_pack_v0/tools/check_release_grade_reference_run_v0.py \
-  --status examples/release_grade_reference_run_v0/status.release_grade.pass.example.json \
-  --manifest examples/release_grade_reference_run_v0/release_authority_v0.release_grade.pass.example.json
+Should the primary CI workflow allow or block this release?
 ```
 
-Expected result:
+That decision remains with the canonical PULSEmech release-authority path.
 
-```text
-OK: release-grade reference run criteria satisfied
-```
-
-This example package is a reference surface only. It does not prove that a real
-production release occurred, and it does not change release semantics, gate
-policy, status.json, check_gates.py, or release authority.
+A completed public release-grade reference-run record should be finalized only after the run satisfies the qualification criteria and its concrete artifact package is available for review.
 
 ---
 
@@ -433,11 +561,13 @@ Not qualified, but the normal release outcome is still determined by the
 existing release-authority path:
 
 ```text
-status.json
+recorded release evidence
++ final status.json
 + declared gate policy
-+ workflow-effective required gate set
-+ check_gates.py
++ workflow-effective materialized required gate set
++ PULSE_safe_pack_v0/tools/check_gates.py
 + primary CI workflow
+= primary CI allow/block release decision
 ```
 
 The qualification step answers a different question:
@@ -446,7 +576,7 @@ Does this run satisfy the documented release-grade reference-run criteria?
 
 It does not answer:
 
-Should this release pass?
+Should the primary CI workflow allow or block this release?
 
 That decision remains with the normal PULSE release-authority path.
 
@@ -457,8 +587,8 @@ That decision remains with the normal PULSE release-authority path.
 A release-grade reference run is not:
 
 - a new release policy  
-- a new gate set  
-- a replacement for check_gates.py  
+- a new gate set
+- a replacement for `PULSE_safe_pack_v0/tools/check_gates.py`
 - a replacement for status.json  
 - a dashboard-derived decision  
 - a shadow-layer promotion  
@@ -480,8 +610,13 @@ When reviewing a candidate release-grade reference run, check:
 - Were any required gates missing or non-true?  
 - Was external evidence required?  
 - Were external summaries present?  
-- Was stubbed/scaffolded evidence absent from the release-grade path?  
-- Did `check_gates.py` enforce the required gates?  
+- Was stubbed/scaffolded evidence absent from the release-grade path?                                           - Did canonical candidate replay exactly match the supplied candidate set?
+- Did recorded release-evidence verification succeed?
+- Did canonical verifier replay exactly match the supplied verifier report?
+- Was release-required materialization atomic and policy-derived?
+- Did required external evidence pass exact signer and cryptographic attestation verification?
+- Did `PULSE_safe_pack_v0/tools/check_gates.py` enforce the exact workflow-effective materialized required gate set?
+- Was the primary CI result recorded as allow or block? 
 - Was `release_authority_v0.json` produced?  
 - Did the manifest validate?  
 - Did the Quality Ledger include the release authority section?  
@@ -508,15 +643,31 @@ Release-grade reference run = materialized evidence release-authority reference
 
 ---
 
-## Next implementation steps
+## Next operational steps
 
-Suggested next steps:
+The verifier, canonical replay, release-required materializer, qualification checker, and reference-run packaging path are implemented.
 
-* Use the recorded release-evidence verifier for detector materialization, canonical external summaries, and refusal-delta evidence.
-* Only after verifier-admitted evidence is available, allow `--release-grade-materialized` to fold verified evidence into release-required gate booleans.
-* Add public reference-run packaging in the primary workflow for release-grade runs.
-* Produce one non-stubbed release-grade reference run.
-* Archive its `status.json`, Quality Ledger, release authority manifest, and audit bundle.
-* Document the run in a short reference-run note.
-* Link the reference run from the README or documentation index.
-* Use the reference run as the baseline for future enterprise-grade release governance examples.
+The next work is not to rebuild those layers.
+
+The next operational sequence is:
+
+1. replace deferred or wildcard release-grade signer identities with one exact operational workflow identity;
+2. implement the current-run canonical external-evidence producer lane;
+3. generate a cryptographic attestation bundle for the current-run external summary;
+4. build the canonical external-summary envelope from the verified run identity and summary digest;
+5. execute the controlled strict release-grade workflow;
+6. preserve the complete current-run evidence, candidate, verifier, materialization, final-status, and CI decision chain;
+7. publish the release-grade reference artifact bundle;
+8. complete `docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md` with concrete run identity, artifact URLs, and SHA-256 digests;
+9. link the completed public reference run from the README and documentation index;
+10. use the completed run as the baseline for independent reproduction and later portability work.
+
+The progression is:
+
+```text
+exact operational signer identity
+→ current-run attested external evidence
+→ controlled strict release-grade run
+→ complete artifact bundle
+→ completed public reference-run record
+→ independent reproduction


### PR DESCRIPTION
## Summary

Align the release-grade reference-run document with the currently implemented PULSEmech evidence-to-decision path.

The document previously described verifier-backed evidence admission, release-required materialization, and reference-run packaging as future work even though those layers are now implemented.

This change updates the operational reference without weakening or rewriting the target reference-run state.

## Changes

Update:

```text
docs/release_grade_reference_run_v0.md
```

The document now:

- records current-run required-gate evidence production as implemented
- records non-stubbed candidate release-state production as implemented
- records canonical candidate production and replay as implemented
- records the recorded release-evidence verifier as implemented
- records canonical verifier replay before materialization as implemented
- records policy-derived release-required materialization as implemented
- records external-summary schema and semantic validation as implemented
- records signer-policy admission and cryptographic attestation verification as implemented
- removes stale wording that deferred verifier-backed fold-in to a future PR
- expands the required external-evidence contract
- updates the expected release-grade artifact set
- aligns the normative authority path with the canonical safe-pack checker
- expands the completed-run acceptance criteria
- restores and updates the full qualification-checker section
- preserves release-grade qualification as advisory and non-authoritative
- replaces completed implementation tasks in the next-steps section with the actual remaining operational sequence

## Current implemented path

```text
recorded current-run release evidence
→ non-stubbed candidate release state
→ canonical candidate production
→ canonical candidate replay
→ recorded release-evidence verification
→ canonical verifier replay
→ policy-derived release-required gate materialization
→ final status.json
→ workflow-effective materialized required gate set
→ PULSE_safe_pack_v0/tools/check_gates.py
→ primary CI allow/block release decision
```

## Remaining operational path

```text
exact operational signer identity
→ current-run attested external evidence
→ controlled strict release-grade run
→ complete artifact bundle
→ completed public reference-run record
→ independent reproduction
```

## Qualification boundary

The release-grade qualification checker remains:

```text
PULSE_safe_pack_v0/tools/check_release_grade_reference_run_v0.py
```

Its role is to determine whether a produced run satisfies the documented reference-run criteria.

It does not:

- create release authority
- admit candidate evidence
- replace canonical candidate replay
- replace recorded release-evidence verification
- replace canonical verifier replay
- materialize release-required gates
- replace `PULSE_safe_pack_v0/tools/check_gates.py`
- change the primary CI allow/block result

## Run-note boundary

This PR does not rewrite or weaken:

```text
docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md
```

The run note remains the target record to be completed by the first real public non-stubbed release-grade reference run.

The work progresses toward that record rather than converting it back into a weaker planning document.

## Scope

```text
docs/release_grade_reference_run_v0.md
```

## Boundary

- documentation only
- no policy change
- no registry change
- no schema change
- no workflow change
- no tool change
- no test change
- no evidence-admission change
- no verifier change
- no materializer change
- no gate-enforcement change
- no `status.json` semantics change
- no release-decision behavior change

## Result

After this change:

```text
release-grade operational reference
= implemented PULSEmech path
+ actual remaining reference-run work
```