### PR TITLE
docs(ref): align recorded verifier with implemented replay path

### DIFF
--- a/docs/recorded_release_evidence_verifier_v0.md
+++ b/docs/recorded_release_evidence_verifier_v0.md
@@ -31,7 +31,7 @@ run identity
 → canonical producer output
 → raw evidence
 → expected relation bindings
-→ declared release-required gates
+→ declared gate-materialization entries
 ```
 
 The verifier is a mandatory evidence-admission prerequisite in the release-grade path.
@@ -40,6 +40,8 @@ It does not:
 
 - modify `status.json`;
 - materialize release-required gates;
+- establish complete policy-gate coverage by itself;
+- replace full input-manifest schema validation;
 - replace declared policy;
 - replace the primary CI workflow;
 - replace `PULSE_safe_pack_v0/tools/check_gates.py`;
@@ -53,14 +55,16 @@ It does not:
 - verifier tool: `PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py`
 - report schema: `recorded_release_evidence_verifier_v0`
 - report version: `0.2.0`
-- input manifest schema: `release_evidence_input_manifest_v0`
+- expected manifest schema-version identity: `release_evidence_input_manifest_v0`
 - expected run mode: `prod`
 - expected policy set: `required+release_required`
 - output artifact: `PULSE_safe_pack_v0/artifacts/recorded_release_evidence_verifier_v0.json`
 - canonical candidate replay: implemented
-- verified producer-trust derivation: implemented
+- replay-derived producer-trust verification: implemented
 - relation-binding verification: implemented
-- gate-materialization admissibility: implemented
+- manifest-declared gate admissibility: implemented
+- full policy gate coverage in the verifier alone: not implemented
+- full policy gate coverage in the materializer: implemented
 - canonical verifier replay before materialization: implemented
 - verifier-bound release-required materialization: implemented
 - final release evaluator: `PULSE_safe_pack_v0/tools/check_gates.py`
@@ -77,7 +81,7 @@ tests/test_materialize_release_required_from_verifier_v0.py
 tests/test_check_external_summary_attestation_v1.py
 ```
 
-The relevant tools are registered in:
+The relevant tools and tests are registered in:
 
 ```text
 ci/tools-tests.list
@@ -113,7 +117,11 @@ Producer trust is not accepted from self-declaration.
 
 A supplied verifier report is not accepted as authority by declaration.
 
-The evidence path proves its claims through canonical replay.
+A manifest entry is not accepted merely because it claims that verification is required.
+
+A declared gate relation is not accepted merely because it appears in the manifest.
+
+The evidence path proves its claims through current-run binding and canonical replay.
 
 ## Inputs
 
@@ -123,29 +131,33 @@ The verifier consumes:
 PULSE_safe_pack_v0/artifacts/release_evidence_input_manifest_v0.json
 ```
 
-and a repository root used to resolve:
+and a repository root used to resolve the mechanically consumed:
 
-- the declared gate policy;
-- the gate registry;
-- current-run candidate artifacts;
-- raw evidence artifacts;
-- checked-in producer code;
-- canonical producer inputs;
-- schemas and threshold files used by candidate production.
+- declared gate-policy path;
+- gate-registry path;
+- candidate artifact paths;
+- raw-evidence paths;
+- checked-in candidate producer;
+- candidate producer inputs;
+- policy and registry files used during verification.
 
 The manifest is a declaration surface.
 
-It specifies what must be verified.
+It specifies the evidence, relations, and gate-materialization entries that the verifier is asked to inspect.
 
-It is not proof that its declarations are satisfied.
+It is not proof that those declarations are satisfied.
 
-## Manifest contract
+## Manifest validation boundary
 
-The verifier requires a valid and non-ambiguous manifest.
+The verifier requires a JSON object that is parseable without duplicate object keys and contains the fields consumed by its implemented checks.
 
-Duplicate JSON keys fail closed.
+It checks:
 
-The manifest must contain non-empty:
+```text
+schema_version = release_evidence_input_manifest_v0
+```
+
+It reads these object sections:
 
 ```text
 run_identity
@@ -157,9 +169,48 @@ expected_relation_bindings
 expected_gate_materialization
 ```
 
-### Run identity
+The following sections must be non-empty:
 
-The run identity must satisfy:
+```text
+candidate_evidence
+expected_relation_bindings
+expected_gate_materialization
+```
+
+The remaining object sections are subject to the field-level checks described below.
+
+Duplicate JSON object keys fail closed.
+
+The recorded release-evidence verifier does not invoke:
+
+```text
+PULSE_safe_pack_v0/tools/check_release_evidence_input_manifest_v0.py
+```
+
+and does not independently establish complete conformance to:
+
+```text
+schemas/release_evidence_input_manifest_v0.schema.json
+```
+
+Schema-required fields that are not consumed by the recorded verifier are outside this verifier's direct validation boundary.
+
+For example, a full-schema contract may require additional document or metadata fields that are not used by the recorded verifier's mechanical admission logic.
+
+Therefore:
+
+```text
+mechanically accepted by the recorded verifier
+≠ fully schema-validated input manifest
+```
+
+A claim of complete input-manifest schema validity requires the separate schema checker or another explicitly equivalent full-schema validation path.
+
+The recorded verifier's direct manifest contract is limited to the fields and bindings it mechanically reads and checks.
+
+## Run identity
+
+The mechanically consumed run identity must satisfy:
 
 ```text
 run_identity.git_sha = concrete 40-hex commit SHA
@@ -167,55 +218,104 @@ run_identity.run_key = non-empty current-run identity
 run_identity.run_mode = prod
 ```
 
-### Subject identity
+The verifier rejects a non-production run mode for this release-grade path.
 
-The subject must satisfy:
+## Subject identity
+
+The mechanically consumed subject must include:
+
+```text
+subject.commit_sha
+```
+
+The subject commit must satisfy:
 
 ```text
 subject.commit_sha = run_identity.git_sha
 ```
 
-### Policy binding
+The verifier records the corresponding verified-subject fields in its report.
 
-The policy binding must satisfy:
+## Policy binding
+
+The mechanically consumed policy binding must satisfy:
 
 ```text
 policy_binding.policy_set = required+release_required
-policy_binding.policy_path = non-empty repository-relative path
+policy_binding.policy_path = non-empty path text
 policy_binding.policy_sha256 = concrete SHA-256
 ```
 
-### Registry binding
+The verifier resolves the declared policy path from the supplied repository root.
 
-The registry binding must satisfy:
+It reads the current policy file and recomputes its digest.
+
+The actual digest must match:
 
 ```text
-registry_binding.registry_path = non-empty repository-relative path
+policy_binding.policy_sha256
+```
+
+The policy must expose:
+
+```text
+gates.release_required
+```
+
+as a non-empty gate list.
+
+Duplicate YAML mapping keys fail closed.
+
+## Registry binding
+
+The mechanically consumed registry binding must satisfy:
+
+```text
+registry_binding.registry_path = non-empty path text
 registry_binding.registry_sha256 = concrete SHA-256
 ```
 
-The current policy and registry files are loaded from the repository and hashed again.
+The verifier resolves the declared registry path from the supplied repository root.
 
-Their actual digests must match the manifest.
+It reads the current registry file and recomputes its digest.
 
-Duplicate YAML keys fail closed.
-
-Every release-required gate referenced by candidate evidence or relation bindings must exist in:
+The actual digest must match:
 
 ```text
-pulse_gate_policy_v0.yml
-pulse_gate_registry_v0.yml
+registry_binding.registry_sha256
 ```
+
+The registry must expose a non-empty top-level:
+
+```text
+gates
+```
+
+mapping.
+
+Duplicate YAML mapping keys fail closed.
+
+Every gate referenced by a candidate, relation, or manifest-declared materialization entry is checked for membership in:
+
+```text
+policy.gates.release_required
+```
+
+and the gate registry.
+
+This verifier-side membership check does not prove that the manifest declares every gate in the policy.
+
+Complete policy coverage is a later materializer responsibility.
 
 ## Candidate manifest entries
 
-Every candidate evidence entry must declare:
+Every candidate evidence entry must be an object and must declare:
 
 ```text
 verification_required = true
 ```
 
-Each entry must include:
+Each entry is mechanically expected to provide:
 
 ```text
 path
@@ -226,44 +326,85 @@ required_for_gates
 provenance_expectations
 ```
 
-The provenance expectation must require:
+The provenance expectation must declare:
 
 ```text
 trusted_producer_required = true
 ```
 
-This requirement does not mean that a candidate can prove producer trust by containing its own trusted-producer field.
+The `required_for_gates` value must be a non-empty array of unique, non-empty gate IDs.
 
-Producer trust is established only through canonical replay equality.
+The candidate manifest entry's gate IDs must belong to the active release-required policy set and the registry.
+
+The manifest path and digest declarations are inputs to verification.
+
+They do not establish candidate validity by themselves.
 
 ## Canonical candidate replay
 
 Before individual candidate admission, the verifier reruns the checked-in recorded-release candidate producer in memory.
 
-The replay uses the same canonical producer implementation and repository inputs as normal candidate production.
+The replay uses the current repository state and current candidate-producer inputs.
 
 The replay does not:
 
 - clear candidate output directories;
 - write candidate envelopes;
-- replace the candidate index;
+- replace on-disk candidate artifacts;
+- replace the on-disk candidate index;
 - modify `status.json`;
 - materialize release-required gates;
 - create release authority.
 
-The replayed candidate set must exactly match the candidate set declared in the runtime manifest.
+The canonical replay returns:
+
+- a replayed candidate mapping;
+- a replayed candidate-index representation;
+- replay errors, if any.
+
+The replayed candidate IDs must exactly match the candidate IDs declared in:
+
+```text
+manifest.candidate_evidence
+```
 
 The verifier rejects:
 
-- missing canonical candidates;
-- additional non-canonical candidates;
-- missing candidate-index entries;
-- extra candidate-index entries;
-- modified candidate envelopes;
-- substituted candidate envelopes;
-- producer metadata that differs from canonical production.
+- canonical candidates missing from the manifest;
+- manifest candidates absent from canonical replay;
+- canonical replay failure;
+- an internally inconsistent replayed index;
+- modified supplied candidate envelopes;
+- substituted supplied candidate envelopes;
+- mechanically relevant producer output that differs from canonical replay.
 
-Only the non-authoritative creation timestamp representation may be normalized for deterministic comparison.
+The verifier does not directly validate the separately stored on-disk:
+
+```text
+recorded_release_candidate_index_v0.json
+```
+
+as an independent input artifact.
+
+Its direct completeness comparison is between:
+
+```text
+canonical replay candidate IDs
+```
+
+and:
+
+```text
+manifest.candidate_evidence IDs
+```
+
+Only the non-authoritative:
+
+```text
+created_utc
+```
+
+representation is normalized for deterministic envelope comparison.
 
 All mechanically relevant candidate fields must remain equal.
 
@@ -277,7 +418,9 @@ provenance.trusted_producer = true
 
 but that field does not independently prove producer trust.
 
-The verifier sets:
+When trusted producer provenance is required, the supplied candidate must contain the expected producer declaration.
+
+However, the verifier sets:
 
 ```text
 trusted_producer_verified = true
@@ -296,31 +439,40 @@ Verified producer trust requires:
 
 ```text
 current repository state
-+ current-run evidence
++ current-run producer inputs
 + checked-in canonical producer
-+ replayed candidate envelope
++ canonical candidate replay
 = supplied candidate envelope
 ```
 
 ## Candidate evidence verification
 
-Each candidate is checked for:
+Each candidate is mechanically checked for:
 
-1. repository-relative artifact presence;
-2. regular-file status;
-3. artifact SHA-256 equality with the manifest;
-4. expected schema-version equality;
-5. current-run identity equality;
-6. subject-binding equality;
-7. commit binding to the manifest subject;
-8. policy-set equality;
-9. policy-digest equality;
-10. canonical candidate replay equality;
-11. verified producer trust;
-12. raw-evidence path presence;
-13. raw-evidence SHA-256 equality;
-14. exact `required_for_gates` equality;
-15. membership of every declared gate in policy and registry.
+1. candidate-manifest entry object shape;
+2. `verification_required = true`;
+3. expected SHA-256 shape;
+4. expected schema-version presence;
+5. expected subject-binding fields;
+6. non-empty expected required-gate list;
+7. trusted-producer requirement declaration;
+8. candidate artifact path presence;
+9. candidate artifact regular-file status;
+10. candidate artifact SHA-256 equality with the manifest;
+11. candidate artifact JSON object parsing;
+12. candidate schema-version equality;
+13. candidate run-identity equality;
+14. candidate subject-binding equality;
+15. commit binding to the manifest subject;
+16. candidate policy-set equality;
+17. candidate policy-digest equality;
+18. canonical candidate replay equality;
+19. replay-derived producer-trust verification;
+20. raw-evidence path presence;
+21. raw-evidence file presence;
+22. raw-evidence SHA-256 equality;
+23. exact `required_for_gates` equality;
+24. candidate gate membership in policy and registry.
 
 A candidate is marked:
 
@@ -328,7 +480,7 @@ A candidate is marked:
 status = verified
 ```
 
-only when all candidate checks succeed.
+only when its complete candidate-level error list is empty.
 
 Otherwise it remains:
 
@@ -338,26 +490,35 @@ status = failed
 
 ## External-summary candidate boundary
 
-External-summary-specific admission occurs during canonical candidate production.
+External-summary-specific admission occurs during canonical recorded-release candidate production.
 
-For release-grade external candidates, the canonical producer must enforce the applicable:
+For release-grade external candidates, the canonical producer applies the relevant:
 
+- external-summary JSON requirement;
 - external-summary schema;
 - detector-specific tool identity;
 - detector-specific metric identity;
 - threshold reference;
-- threshold semantics;
+- threshold URI;
+- threshold comparator semantics;
+- metric pass state;
 - aggregate result;
-- subject and commit binding;
-- summary digest binding;
-- raw-evidence digest binding;
+- required release-contribution mode;
+- run-key binding;
+- release-candidate binding;
+- subject-kind binding;
+- subject-ID binding;
+- current-commit subject digest;
+- raw-evidence path containment;
+- raw-evidence digest;
+- summary digest;
 - external-summary envelope binding;
 - signer-policy admission;
 - cryptographic attestation verification.
 
 The recorded release-evidence verifier does not accept a separately supplied assertion that these checks succeeded.
 
-Instead, it replays the same checked-in candidate producer from the current repository and current-run evidence.
+Instead, it reruns the same checked-in candidate producer from the current repository and current-run inputs.
 
 The replayed candidate envelope must match the supplied candidate envelope.
 
@@ -370,7 +531,12 @@ external-summary declaration
 
 The cryptographic attestation-verification capability is implemented.
 
-The exact operational signer identity and current-run attested external-evidence producer lane remain pending.
+The following remain operationally pending:
+
+```text
+exact operational release-grade signer identity
+current-run attested external-evidence production lane
+```
 
 ## Relation-binding verification
 
@@ -383,44 +549,76 @@ artifact_to_subject
 artifact_to_gate
 ```
 
+Every relation entry must be an object and must provide mechanically valid:
+
+```text
+binding_type
+source_evidence_id
+expected_gate_id
+target
+```
+
+The relation's expected gate must belong to:
+
+```text
+policy.gates.release_required
+```
+
+and the gate registry.
+
+The relation's source candidate must exist and must already be verified.
+
 ### `artifact_to_subject`
 
 An `artifact_to_subject` relation must:
 
 - use verified candidate evidence;
-- bind to the current run;
-- bind to the current subject;
-- target:
+- preserve the candidate's subject binding;
+- bind to the current run identity;
+- target exactly:
 
 ```text
 subject.commit_sha
 ```
-
-- preserve the candidate subject binding.
 
 ### `artifact_to_gate`
 
 An `artifact_to_gate` relation must:
 
 - use verified candidate evidence;
-- target a gate declared in `gates.release_required`;
-- target a registry-backed gate;
-- use the exact target form:
+- name a gate listed in the candidate's `required_for_gates`;
+- target exactly:
 
 ```text
 gate.<gate_id>
 ```
 
-A relation is satisfied only when:
+A relation is marked:
 
-- its source candidate is verified;
-- its expected gate exists;
-- its binding type is supported;
-- its target is mechanically exact.
+```text
+status = verified
+```
+
+only when its relation-level error list is empty.
+
+A declared relation does not prove itself.
+
+Therefore:
+
+```text
+relation declared
+≠ relation satisfied
+```
 
 ## Gate-materialization admissibility
 
-For each declared release-required gate, the verifier checks:
+The verifier iterates over the gate entries declared in:
+
+```text
+manifest.expected_gate_materialization
+```
+
+For each declared gate entry, it checks:
 
 ```text
 expected_value = true
@@ -428,7 +626,7 @@ policy_relation = release_required
 materialization_allowed_without_verifier = false
 ```
 
-The gate entry must contain non-empty:
+Each declared entry must contain non-empty:
 
 ```text
 candidate_evidence_ids
@@ -437,19 +635,87 @@ relation_binding_ids
 
 Every listed candidate evidence ID must be verified.
 
-Every listed relation binding ID must be satisfied.
+Every listed relation-binding ID must be satisfied.
 
-Every candidate used for a gate must have at least one satisfied `artifact_to_gate` relation targeting that exact gate.
+Every relation used for the gate must have mechanically consistent source and target data.
+
+Every candidate used for a declared gate must have at least one satisfied:
+
+```text
+artifact_to_gate
+```
+
+relation targeting that exact gate.
+
+Each manifest-declared gate must belong to:
+
+```text
+policy.gates.release_required
+```
+
+and exist in the gate registry.
 
 The verifier produces:
 
 ```text
+status = verified
 admissible = true
 ```
 
-only when all gate-materialization prerequisites succeed.
+for a declared gate entry only when all of that entry's materialization prerequisites succeed.
 
-Admissibility does not itself write the gate into `status.json`.
+The verifier establishes:
+
+- per-entry evidence verification;
+- per-entry relation verification;
+- per-entry gate-target verification;
+- per-entry policy and registry membership;
+- per-entry admissibility.
+
+The verifier does not independently prove that:
+
+```text
+manifest.expected_gate_materialization
+```
+
+contains every gate declared by:
+
+```text
+policy.gates.release_required
+```
+
+A manifest may omit a policy release-required gate without that omission being identified as complete-policy-coverage failure by the verifier itself.
+
+Complete policy-derived coverage is enforced later by:
+
+```text
+PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
+```
+
+The materializer iterates over the complete gate set derived from:
+
+```text
+policy.gates.release_required
+```
+
+and requires a verified, admissible report entry for every policy-derived gate before materialization.
+
+Therefore:
+
+```text
+verifier status = verified
+≠ complete policy gate coverage by itself
+```
+
+The complete boundary is:
+
+```text
+verifier per-entry admissibility
++ materializer iteration over every policy release-required gate
+= complete policy-derived materialization coverage
+```
+
+Admissibility does not itself write a gate into `status.json`.
 
 ## Output artifact
 
@@ -490,15 +756,30 @@ The report is:
 status = verified
 ```
 
-only when the complete error list is empty.
+only when the complete aggregated error list is empty.
 
-Missing, malformed, mismatched, or incomplete evidence produces:
+The aggregated error list includes:
+
+- manifest-level errors;
+- candidate-level errors;
+- relation-level errors;
+- manifest-declared gate-admissibility errors.
+
+Missing, malformed, mismatched, or incomplete mechanically consumed evidence produces:
 
 ```text
 status = failed
 ```
 
 and a non-zero CLI result.
+
+A verified report does not by itself prove:
+
+- full input-manifest schema conformance;
+- complete policy release-required gate coverage;
+- final materialization success;
+- final gate-enforcement success;
+- release authority.
 
 ## Materializer binding
 
@@ -529,19 +810,24 @@ The materializer requires:
 
 - canonical verifier replay status `verified`;
 - an empty canonical replay error list;
-- non-empty evidence results;
-- non-empty relation-binding results;
+- non-empty canonical evidence results;
+- non-empty canonical relation-binding results;
 - exact equality between the supplied report and canonical verifier replay after canonical manifest-path normalization;
-- canonical manifest-path resolution;
-- candidate-status run identity matching the verifier;
-- candidate-status subject identity matching the verifier;
-- `run_mode = prod`;
-- matching policy path;
-- matching policy digest;
-- no stubbed release evidence;
-- no scaffolded release evidence;
-- no pre-existing release-required gate state;
-- explicit admissibility for every policy-derived release-required gate.
+- manifest-path resolution to the supplied manifest;
+- candidate-state `git_sha` matching verifier run identity;
+- candidate-state `run_key` matching verifier run identity;
+- candidate-state `run_mode = prod`;
+- verifier `verified_subjects.git_sha` matching candidate-state `git_sha`;
+- verifier `verified_subjects.run_key` matching candidate-state `run_key`;
+- verifier `verified_subjects.commit_sha` matching candidate-state `git_sha`;
+- current policy path matching the candidate state;
+- current policy digest matching the candidate state;
+- verifier policy set equal to `required+release_required`;
+- verifier policy digest matching the current policy;
+- verifier registry digest matching the current registry;
+- no stubbed candidate state;
+- no scaffolded candidate state;
+- no pre-existing policy-derived release-required gate entries.
 
 All later admission checks consume the freshly replayed canonical report.
 
@@ -563,40 +849,85 @@ supplied manifest
 = supplied verifier report
 ```
 
+## Complete policy coverage in the materializer
+
+The materializer derives the complete gate set from:
+
+```text
+policy.gates.release_required
+```
+
+It verifies that every policy-derived gate exists in the current registry.
+
+It then iterates over every policy-derived release-required gate.
+
+For each policy-derived gate, it requires a corresponding object in:
+
+```text
+verifier_report.gate_materialization_admissibility
+```
+
+The corresponding entry must satisfy:
+
+```text
+status = verified
+admissible = true
+errors = absent or empty
+```
+
+If any policy-derived gate lacks a corresponding admissible entry, materialization fails closed.
+
+This is the layer that closes the complete policy-coverage boundary.
+
+Therefore:
+
+```text
+manifest omission of a policy release-required gate
+→ verifier may still verify declared entries
+→ materializer detects missing policy-gate admissibility
+→ no release-required materialization
+```
+
 ## Materialization behavior
 
-After every admission check succeeds, the materializer writes literal `true` values for the policy-derived `release_required` gate set into:
+After every replay, identity, policy, registry, state, and complete-coverage check succeeds, the materializer writes literal `true` values for the complete policy-derived `release_required` gate set into:
 
 ```text
 status["gates"]
 ```
 
-Failed admission must not partially mutate candidate release state.
+The materializer works on a detached copy of the candidate gate mapping.
 
-The materializer works on a detached gate-state copy and writes output only after the complete admission path succeeds.
+Failed admission must not partially mutate the candidate release state.
 
 Therefore:
 
 ```text
-failed verifier replay
+failed canonical verifier replay
 → no release-required materialization
 
-modified verifier report
+modified supplied verifier report
 → no release-required materialization
 
 empty evidence or relation results
 → no release-required materialization
 
-incomplete admissibility
+manifest-declared gate entry not admissible
+→ no release-required materialization
+
+policy release-required gate missing from admissibility map
 → no release-required materialization
 
 run or subject mismatch
 → no release-required materialization
 
-policy mismatch
+policy or registry mismatch
 → no release-required materialization
 
 stubbed or scaffolded state
+→ no release-required materialization
+
+pre-existing release-required gate state
 → no release-required materialization
 ```
 
@@ -606,10 +937,16 @@ The verifier and materializer occupy different layers:
 
 ```text
 recorded release-evidence verifier
-= candidate, evidence, relation, and admissibility verification
+= mechanically consumed manifest checks
++ candidate verification
++ canonical candidate replay
++ relation verification
++ manifest-declared per-gate admissibility
 
 release-required materializer
-= policy-derived gate-state materialization
+= canonical verifier replay
++ full policy gate coverage
++ policy-derived gate-state materialization
 
 PULSE_safe_pack_v0/tools/check_gates.py
 = strict final gate enforcement
@@ -620,6 +957,8 @@ The verifier report is not the final release decision.
 Canonical candidate replay is not the final release decision.
 
 Canonical verifier replay is not the final release decision.
+
+Per-entry admissibility is not complete policy coverage.
 
 Materialized gate state is not the final release decision by itself.
 
@@ -639,10 +978,13 @@ recorded release evidence
 
 The following are non-authorizing carriers:
 
+- input manifests;
 - candidate envelopes;
-- candidate indexes;
+- candidate-index artifacts;
 - verifier reports;
 - attestation reports;
+- canonical replay results;
+- admissibility maps;
 - materializer diagnostics;
 - `release_authority_v0.json`;
 - `release_decision_v0.json`;
@@ -683,53 +1025,118 @@ ERRORS (fail-closed):
 Verifier report written to <path>
 ```
 
+A successful direct verifier invocation means that the mechanically consumed manifest declarations and the resulting candidate, relation, and declared-gate checks succeeded.
+
+It does not by itself mean that:
+
+- the manifest passed the complete JSON schema;
+- every policy release-required gate was declared by the manifest;
+- materialization succeeded;
+- strict final gate enforcement succeeded;
+- release was allowed.
+
 ## Failure behavior
 
 The verifier fails closed on, among other conditions:
 
 - missing manifest;
-- malformed manifest;
+- malformed manifest JSON;
 - duplicate JSON keys;
-- wrong manifest schema version;
+- wrong manifest schema-version identity;
+- missing mechanically consumed object sections;
+- empty candidate-evidence mapping;
+- empty expected-relation mapping;
+- empty expected-materialization mapping;
 - non-production run mode;
+- invalid run commit identity;
+- empty run key;
 - subject and run commit mismatch;
 - wrong policy set;
-- missing policy or registry path;
-- policy or registry digest mismatch;
-- duplicate YAML keys;
-- unknown release-required gate IDs;
-- empty candidate set;
-- empty relation-binding set;
-- empty expected-materialization set;
+- missing policy path text;
+- invalid policy digest;
+- missing registry path text;
+- invalid registry digest;
+- current policy digest mismatch;
+- current registry digest mismatch;
+- duplicate policy or registry YAML keys;
+- missing or empty policy `release_required` list;
+- empty registry gate mapping;
+- manifest-declared unknown gate IDs;
 - canonical candidate replay failure;
-- missing canonical candidates;
-- extra non-canonical candidates;
-- candidate-index mismatch;
+- canonical candidates missing from the manifest;
+- manifest candidates absent from canonical replay;
+- internally inconsistent replayed candidate IDs;
 - modified candidate envelopes;
 - substituted candidate envelopes;
-- substituted producer metadata;
+- substituted mechanically relevant producer metadata;
+- candidate entry not requiring verification;
 - candidate artifact digest mismatch;
-- candidate schema mismatch;
-- run-identity mismatch;
-- subject-binding mismatch;
-- policy-binding mismatch;
+- candidate schema-version mismatch;
+- candidate run-identity mismatch;
+- candidate subject-binding mismatch;
+- candidate policy-binding mismatch;
 - self-declared producer trust without replay equality;
+- raw-evidence file missing;
 - raw-evidence digest mismatch;
 - `required_for_gates` mismatch;
-- unsatisfied relation binding;
+- unsupported relation type;
+- missing relation source;
+- relation source not verified;
 - incorrect relation target;
-- incomplete gate-target relations;
-- non-literal expected gate value;
-- wrong policy relation;
+- relation gate missing from the manifest-declared materialization mapping;
+- manifest-declared materialization entry with non-literal expected value;
+- wrong materialization policy relation;
 - materialization allowed without verifier;
-- missing candidate IDs;
-- missing relation IDs;
-- any non-empty verifier error list.
+- missing candidate evidence IDs;
+- missing relation-binding IDs;
+- candidate without an exact gate-target relation;
+- any non-empty aggregated verifier error list.
+
+The verifier does not directly fail merely because a policy release-required gate is omitted from:
+
+```text
+manifest.expected_gate_materialization
+```
+
+That complete-coverage omission is detected later by the materializer.
+
+## Separate full-schema validation
+
+The repository contains a separate input-manifest schema and checker:
+
+```text
+schemas/release_evidence_input_manifest_v0.schema.json
+PULSE_safe_pack_v0/tools/check_release_evidence_input_manifest_v0.py
+```
+
+Those surfaces establish a broader manifest-contract boundary than the direct checks implemented by:
+
+```text
+check_recorded_release_evidence_v0.py
+```
+
+When complete manifest schema validity is required, the separate checker must run successfully or an explicitly equivalent full-schema validation must be demonstrated.
+
+The two claims must remain distinct:
+
+```text
+full manifest schema valid
+```
+
+and:
+
+```text
+recorded verifier mechanically accepted the consumed fields
+```
+
+Neither claim should be inferred from the other without the corresponding check.
 
 ## Non-goals
 
 The recorded release-evidence verifier is not:
 
+- a complete input-manifest schema validator;
+- a complete policy-gate coverage checker by itself;
 - a current-run evidence producer;
 - an external detector;
 - an external-summary signer;
@@ -755,15 +1162,16 @@ current-run required-gate evidence production
 canonical candidate production
 canonical candidate replay
 recorded release-evidence verification
-verified producer-trust derivation
+replay-derived producer-trust verification
 relation-binding verification
-gate-materialization admissibility
+manifest-declared per-gate admissibility
 canonical verifier replay
+full policy gate coverage in the materializer
 verifier-bound release-required materialization
 cryptographic external-summary attestation verification capability
 ```
 
-The next work is not to rebuild the verifier.
+The next work is not to rebuild the recorded verifier.
 
 The remaining operational sequence is:
 

--- a/docs/recorded_release_evidence_verifier_v0.md
+++ b/docs/recorded_release_evidence_verifier_v0.md
@@ -2,156 +2,664 @@
 
 ## Purpose
 
-This document defines the recorded release-evidence verifier prerequisite surface for release-grade materialization.
+This document defines the implemented recorded release-evidence verification layer used before release-required gate materialization.
 
-The verifier checks whether candidate detector materialization artifacts, canonical external summaries, and refusal-delta evidence are sufficiently bound to:
+The implemented release-grade evidence path is:
 
-    run identity
-    → subject binding
-    → declared policy context
-    → trusted provenance expectations
-    → raw evidence digest
-    → expected gate materialization relations
+```text
+current-run required-gate evidence
+→ non-stubbed candidate release state
+→ canonical candidate production
+→ runtime release-evidence input manifest
+→ canonical candidate replay
+→ recorded release-evidence verification
+→ recorded release-evidence verifier report
+→ canonical verifier replay by the materializer
+→ policy-derived release-required gate materialization
+→ final status.json
+→ workflow-effective materialized required gate set
+→ PULSE_safe_pack_v0/tools/check_gates.py
+→ primary CI allow/block release decision
+```
 
-The verifier is prerequisite-only.
+The verifier determines whether candidate evidence is sufficiently bound to:
 
-It does not compute release authority.
-It does not replace `check_gates.py`.
-It does not change `status.json` semantics.
-It does not promote diagnostic or reader surfaces into release authority.
+```text
+run identity
+→ subject identity
+→ declared policy and registry
+→ canonical producer output
+→ raw evidence
+→ expected relation bindings
+→ declared release-required gates
+```
+
+The verifier is a mandatory evidence-admission prerequisite in the release-grade path.
+
+It does not:
+
+- modify `status.json`;
+- materialize release-required gates;
+- replace declared policy;
+- replace the primary CI workflow;
+- replace `PULSE_safe_pack_v0/tools/check_gates.py`;
+- independently create release authority.
 
 ## Status
 
-- stage: implemented prerequisite checker
-- normative: false
-- authority role: prerequisite evidence-binding checker
-- tool: `PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py`
-- test coverage: `tests/test_check_recorded_release_evidence_v0.py`
-- tools-test coverage: `ci/tools-tests.list`
+- stage: implemented and wired into the release-grade path
+- normative release-decision role: none
+- evidence role: mandatory release-grade evidence-admission prerequisite
+- verifier tool: `PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py`
+- report schema: `recorded_release_evidence_verifier_v0`
+- report version: `0.2.0`
+- input manifest schema: `release_evidence_input_manifest_v0`
+- expected run mode: `prod`
+- expected policy set: `required+release_required`
 - output artifact: `PULSE_safe_pack_v0/artifacts/recorded_release_evidence_verifier_v0.json`
-- release-required fold-in status: not enabled in this step
+- canonical candidate replay: implemented
+- verified producer-trust derivation: implemented
+- relation-binding verification: implemented
+- gate-materialization admissibility: implemented
+- canonical verifier replay before materialization: implemented
+- verifier-bound release-required materialization: implemented
+- final release evaluator: `PULSE_safe_pack_v0/tools/check_gates.py`
+- current-run attested external-evidence production lane: pending
+- exact operational release-grade signer identity: pending
+- complete release-grade reference packaging: pending
+
+Test coverage includes:
+
+```text
+tests/test_check_recorded_release_evidence_v0.py
+tests/test_release_grade_candidate_evidence_path_v0.py
+tests/test_materialize_release_required_from_verifier_v0.py
+tests/test_check_external_summary_attestation_v1.py
+```
+
+The relevant tools are registered in:
+
+```text
+ci/tools-tests.list
+```
 
 ## Why this exists
 
-`--release-grade-materialized` must remain fail-closed until release-required detector materialization, canonical external summary, and refusal-delta artifacts are verified rather than merely declared.
+Local files can exist and still be:
 
-Local JSON files can exist and still be wrong.
+- stale;
+- incomplete;
+- malformed;
+- substituted;
+- detached from the current run;
+- detached from the current commit;
+- detached from the current release candidate;
+- detached from the declared policy;
+- produced by an unverified path;
+- bound to the wrong raw evidence;
+- associated with the wrong release-required gate.
 
-The missing step was not another dashboard or summary.
-The missing step was a machine-readable verifier that proves candidate artifacts are:
+The following declarations are not sufficient by themselves:
 
-- present
-- digest-bound
-- subject-bound
-- run-bound
-- policy-bound
-- provenance-checked
-- raw-evidence-bound
-- relation-bound to the declared release-required gates
+```text
+provenance.trusted_producer = true
+status = verified
+admissible = true
+canonical-looking filename
+matching digest recorded inside an unverified object
+```
+
+Producer trust is not accepted from self-declaration.
+
+A supplied verifier report is not accepted as authority by declaration.
+
+The evidence path proves its claims through canonical replay.
 
 ## Inputs
 
 The verifier consumes:
 
-- `release_evidence_input_manifest_v0.json`
-- repository-relative candidate artifact paths declared in that manifest
-- repository-relative raw evidence paths declared inside those candidate artifacts
+```text
+PULSE_safe_pack_v0/artifacts/release_evidence_input_manifest_v0.json
+```
 
-The manifest remains the declaration surface.
-The verifier answers whether those declarations are actually satisfied.
+and a repository root used to resolve:
 
-## Candidate artifact minimum shape
+- the declared gate policy;
+- the gate registry;
+- current-run candidate artifacts;
+- raw evidence artifacts;
+- checked-in producer code;
+- canonical producer inputs;
+- schemas and threshold files used by candidate production.
 
-Each candidate artifact is expected to provide at least:
+The manifest is a declaration surface.
 
-- `schema_version`
-- `run_identity.git_sha`
-- `run_identity.run_key`
-- `run_identity.run_mode`
-- `subject_binding.git_sha`
-- `subject_binding.run_key`
-- `policy_binding.policy_set`
-- `policy_binding.policy_sha256`
-- `provenance.trusted_producer`
-- `raw_evidence_binding.path`
-- `raw_evidence_binding.sha256`
-- `required_for_gates[]`
+It specifies what must be verified.
 
-The verifier reads the candidate artifact itself.
-It does not trust the manifest alone.
+It is not proof that its declarations are satisfied.
 
-## Verification path
+## Manifest contract
 
-For every candidate evidence item marked `verification_required=true`, the verifier checks:
+The verifier requires a valid and non-ambiguous manifest.
 
-1. artifact presence
-2. artifact sha256 against `expected_sha256`
-3. `schema_version` match
-4. `run_identity` match
-5. `subject_binding` match
-6. `policy_binding` match
-7. trusted producer requirement when declared
-8. raw evidence presence
-9. raw evidence sha256 match
-10. `required_for_gates` match
+Duplicate JSON keys fail closed.
 
-Then it checks the declared relation bindings:
+The manifest must contain non-empty:
 
-- `artifact_to_subject`
-- `artifact_to_gate`
+```text
+run_identity
+subject
+policy_binding
+registry_binding
+candidate_evidence
+expected_relation_bindings
+expected_gate_materialization
+```
 
-Then it checks gate materialization admissibility:
+### Run identity
 
-- candidate evidence IDs are verified
-- relation binding IDs are satisfied
-- `expected_value=true`
-- `policy_relation=release_required`
-- `materialization_allowed_without_verifier=false`
+The run identity must satisfy:
+
+```text
+run_identity.git_sha = concrete 40-hex commit SHA
+run_identity.run_key = non-empty current-run identity
+run_identity.run_mode = prod
+```
+
+### Subject identity
+
+The subject must satisfy:
+
+```text
+subject.commit_sha = run_identity.git_sha
+```
+
+### Policy binding
+
+The policy binding must satisfy:
+
+```text
+policy_binding.policy_set = required+release_required
+policy_binding.policy_path = non-empty repository-relative path
+policy_binding.policy_sha256 = concrete SHA-256
+```
+
+### Registry binding
+
+The registry binding must satisfy:
+
+```text
+registry_binding.registry_path = non-empty repository-relative path
+registry_binding.registry_sha256 = concrete SHA-256
+```
+
+The current policy and registry files are loaded from the repository and hashed again.
+
+Their actual digests must match the manifest.
+
+Duplicate YAML keys fail closed.
+
+Every release-required gate referenced by candidate evidence or relation bindings must exist in:
+
+```text
+pulse_gate_policy_v0.yml
+pulse_gate_registry_v0.yml
+```
+
+## Candidate manifest entries
+
+Every candidate evidence entry must declare:
+
+```text
+verification_required = true
+```
+
+Each entry must include:
+
+```text
+path
+expected_sha256
+schema_version
+subject_binding
+required_for_gates
+provenance_expectations
+```
+
+The provenance expectation must require:
+
+```text
+trusted_producer_required = true
+```
+
+This requirement does not mean that a candidate can prove producer trust by containing its own trusted-producer field.
+
+Producer trust is established only through canonical replay equality.
+
+## Canonical candidate replay
+
+Before individual candidate admission, the verifier reruns the checked-in recorded-release candidate producer in memory.
+
+The replay uses the same canonical producer implementation and repository inputs as normal candidate production.
+
+The replay does not:
+
+- clear candidate output directories;
+- write candidate envelopes;
+- replace the candidate index;
+- modify `status.json`;
+- materialize release-required gates;
+- create release authority.
+
+The replayed candidate set must exactly match the candidate set declared in the runtime manifest.
+
+The verifier rejects:
+
+- missing canonical candidates;
+- additional non-canonical candidates;
+- missing candidate-index entries;
+- extra candidate-index entries;
+- modified candidate envelopes;
+- substituted candidate envelopes;
+- producer metadata that differs from canonical production.
+
+Only the non-authoritative creation timestamp representation may be normalized for deterministic comparison.
+
+All mechanically relevant candidate fields must remain equal.
+
+## Producer-trust verification
+
+A candidate envelope may contain:
+
+```text
+provenance.trusted_producer = true
+```
+
+but that field does not independently prove producer trust.
+
+The verifier sets:
+
+```text
+trusted_producer_verified = true
+```
+
+only when the supplied candidate envelope matches the envelope recomputed by canonical candidate replay.
+
+Therefore:
+
+```text
+self-declared trusted producer
+≠ verified producer trust
+```
+
+Verified producer trust requires:
+
+```text
+current repository state
++ current-run evidence
++ checked-in canonical producer
++ replayed candidate envelope
+= supplied candidate envelope
+```
+
+## Candidate evidence verification
+
+Each candidate is checked for:
+
+1. repository-relative artifact presence;
+2. regular-file status;
+3. artifact SHA-256 equality with the manifest;
+4. expected schema-version equality;
+5. current-run identity equality;
+6. subject-binding equality;
+7. commit binding to the manifest subject;
+8. policy-set equality;
+9. policy-digest equality;
+10. canonical candidate replay equality;
+11. verified producer trust;
+12. raw-evidence path presence;
+13. raw-evidence SHA-256 equality;
+14. exact `required_for_gates` equality;
+15. membership of every declared gate in policy and registry.
+
+A candidate is marked:
+
+```text
+status = verified
+```
+
+only when all candidate checks succeed.
+
+Otherwise it remains:
+
+```text
+status = failed
+```
+
+## External-summary candidate boundary
+
+External-summary-specific admission occurs during canonical candidate production.
+
+For release-grade external candidates, the canonical producer must enforce the applicable:
+
+- external-summary schema;
+- detector-specific tool identity;
+- detector-specific metric identity;
+- threshold reference;
+- threshold semantics;
+- aggregate result;
+- subject and commit binding;
+- summary digest binding;
+- raw-evidence digest binding;
+- external-summary envelope binding;
+- signer-policy admission;
+- cryptographic attestation verification.
+
+The recorded release-evidence verifier does not accept a separately supplied assertion that these checks succeeded.
+
+Instead, it replays the same checked-in candidate producer from the current repository and current-run evidence.
+
+The replayed candidate envelope must match the supplied candidate envelope.
+
+Therefore:
+
+```text
+external-summary declaration
+≠ admitted external evidence
+```
+
+The cryptographic attestation-verification capability is implemented.
+
+The exact operational signer identity and current-run attested external-evidence producer lane remain pending.
+
+## Relation-binding verification
+
+After candidate verification, the verifier checks the manifest-declared relations.
+
+Supported relation types are:
+
+```text
+artifact_to_subject
+artifact_to_gate
+```
+
+### `artifact_to_subject`
+
+An `artifact_to_subject` relation must:
+
+- use verified candidate evidence;
+- bind to the current run;
+- bind to the current subject;
+- target:
+
+```text
+subject.commit_sha
+```
+
+- preserve the candidate subject binding.
+
+### `artifact_to_gate`
+
+An `artifact_to_gate` relation must:
+
+- use verified candidate evidence;
+- target a gate declared in `gates.release_required`;
+- target a registry-backed gate;
+- use the exact target form:
+
+```text
+gate.<gate_id>
+```
+
+A relation is satisfied only when:
+
+- its source candidate is verified;
+- its expected gate exists;
+- its binding type is supported;
+- its target is mechanically exact.
+
+## Gate-materialization admissibility
+
+For each declared release-required gate, the verifier checks:
+
+```text
+expected_value = true
+policy_relation = release_required
+materialization_allowed_without_verifier = false
+```
+
+The gate entry must contain non-empty:
+
+```text
+candidate_evidence_ids
+relation_binding_ids
+```
+
+Every listed candidate evidence ID must be verified.
+
+Every listed relation binding ID must be satisfied.
+
+Every candidate used for a gate must have at least one satisfied `artifact_to_gate` relation targeting that exact gate.
+
+The verifier produces:
+
+```text
+admissible = true
+```
+
+only when all gate-materialization prerequisites succeed.
+
+Admissibility does not itself write the gate into `status.json`.
 
 ## Output artifact
 
 The verifier writes:
 
-    PULSE_safe_pack_v0/artifacts/recorded_release_evidence_verifier_v0.json
+```text
+PULSE_safe_pack_v0/artifacts/recorded_release_evidence_verifier_v0.json
+```
 
-Minimum output contents:
+The report contains:
 
-- report schema/version
-- verifier status: `verified | failed`
-- manifest path/digest/schema version
-- run identity
-- subject
-- policy binding
-- registry binding when present
-- per-evidence verification results
-- per-relation verification results
-- per-gate admissibility results
-- verified subject summary
-- fail-closed error list
+```text
+schema_version
+report_version
+status
+manifest
+run_identity
+subject
+policy_binding
+registry_binding
+verified_subjects
+evidence_results
+relation_binding_results
+gate_materialization_admissibility
+errors
+```
+
+The only top-level verifier statuses are:
+
+```text
+verified
+failed
+```
+
+The report is:
+
+```text
+status = verified
+```
+
+only when the complete error list is empty.
+
+Missing, malformed, mismatched, or incomplete evidence produces:
+
+```text
+status = failed
+```
+
+and a non-zero CLI result.
+
+## Materializer binding
+
+The verifier report is consumed by:
+
+```text
+PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
+```
+
+The materializer does not trust the supplied verifier report as a standalone authority object.
+
+Before materialization, it requires:
+
+```text
+--manifest
+--repo-root
+```
+
+and reruns:
+
+```text
+check_recorded_release_evidence(...)
+```
+
+from the supplied manifest and repository root.
+
+The materializer requires:
+
+- canonical verifier replay status `verified`;
+- an empty canonical replay error list;
+- non-empty evidence results;
+- non-empty relation-binding results;
+- exact equality between the supplied report and canonical verifier replay after canonical manifest-path normalization;
+- canonical manifest-path resolution;
+- candidate-status run identity matching the verifier;
+- candidate-status subject identity matching the verifier;
+- `run_mode = prod`;
+- matching policy path;
+- matching policy digest;
+- no stubbed release evidence;
+- no scaffolded release evidence;
+- no pre-existing release-required gate state;
+- explicit admissibility for every policy-derived release-required gate.
+
+All later admission checks consume the freshly replayed canonical report.
+
+They do not consume the supplied report as an independent trust source.
+
+Therefore:
+
+```text
+supplied verifier report
+≠ trusted verifier result
+```
+
+A trusted verifier result requires:
+
+```text
+supplied manifest
++ current repository root
++ canonical verifier replay
+= supplied verifier report
+```
+
+## Materialization behavior
+
+After every admission check succeeds, the materializer writes literal `true` values for the policy-derived `release_required` gate set into:
+
+```text
+status["gates"]
+```
+
+Failed admission must not partially mutate candidate release state.
+
+The materializer works on a detached gate-state copy and writes output only after the complete admission path succeeds.
+
+Therefore:
+
+```text
+failed verifier replay
+→ no release-required materialization
+
+modified verifier report
+→ no release-required materialization
+
+empty evidence or relation results
+→ no release-required materialization
+
+incomplete admissibility
+→ no release-required materialization
+
+run or subject mismatch
+→ no release-required materialization
+
+policy mismatch
+→ no release-required materialization
+
+stubbed or scaffolded state
+→ no release-required materialization
+```
+
+## Mechanical layer separation
+
+The verifier and materializer occupy different layers:
+
+```text
+recorded release-evidence verifier
+= candidate, evidence, relation, and admissibility verification
+
+release-required materializer
+= policy-derived gate-state materialization
+
+PULSE_safe_pack_v0/tools/check_gates.py
+= strict final gate enforcement
+```
+
+The verifier report is not the final release decision.
+
+Canonical candidate replay is not the final release decision.
+
+Canonical verifier replay is not the final release decision.
+
+Materialized gate state is not the final release decision by itself.
 
 ## Authority boundary
 
-The verifier is not release authority.
+The normative release path remains:
 
-Its role is:
+```text
+recorded release evidence
+→ final status.json
+→ declared gate policy
+→ workflow-effective materialized required gate set
+→ PULSE_safe_pack_v0/tools/check_gates.py
+→ primary CI workflow
+→ primary CI allow/block release decision
+```
 
-    candidate detector/external/refusal artifact
-    → recorded evidence verification
-    → admissibility report
-    → later release-grade materialization input
+The following are non-authorizing carriers:
 
-The normative release decision remains:
+- candidate envelopes;
+- candidate indexes;
+- verifier reports;
+- attestation reports;
+- materializer diagnostics;
+- `release_authority_v0.json`;
+- `release_decision_v0.json`;
+- `artifact_provenance_binding_v0.json`;
+- Quality Ledger;
+- audit bundles;
+- dashboards;
+- Pages;
+- reference-run notes.
 
-    recorded release evidence
-    → status.json
-    → declared gate policy
-    → workflow-effective required gate set
-    → check_gates.py
-    → primary CI allow/block decision
+They may preserve, verify, bind, explain, or publish evidence.
+
+They do not independently authorize, block, or override release.
 
 ## CLI
 
-Example:
+Run the verifier from the repository root:
 
 ```bash
 python PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py \
@@ -160,34 +668,116 @@ python PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py \
   --out-json PULSE_safe_pack_v0/artifacts/recorded_release_evidence_verifier_v0.json
 ```
 
-Success output:
+Successful verification returns:
 
-    OK: recorded release-evidence verification satisfied
+```text
+OK: recorded release-evidence verification satisfied
+Verifier report written to <path>
+```
 
-Failure output:
+Failed verification returns a non-zero exit code and:
 
-    ERRORS (fail-closed):
-      - ...
+```text
+ERRORS (fail-closed):
+ - ...
+Verifier report written to <path>
+```
+
+## Failure behavior
+
+The verifier fails closed on, among other conditions:
+
+- missing manifest;
+- malformed manifest;
+- duplicate JSON keys;
+- wrong manifest schema version;
+- non-production run mode;
+- subject and run commit mismatch;
+- wrong policy set;
+- missing policy or registry path;
+- policy or registry digest mismatch;
+- duplicate YAML keys;
+- unknown release-required gate IDs;
+- empty candidate set;
+- empty relation-binding set;
+- empty expected-materialization set;
+- canonical candidate replay failure;
+- missing canonical candidates;
+- extra non-canonical candidates;
+- candidate-index mismatch;
+- modified candidate envelopes;
+- substituted candidate envelopes;
+- substituted producer metadata;
+- candidate artifact digest mismatch;
+- candidate schema mismatch;
+- run-identity mismatch;
+- subject-binding mismatch;
+- policy-binding mismatch;
+- self-declared producer trust without replay equality;
+- raw-evidence digest mismatch;
+- `required_for_gates` mismatch;
+- unsatisfied relation binding;
+- incorrect relation target;
+- incomplete gate-target relations;
+- non-literal expected gate value;
+- wrong policy relation;
+- materialization allowed without verifier;
+- missing candidate IDs;
+- missing relation IDs;
+- any non-empty verifier error list.
 
 ## Non-goals
 
-This verifier is not:
+The recorded release-evidence verifier is not:
 
-- a new release gate
-- a replacement for `check_gates.py`
-- a replacement for `status.json`
-- a second release-decision engine
-- automatic promotion of detector/external/refusal artifacts into release-required truth values
-- a policy override
+- a current-run evidence producer;
+- an external detector;
+- an external-summary signer;
+- an attestation issuer;
+- a new release policy;
+- a new release gate;
+- a replacement for `status.json`;
+- a replacement for the release-required materializer;
+- a replacement for `PULSE_safe_pack_v0/tools/check_gates.py`;
+- a dashboard-derived decision;
+- a reader-surface decision;
+- a second release-decision engine;
+- an independent break-glass path;
+- complete reference-package verification;
+- a completed public reference-run record.
 
-## Follow-up
+## Current operational boundary
 
-A later PR may allow `--release-grade-materialized` to fold only verifier-admitted evidence into release-required gate booleans.
+The following are implemented:
 
-That later step must remain:
+```text
+current-run required-gate evidence production
+canonical candidate production
+canonical candidate replay
+recorded release-evidence verification
+verified producer-trust derivation
+relation-binding verification
+gate-materialization admissibility
+canonical verifier replay
+verifier-bound release-required materialization
+cryptographic external-summary attestation verification capability
+```
 
-- policy-derived
-- explicit
-- fail-closed
-- non-shadow
-- non-reader-authoritative
+The next work is not to rebuild the verifier.
+
+The remaining operational sequence is:
+
+```text
+exact operational release-grade signer identity
+→ current-run attested external evidence
+→ complete evidence-chain packaging
+→ complete-package verification
+→ controlled strict release-grade execution
+→ completed public reference-run record
+```
+
+The first completed run must be recorded in:
+
+```text
+docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md
+```


### PR DESCRIPTION
## Summary

Align the recorded release-evidence verifier documentation with the currently implemented PULSEmech evidence-admission, replay, and materialization path.

The previous document still described verifier-backed release-required fold-in as future work.

The checked-in implementation now includes:

- canonical candidate replay
- replay-derived producer-trust verification
- recorded release-evidence verification
- relation-binding verification
- gate-materialization admissibility
- canonical verifier replay by the materializer
- verifier-bound, policy-derived release-required materialization

## Changes

Update:

```text
docs/recorded_release_evidence_verifier_v0.md
```

The document now describes the implemented path:

```text
current-run required-gate evidence
→ non-stubbed candidate release state
→ canonical candidate production
→ runtime release-evidence input manifest
→ canonical candidate replay
→ recorded release-evidence verification
→ recorded release-evidence verifier report
→ canonical verifier replay by the materializer
→ policy-derived release-required gate materialization
→ final status.json
→ workflow-effective materialized required gate set
→ PULSE_safe_pack_v0/tools/check_gates.py
→ primary CI allow/block release decision
```

## Candidate replay

Document that the verifier reruns the checked-in canonical candidate producer in memory and rejects:

- missing canonical candidates
- extra non-canonical candidates
- candidate-index drift
- modified candidate envelopes
- substituted candidate envelopes
- producer metadata that differs from canonical production

The document now makes the producer-trust boundary explicit:

```text
self-declared trusted producer
≠ verified producer trust
```

Producer trust is verified only when the supplied candidate envelope matches canonical candidate replay.

## Evidence verification

Document the current checks for:

- manifest schema and required sections
- production run mode
- run and subject identity
- policy and registry paths
- policy and registry digests
- duplicate JSON and YAML keys
- candidate artifact digest
- candidate schema
- run and subject bindings
- policy binding
- raw-evidence digest
- exact required-gate relations
- release-required policy and registry membership

## Relation and admissibility verification

Document the supported relation types:

```text
artifact_to_subject
artifact_to_gate
```

Document that gate-materialization admissibility requires:

```text
expected_value = true
policy_relation = release_required
materialization_allowed_without_verifier = false
```

Every candidate and relation used for a release-required gate must be verified and mechanically bound to that exact gate.

## External-summary boundary

Clarify that external-summary-specific schema, semantic, signer-policy, digest, envelope, and cryptographic-attestation checks occur during canonical candidate production.

The recorded verifier binds those results through canonical candidate replay rather than accepting a separately supplied success assertion.

The document distinguishes:

```text
cryptographic attestation-verification capability: implemented
exact operational signer identity: pending
current-run attested external-evidence producer lane: pending
```

## Materializer binding

Document that:

```text
PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
```

does not trust the supplied verifier report as an independent authority object.

Before materialization, it reruns the canonical verifier from:

```text
--manifest
--repo-root
```

and requires the supplied report to match canonical verifier replay.

The materializer also requires:

- verified replay status
- empty replay errors
- non-empty evidence results
- non-empty relation-binding results
- matching run and subject identity
- `run_mode = prod`
- matching policy path and digest
- no stubbed or scaffolded state
- no pre-existing release-required gate values
- explicit admissibility for every policy-derived release-required gate

## Materialization boundary

Document that successful admission writes policy-derived literal `true` values into:

```text
status["gates"]
```

Failed admission must not partially mutate candidate release state.

The mechanical roles remain separate:

```text
recorded release-evidence verifier
= evidence and relation admission

release-required materializer
= policy-derived gate-state materialization

PULSE_safe_pack_v0/tools/check_gates.py
= strict final gate enforcement
```

## Authority boundary

The verifier report, candidate replay, verifier replay, and materialized gate state do not independently create release authority.

The normative path remains:

```text
recorded release evidence
→ final status.json
→ declared gate policy
→ workflow-effective materialized required gate set
→ PULSE_safe_pack_v0/tools/check_gates.py
→ primary CI workflow
→ primary CI allow/block release decision
```

## Remaining operational work

The document preserves the actual remaining path:

```text
exact operational release-grade signer identity
→ current-run attested external evidence
→ complete evidence-chain packaging
→ complete-package verification
→ controlled strict release-grade execution
→ completed public reference-run record
```

## Scope

```text
docs/recorded_release_evidence_verifier_v0.md
```

## Boundary

- documentation only
- no policy change
- no registry change
- no schema change
- no workflow change
- no tool change
- no test change
- no candidate-production change
- no verifier behavior change
- no materializer behavior change
- no gate-enforcement change
- no `status.json` semantics change
- no release-decision behavior change

## Result

After this change:

```text
recorded verifier documentation
= implemented candidate replay
+ implemented verifier replay
+ implemented verifier-bound materialization
+ actual remaining operational work
```