### PR TITLE
docs(index): align documentation map with current verifier path

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,123 +1,231 @@
 # Documentation index
 
-This page is the fuller index of repo documentation.
-The README “Documentation map” is intentionally curated (entrypoint-first).
-If you add/rename a doc under `docs/`, please update this index.
+This page is the fuller index of repository documentation.
 
-## Start here (entrypoints)
+The README documentation map is intentionally curated and entrypoint-first.
 
-- Running PULSE in CI: [QUICKSTART_CORE_v0.md](QUICKSTART_CORE_v0.md)
-- External PULSE review entrypoint: [PULSE_EXTERNAL_REVIEW_ENTRYPOINT_v0.md](PULSE_EXTERNAL_REVIEW_ENTRYPOINT_v0.md)
-- PULSE risk-to-hardening map: [PULSE_RISK_TO_HARDENING_MAP_v0.md](PULSE_RISK_TO_HARDENING_MAP_v0.md)
-- Understanding the source of truth (`status.json`): [status_json.md](status_json.md)
-- When things fail (triage): [RUNBOOK.md](RUNBOOK.md)
+This index separates:
+
+```text
+current implementation
+current operational target
+legacy diagnostic surface
+historical design record
+reader / audit surface
+future or staged work
+```
+
+If a document is added, renamed, superseded, or changes implementation status, update this index.
+
+## Status labels
+
+- **Current implementation** — describes checked-in mechanics that are implemented and testable.
+- **Current operational reference** — defines the present release-grade path and its completion boundary.
+- **Pending operational target** — describes work required before the first completed public reference run.
+- **Legacy diagnostic surface** — remains implemented and tested, but is not the current authority or admission path.
+- **Historical design record** — preserves earlier design reasoning but is not the current implementation source of truth.
+- **Reader / audit surface** — renders, preserves, or explains state without independently creating release authority.
 
 ---
 
-## Orientation & contracts
+## Start here
 
-- [STATE_v0.md](STATE_v0.md) — Current snapshot of PULSE v0 gates, signals, and tooling.
-- [QUICKSTART_CORE_v0.md](QUICKSTART_CORE_v0.md) — Minimal steps to run the core pipeline.
+- Running the Core PULSE lane: [QUICKSTART_CORE_v0.md](QUICKSTART_CORE_v0.md)
+- Current release-grade operational reference: [release_grade_reference_run_v0.md](release_grade_reference_run_v0.md)
+- Current recorded evidence verifier: [recorded_release_evidence_verifier_v0.md](recorded_release_evidence_verifier_v0.md)
+- Understanding the source of truth: [status_json.md](status_json.md)
+- External PULSE review entrypoint: [PULSE_EXTERNAL_REVIEW_ENTRYPOINT_v0.md](PULSE_EXTERNAL_REVIEW_ENTRYPOINT_v0.md)
+- PULSE risk-to-hardening map: [PULSE_RISK_TO_HARDENING_MAP_v0.md](PULSE_RISK_TO_HARDENING_MAP_v0.md)
+- Operational triage and reruns: [RUNBOOK.md](RUNBOOK.md)
+
+---
+
+## Current release-grade evidence path
+
+The current implemented PULSEmech path is:
+
+```text
+recorded current-run release evidence
+→ non-stubbed candidate release state
+→ canonical candidate production
+→ canonical candidate replay
+→ recorded release-evidence verification
+→ canonical verifier replay
+→ policy-derived release-required gate materialization
+→ final status.json
+→ workflow-effective materialized required gate set
+→ PULSE_safe_pack_v0/tools/check_gates.py
+→ primary CI allow/block release decision
+```
+
+Read these documents in this order:
+
+1. [release_grade_reference_run_v0.md](release_grade_reference_run_v0.md)  
+   **Current operational reference.** Defines the implemented release-grade path, advisory qualification boundary, baseline bundle boundary, complete target package, and completed-run acceptance criteria.
+
+2. [recorded_release_evidence_verifier_v0.md](recorded_release_evidence_verifier_v0.md)  
+   **Current implementation.** Defines canonical candidate replay, recorded evidence verification, relation verification, manifest-declared gate admissibility, canonical verifier replay, and materializer coverage boundaries.
+
+3. [release_reference_external_evidence_integration_v1.md](release_reference_external_evidence_integration_v1.md)  
+   External-summary schema, envelope, signer-policy, verification-before-fold-in, and failure-mode contract.
+
+4. [RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md](RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md)  
+   **Pending operational target.** Target record to be completed from the first real public non-stubbed release-grade run. It is not proof that the run already exists.
+
+5. [PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md](PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md)  
+   Operational plan for the remaining path toward exact signer identity, current-run attested evidence, complete packaging, controlled execution, and the completed public record.
+
+6. [PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md](PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md)  
+   **Historical design record and legacy diagnostic boundary.** Not the current verifier implementation entrypoint.
+
+---
+
+## Orientation and contracts
+
+- [STATE_v0.md](STATE_v0.md) — Broad repository-state snapshot. For the current release-grade evidence path, use the release-grade reference and recorded-verifier documents above.
+- [QUICKSTART_CORE_v0.md](QUICKSTART_CORE_v0.md) — Minimal steps for the Core pipeline.
 - [RUNBOOK.md](RUNBOOK.md) — Operational runbook for triage and reruns.
 - [STATUS_CONTRACT.md](STATUS_CONTRACT.md) — Contract for `status.json` shape and semantics.
-- [GATE_SETS.md](GATE_SETS.md) — Human-readable matrix of the current `core_required` and `required` policy sets.
-- [GLOSSARY_v0.md](GLOSSARY_v0.md) — Canonical term definitions used across docs.
-- [PULSEMECH_ARCHITECTURE_MAP_v0_1.md](PULSEMECH_ARCHITECTURE_MAP_v0_1.md) — How to read the PULSEmech architecture map and its release-authority boundary.
-- [release_authority_manifest_v0.md](release_authority_manifest_v0.md) — Implemented v0 audit-manifest contract surface for recording the release-authority chain across evidence, policy, evaluator, workflow lane, decision output, and diagnostic context. 
-- [release_grade_reference_run_v0.md](release_grade_reference_run_v0.md) — Operational definition of a non-stubbed release-grade PULSE reference run, including evidence requirements, artifact expectations, authority boundary, and reviewer checklist.
-- [PULSE_TITLE_CONTINUITY_v0.md](PULSE_TITLE_CONTINUITY_v0.md) — Title-continuity provenance note connecting the current repository-facing title with the earlier Kaggle/publication-facing title.
+- [status_json.md](status_json.md) — How to read the normative release-state artifact.
+- [GATE_SETS.md](GATE_SETS.md) — Human-readable gate-set orientation.
+- [GLOSSARY_v0.md](GLOSSARY_v0.md) — Canonical terminology used across repository documentation.
+- [WORKFLOW_MAP.md](WORKFLOW_MAP.md) — Workflow structure and lane orientation.
+- [PULSEMECH_ARCHITECTURE_MAP_v0_1.md](PULSEMECH_ARCHITECTURE_MAP_v0_1.md) — PULSEmech architecture map and release-authority boundary.
+- [release_authority_manifest_v0.md](release_authority_manifest_v0.md) — Audit-manifest contract for preserving the release-authority chain without becoming a second decision engine.
+- [release_grade_reference_run_v0.md](release_grade_reference_run_v0.md) — Current release-grade operational definition and completion boundary.
+- [recorded_release_evidence_verifier_v0.md](recorded_release_evidence_verifier_v0.md) — Current recorded evidence verifier, replay, admissibility, and materializer boundary.
+- [RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md](RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md) — Target public run record to be completed from an actual controlled run.
+- [PULSE_TITLE_CONTINUITY_v0.md](PULSE_TITLE_CONTINUITY_v0.md) — Title-continuity provenance across repository and publication surfaces.
 
-## Docs-to-core role map
+---
 
-Use this map when connecting documentation to the current core release-authority mechanism. The map is orienting/index-level only; it does not create new authority beyond the artifact-bound path defined by the linked contracts.
+## Documentation-to-core role map
 
-| Bucket | Core role | Primary docs |
+This map connects documentation to the current release-authority mechanism.
+
+It is orienting only.
+
+It does not create authority beyond the artifact-bound path defined by the linked contracts.
+
+| Bucket | Core role | Primary documents |
 |---|---|---|
-| Core mechanics | Explains the mechanical release-authority path and its reviewable checklist. | [PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md](PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md), [PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md](PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md), [PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md](PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md), [PULSE_RELEASE_STATE_TRANSFORMATION_v0.md](PULSE_RELEASE_STATE_TRANSFORMATION_v0.md) |
-| Authority boundary | Separates release execution, approval, public narrative, manifests, and external evidence from the actual authority carrier. | [PULSEMECH_ARCHITECTURE_MAP_v0_1.md](PULSEMECH_ARCHITECTURE_MAP_v0_1.md), [PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md](PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md), [PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md](PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md), [release_authority_boundary_v1.md](release_authority_boundary_v1.md), [MAINTAINER_AUTHORITY_BOUNDARY_v0.md](MAINTAINER_AUTHORITY_BOUNDARY_v0.md) |
-| Status / policy / gate-set / workflow contracts | Defines the normative carrier tuple for `status.json`, declared policy, workflow-effective materialized required gates, and strict fail-closed enforcement. | [status_json.md](status_json.md), [STATUS_CONTRACT.md](STATUS_CONTRACT.md), [GATE_SETS.md](GATE_SETS.md), [WORKFLOW_MAP.md](WORKFLOW_MAP.md), [RELEASE_DECISION_v0.md](RELEASE_DECISION_v0.md), [PULSE_RELEASE_GRADE_MATERIALIZED_LANE_v0.md](PULSE_RELEASE_GRADE_MATERIALIZED_LANE_v0.md) |
-| Verifier / evidence path | Tracks the diagnostic verifier line, schema-only / delta boundaries, relation-binding prerequisites, and evidence-promotion constraints before any trusted verifier can materialize gates. | [PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md](PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md), [PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_DELTA_MAP_v0.md](PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_DELTA_MAP_v0.md), [PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_ONLY_DRAFT_BOUNDARY_v0.md](PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_ONLY_DRAFT_BOUNDARY_v0.md), [PULSE_RELEASE_EVIDENCE_RELATION_BINDING_PROMOTION_PREREQUISITES_v0.md](PULSE_RELEASE_EVIDENCE_RELATION_BINDING_PROMOTION_PREREQUISITES_v0.md), [PULSE_RELEASE_EVIDENCE_EXPECTATION_SUMMARY_v0.md](PULSE_RELEASE_EVIDENCE_EXPECTATION_SUMMARY_v0.md), [PULSE_EVIDENCE_FOLD_IN_ADMISSIBILITY_v0.md](PULSE_EVIDENCE_FOLD_IN_ADMISSIBILITY_v0.md), [PULSE_EXTERNAL_EVIDENCE_MATERIALIZATION_BOUNDARY_v0.md](PULSE_EXTERNAL_EVIDENCE_MATERIALIZATION_BOUNDARY_v0.md) |
-| Reader surfaces | Shows how humans read recorded state without letting dashboards, summaries, or Pages become authority carriers. | [quality_ledger.md](quality_ledger.md), [release_grade_reference_run_v0.md](release_grade_reference_run_v0.md), [PULSE_PUBLIC_SURFACE_CONTRACT_v0.md](PULSE_PUBLIC_SURFACE_CONTRACT_v0.md), [PULSE_PUBLIC_PRIVATE_ARTIFACT_BOUNDARY_v0.md](PULSE_PUBLIC_PRIVATE_ARTIFACT_BOUNDARY_v0.md), [PULSE_NATIVE_REVIEW_FRAME_v0.md](PULSE_NATIVE_REVIEW_FRAME_v0.md) |
-| Audit sidecars / provenance sidecars | Records digest-backed relation, manifest, attestation subject, and cryptographic-binding sidecars around the authority path without replacing it. | [ARTIFACT_PROVENANCE_BINDING_v0.md](ARTIFACT_PROVENANCE_BINDING_v0.md), [release_authority_manifest_v0.md](release_authority_manifest_v0.md), [RELEASE_AUTHORITY_ATTESTATION_SUBJECT_v0.md](RELEASE_AUTHORITY_ATTESTATION_SUBJECT_v0.md), [RELEASE_AUTHORITY_CRYPTOGRAPHIC_BINDING_v0.md](RELEASE_AUTHORITY_CRYPTOGRAPHIC_BINDING_v0.md), [ANCHOR_INTEGRITY_v0.md](ANCHOR_INTEGRITY_v0.md) |
-| Diagnostic / shadow surfaces | Keeps overlays, EPF/paradox/topology/field surfaces, and shadow inventory outputs diagnostic unless a future policy explicitly promotes them. | [OPTIONAL_LAYERS.md](OPTIONAL_LAYERS.md), [NORMATIVE_SHADOW_INVENTORY_MODEL_v0.md](NORMATIVE_SHADOW_INVENTORY_MODEL_v0.md), [SHADOW_ARTIFACT_COMMON_v0.md](SHADOW_ARTIFACT_COMMON_v0.md), [PULSE_epf_shadow_quickstart_v0.md](PULSE_epf_shadow_quickstart_v0.md), [PULSE_paradox_core_v0.md](PULSE_paradox_core_v0.md), [PULSE_topology_overview_v0.md](PULSE_topology_overview_v0.md), [PULSE_decision_field_v0_overview.md](PULSE_decision_field_v0_overview.md) |
-| Staged future work | Collects explicitly non-current work items, future lanes, and hardening plans that must not be read as implemented authority. | [FUTURE_LIBRARY.md](FUTURE_LIBRARY.md), [FUTURE_READY_WORKMODE.md](FUTURE_READY_WORKMODE.md), [PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md](PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md), [UNREALIZED_DOCUMENTATION_PLANS_AUDIT_2026-06-05.md](UNREALIZED_DOCUMENTATION_PLANS_AUDIT_2026-06-05.md), [PULSE_HARDENING_BOUNDARY_MAP_v0.md](PULSE_HARDENING_BOUNDARY_MAP_v0.md) |
-| Adoption / external review support | Supports external review, operator handoff, governance packets, and challenge/review packets while preserving the authority boundary. | [PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md](PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md), [EXTERNAL_VERIFICATION_PATH_v0.md](EXTERNAL_VERIFICATION_PATH_v0.md), [EXTERNAL_VERIFICATION_PACKET_v0.md](EXTERNAL_VERIFICATION_PACKET_v0.md), [GOVERNANCE_PACK_v0.md](GOVERNANCE_PACK_v0.md), [OPERATOR_HANDOFF_v0.md](OPERATOR_HANDOFF_v0.md), [OUTSIDE_REVIEW_RESPONSE.md](OUTSIDE_REVIEW_RESPONSE.md), [AUTHORITY_IMPACT_AUDIT_CHECKLIST_v0.md](AUTHORITY_IMPACT_AUDIT_CHECKLIST_v0.md) |
+| Core mechanics | Explains the connected evidence-to-decision path. | [PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md](PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md), [PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md](PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md), [PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md](PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md), [PULSE_RELEASE_STATE_TRANSFORMATION_v0.md](PULSE_RELEASE_STATE_TRANSFORMATION_v0.md) |
+| Authority boundary | Separates execution, approval, reader surfaces, manifests, attestations, and audit sidecars from the normative authority carrier. | [PULSEMECH_ARCHITECTURE_MAP_v0_1.md](PULSEMECH_ARCHITECTURE_MAP_v0_1.md), [PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md](PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md), [PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md](PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md), [release_authority_boundary_v1.md](release_authority_boundary_v1.md), [MAINTAINER_AUTHORITY_BOUNDARY_v0.md](MAINTAINER_AUTHORITY_BOUNDARY_v0.md) |
+| Status, policy, gate-set, and workflow contracts | Defines the normative carrier tuple for final state, declared policy, workflow-effective gates, strict enforcement, and primary CI outcome. | [status_json.md](status_json.md), [STATUS_CONTRACT.md](STATUS_CONTRACT.md), [GATE_SETS.md](GATE_SETS.md), [WORKFLOW_MAP.md](WORKFLOW_MAP.md), [RELEASE_DECISION_v0.md](RELEASE_DECISION_v0.md), [PULSE_RELEASE_GRADE_MATERIALIZED_LANE_v0.md](PULSE_RELEASE_GRADE_MATERIALIZED_LANE_v0.md) |
+| Current verifier and evidence admission | Defines current-run candidate replay, recorded evidence verification, relation verification, gate admissibility, canonical verifier replay, and verifier-bound materialization. | [recorded_release_evidence_verifier_v0.md](recorded_release_evidence_verifier_v0.md), [release_grade_reference_run_v0.md](release_grade_reference_run_v0.md), [release_reference_external_evidence_integration_v1.md](release_reference_external_evidence_integration_v1.md), [PULSE_EXTERNAL_EVIDENCE_MATERIALIZATION_BOUNDARY_v0.md](PULSE_EXTERNAL_EVIDENCE_MATERIALIZATION_BOUNDARY_v0.md) |
+| Legacy verifier diagnostics and historical prerequisites | Preserves the earlier failure-only verifier-report line, expectation summaries, schema drafts, and relation-promotion prerequisites without presenting them as the current admission path. | [PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md](PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md), [PULSE_RELEASE_EVIDENCE_EXPECTATION_SUMMARY_v0.md](PULSE_RELEASE_EVIDENCE_EXPECTATION_SUMMARY_v0.md), [PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_DELTA_MAP_v0.md](PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_DELTA_MAP_v0.md), [PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_ONLY_DRAFT_BOUNDARY_v0.md](PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_ONLY_DRAFT_BOUNDARY_v0.md), [PULSE_RELEASE_EVIDENCE_RELATION_BINDING_PROMOTION_PREREQUISITES_v0.md](PULSE_RELEASE_EVIDENCE_RELATION_BINDING_PROMOTION_PREREQUISITES_v0.md), [PULSE_EVIDENCE_FOLD_IN_ADMISSIBILITY_v0.md](PULSE_EVIDENCE_FOLD_IN_ADMISSIBILITY_v0.md) |
+| Release-grade reference and public record | Defines what a completed public run must contain and where its concrete run identity is recorded. | [release_grade_reference_run_v0.md](release_grade_reference_run_v0.md), [RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md](RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md), [PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md](PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md) |
+| Reader surfaces | Shows recorded state without allowing dashboards, summaries, notebooks, or Pages to become authority carriers. | [quality_ledger.md](quality_ledger.md), [PULSE_PUBLIC_SURFACE_CONTRACT_v0.md](PULSE_PUBLIC_SURFACE_CONTRACT_v0.md), [PULSE_PUBLIC_PRIVATE_ARTIFACT_BOUNDARY_v0.md](PULSE_PUBLIC_PRIVATE_ARTIFACT_BOUNDARY_v0.md), [PULSE_NATIVE_REVIEW_FRAME_v0.md](PULSE_NATIVE_REVIEW_FRAME_v0.md) |
+| Audit and provenance sidecars | Preserves digest-backed decision, binding, manifest, attestation-subject, and cryptographic-verification state around the normative path. | [ARTIFACT_PROVENANCE_BINDING_v0.md](ARTIFACT_PROVENANCE_BINDING_v0.md), [release_authority_manifest_v0.md](release_authority_manifest_v0.md), [RELEASE_AUTHORITY_ATTESTATION_SUBJECT_v0.md](RELEASE_AUTHORITY_ATTESTATION_SUBJECT_v0.md), [RELEASE_AUTHORITY_CRYPTOGRAPHIC_BINDING_v0.md](RELEASE_AUTHORITY_CRYPTOGRAPHIC_BINDING_v0.md), [ANCHOR_INTEGRITY_v0.md](ANCHOR_INTEGRITY_v0.md) |
+| Diagnostic and shadow surfaces | Keeps EPF, paradox, topology, field, overlay, and shadow inventory outputs diagnostic unless explicitly admitted through declared policy and strict enforcement. | [OPTIONAL_LAYERS.md](OPTIONAL_LAYERS.md), [NORMATIVE_SHADOW_INVENTORY_MODEL_v0.md](NORMATIVE_SHADOW_INVENTORY_MODEL_v0.md), [SHADOW_ARTIFACT_COMMON_v0.md](SHADOW_ARTIFACT_COMMON_v0.md), [PULSE_epf_shadow_quickstart_v0.md](PULSE_epf_shadow_quickstart_v0.md), [PULSE_paradox_core_v0.md](PULSE_paradox_core_v0.md), [PULSE_topology_overview_v0.md](PULSE_topology_overview_v0.md), [PULSE_decision_field_v0_overview.md](PULSE_decision_field_v0_overview.md) |
+| Pending operational work | Collects the remaining exact-signer, current-run attested-evidence, complete-package, controlled-run, and portability work. | [PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md](PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md), [FUTURE_LIBRARY.md](FUTURE_LIBRARY.md), [FUTURE_READY_WORKMODE.md](FUTURE_READY_WORKMODE.md), [PULSE_HARDENING_BOUNDARY_MAP_v0.md](PULSE_HARDENING_BOUNDARY_MAP_v0.md), [UNREALIZED_DOCUMENTATION_PLANS_AUDIT_2026-06-05.md](UNREALIZED_DOCUMENTATION_PLANS_AUDIT_2026-06-05.md) |
+| Adoption and external review | Supports operator handoff, external review, governance packets, and challenge packets while preserving the authority boundary. | [PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md](PULSE_REVIEWABLE_MECHANICS_CHECKLIST_v0.md), [EXTERNAL_VERIFICATION_PATH_v0.md](EXTERNAL_VERIFICATION_PATH_v0.md), [EXTERNAL_VERIFICATION_PACKET_v0.md](EXTERNAL_VERIFICATION_PACKET_v0.md), [GOVERNANCE_PACK_v0.md](GOVERNANCE_PACK_v0.md), [OPERATOR_HANDOFF_v0.md](OPERATOR_HANDOFF_v0.md), [OUTSIDE_REVIEW_RESPONSE.md](OUTSIDE_REVIEW_RESPONSE.md), [AUTHORITY_IMPACT_AUDIT_CHECKLIST_v0.md](AUTHORITY_IMPACT_AUDIT_CHECKLIST_v0.md) |
 
-## Status, ledger & external signals
+---
 
-- [status_json.md](status_json.md) — How to read `status.json` (metrics, gates, consumers).
-- [quality_ledger.md](quality_ledger.md) — Quality Ledger layout and purpose.
-- [refusal_delta_gate.md](refusal_delta_gate.md) — Refusal-delta summary format + fail-closed semantics.
-- [EXTERNAL_DETECTORS.md](EXTERNAL_DETECTORS.md) — External detectors policy & modes (gating vs advisory).
-- [external_detector_summaries.md](external_detector_summaries.md) — Folding external detector summaries into status/ledger.
-- [AGENT_ORCHESTRATION_EVIDENCE_BRIDGE_v0.md](AGENT_ORCHESTRATION_EVIDENCE_BRIDGE_v0.md) — Boundary for treating agent-orchestration proof-of-work as diagnostic release evidence without granting release authority.
+## Status, ledger, and external evidence
 
-## Paradox field & edges
+- [status_json.md](status_json.md) — Reading final release state, metrics, gates, and consumers.
+- [quality_ledger.md](quality_ledger.md) — Quality Ledger structure and non-authorizing reader role.
+- [refusal_delta_gate.md](refusal_delta_gate.md) — Refusal-delta evidence and fail-closed semantics.
+- [EXTERNAL_DETECTORS.md](EXTERNAL_DETECTORS.md) — External detector policy and advisory/gating modes.
+- [external_detector_summaries.md](external_detector_summaries.md) — External detector summary integration.
+- [release_reference_external_evidence_integration_v1.md](release_reference_external_evidence_integration_v1.md) — External summary schema, envelope, signer-policy, and verification-before-fold-in contract.
+- [AGENT_ORCHESTRATION_EVIDENCE_BRIDGE_v0.md](AGENT_ORCHESTRATION_EVIDENCE_BRIDGE_v0.md) — Boundary for agent-orchestration evidence without independent release authority.
 
-- [PULSE_paradox_field_v0_walkthrough.md](PULSE_paradox_field_v0_walkthrough.md) — How to read `paradox_field_v0`.
-- [Pulse_paradox_edges_v0_status.md](Pulse_paradox_edges_v0_status.md) — Status/roadmap for `paradox_edges_v0.jsonl`.
-- [paradox_edges_case_studies.md](paradox_edges_case_studies.md) — Case studies (fixture + non-fixture).
-- [PARADOX_RUNBOOK.md](PARADOX_RUNBOOK.md) — What to do when EPF shadow disagrees with baseline.
-- [Paradox Gate triage SVG v0](paradox_gate_triage_svg_v0.md) — Shadow-only Paradox Gate triage SVG input/contract/render flow.
-- [Paradox diagram v0](paradox_diagram_v0.md) — How to generate and read the Mermaid topology view.
-- [PULSE_paradox_core_v0.md](PULSE_paradox_core_v0.md) — Paradox Core v0 (deterministic core projection + markdown reviewer summary).
+---
 
-## EPF shadow & hazard diagnostics
+## Release evidence verification
+
+### Current implementation
+
+- [recorded_release_evidence_verifier_v0.md](recorded_release_evidence_verifier_v0.md) — Current recorded evidence verifier, canonical replay, per-entry admissibility, materializer coverage, and authority boundary.
+- [release_grade_reference_run_v0.md](release_grade_reference_run_v0.md) — Current release-grade operational reference and complete-package boundary.
+- [release_reference_external_evidence_integration_v1.md](release_reference_external_evidence_integration_v1.md) — External evidence contract and verification-before-fold-in surface.
+
+### Pending operational target
+
+- [PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md](PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md) — Remaining path toward exact signer identity, current-run attested evidence, complete packaging, and the controlled strict run.
+- [RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md](RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md) — Target record to be completed from the first real public non-stubbed run.
+
+### Historical and legacy surfaces
+
+- [PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md](PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md) — Superseded as the current implementation entrypoint; retained as a historical verifier design and legacy diagnostic-surface record.
+- [PULSE_RELEASE_EVIDENCE_EXPECTATION_SUMMARY_v0.md](PULSE_RELEASE_EVIDENCE_EXPECTATION_SUMMARY_v0.md) — Reader-only diagnostic summary for legacy pre-materialization gaps.
+- [PULSE_RELEASE_EVIDENCE_RELATION_BINDING_PROMOTION_PREREQUISITES_v0.md](PULSE_RELEASE_EVIDENCE_RELATION_BINDING_PROMOTION_PREREQUISITES_v0.md) — Historical relation-binding promotion prerequisites.
+- [PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_DELTA_MAP_v0.md](PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_DELTA_MAP_v0.md) — Historical verifier schema-delta map.
+- [PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_ONLY_DRAFT_BOUNDARY_v0.md](PULSE_RELEASE_EVIDENCE_TRUSTED_VERIFIER_SCHEMA_ONLY_DRAFT_BOUNDARY_v0.md) — Historical schema-only draft boundary.
+
+---
+
+## Release-state transformation
+
+- [PULSE_RELEASE_STATE_TRANSFORMATION_v0.md](PULSE_RELEASE_STATE_TRANSFORMATION_v0.md) — PULSEmech as a closed release-state transformation path.
+- [PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md](PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md) — Pre-materialization mechanics and relation-bearing pre-state hooks.
+- [PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md](PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md) — Mechanical bridge between recorded evidence and release authority.
+
+---
+
+## Paradox field and edges
+
+- [PULSE_paradox_field_v0_walkthrough.md](PULSE_paradox_field_v0_walkthrough.md) — Reading `paradox_field_v0`.
+- [Pulse_paradox_edges_v0_status.md](Pulse_paradox_edges_v0_status.md) — Status and roadmap for `paradox_edges_v0.jsonl`.
+- [paradox_edges_case_studies.md](paradox_edges_case_studies.md) — Fixture and non-fixture case studies.
+- [PARADOX_RUNBOOK.md](PARADOX_RUNBOOK.md) — Triage when the EPF shadow disagrees with baseline.
+- [paradox_gate_triage_svg_v0.md](paradox_gate_triage_svg_v0.md) — Shadow-only Paradox Gate triage SVG flow.
+- [paradox_diagram_v0.md](paradox_diagram_v0.md) — Mermaid topology generation and reading.
+- [PULSE_paradox_core_v0.md](PULSE_paradox_core_v0.md) — Deterministic Paradox Core projection and reviewer summary.
+
+---
+
+## EPF shadow and hazard diagnostics
 
 - [PULSE_epf_shadow_quickstart_v0.md](PULSE_epf_shadow_quickstart_v0.md) — Command-level EPF shadow quickstart.
-- [epf_relational_grail.md](epf_relational_grail.md) — Relational hazard overview + calibration/CLI examples.
-- [epf_hazard_inspect.md](epf_hazard_inspect.md) — Inspect `epf_hazard_log.jsonl` from the CLI.
+- [epf_relational_grail.md](epf_relational_grail.md) — Relational hazard overview and calibration examples.
+- [epf_hazard_inspect.md](epf_hazard_inspect.md) — Inspecting `epf_hazard_log.jsonl`.
 
-## Topology & field-first interpretation
+---
 
-- [PULSE_topology_overview_v0.md](PULSE_topology_overview_v0.md) — Topology layer overview (diagnostic overlay).
-- [PULSE_decision_field_v0_overview.md](PULSE_decision_field_v0_overview.md) — Decision field v0 overview.
-- [PULSE_decision_engine_v0.md](PULSE_decision_engine_v0.md) — Decision Engine v0 outputs and semantics.
-- [FIELD_FIRST_INTERPRETATION.md](FIELD_FIRST_INTERPRETATION.md) — Field-first interpretation (question as projection).
+## Topology and field-first interpretation
 
-## Examples & contributing
+- [PULSE_topology_overview_v0.md](PULSE_topology_overview_v0.md) — Diagnostic topology layer.
+- [PULSE_decision_field_v0_overview.md](PULSE_decision_field_v0_overview.md) — Decision-field overview.
+- [PULSE_decision_engine_v0.md](PULSE_decision_engine_v0.md) — Decision Engine outputs and semantics.
+- [FIELD_FIRST_INTERPRETATION.md](FIELD_FIRST_INTERPRETATION.md) — Field-first interpretation and projection.
+
+---
+
+## Examples and contributing
 
 - [examples/README.md](examples/README.md) — Reproducible examples index.
-- [examples/transitions_case_study_v0/README.md](examples/transitions_case_study_v0/README.md) — Transitions → paradox field/edges case study.
-- [PR_SUMMARY_TOOLS.md](PR_SUMMARY_TOOLS.md) — PR summary tooling (canonical scripts).
-- [../CONTRIBUTING.md](../CONTRIBUTING.md) — Contributing and workflow conventions.
+- [examples/transitions_case_study_v0/README.md](examples/transitions_case_study_v0/README.md) — Transitions to paradox field/edges case study.
+- [PR_SUMMARY_TOOLS.md](PR_SUMMARY_TOOLS.md) — Canonical PR summary tooling.
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) — Contribution and workflow conventions.
 
-## Theory & measurement protocols (probe)
+---
 
-- [theory_overlay_v0.md](theory_overlay_v0.md) — Theory Overlay v0 (shadow): contract, workflow wiring, and how to read the overlay artifact.
-- [time_as_consequence_v0_1.md](time_as_consequence_v0_1.md) — Workshop paper (v0.1): “time as consequence” via record-based operational definitions.
-- [time_as_consequence_one_pager_v0_1.md](time_as_consequence_one_pager_v0_1.md) — One-page summary (v0.1) of the record-based time framework.
-- [gravity_record_protocol_appendix_v0_1.md](gravity_record_protocol_appendix_v0_1.md) — Appendix (v0.1): gravity as a record test (λ/s/κ protocols + horizon taxonomy).
-- [gravity_record_protocol_inputs_v0_1.md](gravity_record_protocol_inputs_v0_1.md) — Inputs bundle spec (v0.1): raw producer contract for Gravity Record Protocol runs.
-- [gravity_record_protocol_decodability_wall_v0_1.md](gravity_record_protocol_decodability_wall_v0_1.md) — Decodability Wall spec (v0.1): operational decodability threshold + critical radius definition and calibration notes.
+## Theory and measurement protocols
 
-## Optional layers & research surfaces
+- [theory_overlay_v0.md](theory_overlay_v0.md) — Theory Overlay v0 diagnostic contract.
+- [time_as_consequence_v0_1.md](time_as_consequence_v0_1.md) — Workshop paper on time as consequence.
+- [time_as_consequence_one_pager_v0_1.md](time_as_consequence_one_pager_v0_1.md) — One-page summary.
+- [gravity_record_protocol_appendix_v0_1.md](gravity_record_protocol_appendix_v0_1.md) — Gravity Record Protocol appendix.
+- [gravity_record_protocol_inputs_v0_1.md](gravity_record_protocol_inputs_v0_1.md) — Raw producer input contract.
+- [gravity_record_protocol_decodability_wall_v0_1.md](gravity_record_protocol_decodability_wall_v0_1.md) — Decodability threshold and critical-radius specification.
+
+---
+
+## Optional layers and research surfaces
 
 - [OPTIONAL_LAYERS.md](OPTIONAL_LAYERS.md) — Shadow workflows, overlays, experiments, and publication surfaces that do not define release outcomes by default.
 
 ### External challenge companions
 
 - [../parameter_golf_v0/README.md](../parameter_golf_v0/README.md) — Parameter Golf v0 shadow-only evidence companion.
-- [parameter_golf_submission_evidence_v0.md](parameter_golf_submission_evidence_v0.md) — Notes on the Parameter Golf submission-evidence contract and reviewer-facing receipt surface.
+- [parameter_golf_submission_evidence_v0.md](parameter_golf_submission_evidence_v0.md) — Parameter Golf submission-evidence contract and reviewer receipt surface.
 
-## Terminology / language rules
+---
 
-- [PULSE_MECHANICAL_TRANSITION_LANGUAGE_v0.md](PULSE_MECHANICAL_TRANSITION_LANGUAGE_v0.md) — Repository-facing wording and review rule for preserving PULSEmech transition-bearing language.
+## Terminology and language rules
 
-## Release evidence verification
-
-- [PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md](PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md) — Informational reference note for the future trusted verifier boundary required before release-grade evidence can materialize release-required gates.
-
-
-## Release-state transformation
-
-- [PULSE_RELEASE_STATE_TRANSFORMATION_v0.md](PULSE_RELEASE_STATE_TRANSFORMATION_v0.md) — Informational reference note for reading PULSEmech as a closed release-state transformation path.
-
-## Pre-materialization mechanics
-
-- [PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md](PULSE_PRE_MATERIALIZATION_GATE_MECHANICS_v0.md) — Informational reference note for pre-materialization gate mechanics and relation-binding pre-state hooks.
-
-
-## Release evidence expectation summary
-
-- [PULSE_RELEASE_EVIDENCE_EXPECTATION_SUMMARY_v0.md](PULSE_RELEASE_EVIDENCE_EXPECTATION_SUMMARY_v0.md) — Reader-only diagnostic summary for pre-materialization evidence, relation, and gate-materialization gaps.
+- [PULSE_MECHANICAL_TRANSITION_LANGUAGE_v0.md](PULSE_MECHANICAL_TRANSITION_LANGUAGE_v0.md) — Wording and review rule for preserving transition-bearing PULSEmech language.


### PR DESCRIPTION
## Summary

Align the documentation index with the current implemented PULSEmech release-grade evidence path.

The previous index still presented the historical verifier design as a future trusted-verifier entrypoint and did not clearly separate:

```text
current implementation
current operational target
legacy diagnostic surface
historical design record
reader / audit surface
pending work
```

This change makes the documentation entry path mechanically unambiguous.

## Changes

Update:

```text
docs/INDEX.md
```

### Current entrypoints

Promote these documents as the current release-grade entry path:

```text
docs/release_grade_reference_run_v0.md
docs/recorded_release_evidence_verifier_v0.md
docs/release_reference_external_evidence_integration_v1.md
docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md
docs/PULSE_RELEASE_GRADE_NEXT_RUN_PLAN_v0.md
```

### Current implementation path

Record the implemented evidence-to-decision path:

```text
recorded current-run release evidence
→ non-stubbed candidate release state
→ canonical candidate production
→ canonical candidate replay
→ recorded release-evidence verification
→ canonical verifier replay
→ policy-derived release-required gate materialization
→ final status.json
→ workflow-effective materialized required gate set
→ PULSE_safe_pack_v0/tools/check_gates.py
→ primary CI allow/block release decision
```

### Verifier separation

Distinguish the current recorded verifier from the retained historical and diagnostic verifier surfaces.

Current implementation:

```text
docs/recorded_release_evidence_verifier_v0.md
```

Historical design and legacy diagnostic boundary:

```text
docs/PULSE_RELEASE_EVIDENCE_VERIFIER_v0.md
```

The index no longer describes the current trusted-verifier path as future work.

### Documentation status labels

Add explicit documentation-status categories:

- current implementation
- current operational reference
- pending operational target
- legacy diagnostic surface
- historical design record
- reader / audit surface

These labels prevent historical plans, fixtures, reader surfaces, and current mechanics from being flattened into one documentation category.

### Release-grade reference boundary

Identify:

```text
docs/release_grade_reference_run_v0.md
```

as the current operational definition of the completed release-grade reference path.

Identify:

```text
docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md
```

as the target record to be completed from the first actual public non-stubbed release-grade run.

The run note is not represented as proof that the completed run already exists.

### Role-map alignment

Split the previous verifier/evidence bucket into:

```text
Current verifier and evidence admission
```

and:

```text
Legacy verifier diagnostics and historical prerequisites
```

Add a separate bucket for:

```text
Release-grade reference and public record
```

This preserves the distinction between implemented mechanics, retained diagnostics, and pending operational completion.

### Authority boundary

The index remains an orienting reader surface.

It does not create or change release authority.

The normative path remains:

```text
recorded release evidence
→ final status.json
→ declared gate policy
→ workflow-effective materialized required gate set
→ PULSE_safe_pack_v0/tools/check_gates.py
→ primary CI workflow
→ primary CI allow/block release decision
```

## Scope

```text
docs/INDEX.md
```

## Boundary

- documentation index only
- no policy change
- no registry change
- no schema change
- no workflow change
- no tool change
- no test change
- no verifier behavior change
- no materializer behavior change
- no gate-enforcement change
- no `status.json` semantics change
- no release-decision behavior change

## Result

After this change:

```text
current implementation
→ current implementation documents

historical design
→ historical design documents

legacy diagnostics
→ legacy diagnostic documents

remaining operational work
→ next-run and public-record documents
```