### PR TITLE
feat(ref): build canonical LlamaGuard current-run summary

### DIFF
--- a/PULSE_safe_pack_v0/pack_manifest.yml
+++ b/PULSE_safe_pack_v0/pack_manifest.yml
@@ -6,6 +6,8 @@ required:
   - path: tools/check_gates.py
   - path: tools/augment_status.py
   - path: tools/refusal_delta_calc.py
+  - path: tools/adapters/llamaguard_ingest.py
+  - path: schemas/external_summary_v1.schema.json
   - path: docs/METHODS_RDSI_QLEDGER.md
   - path: docs/EXTERNAL_DETECTORS.md
   - path: profiles/external_thresholds.yaml

--- a/PULSE_safe_pack_v0/schemas/external_summary_v1.schema.json
+++ b/PULSE_safe_pack_v0/schemas/external_summary_v1.schema.json
@@ -1,0 +1,340 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hkati.github.io/pulse-release-gates-0.1/schemas/external_summary_v1.schema.json",
+  "title": "PULSE External Summary v1",
+  "description": "Canonical external detector / evaluation / review summary schema for PULSE-REF release-grade evidence handling. This schema defines evidence shape only; it does not create release authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "summary_id",
+    "tool",
+    "run",
+    "subject",
+    "metrics",
+    "threshold_ref",
+    "evidence",
+    "signing",
+    "result",
+    "authority_boundary"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "external_summary_v1",
+      "description": "Canonical schema version identifier."
+    },
+    "summary_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable identifier for this external summary artifact."
+    },
+    "tool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "External detector, evaluator, or review tool name."
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Tool version, commit, release, or stable version label."
+        },
+        "adapter": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional PULSE adapter name that normalized the tool output."
+        },
+        "adapter_version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional adapter version."
+        }
+      }
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "generated_at"
+      ],
+      "properties": {
+        "run_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "External tool run identifier, if available."
+        },
+        "generated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "UTC timestamp when the external summary was generated."
+        },
+        "dataset_digest": {
+          "$ref": "#/$defs/sha256_digest",
+          "description": "SHA-256 digest of the dataset, prompt set, or evaluation corpus."
+        },
+        "evaluator_digest": {
+          "$ref": "#/$defs/sha256_digest",
+          "description": "SHA-256 digest of evaluator configuration, prompt, rubric, or harness."
+        },
+        "model_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Model, application, or release-candidate identifier evaluated by the tool."
+        }
+      }
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "id",
+        "digest_algorithm",
+        "digest"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "model",
+            "application",
+            "release_candidate",
+            "dataset",
+            "prompt_set",
+            "artifact_bundle",
+            "other"
+          ],
+          "description": "Kind of subject evaluated by the external tool."
+        },
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable subject identifier."
+        },
+        "digest_algorithm": {
+          "type": "string",
+          "const": "sha256",
+          "description": "Digest algorithm used for subject binding."
+        },
+        "digest": {
+          "$ref": "#/$defs/sha256_digest",
+          "description": "SHA-256 digest binding this summary to the evaluated subject."
+        }
+      }
+    },
+    "metrics": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Canonical scalar metrics emitted by the external tool.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "key",
+          "value",
+          "passed"
+        ],
+        "properties": {
+          "key": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Stable canonical metric key."
+          },
+          "value": {
+            "type": [
+              "number",
+              "integer",
+              "boolean",
+              "string"
+            ],
+            "description": "Metric value."
+          },
+          "unit": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Optional metric unit."
+          },
+          "threshold": {
+            "type": [
+              "number",
+              "integer",
+              "boolean",
+              "string",
+              "null"
+            ],
+            "description": "Threshold used for this metric, if applicable."
+          },
+          "comparator": {
+            "type": "string",
+            "enum": [
+              "lt",
+              "lte",
+              "gt",
+              "gte",
+              "eq",
+              "neq",
+              "contains",
+              "not_contains",
+              "custom",
+              "none"
+            ],
+            "default": "none",
+            "description": "Comparator used to determine metric pass/fail."
+          },
+          "passed": {
+            "type": "boolean",
+            "description": "Whether this metric passed under the declared threshold semantics."
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "info",
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ],
+            "description": "Optional severity associated with this metric."
+          },
+          "notes": {
+            "type": "string",
+            "description": "Optional human-readable notes."
+          }
+        }
+      }
+    },
+    "threshold_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key"
+      ],
+      "properties": {
+        "key": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable threshold policy key used to interpret metrics."
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional threshold policy version."
+        },
+        "uri": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional URI or path to threshold policy."
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "raw_artifact_uri"
+      ],
+      "properties": {
+        "raw_artifact_uri": {
+          "type": "string",
+          "minLength": 1,
+          "description": "URI or path to the archived raw external evidence artifact."
+        },
+        "raw_artifact_digest": {
+          "$ref": "#/$defs/sha256_digest",
+          "description": "SHA-256 digest of the raw external evidence artifact."
+        },
+        "summary_digest": {
+          "$ref": "#/$defs/sha256_digest",
+          "description": "SHA-256 digest of this summary artifact, if computed externally."
+        }
+      }
+    },
+    "signing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "identity"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "sigstore-keyless",
+            "sigstore-kms",
+            "github-attestation",
+            "kms",
+            "unsigned",
+            "other"
+          ],
+          "description": "Signing or attestation mode for this external summary."
+        },
+        "identity": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Signer identity, workflow identity, KMS identity, or explicit unsigned identity marker."
+        },
+        "bundle_path": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Path or URI to signature / attestation bundle, if applicable."
+        },
+        "verified": {
+          "type": "boolean",
+          "description": "Whether signature / attestation verification has succeeded before release-decision fold-in."
+        }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "passed"
+      ],
+      "properties": {
+        "passed": {
+          "type": "boolean",
+          "description": "Aggregate pass/fail result for this external summary."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Optional human-readable reason for aggregate result."
+        },
+        "release_contribution": {
+          "type": "string",
+          "enum": [
+            "required",
+            "advisory",
+            "diagnostic"
+          ],
+          "description": "Declared contribution mode. Required contribution only becomes release authority if promoted by declared PULSE policy."
+        }
+      }
+    },
+    "authority_boundary": {
+      "type": "string",
+      "const": "This external summary does not define release authority. It is recorded evidence that may be folded into status.json only after schema, identity, signer, and policy validation.",
+      "description": "Authority-boundary statement."
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Optional non-normative extension fields for tool-specific metadata.",
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "sha256_digest": {
+      "type": "string",
+      "pattern": "^[a-fA-F0-9]{64}$",
+      "description": "Hex-encoded SHA-256 digest."
+    }
+  }
+}

--- a/PULSE_safe_pack_v0/tools/adapters/llamaguard_ingest.py
+++ b/PULSE_safe_pack_v0/tools/adapters/llamaguard_ingest.py
@@ -1,31 +1,1357 @@
 #!/usr/bin/env python3
-"""
-Ingest Llama Guard classifications and summarize violation rate.
-Input JSONL: each line -> {"input": "...", "output": "...", "llamaguard": {"label":"safe|unsafe", "categories":["HATE","VIOLENCE",...]}}
-Usage:
-  python tools/adapters/llamaguard_ingest.py --in path/to/lg.jsonl --out PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.json
-"""
-import json, argparse
-ap = argparse.ArgumentParser()
-ap.add_argument('--in', dest='inp', required=True)
-ap.add_argument('--out', required=True)
-a = ap.parse_args()
+"""Build a current-run canonical LlamaGuard external summary.
 
-n=0; unsafe=0; cats={}
-with open(a.inp, encoding='utf-8') as f:
-    for line in f:
-        line=line.strip()
-        if not line: continue
-        n += 1
-        obj = json.loads(line)
-        lg = (obj.get('llamaguard') or {})
-        label = (lg.get('label') or '').lower()
-        if label=='unsafe':
-            unsafe += 1
-            for c in lg.get('categories') or []:
-                cats[c] = cats.get(c,0)+1
+Input:
 
-rate = (unsafe/n) if n else 0.0
-summary = {"tool":"llamaguard","n":n,"unsafe":unsafe,"violation_rate":rate,"by_category":cats}
-open(a.out,'w',encoding='utf-8').write(json.dumps(summary,indent=2))
-print("Wrote", a.out)
+    PULSE_safe_pack_v0/artifacts/external/llamaguard_raw.jsonl
+
+Each non-empty JSONL record must contain:
+
+    {
+      "input": "...",
+      "output": "...",
+      "llamaguard": {
+        "label": "safe" | "unsafe",
+        "categories": ["..."]
+      }
+    }
+
+Output:
+
+    PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.json
+
+The produced artifact conforms to external_summary_v1 and remains
+non-authoritative. It does not create an attestation, materialize gates,
+modify status.json, or replace check_gates.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import math
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+TOOL_NAME = "llamaguard"
+ADAPTER_NAME = "llamaguard_ingest"
+ADAPTER_VERSION = "1.0.0"
+
+SUMMARY_SCHEMA_VERSION = "external_summary_v1"
+SUMMARY_SCHEMA_REL = "schemas/external_summary_v1.schema.json"
+THRESHOLDS_REL = (
+    "PULSE_safe_pack_v0/profiles/external_thresholds.yaml"
+)
+THRESHOLD_KEY = "llamaguard_violation_rate_max"
+
+EXTERNAL_DIR_REL = "PULSE_safe_pack_v0/artifacts/external"
+RAW_REL = f"{EXTERNAL_DIR_REL}/llamaguard_raw.jsonl"
+SUMMARY_REL = f"{EXTERNAL_DIR_REL}/llamaguard_summary.json"
+
+AUTHORITY_BOUNDARY = (
+    "This external summary does not define release authority. "
+    "It is recorded evidence that may be folded into status.json "
+    "only after schema, identity, signer, and policy validation."
+)
+
+GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)
+SIGNER_IDENTITY_RE = re.compile(
+    r"^repo:"
+    r"(?P<repository>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)"
+    r":workflow:"
+    r"(?P<workflow>[A-Za-z0-9_.\-/]+\.ya?ml)$"
+)
+
+WILDCARD_TOKENS = ("*", "?", "[", "]")
+
+STALE_OUTPUTS = (
+    "llamaguard_summary.json",
+    "llamaguard_summary.jsonl",
+    "llamaguard_summary.envelope.json",
+    "llamaguard_summary.bundle.json",
+    "llamaguard_summary.attestation.json",
+    "llamaguard_attestation_verifier_v1.json",
+)
+
+
+class ProducerError(ValueError):
+    """Fail-closed producer error."""
+
+
+class UniqueYamlLoader(yaml.SafeLoader):
+    """YAML loader that rejects duplicate mapping keys."""
+
+
+def _yaml_mapping(
+    loader: UniqueYamlLoader,
+    node: Any,
+    deep: bool = False,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+
+    for key_node, value_node in node.value:
+        key = loader.construct_object(
+            key_node,
+            deep=deep,
+        )
+
+        if key in result:
+            raise ProducerError(
+                f"duplicate YAML key {key!r}"
+            )
+
+        result[key] = loader.construct_object(
+            value_node,
+            deep=deep,
+        )
+
+    return result
+
+
+UniqueYamlLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _yaml_mapping,
+)
+
+
+def _json_object(
+    pairs: list[tuple[str, Any]],
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+
+    for key, value in pairs:
+        if key in result:
+            raise ProducerError(
+                f"duplicate JSON key {key!r}"
+            )
+
+        result[key] = value
+
+    return result
+
+
+def _reject_nonfinite(value: str) -> None:
+    raise ProducerError(
+        f"non-finite JSON constant {value!r}"
+    )
+
+
+def _require_text(
+    value: Any,
+    label: str,
+) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ProducerError(
+            f"{label} must be a non-empty string"
+        )
+
+    return value.strip()
+
+
+def _resolve(
+    repo_root: Path,
+    supplied: Path,
+) -> Path:
+    if supplied.is_absolute():
+        return supplied.resolve()
+
+    return (repo_root / supplied).resolve()
+
+
+def _require_inside(
+    path: Path,
+    parent: Path,
+    label: str,
+) -> None:
+    try:
+        path.resolve().relative_to(
+            parent.resolve()
+        )
+
+    except ValueError as exc:
+        raise ProducerError(
+            f"{label} must remain inside {parent}"
+        ) from exc
+
+
+def _require_regular_file(
+    path: Path,
+    label: str,
+) -> None:
+    if path.is_symlink() or not path.is_file():
+        raise ProducerError(
+            f"{label} must be a regular non-symlink file: "
+            f"{path}"
+        )
+
+
+def _require_canonical_path(
+    actual: Path,
+    expected: Path,
+    label: str,
+) -> None:
+    if actual.resolve() != expected.resolve():
+        raise ProducerError(
+            f"{label} must use canonical path "
+            f"{expected}"
+        )
+
+
+def _repo_relative(
+    repo_root: Path,
+    path: Path,
+) -> str:
+    try:
+        return (
+            path.resolve()
+            .relative_to(repo_root.resolve())
+            .as_posix()
+        )
+
+    except ValueError as exc:
+        raise ProducerError(
+            f"path escapes repository root: {path}"
+        ) from exc
+
+
+def _sha256_file(path: Path) -> str:
+    _require_regular_file(
+        path,
+        f"SHA-256 input {path}",
+    )
+
+    digest = hashlib.sha256()
+
+    with path.open("rb") as handle:
+        for chunk in iter(
+            lambda: handle.read(65536),
+            b"",
+        ):
+            digest.update(chunk)
+
+    return digest.hexdigest()
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_json(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+    return _sha256_bytes(encoded)
+
+
+def _load_json_object(
+    path: Path,
+    label: str,
+) -> dict[str, Any]:
+    _require_regular_file(path, label)
+
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_json_object,
+            parse_constant=_reject_nonfinite,
+        )
+
+    except ProducerError:
+        raise
+
+    except Exception as exc:
+        raise ProducerError(
+            f"{label} is not valid JSON: {exc}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise ProducerError(
+            f"{label} must be a JSON object"
+        )
+
+    return payload
+
+
+def _load_yaml_mapping(
+    path: Path,
+    label: str,
+) -> dict[str, Any]:
+    _require_regular_file(path, label)
+
+    try:
+        payload = yaml.load(
+            path.read_text(encoding="utf-8"),
+            Loader=UniqueYamlLoader,
+        )
+
+    except ProducerError:
+        raise
+
+    except Exception as exc:
+        raise ProducerError(
+            f"{label} is not valid YAML: {exc}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise ProducerError(
+            f"{label} must be a YAML mapping"
+        )
+
+    return payload
+
+
+def _normalize_generated_at(value: Any) -> str:
+    text = _require_text(
+        value,
+        "generated_at",
+    )
+
+    parse_value = (
+        text[:-1] + "+00:00"
+        if text.endswith("Z")
+        else text
+    )
+
+    try:
+        timestamp = dt.datetime.fromisoformat(
+            parse_value
+        )
+
+    except ValueError as exc:
+        raise ProducerError(
+            "generated_at must be an ISO-8601 "
+            "date-time"
+        ) from exc
+
+    if timestamp.tzinfo is None:
+        raise ProducerError(
+            "generated_at must include a timezone"
+        )
+
+    normalized = timestamp.astimezone(
+        dt.timezone.utc
+    ).replace(microsecond=0)
+
+    return (
+        normalized.isoformat(
+            timespec="seconds"
+        )
+        .replace("+00:00", "Z")
+    )
+
+
+def _validate_repository(value: Any) -> str:
+    repository = _require_text(
+        value,
+        "repository",
+    )
+
+    parts = repository.split("/")
+
+    if (
+        len(parts) != 2
+        or not all(parts)
+        or any(
+            not re.fullmatch(
+                r"[A-Za-z0-9_.-]+",
+                part,
+            )
+            for part in parts
+        )
+    ):
+        raise ProducerError(
+            "repository must use '<owner>/<repo>' form"
+        )
+
+    return repository
+
+
+def _validate_git_sha(value: Any) -> str:
+    git_sha = _require_text(
+        value,
+        "git_sha",
+    ).lower()
+
+    if not GIT_SHA_RE.fullmatch(git_sha):
+        raise ProducerError(
+            "git_sha must be a concrete 40-hex SHA"
+        )
+
+    return git_sha
+
+
+def _validate_signer_identity(
+    value: Any,
+    repository: str,
+) -> str:
+    identity = _require_text(
+        value,
+        "signer_identity",
+    )
+
+    if any(
+        token in identity
+        for token in WILDCARD_TOKENS
+    ):
+        raise ProducerError(
+            "signer_identity must be exact and "
+            "must not contain wildcards"
+        )
+
+    match = SIGNER_IDENTITY_RE.fullmatch(
+        identity
+    )
+
+    if match is None:
+        raise ProducerError(
+            "signer_identity must use "
+            "'repo:<owner>/<repo>:workflow:"
+            "<exact-workflow-path>.yml' form"
+        )
+
+    if match.group("repository") != repository:
+        raise ProducerError(
+            "signer_identity repository must match "
+            "the declared repository"
+        )
+
+    workflow = match.group("workflow")
+
+    if not workflow.startswith(
+        ".github/workflows/"
+    ):
+        raise ProducerError(
+            "signer_identity workflow must use an "
+            "exact .github/workflows/*.yml path"
+        )
+
+    workflow_path = Path(workflow)
+
+    if (
+        workflow_path.is_absolute()
+        or ".." in workflow_path.parts
+    ):
+        raise ProducerError(
+            "signer workflow path is unsafe"
+        )
+
+    return identity
+
+
+def _load_threshold(
+    thresholds_path: Path,
+) -> float:
+    payload = _load_yaml_mapping(
+        thresholds_path,
+        "external threshold policy",
+    )
+
+    value = payload.get(THRESHOLD_KEY)
+
+    if isinstance(value, bool):
+        raise ProducerError(
+            f"{THRESHOLD_KEY} must be numeric"
+        )
+
+    try:
+        threshold = float(value)
+
+    except (TypeError, ValueError) as exc:
+        raise ProducerError(
+            f"{THRESHOLD_KEY} must be numeric"
+        ) from exc
+
+    if not math.isfinite(threshold):
+        raise ProducerError(
+            f"{THRESHOLD_KEY} must be finite"
+        )
+
+    if threshold < 0.0 or threshold > 1.0:
+        raise ProducerError(
+            f"{THRESHOLD_KEY} must be between 0 and 1"
+        )
+
+    return threshold
+
+
+def _read_llamaguard_jsonl(
+    path: Path,
+) -> tuple[int, int, dict[str, int]]:
+    _require_regular_file(
+        path,
+        "LlamaGuard raw evidence",
+    )
+
+    total = 0
+    unsafe = 0
+    category_counts: dict[str, int] = {}
+
+    try:
+        handle = path.open(
+            "r",
+            encoding="utf-8",
+            errors="strict",
+        )
+
+    except OSError as exc:
+        raise ProducerError(
+            f"could not open LlamaGuard raw evidence: "
+            f"{exc}"
+        ) from exc
+
+    with handle:
+        for line_number, raw_line in enumerate(
+            handle,
+            start=1,
+        ):
+            text = raw_line.strip()
+
+            if not text:
+                continue
+
+            try:
+                record = json.loads(
+                    text,
+                    object_pairs_hook=_json_object,
+                    parse_constant=_reject_nonfinite,
+                )
+
+            except ProducerError as exc:
+                raise ProducerError(
+                    f"LlamaGuard raw evidence line "
+                    f"{line_number}: {exc}"
+                ) from exc
+
+            except Exception as exc:
+                raise ProducerError(
+                    f"LlamaGuard raw evidence line "
+                    f"{line_number} is not valid JSON: "
+                    f"{exc}"
+                ) from exc
+
+            if not isinstance(record, dict):
+                raise ProducerError(
+                    f"LlamaGuard raw evidence line "
+                    f"{line_number} must be an object"
+                )
+
+            if not isinstance(
+                record.get("input"),
+                str,
+            ):
+                raise ProducerError(
+                    f"LlamaGuard raw evidence line "
+                    f"{line_number}.input must be a string"
+                )
+
+            if not isinstance(
+                record.get("output"),
+                str,
+            ):
+                raise ProducerError(
+                    f"LlamaGuard raw evidence line "
+                    f"{line_number}.output must be a string"
+                )
+
+            classification = record.get(
+                "llamaguard"
+            )
+
+            if not isinstance(
+                classification,
+                dict,
+            ):
+                raise ProducerError(
+                    f"LlamaGuard raw evidence line "
+                    f"{line_number}.llamaguard "
+                    "must be an object"
+                )
+
+            label_raw = classification.get(
+                "label"
+            )
+
+            if not isinstance(label_raw, str):
+                raise ProducerError(
+                    f"LlamaGuard raw evidence line "
+                    f"{line_number}.llamaguard.label "
+                    "must be a string"
+                )
+
+            label = label_raw.strip().lower()
+
+            if label not in {"safe", "unsafe"}:
+                raise ProducerError(
+                    f"LlamaGuard raw evidence line "
+                    f"{line_number}.llamaguard.label "
+                    "must be 'safe' or 'unsafe'"
+                )
+
+            categories_raw = classification.get(
+                "categories",
+                [],
+            )
+
+            if not isinstance(
+                categories_raw,
+                list,
+            ):
+                raise ProducerError(
+                    f"LlamaGuard raw evidence line "
+                    f"{line_number}.llamaguard."
+                    "categories must be an array"
+                )
+
+            categories: set[str] = set()
+
+            for category_raw in categories_raw:
+                if (
+                    not isinstance(
+                        category_raw,
+                        str,
+                    )
+                    or not category_raw.strip()
+                ):
+                    raise ProducerError(
+                        f"LlamaGuard raw evidence line "
+                        f"{line_number}.llamaguard."
+                        "categories entries must be "
+                        "non-empty strings"
+                    )
+
+                categories.add(
+                    category_raw.strip()
+                )
+
+            total += 1
+
+            if label == "unsafe":
+                unsafe += 1
+
+                for category in categories:
+                    category_counts[category] = (
+                        category_counts.get(
+                            category,
+                            0,
+                        )
+                        + 1
+                    )
+
+    if total == 0:
+        raise ProducerError(
+            "LlamaGuard raw evidence must contain "
+            "at least one classification"
+        )
+
+    return total, unsafe, category_counts
+
+
+def _clear_stale_outputs(
+    external_dir: Path,
+) -> None:
+    external_dir.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    for filename in STALE_OUTPUTS:
+        path = external_dir / filename
+
+        if not path.exists() and not path.is_symlink():
+            continue
+
+        if path.is_dir() and not path.is_symlink():
+            raise ProducerError(
+                f"stale output path is a directory: "
+                f"{path}"
+            )
+
+        path.unlink()
+
+    for temp_path in external_dir.glob(
+        ".llamaguard_summary.*.tmp"
+    ):
+        if temp_path.is_dir() and not temp_path.is_symlink():
+            raise ProducerError(
+                f"temporary output path is a directory: "
+                f"{temp_path}"
+            )
+
+        temp_path.unlink()
+
+
+def _validate_summary_schema(
+    summary: dict[str, Any],
+    schema_path: Path,
+) -> None:
+    schema = _load_json_object(
+        schema_path,
+        "external summary schema",
+    )
+
+    try:
+        Draft202012Validator.check_schema(
+            schema
+        )
+
+    except Exception as exc:
+        raise ProducerError(
+            f"external summary schema is invalid: "
+            f"{exc}"
+        ) from exc
+
+    validator = Draft202012Validator(
+        schema,
+        format_checker=FormatChecker(),
+    )
+
+    errors = sorted(
+        validator.iter_errors(summary),
+        key=lambda item: list(
+            item.absolute_path
+        ),
+    )
+
+    if not errors:
+        return
+
+    formatted: list[str] = []
+
+    for error in errors:
+        location = ".".join(
+            str(part)
+            for part in error.absolute_path
+        )
+
+        formatted.append(
+            (
+                f"{location}: "
+                if location
+                else ""
+            )
+            + error.message
+        )
+
+    raise ProducerError(
+        "generated external summary failed schema "
+        "validation:\n - "
+        + "\n - ".join(formatted)
+    )
+
+
+def _write_json_atomic(
+    path: Path,
+    payload: dict[str, Any],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    descriptor, temp_name = tempfile.mkstemp(
+        prefix=".llamaguard_summary.",
+        suffix=".tmp",
+        dir=str(path.parent),
+        text=True,
+    )
+
+    temp_path = Path(temp_name)
+
+    try:
+        with os.fdopen(
+            descriptor,
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            json.dump(
+                payload,
+                handle,
+                indent=2,
+                sort_keys=True,
+                ensure_ascii=False,
+                allow_nan=False,
+            )
+
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        os.replace(
+            temp_path,
+            path,
+        )
+
+    except Exception:
+        if temp_path.exists():
+            temp_path.unlink()
+
+        raise
+
+
+def _build_summary(
+    *,
+    repo_root: Path,
+    raw_path: Path,
+    dataset_path: Path,
+    evaluator_manifest_path: Path | None,
+    schema_path: Path,
+    thresholds_path: Path,
+    run_id: str,
+    generated_at: str,
+    release_candidate: str,
+    git_sha: str,
+    repository: str,
+    signer_identity: str,
+    tool_version: str,
+    adapter_version: str,
+) -> dict[str, Any]:
+    total, unsafe, category_counts = (
+        _read_llamaguard_jsonl(
+            raw_path
+        )
+    )
+
+    threshold = _load_threshold(
+        thresholds_path
+    )
+
+    violation_rate = unsafe / total
+    passed = violation_rate <= threshold
+
+    raw_sha = _sha256_file(raw_path)
+    dataset_sha = _sha256_file(dataset_path)
+    adapter_path = Path(__file__).resolve()
+    adapter_sha = _sha256_file(adapter_path)
+
+    evaluator_manifest_sha: str | None = None
+    evaluator_source: str
+
+    if evaluator_manifest_path is not None:
+        evaluator_manifest_sha = _sha256_file(
+            evaluator_manifest_path
+        )
+        evaluator_source = _repo_relative(
+            repo_root,
+            evaluator_manifest_path,
+        )
+
+    else:
+        evaluator_source = _repo_relative(
+            repo_root,
+            adapter_path,
+        )
+
+    evaluator_digest = _sha256_json(
+        {
+            "tool": TOOL_NAME,
+            "tool_version": tool_version,
+            "adapter": ADAPTER_NAME,
+            "adapter_version": adapter_version,
+            "adapter_sha256": adapter_sha,
+            "evaluator_manifest_sha256": (
+                evaluator_manifest_sha
+            ),
+        }
+    )
+
+    subject_digest = _sha256_bytes(
+        git_sha.encode("utf-8")
+    )
+
+    run_token = _sha256_bytes(
+        run_id.encode("utf-8")
+    )[:12]
+
+    summary_id = (
+        "pulse_external_llamaguard_"
+        f"{git_sha[:12]}_"
+        f"{run_token}_"
+        f"{raw_sha[:12]}"
+    )
+
+    raw_relative = _repo_relative(
+        repo_root,
+        raw_path,
+    )
+
+    dataset_relative = _repo_relative(
+        repo_root,
+        dataset_path,
+    )
+
+    reason = (
+        "LlamaGuard violation rate "
+        f"{violation_rate:.12g} "
+        f"{'<=' if passed else '>'} "
+        f"canonical threshold {threshold:.12g}."
+    )
+
+    summary: dict[str, Any] = {
+        "schema_version": (
+            SUMMARY_SCHEMA_VERSION
+        ),
+        "summary_id": summary_id,
+        "tool": {
+            "name": TOOL_NAME,
+            "version": tool_version,
+            "adapter": ADAPTER_NAME,
+            "adapter_version": adapter_version,
+        },
+        "run": {
+            "run_id": run_id,
+            "generated_at": generated_at,
+            "dataset_digest": dataset_sha,
+            "evaluator_digest": evaluator_digest,
+            "model_id": release_candidate,
+        },
+        "subject": {
+            "kind": "release_candidate",
+            "id": release_candidate,
+            "digest_algorithm": "sha256",
+            "digest": subject_digest,
+        },
+        "metrics": [
+            {
+                "key": (
+                    "llamaguard_violation_rate"
+                ),
+                "value": violation_rate,
+                "unit": "rate",
+                "threshold": threshold,
+                "comparator": "lte",
+                "passed": passed,
+                "severity": "critical",
+                "notes": (
+                    f"{unsafe} unsafe classification(s) "
+                    f"across {total} current-run "
+                    "LlamaGuard record(s)."
+                ),
+            }
+        ],
+        "threshold_ref": {
+            "key": THRESHOLD_KEY,
+            "version": "v0",
+            "uri": THRESHOLDS_REL,
+        },
+        "evidence": {
+            "raw_artifact_uri": raw_relative,
+            "raw_artifact_digest": raw_sha,
+        },
+        "signing": {
+            "mode": "github-attestation",
+            "identity": signer_identity,
+        },
+        "result": {
+            "passed": passed,
+            "reason": reason,
+            "release_contribution": "required",
+        },
+        "authority_boundary": (
+            AUTHORITY_BOUNDARY
+        ),
+        "extensions": {
+            "repository": repository,
+            "source_commit": git_sha,
+            "dataset_path": dataset_relative,
+            "evaluator_source": evaluator_source,
+            "adapter_sha256": adapter_sha,
+            "classification_counts": {
+                "total": total,
+                "safe": total - unsafe,
+                "unsafe": unsafe,
+                "by_category": dict(
+                    sorted(
+                        category_counts.items()
+                    )
+                ),
+            },
+            "producer_boundary": {
+                "creates_release_authority": False,
+                "materializes_status": False,
+                "materializes_release_required": False,
+                "creates_attestation": False,
+                "replaces_check_gates": False,
+            },
+        },
+    }
+
+    _validate_summary_schema(
+        summary,
+        schema_path,
+    )
+
+    return summary
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build a canonical current-run "
+            "LlamaGuard external_summary_v1 "
+            "artifact."
+        )
+    )
+
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root.",
+    )
+    parser.add_argument(
+        "--in",
+        dest="raw_input",
+        default=RAW_REL,
+        help=(
+            "Canonical current-run LlamaGuard "
+            "JSONL evidence."
+        ),
+    )
+    parser.add_argument(
+        "--dataset",
+        default=None,
+        help=(
+            "Dataset or prompt-set file. "
+            "Defaults to the raw evidence file."
+        ),
+    )
+    parser.add_argument(
+        "--evaluator-manifest",
+        default=None,
+        help=(
+            "Optional evaluator configuration or "
+            "manifest file included in evaluator "
+            "digest derivation."
+        ),
+    )
+    parser.add_argument(
+        "--out",
+        default=SUMMARY_REL,
+        help="Canonical output summary path.",
+    )
+    parser.add_argument(
+        "--schema",
+        default=SUMMARY_SCHEMA_REL,
+        help="Canonical external summary schema.",
+    )
+    parser.add_argument(
+        "--thresholds",
+        default=THRESHOLDS_REL,
+        help="Canonical external threshold policy.",
+    )
+    parser.add_argument(
+        "--run-id",
+        default=os.getenv("PULSE_RUN_KEY"),
+        help="Current PULSE run key.",
+    )
+    parser.add_argument(
+        "--generated-at",
+        default=os.getenv("PULSE_CREATED_UTC"),
+        help="Current-run UTC date-time.",
+    )
+    parser.add_argument(
+        "--release-candidate",
+        default=os.getenv(
+            "PULSE_RELEASE_CANDIDATE"
+        ),
+        help="Current release-candidate identity.",
+    )
+    parser.add_argument(
+        "--git-sha",
+        default=os.getenv("GITHUB_SHA"),
+        help="Current concrete 40-hex commit SHA.",
+    )
+    parser.add_argument(
+        "--repository",
+        default=os.getenv("GITHUB_REPOSITORY"),
+        help="Current repository in owner/name form.",
+    )
+    parser.add_argument(
+        "--signer-identity",
+        default=os.getenv(
+            "PULSE_EXTERNAL_SIGNER_IDENTITY"
+        ),
+        help=(
+            "Exact GitHub workflow signer identity."
+        ),
+    )
+    parser.add_argument(
+        "--tool-version",
+        default=os.getenv(
+            "LLAMAGUARD_VERSION"
+        ),
+        help="Concrete LlamaGuard version.",
+    )
+    parser.add_argument(
+        "--adapter-version",
+        default=ADAPTER_VERSION,
+        help="Adapter version.",
+    )
+
+    return parser
+
+
+def main(
+    argv: list[str] | None = None,
+) -> int:
+    args = _parser().parse_args(argv)
+
+    try:
+        repo_root = Path(
+            args.repo_root
+        ).resolve()
+
+        if not repo_root.is_dir():
+            raise ProducerError(
+                f"repository root is not a directory: "
+                f"{repo_root}"
+            )
+
+        external_dir = (
+            repo_root / EXTERNAL_DIR_REL
+        ).resolve()
+
+        output_path = _resolve(
+            repo_root,
+            Path(args.out),
+        )
+
+        canonical_output = (
+            repo_root / SUMMARY_REL
+        ).resolve()
+
+        _require_canonical_path(
+            output_path,
+            canonical_output,
+            "output summary",
+        )
+
+        _require_inside(
+            output_path,
+            repo_root,
+            "output summary",
+        )
+
+        # Clear stale generated evidence before any
+        # current-run summary admission attempt.
+        _clear_stale_outputs(
+            external_dir
+        )
+
+        raw_path = _resolve(
+            repo_root,
+            Path(args.raw_input),
+        )
+
+        canonical_raw = (
+            repo_root / RAW_REL
+        ).resolve()
+
+        _require_canonical_path(
+            raw_path,
+            canonical_raw,
+            "LlamaGuard raw evidence",
+        )
+
+        _require_inside(
+            raw_path,
+            external_dir,
+            "LlamaGuard raw evidence",
+        )
+
+        _require_regular_file(
+            raw_path,
+            "LlamaGuard raw evidence",
+        )
+
+        dataset_path = (
+            raw_path
+            if args.dataset is None
+            else _resolve(
+                repo_root,
+                Path(args.dataset),
+            )
+        )
+
+        _require_inside(
+            dataset_path,
+            repo_root,
+            "dataset",
+        )
+
+        _require_regular_file(
+            dataset_path,
+            "dataset",
+        )
+
+        evaluator_manifest_path: Path | None = None
+
+        if args.evaluator_manifest is not None:
+            evaluator_manifest_path = _resolve(
+                repo_root,
+                Path(args.evaluator_manifest),
+            )
+
+            _require_inside(
+                evaluator_manifest_path,
+                repo_root,
+                "evaluator manifest",
+            )
+
+            _require_regular_file(
+                evaluator_manifest_path,
+                "evaluator manifest",
+            )
+
+        schema_path = _resolve(
+            repo_root,
+            Path(args.schema),
+        )
+
+        _require_canonical_path(
+            schema_path,
+            (
+                repo_root
+                / SUMMARY_SCHEMA_REL
+            ).resolve(),
+            "external summary schema",
+        )
+
+        thresholds_path = _resolve(
+            repo_root,
+            Path(args.thresholds),
+        )
+
+        _require_canonical_path(
+            thresholds_path,
+            (
+                repo_root
+                / THRESHOLDS_REL
+            ).resolve(),
+            "external threshold policy",
+        )
+
+        run_id = _require_text(
+            args.run_id,
+            "run_id",
+        )
+
+        generated_at = (
+            _normalize_generated_at(
+                args.generated_at
+            )
+        )
+
+        release_candidate = _require_text(
+            args.release_candidate,
+            "release_candidate",
+        )
+
+        git_sha = _validate_git_sha(
+            args.git_sha
+        )
+
+        repository = _validate_repository(
+            args.repository
+        )
+
+        signer_identity = (
+            _validate_signer_identity(
+                args.signer_identity,
+                repository,
+            )
+        )
+
+        tool_version = _require_text(
+            args.tool_version,
+            "tool_version",
+        )
+
+        adapter_version = _require_text(
+            args.adapter_version,
+            "adapter_version",
+        )
+
+        summary = _build_summary(
+            repo_root=repo_root,
+            raw_path=raw_path,
+            dataset_path=dataset_path,
+            evaluator_manifest_path=(
+                evaluator_manifest_path
+            ),
+            schema_path=schema_path,
+            thresholds_path=thresholds_path,
+            run_id=run_id,
+            generated_at=generated_at,
+            release_candidate=(
+                release_candidate
+            ),
+            git_sha=git_sha,
+            repository=repository,
+            signer_identity=signer_identity,
+            tool_version=tool_version,
+            adapter_version=adapter_version,
+        )
+
+        _write_json_atomic(
+            output_path,
+            summary,
+        )
+
+    except ProducerError as exc:
+        print(
+            f"ERROR: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"ERROR: unexpected producer failure: "
+            f"{exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    metric = summary["metrics"][0]
+    passed = summary["result"]["passed"]
+
+    print(
+        "OK: canonical LlamaGuard external summary "
+        f"written to {output_path}"
+    )
+    print(
+        "LlamaGuard current-run result: "
+        f"value={metric['value']} "
+        f"threshold={metric['threshold']} "
+        f"passed={passed}"
+    )
+
+    if passed is not True:
+        print(
+            "ERROR: LlamaGuard current-run evidence "
+            "exceeds the canonical threshold",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/PULSE_safe_pack_v0/tools/adapters/llamaguard_ingest.py
+++ b/PULSE_safe_pack_v0/tools/adapters/llamaguard_ingest.py
@@ -48,7 +48,10 @@ ADAPTER_NAME = "llamaguard_ingest"
 ADAPTER_VERSION = "1.0.0"
 
 SUMMARY_SCHEMA_VERSION = "external_summary_v1"
-SUMMARY_SCHEMA_REL = "schemas/external_summary_v1.schema.json"
+SUMMARY_SCHEMA_REL = (
+    "PULSE_safe_pack_v0/schemas/"
+    "external_summary_v1.schema.json"
+)
 THRESHOLDS_REL = (
     "PULSE_safe_pack_v0/profiles/external_thresholds.yaml"
 )
@@ -65,14 +68,12 @@ AUTHORITY_BOUNDARY = (
 )
 
 GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
-SHA256_RE = re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)
 SIGNER_IDENTITY_RE = re.compile(
     r"^repo:"
     r"(?P<repository>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)"
     r":workflow:"
     r"(?P<workflow>[A-Za-z0-9_.\-/]+\.ya?ml)$"
 )
-
 WILDCARD_TOKENS = ("*", "?", "[", "]")
 
 STALE_OUTPUTS = (
@@ -147,6 +148,56 @@ def _reject_nonfinite(value: str) -> None:
     )
 
 
+def _require_finite_json_tree(
+    value: Any,
+    label: str,
+) -> None:
+    """Reject every non-finite number in a parsed JSON tree."""
+
+    if (
+        value is None
+        or isinstance(
+            value,
+            (
+                str,
+                bool,
+                int,
+            ),
+        )
+    ):
+        return
+
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ProducerError(
+                f"{label} contains a non-finite number"
+            )
+
+        return
+
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _require_finite_json_tree(
+                item,
+                f"{label}[{index}]",
+            )
+
+        return
+
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _require_finite_json_tree(
+                item,
+                f"{label}.{key}",
+            )
+
+        return
+
+    raise ProducerError(
+        f"{label} contains an unsupported JSON value"
+    )
+
+
 def _require_text(
     value: Any,
     label: str,
@@ -163,10 +214,15 @@ def _resolve(
     repo_root: Path,
     supplied: Path,
 ) -> Path:
-    if supplied.is_absolute():
-        return supplied.resolve()
+    """Return a lexical absolute path without following symlinks."""
 
-    return (repo_root / supplied).resolve()
+    candidate = (
+        supplied
+        if supplied.is_absolute()
+        else repo_root / supplied
+    )
+
+    return Path(os.path.abspath(candidate))
 
 
 def _require_inside(
@@ -201,7 +257,10 @@ def _require_canonical_path(
     expected: Path,
     label: str,
 ) -> None:
-    if actual.resolve() != expected.resolve():
+    if (
+        Path(os.path.abspath(actual))
+        != Path(os.path.abspath(expected))
+    ):
         raise ProducerError(
             f"{label} must use canonical path "
             f"{expected}"
@@ -284,6 +343,11 @@ def _load_json_object(
         raise ProducerError(
             f"{label} must be a JSON object"
         )
+
+    _require_finite_json_tree(
+        payload,
+        label,
+    )
 
     return payload
 
@@ -550,6 +614,14 @@ def _read_llamaguard_jsonl(
                     f"LlamaGuard raw evidence line "
                     f"{line_number} must be an object"
                 )
+
+            _require_finite_json_tree(
+                record,
+                (
+                    "LlamaGuard raw evidence line "
+                    f"{line_number}"
+                ),
+            )
 
             if not isinstance(
                 record.get("input"),
@@ -1047,7 +1119,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--schema",
         default=SUMMARY_SCHEMA_REL,
-        help="Canonical external summary schema.",
+        help="Bundled canonical external summary schema.",
     )
     parser.add_argument(
         "--thresholds",

--- a/PULSE_safe_pack_v0/tools/augment_status.py
+++ b/PULSE_safe_pack_v0/tools/augment_status.py
@@ -1,30 +1,17 @@
 #!/usr/bin/env python3
-"""
-Augment the baseline status.json with derived signals and summaries.
+"""Augment baseline status.json with derived evidence summaries.
 
-This script takes the core PULSE status artefact (gate results + metrics),
-as written by run_all.py, and enriches it with:
+The tool folds refusal-delta and external-detector evidence into status.json.
+It remains a materialization helper, not a second release-decision engine.
+Release authority remains declared-policy enforcement over materialized state.
 
-- refusal-delta summary (if present),
-- refusal-delta evidence-presence state,
-- external detector summaries (when configured),
+External summaries may use either:
 
-and then wires these into:
+- legacy top-level metric keys, or
+- canonical external_summary_v1 metrics[] entries.
 
-- gates.refusal_delta_pass
-- gates.refusal_delta_evidence_present
-- gates.external_all_pass
-- external.metrics / external.all_pass
-
-The resulting extended status.json is consumed by check_gates.py
-and reporting tooling. It does not create a second decision engine:
-release authority remains declared-policy gate enforcement over the
-materialized status artefact.
-
-Optional strict mode:
-- when --require_external_summaries is enabled, missing external summaries
-  make external_all_pass fail closed
-- default behavior remains onboarding-friendly unless that flag is used
+When --require_external_summaries is enabled, absence of a successfully folded
+canonical detector summary makes external_all_pass fail closed.
 """
 
 from __future__ import annotations
@@ -33,210 +20,12 @@ import argparse
 import glob
 import hashlib
 import json
+import math
 import os
 from typing import Any, Dict, Optional
 
 import yaml
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def jload(path: str) -> Optional[Dict[str, Any]]:
-    """Best-effort JSON loader: returns dict or None on failure."""
-    try:
-        with open(path, encoding="utf-8") as f:
-            obj = json.load(f)
-        return obj if isinstance(obj, dict) else None
-    except Exception:
-        return None
-
-
-def jload_with_raw_bytes(path: str) -> tuple[Optional[Dict[str, Any]], Optional[bytes]]:
-    """Best-effort JSON loader returning (dict, raw_bytes) or (None, None) on failure."""
-    try:
-        raw = open(path, "rb").read()
-        obj = json.loads(raw)
-        return (obj, raw) if isinstance(obj, dict) else (None, None)
-    except Exception:
-        return None, None
-
-
-def jload_json_or_jsonl(path: str) -> Optional[Dict[str, Any]]:
-    """
-    Best-effort loader for either:
-      - JSON file containing a single object, or
-      - JSONL file where each non-empty line is a JSON object.
-
-    Returns the last successfully parsed dict (common JSONL pattern),
-    or None on failure.
-    """
-    try:
-        if path.lower().endswith(".jsonl"):
-            last: Optional[Dict[str, Any]] = None
-            with open(path, encoding="utf-8") as f:
-                for raw in f:
-                    ln = raw.strip()
-                    if not ln:
-                        continue
-                    obj = json.loads(ln)
-                    if isinstance(obj, dict):
-                        last = obj
-            return last
-        return jload(path)
-    except Exception:
-        return None
-
-
-def yload(path: str) -> Optional[Dict[str, Any]]:
-    """Best-effort YAML loader: returns dict or None on failure."""
-    try:
-        with open(path, encoding="utf-8") as f:
-            obj = yaml.safe_load(f)
-        return obj if isinstance(obj, dict) else None
-    except Exception:
-        return None
-
-
-def coerce_float_strict(x: Any, default: float) -> tuple[float, bool]:
-    """
-    Coerce a value to float.
-    Returns (value, ok). ok=False means "present but not parseable".
-
-    Supports simple wrappers (single-value dict/list), which sometimes appear in adapters.
-    """
-    if x is None:
-        return default, False
-
-    if isinstance(x, (int, float)):
-        return float(x), True
-
-    if isinstance(x, str):
-        try:
-            return float(x.strip()), True
-        except Exception:
-            return default, False
-
-    if isinstance(x, dict):
-        # allow a single-value dict wrapper
-        if len(x) == 1:
-            only = next(iter(x.values()))
-            return coerce_float_strict(only, default)
-        return default, False
-
-    if isinstance(x, list):
-        # allow a single-value list wrapper
-        if len(x) == 1:
-            return coerce_float_strict(x[0], default)
-        return default, False
-
-    return default, False
-
-
-def ensure_meta(status: Dict[str, Any]) -> Dict[str, Any]:
-    """Ensure status has a dict-valued meta block and return it."""
-    meta = status.get("meta")
-    if isinstance(meta, dict):
-        return meta
-    status["meta"] = {}
-    return status["meta"]
-
-
-def extract_q1_n_eligible(q1: Dict[str, Any]) -> tuple[Optional[Any], bool]:
-    """
-    Extract the eligible-count source for q1_reference_shadow.n_eligible.
-
-    Accepted source shapes:
-    - top-level n_eligible
-    - canonical top-level n
-    - nested counts.n_eligible
-
-    Returns (value, found).
-    """
-    if "n_eligible" in q1:
-        return q1["n_eligible"], True
-
-    if "n" in q1:
-        return q1["n"], True
-
-    counts = q1.get("counts")
-    if isinstance(counts, dict) and "n_eligible" in counts:
-        return counts["n_eligible"], True
-
-    return None, False
-
-
-def build_q1_reference_shadow_block(
-    q1: Dict[str, Any],
-    *,
-    abs_path: str,
-    raw: bytes,
-) -> Optional[Dict[str, Any]]:
-    """
-    Build the q1_reference_shadow block from a valid source summary.
-
-    Required source fields:
-    - pass
-    - grounded_rate
-    - wilson_lower_bound
-    - threshold
-    - eligible-count source: n_eligible OR canonical n OR counts.n_eligible
-    """
-    required_fields = (
-        "pass",
-        "grounded_rate",
-        "wilson_lower_bound",
-        "threshold",
-    )
-    if any(field not in q1 for field in required_fields):
-        return None
-
-    n_eligible, found_n = extract_q1_n_eligible(q1)
-    if not found_n:
-        return None
-
-    return {
-        "pass": q1["pass"],
-        "grounded_rate": q1["grounded_rate"],
-        "wilson_lower_bound": q1["wilson_lower_bound"],
-        "n_eligible": n_eligible,
-        "threshold": q1["threshold"],
-        "summary_artifact": {
-            "path": abs_path,
-            "sha256": hashlib.sha256(raw).hexdigest(),
-        },
-    }
-
-
-def fold_q1_reference_shadow(status: Dict[str, Any], summary_path: Optional[str]) -> None:
-    """
-    Optionally fold a valid Q1 reference summary into status["meta"]["q1_reference_shadow"].
-
-    Behavior:
-    - if summary_path is None: no-op
-    - if explicitly provided but invalid / missing / incomplete: omit the block
-    - if valid and complete: copy / map fields without recomputation
-    """
-    if summary_path is None:
-        return
-
-    existing_meta = status.get("meta")
-    if isinstance(existing_meta, dict):
-        existing_meta.pop("q1_reference_shadow", None)
-
-    abs_path = os.path.abspath(summary_path)
-    q1, raw = jload_with_raw_bytes(abs_path)
-    if q1 is None or raw is None:
-        return
-
-    shadow = build_q1_reference_shadow_block(q1, abs_path=abs_path, raw=raw)
-    if shadow is None:
-        return
-
-    meta = ensure_meta(status)
-    meta["q1_reference_shadow"] = shadow
 
 CANONICAL_EXTERNAL_SUMMARY_FILENAMES = (
     "llamaguard_summary.json",
@@ -254,51 +43,485 @@ CANONICAL_EXTERNAL_SUMMARY_FILENAMES = (
 )
 
 
-def list_external_summary_files(ext_dir: str) -> list[str]:
-    if not os.path.isdir(ext_dir):
-        return []
-
-    files = sorted(glob.glob(os.path.join(ext_dir, "*_summary.json")))
-    files += sorted(glob.glob(os.path.join(ext_dir, "*_summary.jsonl")))
-    return sorted(files)
+# ---------------------------------------------------------------------------
+# Loaders and scalar helpers
+# ---------------------------------------------------------------------------
 
 
-def list_canonical_external_summary_files(ext_dir: str) -> list[str]:
-    if not os.path.isdir(ext_dir):
-        return []
+def jload(path: str) -> Optional[Dict[str, Any]]:
+    """Best-effort JSON loader: return a dict or None."""
 
-    out: list[str] = []
-    for filename in CANONICAL_EXTERNAL_SUMMARY_FILENAMES:
-        path = os.path.join(ext_dir, filename)
-        if os.path.exists(path):
-            out.append(path)
-    return sorted(out)
+    try:
+        with open(path, encoding="utf-8") as handle:
+            value = json.load(handle)
+
+        return value if isinstance(value, dict) else None
+
+    except Exception:
+        return None
+
+
+def jload_with_raw_bytes(
+    path: str,
+) -> tuple[Optional[Dict[str, Any]], Optional[bytes]]:
+    """Best-effort JSON loader preserving the source bytes."""
+
+    try:
+        raw = open(path, "rb").read()
+        value = json.loads(raw)
+
+        return (
+            (value, raw)
+            if isinstance(value, dict)
+            else (None, None)
+        )
+
+    except Exception:
+        return None, None
+
+
+def jload_json_or_jsonl(
+    path: str,
+) -> Optional[Dict[str, Any]]:
+    """Load one JSON object or the last non-empty JSONL object."""
+
+    try:
+        if path.lower().endswith(".jsonl"):
+            last: Optional[Dict[str, Any]] = None
+
+            with open(path, encoding="utf-8") as handle:
+                for raw in handle:
+                    text = raw.strip()
+
+                    if not text:
+                        continue
+
+                    value = json.loads(text)
+
+                    if isinstance(value, dict):
+                        last = value
+
+            return last
+
+        return jload(path)
+
+    except Exception:
+        return None
+
+
+def yload(path: str) -> Optional[Dict[str, Any]]:
+    """Best-effort YAML loader: return a mapping or None."""
+
+    try:
+        with open(path, encoding="utf-8") as handle:
+            value = yaml.safe_load(handle)
+
+        return value if isinstance(value, dict) else None
+
+    except Exception:
+        return None
+
+
+def coerce_float_strict(
+    value: Any,
+    default: float,
+) -> tuple[float, bool]:
+    """Coerce one scalar to a finite float."""
+
+    if value is None or isinstance(value, bool):
+        return default, False
+
+    if isinstance(value, (int, float)):
+        result = float(value)
+        return (
+            (result, True)
+            if math.isfinite(result)
+            else (default, False)
+        )
+
+    if isinstance(value, str):
+        try:
+            result = float(value.strip())
+        except Exception:
+            return default, False
+
+        return (
+            (result, True)
+            if math.isfinite(result)
+            else (default, False)
+        )
+
+    if isinstance(value, dict) and len(value) == 1:
+        return coerce_float_strict(
+            next(iter(value.values())),
+            default,
+        )
+
+    if isinstance(value, list) and len(value) == 1:
+        return coerce_float_strict(
+            value[0],
+            default,
+        )
+
+    return default, False
 
 
 # ---------------------------------------------------------------------------
-# Main
+# Q1 reader-only shadow projection
+# ---------------------------------------------------------------------------
+
+
+def ensure_meta(
+    status: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Ensure a mapping-valued meta block and return it."""
+
+    meta = status.get("meta")
+
+    if isinstance(meta, dict):
+        return meta
+
+    status["meta"] = {}
+    return status["meta"]
+
+
+def extract_q1_n_eligible(
+    q1: Dict[str, Any],
+) -> tuple[Optional[Any], bool]:
+    """Return the supported Q1 eligible-count source."""
+
+    if "n_eligible" in q1:
+        return q1["n_eligible"], True
+
+    if "n" in q1:
+        return q1["n"], True
+
+    counts = q1.get("counts")
+
+    if (
+        isinstance(counts, dict)
+        and "n_eligible" in counts
+    ):
+        return counts["n_eligible"], True
+
+    return None, False
+
+
+def build_q1_reference_shadow_block(
+    q1: Dict[str, Any],
+    *,
+    abs_path: str,
+    raw: bytes,
+) -> Optional[Dict[str, Any]]:
+    """Build the non-authorizing Q1 reference shadow block."""
+
+    required_fields = (
+        "pass",
+        "grounded_rate",
+        "wilson_lower_bound",
+        "threshold",
+    )
+
+    if any(
+        field not in q1
+        for field in required_fields
+    ):
+        return None
+
+    n_eligible, found_n = extract_q1_n_eligible(q1)
+
+    if not found_n:
+        return None
+
+    return {
+        "pass": q1["pass"],
+        "grounded_rate": q1["grounded_rate"],
+        "wilson_lower_bound": q1[
+            "wilson_lower_bound"
+        ],
+        "n_eligible": n_eligible,
+        "threshold": q1["threshold"],
+        "summary_artifact": {
+            "path": abs_path,
+            "sha256": hashlib.sha256(raw).hexdigest(),
+        },
+    }
+
+
+def fold_q1_reference_shadow(
+    status: Dict[str, Any],
+    summary_path: Optional[str],
+) -> None:
+    """Optionally project Q1 summary state without changing gates."""
+
+    if summary_path is None:
+        return
+
+    existing_meta = status.get("meta")
+
+    if isinstance(existing_meta, dict):
+        existing_meta.pop(
+            "q1_reference_shadow",
+            None,
+        )
+
+    abs_path = os.path.abspath(summary_path)
+    q1, raw = jload_with_raw_bytes(abs_path)
+
+    if q1 is None or raw is None:
+        return
+
+    shadow = build_q1_reference_shadow_block(
+        q1,
+        abs_path=abs_path,
+        raw=raw,
+    )
+
+    if shadow is None:
+        return
+
+    ensure_meta(status)[
+        "q1_reference_shadow"
+    ] = shadow
+
+
+# ---------------------------------------------------------------------------
+# External-summary discovery and canonical metric reading
+# ---------------------------------------------------------------------------
+
+
+def list_external_summary_files(
+    external_dir: str,
+) -> list[str]:
+    if not os.path.isdir(external_dir):
+        return []
+
+    files = sorted(
+        glob.glob(
+            os.path.join(
+                external_dir,
+                "*_summary.json",
+            )
+        )
+    )
+    files += sorted(
+        glob.glob(
+            os.path.join(
+                external_dir,
+                "*_summary.jsonl",
+            )
+        )
+    )
+
+    return sorted(files)
+
+
+def list_canonical_external_summary_files(
+    external_dir: str,
+) -> list[str]:
+    if not os.path.isdir(external_dir):
+        return []
+
+    result: list[str] = []
+
+    for filename in CANONICAL_EXTERNAL_SUMMARY_FILENAMES:
+        path = os.path.join(
+            external_dir,
+            filename,
+        )
+
+        if os.path.exists(path):
+            result.append(path)
+
+    return sorted(result)
+
+
+def extract_external_summary_v1_metric(
+    summary: Dict[str, Any],
+    *,
+    metric_name: str,
+    threshold_key: str,
+    canonical_threshold: float,
+) -> tuple[
+    bool,
+    Any,
+    Optional[bool],
+    Optional[str],
+]:
+    """Read one exact metric from external_summary_v1.
+
+    Returns:
+
+        is_canonical_summary,
+        metric_value,
+        declared_pass,
+        error
+    """
+
+    if (
+        summary.get("schema_version")
+        != "external_summary_v1"
+    ):
+        return False, None, None, None
+
+    metrics = summary.get("metrics")
+
+    if not isinstance(metrics, list):
+        return (
+            True,
+            None,
+            None,
+            "metrics must be an array",
+        )
+
+    matches = [
+        item
+        for item in metrics
+        if (
+            isinstance(item, dict)
+            and item.get("key") == metric_name
+        )
+    ]
+
+    if len(matches) != 1:
+        return (
+            True,
+            None,
+            None,
+            (
+                "canonical metric must occur "
+                "exactly once"
+            ),
+        )
+
+    metric = matches[0]
+
+    if "value" not in metric:
+        return (
+            True,
+            None,
+            None,
+            "canonical metric value is missing",
+        )
+
+    metric_passed = metric.get("passed")
+
+    if not isinstance(metric_passed, bool):
+        return (
+            True,
+            None,
+            None,
+            (
+                "canonical metric passed state "
+                "must be boolean"
+            ),
+        )
+
+    result = summary.get("result")
+
+    if (
+        not isinstance(result, dict)
+        or not isinstance(
+            result.get("passed"),
+            bool,
+        )
+    ):
+        return (
+            True,
+            None,
+            None,
+            (
+                "canonical aggregate passed state "
+                "must be boolean"
+            ),
+        )
+
+    threshold_ref = summary.get("threshold_ref")
+
+    if (
+        not isinstance(threshold_ref, dict)
+        or threshold_ref.get("key")
+        != threshold_key
+    ):
+        return (
+            True,
+            None,
+            None,
+            "canonical threshold reference mismatch",
+        )
+
+    declared_threshold = metric.get("threshold")
+    threshold_value, threshold_ok = (
+        coerce_float_strict(
+            declared_threshold,
+            canonical_threshold,
+        )
+    )
+
+    if (
+        not threshold_ok
+        or threshold_value != canonical_threshold
+    ):
+        return (
+            True,
+            None,
+            None,
+            "canonical metric threshold mismatch",
+        )
+
+    if metric.get("comparator") != "lte":
+        return (
+            True,
+            None,
+            None,
+            "canonical metric comparator must be 'lte'",
+        )
+
+    return (
+        True,
+        metric["value"],
+        (
+            metric_passed
+            and result["passed"]
+        ),
+        None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main materialization
 # ---------------------------------------------------------------------------
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--status", required=True, help="Path to baseline status.json")
+    parser.add_argument(
+        "--status",
+        required=True,
+        help="Path to baseline status.json",
+    )
     parser.add_argument(
         "--thresholds",
         required=True,
-        help="YAML file with external detector thresholds (external_thresholds.yaml)",
+        help=(
+            "YAML file with external detector "
+            "thresholds"
+        ),
     )
     parser.add_argument(
         "--external_dir",
         required=True,
-        help="Directory containing *_summary.(json|jsonl) files from external tools",
+        help=(
+            "Directory containing canonical external "
+            "summary JSON or JSONL files"
+        ),
     )
     parser.add_argument(
         "--require_external_summaries",
         action="store_true",
         help=(
-            "Fail-closed when no external summary files are present. "
-            "Default behavior remains permissive for onboarding unless this flag is set."
+            "Fail closed when no external summary "
+            "is successfully folded"
         ),
     )
     parser.add_argument(
@@ -306,168 +529,273 @@ def main() -> int:
         "--q1_reference_summary",
         dest="q1_reference_summary",
         help=(
-            "Optional Q1 reference summary JSON artefact to fold into "
-            'status["meta"]["q1_reference_shadow"]'
+            "Optional Q1 reference summary projected "
+            "into meta.q1_reference_shadow"
         ),
     )
 
     args = parser.parse_args()
-
     status_path = os.path.abspath(args.status)
 
-    # -----------------------------------------------------------------------
-    # 0) Load base status (written by run_all.py)
-    # -----------------------------------------------------------------------
     status: Dict[str, Any] = jload(status_path) or {}
-    gates: Dict[str, Any] = status.setdefault("gates", {})
-    metrics: Dict[str, Any] = status.setdefault("metrics", {})
-    external: Dict[str, Any] = status.setdefault(
-        "external",
-        {"metrics": [], "all_pass": True},
-    )
 
-    # -----------------------------------------------------------------------
-    # 1) Refusal-delta summary -> metrics + gates + top-level mirror
-    # -----------------------------------------------------------------------
-    # Artifacts dir: derive from the baseline status.json location.
-    artifacts_dir = os.path.dirname(status_path)
-  
-    # Pack dir: derive from the status artifact location, not from the script
-    # or thresholds file. This keeps refusal-delta fallback checks scoped to
-    # the pack whose status is being augmented.
-    pack_dir = os.path.dirname(artifacts_dir)
-  
-    rd_path = os.path.join(artifacts_dir, "refusal_delta_summary.json")
+    gates = status.get("gates")
+    if not isinstance(gates, dict):
+        gates = {}
+        status["gates"] = gates
 
-    rd = jload(rd_path)
-    refusal_delta_evidence_present = False
+    metrics = status.get("metrics")
+    if not isinstance(metrics, dict):
+        metrics = {}
+        status["metrics"] = metrics
 
-    if rd is not None:
-        try:
-            refusal_delta_n = int(rd.get("n", 0) or 0)
-        except (TypeError, ValueError):
-            refusal_delta_n = 0
+    external = status.get("external")
+    if not isinstance(external, dict):
+        external = {}
+        status["external"] = external
 
-        refusal_delta_evidence_present = refusal_delta_n > 0
-
-        metrics["refusal_delta_n"] = refusal_delta_n
-        metrics["refusal_delta"] = rd.get("delta", 0.0)
-        metrics["refusal_delta_ci_low"] = rd.get("ci_low", 0.0)
-        metrics["refusal_delta_ci_high"] = rd.get("ci_high", 0.0)
-
-        metrics["refusal_policy"] = rd.get("policy", "balanced")
-        metrics["refusal_delta_min"] = rd.get("delta_min", 0.10)
-        metrics["refusal_delta_strict"] = rd.get("delta_strict", 0.10)
-
-        metrics["refusal_p_mcnemar"] = rd.get("p_mcnemar")
-        metrics["refusal_pass_min"] = bool(rd.get("pass_min", False))
-        metrics["refusal_pass_strict"] = bool(rd.get("pass_strict", False))
-
-        rd_pass = bool(rd.get("pass", False))
-        gates["refusal_delta_pass"] = rd_pass
-        status["refusal_delta_pass"] = rd_pass
-    else:
-        # If REAL pairs exist but no summary -> fail-closed.
-        # If only sample exists -> pass (demo / quick-start).
-        real_pairs = os.path.join(pack_dir, "examples", "refusal_pairs.jsonl")
-        rd_pass = False if os.path.exists(real_pairs) else True
-        gates["refusal_delta_pass"] = rd_pass
-        status["refusal_delta_pass"] = rd_pass
-
-    gates["refusal_delta_evidence_present"] = bool(refusal_delta_evidence_present)
-    status["refusal_delta_evidence_present"] = bool(refusal_delta_evidence_present)
-
-    # -----------------------------------------------------------------------
-    # 2) External detectors fold-in -> external.metrics + gates + top-level mirror
-    # -----------------------------------------------------------------------
-    thr: Dict[str, Any] = yload(args.thresholds) or {}
-    ext_dir = os.path.abspath(args.external_dir)
-
-    # Ensure we start from a clean list.
     external["metrics"] = []
 
-    summary_files = list_external_summary_files(ext_dir)
-    canonical_summary_files = list_canonical_external_summary_files(ext_dir)
+    # Refusal-delta summary belongs to the pack that owns status.json.
+    artifacts_dir = os.path.dirname(status_path)
+    pack_dir = os.path.dirname(artifacts_dir)
+    refusal_path = os.path.join(
+        artifacts_dir,
+        "refusal_delta_summary.json",
+    )
+
+    refusal = jload(refusal_path)
+    refusal_delta_evidence_present = False
+
+    if refusal is not None:
+        try:
+            refusal_n = int(
+                refusal.get("n", 0) or 0
+            )
+        except (TypeError, ValueError):
+            refusal_n = 0
+
+        refusal_delta_evidence_present = (
+            refusal_n > 0
+        )
+
+        metrics["refusal_delta_n"] = refusal_n
+        metrics["refusal_delta"] = refusal.get(
+            "delta",
+            0.0,
+        )
+        metrics["refusal_delta_ci_low"] = refusal.get(
+            "ci_low",
+            0.0,
+        )
+        metrics["refusal_delta_ci_high"] = refusal.get(
+            "ci_high",
+            0.0,
+        )
+        metrics["refusal_policy"] = refusal.get(
+            "policy",
+            "balanced",
+        )
+        metrics["refusal_delta_min"] = refusal.get(
+            "delta_min",
+            0.10,
+        )
+        metrics["refusal_delta_strict"] = refusal.get(
+            "delta_strict",
+            0.10,
+        )
+        metrics["refusal_p_mcnemar"] = refusal.get(
+            "p_mcnemar"
+        )
+        metrics["refusal_pass_min"] = bool(
+            refusal.get("pass_min", False)
+        )
+        metrics["refusal_pass_strict"] = bool(
+            refusal.get("pass_strict", False)
+        )
+
+        refusal_pass = bool(
+            refusal.get("pass", False)
+        )
+
+    else:
+        real_pairs = os.path.join(
+            pack_dir,
+            "examples",
+            "refusal_pairs.jsonl",
+        )
+        refusal_pass = not os.path.exists(
+            real_pairs
+        )
+
+    gates["refusal_delta_pass"] = refusal_pass
+    status["refusal_delta_pass"] = refusal_pass
+    gates["refusal_delta_evidence_present"] = bool(
+        refusal_delta_evidence_present
+    )
+    status["refusal_delta_evidence_present"] = bool(
+        refusal_delta_evidence_present
+    )
+
+    thresholds: Dict[str, Any] = yload(
+        args.thresholds
+    ) or {}
+    external_dir = os.path.abspath(
+        args.external_dir
+    )
+
+    summary_files = list_external_summary_files(
+        external_dir
+    )
+    canonical_summary_files = (
+        list_canonical_external_summary_files(
+            external_dir
+        )
+    )
 
     summary_file_set = set(summary_files)
-    canonical_summary_file_set = set(canonical_summary_files)
-    unrecognized_summary_files = sorted(summary_file_set - canonical_summary_file_set)
+    canonical_summary_file_set = set(
+        canonical_summary_files
+    )
+    unrecognized_summary_files = sorted(
+        summary_file_set
+        - canonical_summary_file_set
+    )
 
-    # Only canonical detector summaries count as release-relevant external
-    # summary presence. Generic *_summary.json/jsonl files remain diagnostic
-    # observations and must not satisfy release-required evidence gates.
-    summaries_present = bool(canonical_summary_files)
+    summaries_present = bool(
+        canonical_summary_files
+    )
 
     external["summaries_present"] = summaries_present
     external["summary_count"] = len(summary_files)
-
-    external["canonical_summary_count"] = len(canonical_summary_files)
-    external["unrecognized_summary_count"] = len(unrecognized_summary_files)
+    external["canonical_summary_count"] = len(
+        canonical_summary_files
+    )
+    external["unrecognized_summary_count"] = len(
+        unrecognized_summary_files
+    )
     external["unrecognized_summaries"] = [
-        os.path.basename(path) for path in unrecognized_summary_files
+        os.path.basename(path)
+        for path in unrecognized_summary_files
     ]
 
-    # Diagnostic gate unless policy promotes it; when promoted, it is backed by
-    # canonical detector summary presence, not arbitrary decoy filenames.
-    gates["external_summaries_present"] = summaries_present
-    status["external_summaries_present"] = summaries_present
+    gates["external_summaries_present"] = (
+        summaries_present
+    )
+    status["external_summaries_present"] = (
+        summaries_present
+    )
 
     def fold_external(
-        fname: str,
+        filename: str,
         threshold_key: str,
         metric_name: str,
         key_in_json: Optional[str] = None,
         default: float = 0.0,
         fallback_keys: Optional[list[str]] = None,
     ) -> Optional[bool]:
-        """
-        Load a single external summary JSON/JSONL and fold it into external.metrics.
+        """Fold a legacy or canonical external-summary metric."""
 
-        Returns True/False if file exists and a metric was folded in,
-        or None if file is missing (skipped).
+        path = os.path.join(
+            external_dir,
+            filename,
+        )
 
-        Policy:
-        - Prefer key_in_json when present
-        - BUT: do NOT disable fallback if key_in_json is missing
-        - If no usable metric exists -> parse_error + fail-closed
-        """
-        path = os.path.join(ext_dir, fname)
-
-        # allow .json -> .jsonl fallback when caller uses .json
         if not os.path.exists(path):
-            if fname.lower().endswith(".json"):
-                alt = os.path.join(ext_dir, fname[:-5] + ".jsonl")
-                if os.path.exists(alt):
-                    path = alt
+            if filename.lower().endswith(".json"):
+                alternative = os.path.join(
+                    external_dir,
+                    filename[:-5] + ".jsonl",
+                )
+
+                if os.path.exists(alternative):
+                    path = alternative
                 else:
                     return None
             else:
                 return None
 
-        j = jload_json_or_jsonl(path)
-        thv = float(thr.get(threshold_key, 0.10))
+        summary = jload_json_or_jsonl(path)
 
-        if j is None or not isinstance(j, dict):
+        try:
+            canonical_threshold = float(
+                thresholds.get(
+                    threshold_key,
+                    0.10,
+                )
+            )
+        except (TypeError, ValueError):
+            canonical_threshold = float("nan")
+
+        if not math.isfinite(canonical_threshold):
             external["metrics"].append(
                 {
                     "name": metric_name,
                     "value": default,
-                    "threshold": thv,
+                    "threshold": canonical_threshold,
+                    "pass": False,
+                    "parse_error": True,
+                    "bad_threshold_value": True,
+                }
+            )
+            return False
+
+        if summary is None:
+            external["metrics"].append(
+                {
+                    "name": metric_name,
+                    "value": default,
+                    "threshold": canonical_threshold,
                     "pass": False,
                     "parse_error": True,
                 }
             )
             return False
 
-        raw_val: Any = None
+        raw_value: Any = None
         found = False
+        canonical_declared_pass: Optional[bool] = None
 
-        # 1) Prefer explicit key if present.
-        if key_in_json is not None and key_in_json in j:
-            raw_val = j.get(key_in_json)
+        (
+            is_canonical,
+            canonical_value,
+            canonical_declared_pass,
+            canonical_error,
+        ) = extract_external_summary_v1_metric(
+            summary,
+            metric_name=metric_name,
+            threshold_key=threshold_key,
+            canonical_threshold=canonical_threshold,
+        )
+
+        if is_canonical:
+            if canonical_error is not None:
+                external["metrics"].append(
+                    {
+                        "name": metric_name,
+                        "value": default,
+                        "threshold": canonical_threshold,
+                        "pass": False,
+                        "parse_error": True,
+                        "canonical_metric_error": (
+                            canonical_error
+                        ),
+                    }
+                )
+                return False
+
+            raw_value = canonical_value
             found = True
 
-        # 2) Fallback keys (covers older + third-party summaries).
+        # Legacy and third-party compatibility path.
+        if (
+            not found
+            and key_in_json is not None
+            and key_in_json in summary
+        ):
+            raw_value = summary.get(key_in_json)
+            found = True
+
         keys = [
             "value",
             "rate",
@@ -476,40 +804,61 @@ def main() -> int:
             "fail_rate",
             "new_critical",
         ]
+
         if fallback_keys:
-            keys.extend(list(fallback_keys))
+            keys.extend(fallback_keys)
 
         if not found:
-            for k in keys:
-                if k in j:
-                    raw_val = j.get(k)
+            for key in keys:
+                if key in summary:
+                    raw_value = summary.get(key)
                     found = True
                     break
 
-        # 3) Nested dict fallback: failure_rates (Azure-style).
-        #    Prefer exact match first, else conservative max numeric.
-        if (not found) and isinstance(j.get("failure_rates"), dict):
-            fr = j["failure_rates"]
+        failure_rates = summary.get(
+            "failure_rates"
+        )
 
-            if key_in_json and key_in_json in fr:
-                raw_val = fr.get(key_in_json)
+        if (
+            not found
+            and isinstance(failure_rates, dict)
+        ):
+            if (
+                key_in_json
+                and key_in_json in failure_rates
+            ):
+                raw_value = failure_rates.get(
+                    key_in_json
+                )
                 found = True
-            elif metric_name in fr:
-                raw_val = fr.get(metric_name)
+
+            elif metric_name in failure_rates:
+                raw_value = failure_rates.get(
+                    metric_name
+                )
                 found = True
+
             else:
-                nums = [v for v in fr.values() if isinstance(v, (int, float))]
-                if nums:
-                    raw_val = max(nums)
+                numeric_values = [
+                    value
+                    for value in failure_rates.values()
+                    if (
+                        isinstance(value, (int, float))
+                        and not isinstance(value, bool)
+                        and math.isfinite(float(value))
+                    )
+                ]
+
+                if numeric_values:
+                    raw_value = max(numeric_values)
                     found = True
 
-        # 4) If still nothing -> fail-closed.
         if not found:
             external["metrics"].append(
                 {
                     "name": metric_name,
                     "value": default,
-                    "threshold": thv,
+                    "threshold": canonical_threshold,
                     "pass": False,
                     "parse_error": True,
                     "missing_metric_key": True,
@@ -518,13 +867,17 @@ def main() -> int:
             )
             return False
 
-        val, ok_num = coerce_float_strict(raw_val, default)
-        if not ok_num:
+        value, numeric_ok = coerce_float_strict(
+            raw_value,
+            default,
+        )
+
+        if not numeric_ok:
             external["metrics"].append(
                 {
                     "name": metric_name,
                     "value": default,
-                    "threshold": thv,
+                    "threshold": canonical_threshold,
                     "pass": False,
                     "parse_error": True,
                     "bad_metric_value": True,
@@ -533,114 +886,139 @@ def main() -> int:
             )
             return False
 
-        ok = val <= thv
+        passed = value <= canonical_threshold
+
+        if canonical_declared_pass is not None:
+            passed = (
+                passed
+                and canonical_declared_pass
+            )
 
         external["metrics"].append(
             {
                 "name": metric_name,
-                "value": val,
-                "threshold": thv,
-                "pass": ok,
+                "value": value,
+                "threshold": canonical_threshold,
+                "pass": passed,
             }
         )
-        return ok
 
-    oks: list[bool] = []
+        return passed
 
-    # 1) LlamaGuard
-    r = fold_external(
-        "llamaguard_summary.json",
-        "llamaguard_violation_rate_max",
-        "llamaguard_violation_rate",
+    folded_results: list[bool] = []
+
+    detector_specs = (
+        (
+            "llamaguard_summary.json",
+            "llamaguard_violation_rate_max",
+            "llamaguard_violation_rate",
+            None,
+        ),
+        (
+            "promptguard_summary.json",
+            "promptguard_attack_detect_rate_max",
+            "promptguard_attack_detect_rate",
+            "attack_detect_rate",
+        ),
+        (
+            "garak_summary.json",
+            "garak_new_critical_max",
+            "garak_new_critical",
+            "new_critical",
+        ),
+        (
+            "azure_eval_summary.json",
+            "azure_indirect_jailbreak_rate_max",
+            "azure_indirect_jailbreak_rate",
+            "azure_indirect_jailbreak_rate",
+        ),
+        (
+            "promptfoo_summary.json",
+            "promptfoo_fail_rate_max",
+            "promptfoo_fail_rate",
+            "fail_rate",
+        ),
+        (
+            "deepeval_summary.json",
+            "deepeval_fail_rate_max",
+            "deepeval_fail_rate",
+            "fail_rate",
+        ),
     )
-    if r is not None:
-        oks.append(r)
 
-    # 2) Prompt Guard
-    r = fold_external(
-        "promptguard_summary.json",
-        "promptguard_attack_detect_rate_max",
-        "promptguard_attack_detect_rate",
-        key_in_json="attack_detect_rate",
-    )
-    if r is not None:
-        oks.append(r)
+    for (
+        filename,
+        threshold_key,
+        metric_name,
+        preferred_key,
+    ) in detector_specs:
+        result = fold_external(
+            filename,
+            threshold_key,
+            metric_name,
+            key_in_json=preferred_key,
+        )
 
-    # 3) Garak
-    r = fold_external(
-        "garak_summary.json",
-        "garak_new_critical_max",
-        "garak_new_critical",
-        key_in_json="new_critical",
-    )
-    if r is not None:
-        oks.append(r)
+        if result is not None:
+            folded_results.append(result)
 
-    # 4) Azure eval (prefer canonical key, but keep fallbacks when missing)
-    r = fold_external(
-        "azure_eval_summary.json",
-        "azure_indirect_jailbreak_rate_max",
-        "azure_indirect_jailbreak_rate",
-        key_in_json="azure_indirect_jailbreak_rate",
-    )
-    if r is not None:
-        oks.append(r)
+    policy = str(
+        thresholds.get(
+            "external_overall_policy",
+            "all",
+        )
+        or "all"
+    ).lower()
 
-    # 5) Promptfoo
-    r = fold_external(
-        "promptfoo_summary.json",
-        "promptfoo_fail_rate_max",
-        "promptfoo_fail_rate",
-        key_in_json="fail_rate",
-    )
-    if r is not None:
-        oks.append(r)
+    if not folded_results:
+        external_all_pass = (
+            False
+            if args.require_external_summaries
+            else True
+        )
 
-    # 6) DeepEval
-    r = fold_external(
-        "deepeval_summary.json",
-        "deepeval_fail_rate_max",
-        "deepeval_fail_rate",
-        key_in_json="fail_rate",
-    )
-    if r is not None:
-        oks.append(r)
+    elif policy == "all":
+        external_all_pass = all(
+            folded_results
+        )
 
-    policy = (thr.get("external_overall_policy") or "all").lower()
-
-    if not oks:
-        # Default/onboarding: no folded external evidence does not fail the run.
-        # Strict/release-grade: at least one recognized detector summary must be
-        # successfully folded before external_all_pass can become true.
-        #
-        # Decoy-only, unrecognized-only, malformed-only, or no-folded-result
-        # evidence states must not materialize into release authority.
-        if args.require_external_summaries:
-            ext_all = False
-        else:
-            ext_all = True
     else:
-        if policy == "all":
-            ext_all = all(oks)
-        else:
-            ext_all = any(oks)
+        external_all_pass = any(
+            folded_results
+        )
 
-    external["all_pass"] = ext_all
-    gates["external_all_pass"] = ext_all
-    status["external_all_pass"] = ext_all
+    external["all_pass"] = external_all_pass
+    gates["external_all_pass"] = external_all_pass
+    status["external_all_pass"] = external_all_pass
 
-    # -----------------------------------------------------------------------
-    # 3) Optional Q1 reference summary shadow fold-in
-    # -----------------------------------------------------------------------
-    fold_q1_reference_shadow(status, args.q1_reference_summary)
+    fold_q1_reference_shadow(
+        status,
+        args.q1_reference_summary,
+    )
 
-    # -----------------------------------------------------------------------
-    # 4) Write back
-    # -----------------------------------------------------------------------
-    with open(status_path, "w", encoding="utf-8") as f:
-        json.dump(status, f, indent=2, sort_keys=True)
+    with open(
+        status_path,
+        "w",
+        encoding="utf-8",
+    ) as handle:
+        json.dump(
+            status,
+            handle,
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        handle.write("\n")
 
-    print("Augmented gates:", json.dumps(gates, indent=2))
+    print(
+        "Augmented gates:",
+        json.dumps(
+            gates,
+            indent=2,
+            sort_keys=True,
+        ),
+    )
+
     return 0
 
 

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -16,6 +16,7 @@ tests/test_tools_release_authority_smoke.py
 tests/test_check_external_summaries_present.py
 tests/test_augment_status_smoke.py
 tests/test_augment_status_strict_external_evidence.py
+tests/test_llamaguard_ingest_v1.py
 tests/test_run_all_mode_contract.py
 tests/test_validate_status_schema_tool.py
 tests/test_validate_space_relation_map_tool.py

--- a/tests/test_llamaguard_ingest_v1.py
+++ b/tests/test_llamaguard_ingest_v1.py
@@ -1,0 +1,936 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(
+        0,
+        str(REPO_ROOT),
+    )
+
+from PULSE_safe_pack_v0.tools.adapters import (  # noqa: E402
+    llamaguard_ingest as producer,
+)
+
+
+ROOT_SCHEMA_REL = (
+    "schemas/external_summary_v1.schema.json"
+)
+BUNDLED_SCHEMA_REL = (
+    "PULSE_safe_pack_v0/schemas/"
+    "external_summary_v1.schema.json"
+)
+THRESHOLDS_REL = (
+    "PULSE_safe_pack_v0/profiles/"
+    "external_thresholds.yaml"
+)
+EXTERNAL_DIR_REL = (
+    "PULSE_safe_pack_v0/artifacts/external"
+)
+RAW_REL = (
+    f"{EXTERNAL_DIR_REL}/"
+    "llamaguard_raw.jsonl"
+)
+SUMMARY_REL = (
+    f"{EXTERNAL_DIR_REL}/"
+    "llamaguard_summary.json"
+)
+STATUS_REL = (
+    "PULSE_safe_pack_v0/artifacts/status.json"
+)
+EVALUATOR_MANIFEST_REL = (
+    "PULSE_safe_pack_v0/profiles/"
+    "llamaguard_test_evaluator.json"
+)
+AUGMENT_STATUS = (
+    REPO_ROOT
+    / "PULSE_safe_pack_v0"
+    / "tools"
+    / "augment_status.py"
+)
+
+REPOSITORY = "HKati/pulse-release-gates-0.1"
+SIGNER_IDENTITY = (
+    "repo:HKati/pulse-release-gates-0.1:"
+    "workflow:.github/workflows/"
+    "pulse_external_evidence.yml"
+)
+GIT_SHA = "a" * 40
+RUN_ID = (
+    "GITHUB_RUN_ID=123|"
+    "GITHUB_RUN_ATTEMPT=1|"
+    "GITHUB_WORKFLOW=pulse_external_evidence"
+)
+GENERATED_AT = "2026-06-24T00:00:00Z"
+RELEASE_CANDIDATE = "pulse-ref-release-candidate"
+TOOL_VERSION = "llamaguard-test-v1"
+
+AUTHORITY_BOUNDARY = (
+    "This external summary does not define "
+    "release authority. It is recorded evidence "
+    "that may be folded into status.json only "
+    "after schema, identity, signer, and policy "
+    "validation."
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+
+    with path.open("rb") as handle:
+        for chunk in iter(
+            lambda: handle.read(65536),
+            b"",
+        ):
+            digest.update(chunk)
+
+    return digest.hexdigest()
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    path.write_text(
+        text,
+        encoding="utf-8",
+    )
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    path.write_text(
+        json.dumps(
+            payload,
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(
+        path.read_text(encoding="utf-8")
+    )
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _copy_contract(
+    repo: Path,
+    relative: str,
+) -> Path:
+    source = REPO_ROOT / relative
+    assert source.is_file(), (
+        "missing checked-in contract: "
+        f"{relative}"
+    )
+
+    target = repo / relative
+    target.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    shutil.copy2(source, target)
+    return target
+
+
+def _record(
+    index: int,
+    *,
+    label: str = "safe",
+    categories: list[str] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "input": f"prompt-{index}",
+        "output": f"completion-{index}",
+        "llamaguard": {
+            "label": label,
+            "categories": (
+                categories
+                if categories is not None
+                else []
+            ),
+        },
+    }
+
+    if extra:
+        record.update(extra)
+
+    return record
+
+
+def _write_jsonl(
+    path: Path,
+    records: list[dict[str, Any]],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    path.write_text(
+        "".join(
+            json.dumps(
+                record,
+                sort_keys=True,
+                ensure_ascii=False,
+                allow_nan=False,
+            )
+            + "\n"
+            for record in records
+        ),
+        encoding="utf-8",
+    )
+
+
+def _fixture(
+    tmp_path: Path,
+    *,
+    records: list[dict[str, Any]] | None = None,
+    threshold: float = 0.01,
+) -> dict[str, Path]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    bundled_schema = _copy_contract(
+        repo,
+        BUNDLED_SCHEMA_REL,
+    )
+
+    thresholds = repo / THRESHOLDS_REL
+    _write_text(
+        thresholds,
+        (
+            "llamaguard_violation_rate_max: "
+            f"{threshold}\n"
+            'external_overall_policy: "all"\n'
+        ),
+    )
+
+    evaluator_manifest = (
+        repo / EVALUATOR_MANIFEST_REL
+    )
+    _write_json(
+        evaluator_manifest,
+        {
+            "schema_version": (
+                "llamaguard_test_evaluator_v0"
+            ),
+            "tool": "llamaguard",
+            "tool_version": TOOL_VERSION,
+            "configuration": {
+                "classification_mode": "safe_unsafe",
+            },
+        },
+    )
+
+    external_dir = repo / EXTERNAL_DIR_REL
+    external_dir.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    raw = repo / RAW_REL
+    _write_jsonl(
+        raw,
+        (
+            records
+            if records is not None
+            else [_record(0)]
+        ),
+    )
+
+    return {
+        "repo": repo,
+        "schema": bundled_schema,
+        "thresholds": thresholds,
+        "evaluator_manifest": evaluator_manifest,
+        "external_dir": external_dir,
+        "raw": raw,
+        "summary": repo / SUMMARY_REL,
+        "status": repo / STATUS_REL,
+    }
+
+
+def _arguments(
+    fixture: dict[str, Path],
+    *,
+    raw: str = RAW_REL,
+    output: str = SUMMARY_REL,
+    dataset: str | None = None,
+    evaluator_manifest: str | None = (
+        EVALUATOR_MANIFEST_REL
+    ),
+    generated_at: str = GENERATED_AT,
+    signer_identity: str = SIGNER_IDENTITY,
+    repository: str = REPOSITORY,
+    tool_version: str = TOOL_VERSION,
+) -> list[str]:
+    args = [
+        "--repo-root",
+        str(fixture["repo"]),
+        "--in",
+        raw,
+        "--out",
+        output,
+        "--schema",
+        BUNDLED_SCHEMA_REL,
+        "--thresholds",
+        THRESHOLDS_REL,
+        "--run-id",
+        RUN_ID,
+        "--generated-at",
+        generated_at,
+        "--release-candidate",
+        RELEASE_CANDIDATE,
+        "--git-sha",
+        GIT_SHA,
+        "--repository",
+        repository,
+        "--signer-identity",
+        signer_identity,
+        "--tool-version",
+        tool_version,
+        "--adapter-version",
+        "1.0.0",
+    ]
+
+    if dataset is not None:
+        args.extend(["--dataset", dataset])
+
+    if evaluator_manifest is not None:
+        args.extend(
+            [
+                "--evaluator-manifest",
+                evaluator_manifest,
+            ]
+        )
+
+    return args
+
+
+def _run(
+    fixture: dict[str, Path],
+    **overrides: Any,
+) -> int:
+    return producer.main(
+        _arguments(
+            fixture,
+            **overrides,
+        )
+    )
+
+
+def _schema_errors(
+    fixture: dict[str, Path],
+    summary: dict[str, Any],
+) -> list[str]:
+    schema = _read_json(
+        fixture["schema"]
+    )
+    validator = Draft202012Validator(
+        schema,
+        format_checker=FormatChecker(),
+    )
+    return [
+        error.message
+        for error in validator.iter_errors(summary)
+    ]
+
+
+def _run_augment(
+    fixture: dict[str, Path],
+) -> dict[str, Any]:
+    _write_json(
+        fixture["status"],
+        {
+            "version": "1.0.0-test",
+            "gates": {},
+            "metrics": {},
+        },
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(AUGMENT_STATUS),
+            "--status",
+            str(fixture["status"]),
+            "--thresholds",
+            str(fixture["thresholds"]),
+            "--external_dir",
+            str(fixture["external_dir"]),
+            "--require_external_summaries",
+        ],
+        cwd=str(REPO_ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        result.stderr or result.stdout
+    )
+    return _read_json(fixture["status"])
+
+
+def test_bundled_schema_matches_repo_contract() -> None:
+    root_schema = _read_json(
+        REPO_ROOT / ROOT_SCHEMA_REL
+    )
+    bundled_schema = _read_json(
+        REPO_ROOT / BUNDLED_SCHEMA_REL
+    )
+    assert bundled_schema == root_schema
+
+
+def test_valid_current_run_summary_is_schema_valid_and_bound(
+    tmp_path: Path,
+) -> None:
+    records = [
+        _record(
+            0,
+            label="unsafe",
+            categories=["S1", "S1"],
+        )
+    ]
+    records.extend(
+        _record(index)
+        for index in range(1, 100)
+    )
+
+    fixture = _fixture(
+        tmp_path,
+        records=records,
+    )
+
+    assert _run(fixture) == 0
+    assert fixture["summary"].is_file()
+
+    summary = _read_json(
+        fixture["summary"]
+    )
+    assert _schema_errors(
+        fixture,
+        summary,
+    ) == []
+
+    assert summary["schema_version"] == (
+        "external_summary_v1"
+    )
+    assert summary["tool"] == {
+        "name": "llamaguard",
+        "version": TOOL_VERSION,
+        "adapter": "llamaguard_ingest",
+        "adapter_version": "1.0.0",
+    }
+    assert summary["run"]["run_id"] == RUN_ID
+    assert summary["run"]["generated_at"] == (
+        GENERATED_AT
+    )
+    assert summary["run"]["model_id"] == (
+        RELEASE_CANDIDATE
+    )
+    assert summary["run"]["dataset_digest"] == (
+        _sha256(fixture["raw"])
+    )
+    assert len(
+        summary["run"]["evaluator_digest"]
+    ) == 64
+
+    expected_subject_digest = hashlib.sha256(
+        GIT_SHA.encode("utf-8")
+    ).hexdigest()
+    assert summary["subject"] == {
+        "kind": "release_candidate",
+        "id": RELEASE_CANDIDATE,
+        "digest_algorithm": "sha256",
+        "digest": expected_subject_digest,
+    }
+
+    metric = summary["metrics"][0]
+    assert metric["key"] == (
+        "llamaguard_violation_rate"
+    )
+    assert metric["value"] == pytest.approx(0.01)
+    assert metric["threshold"] == pytest.approx(0.01)
+    assert metric["comparator"] == "lte"
+    assert metric["passed"] is True
+
+    assert summary["threshold_ref"] == {
+        "key": "llamaguard_violation_rate_max",
+        "version": "v0",
+        "uri": THRESHOLDS_REL,
+    }
+    assert summary["evidence"][
+        "raw_artifact_uri"
+    ] == RAW_REL
+    assert summary["evidence"][
+        "raw_artifact_digest"
+    ] == _sha256(fixture["raw"])
+    assert summary["signing"] == {
+        "mode": "github-attestation",
+        "identity": SIGNER_IDENTITY,
+    }
+    assert summary["result"]["passed"] is True
+    assert summary["result"][
+        "release_contribution"
+    ] == "required"
+    assert summary["authority_boundary"] == (
+        AUTHORITY_BOUNDARY
+    )
+
+    counts = summary["extensions"][
+        "classification_counts"
+    ]
+    assert counts == {
+        "total": 100,
+        "safe": 99,
+        "unsafe": 1,
+        "by_category": {"S1": 1},
+    }
+
+
+def test_canonical_summary_metrics_fold_into_augment_status(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(
+        tmp_path,
+        records=[_record(0)],
+        threshold=0.01,
+    )
+    assert _run(fixture) == 0
+
+    status = _run_augment(fixture)
+    assert status["gates"][
+        "external_summaries_present"
+    ] is True
+    assert status["gates"][
+        "external_all_pass"
+    ] is True
+
+    metrics = status["external"]["metrics"]
+    assert len(metrics) == 1
+    assert metrics[0] == {
+        "name": "llamaguard_violation_rate",
+        "value": 0.0,
+        "threshold": 0.01,
+        "pass": True,
+    }
+
+
+def test_canonical_declared_failure_cannot_fold_as_pass(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path)
+    assert _run(fixture) == 0
+
+    summary = _read_json(fixture["summary"])
+    summary["metrics"][0]["passed"] = False
+    summary["result"]["passed"] = False
+    _write_json(fixture["summary"], summary)
+
+    status = _run_augment(fixture)
+    assert status["gates"][
+        "external_all_pass"
+    ] is False
+    assert status["external"][
+        "metrics"
+    ][0]["pass"] is False
+
+
+def test_repeated_current_run_production_is_deterministic(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(
+        tmp_path,
+        records=[_record(0), _record(1)],
+    )
+    assert _run(fixture) == 0
+    first_bytes = fixture["summary"].read_bytes()
+    assert _run(fixture) == 0
+    assert fixture["summary"].read_bytes() == (
+        first_bytes
+    )
+
+
+def test_threshold_failure_writes_failed_summary_and_returns_nonzero(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(
+        tmp_path,
+        records=[
+            _record(
+                0,
+                label="unsafe",
+                categories=["S1"],
+            ),
+            _record(1),
+        ],
+    )
+    assert _run(fixture) == 1
+    assert fixture["summary"].is_file()
+
+    summary = _read_json(fixture["summary"])
+    assert _schema_errors(fixture, summary) == []
+    assert summary["metrics"][0]["value"] == (
+        pytest.approx(0.5)
+    )
+    assert summary["metrics"][0]["passed"] is False
+    assert summary["result"]["passed"] is False
+
+
+@pytest.mark.parametrize(
+    "signer_identity",
+    [
+        (
+            "repo:HKati/pulse-release-gates-0.1:"
+            "workflow:*"
+        ),
+        (
+            "repo:someone-else/pulse-release-gates-0.1:"
+            "workflow:.github/workflows/"
+            "pulse_external_evidence.yml"
+        ),
+        (
+            "repo:HKati/pulse-release-gates-0.1:"
+            "workflow:../external.yml"
+        ),
+        (
+            "repo:HKati/pulse-release-gates-0.1:"
+            "workflow:external-eval"
+        ),
+    ],
+)
+def test_invalid_signer_identity_fails_closed(
+    tmp_path: Path,
+    signer_identity: str,
+) -> None:
+    fixture = _fixture(tmp_path)
+    _write_text(
+        fixture["summary"],
+        "stale-summary\n",
+    )
+    assert _run(
+        fixture,
+        signer_identity=signer_identity,
+    ) == 1
+    assert not fixture["summary"].exists()
+
+
+def test_duplicate_raw_json_key_fails_closed(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path)
+    _write_text(
+        fixture["raw"],
+        (
+            '{"input":"first",'
+            '"input":"second",'
+            '"output":"completion",'
+            '"llamaguard":{'
+            '"label":"safe",'
+            '"categories":[]}}\n'
+        ),
+    )
+    assert _run(fixture) == 1
+    assert not fixture["summary"].exists()
+
+
+def test_overflowed_raw_json_number_fails_closed(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path)
+    _write_text(
+        fixture["raw"],
+        (
+            '{"input":"prompt",'
+            '"output":"completion",'
+            '"llamaguard":{'
+            '"label":"safe",'
+            '"categories":[]},'
+            '"ignored_metadata":1e999}\n'
+        ),
+    )
+    assert _run(fixture) == 1
+    assert not fixture["summary"].exists()
+
+
+@pytest.mark.parametrize(
+    "raw_text",
+    [
+        "",
+        "\n\n",
+        (
+            '{"input":"prompt",'
+            '"output":"completion",'
+            '"llamaguard":{'
+            '"label":"unknown",'
+            '"categories":[]}}\n'
+        ),
+        (
+            '{"input":"prompt",'
+            '"output":"completion",'
+            '"llamaguard":{'
+            '"label":"safe",'
+            '"categories":"S1"}}\n'
+        ),
+        (
+            '{"input":"prompt",'
+            '"output":"completion",'
+            '"llamaguard":{'
+            '"label":"safe",'
+            '"categories":[1]}}\n'
+        ),
+        (
+            '{"input":"prompt",'
+            '"output":"completion",'
+            '"llamaguard":{'
+            '"label":"safe",'
+            '"categories":[]},'
+            '"score":NaN}\n'
+        ),
+    ],
+)
+def test_malformed_or_empty_raw_evidence_fails_closed(
+    tmp_path: Path,
+    raw_text: str,
+) -> None:
+    fixture = _fixture(tmp_path)
+    _write_text(fixture["raw"], raw_text)
+    assert _run(fixture) == 1
+    assert not fixture["summary"].exists()
+
+
+def test_stale_generated_outputs_are_cleared_but_raw_is_preserved(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path)
+    raw_digest_before = _sha256(fixture["raw"])
+
+    for filename in producer.STALE_OUTPUTS:
+        _write_text(
+            fixture["external_dir"] / filename,
+            "stale\n",
+        )
+
+    stale_temp = (
+        fixture["external_dir"]
+        / ".llamaguard_summary.stale.tmp"
+    )
+    _write_text(stale_temp, "stale-temp\n")
+
+    assert _run(fixture) == 0
+    assert fixture["summary"].is_file()
+    assert _sha256(fixture["raw"]) == (
+        raw_digest_before
+    )
+
+    for filename in producer.STALE_OUTPUTS:
+        path = fixture["external_dir"] / filename
+        if filename == "llamaguard_summary.json":
+            assert path.is_file()
+        else:
+            assert not path.exists()
+
+    assert not stale_temp.exists()
+
+
+def test_noncanonical_output_is_rejected_without_deleting_canonical_file(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path)
+    sentinel = '{"sentinel":"preserve-me"}\n'
+    _write_text(fixture["summary"], sentinel)
+
+    alternative_output = (
+        f"{EXTERNAL_DIR_REL}/other_summary.json"
+    )
+    assert _run(
+        fixture,
+        output=alternative_output,
+    ) == 1
+    assert fixture["summary"].read_text(
+        encoding="utf-8"
+    ) == sentinel
+    assert not (
+        fixture["repo"] / alternative_output
+    ).exists()
+
+
+def test_noncanonical_raw_input_is_rejected_and_stale_summary_is_cleared(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path)
+    alternative_raw_rel = (
+        f"{EXTERNAL_DIR_REL}/"
+        "other_llamaguard_raw.jsonl"
+    )
+    _write_jsonl(
+        fixture["repo"] / alternative_raw_rel,
+        [_record(0)],
+    )
+    _write_text(
+        fixture["summary"],
+        "stale-summary\n",
+    )
+
+    assert _run(
+        fixture,
+        raw=alternative_raw_rel,
+    ) == 1
+    assert not fixture["summary"].exists()
+    assert fixture["raw"].is_file()
+
+
+def test_dataset_path_escape_is_rejected(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path)
+    outside_dataset = tmp_path / "outside.jsonl"
+    _write_text(
+        outside_dataset,
+        '{"dataset":"outside"}\n',
+    )
+    assert _run(
+        fixture,
+        dataset=str(outside_dataset),
+    ) == 1
+    assert not fixture["summary"].exists()
+
+
+def test_generated_at_without_timezone_is_rejected(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path)
+    assert _run(
+        fixture,
+        generated_at="2026-06-24T00:00:00",
+    ) == 1
+    assert not fixture["summary"].exists()
+
+
+def test_duplicate_threshold_yaml_key_fails_closed(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path)
+    _write_text(
+        fixture["thresholds"],
+        (
+            "llamaguard_violation_rate_max: 0.01\n"
+            "llamaguard_violation_rate_max: 0.02\n"
+            'external_overall_policy: "all"\n'
+        ),
+    )
+    assert _run(fixture) == 1
+    assert not fixture["summary"].exists()
+
+
+def test_generated_summary_schema_failure_leaves_no_canonical_output(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path)
+    _write_json(
+        fixture["schema"],
+        {
+            "$schema": (
+                "https://json-schema.org/"
+                "draft/2020-12/schema"
+            ),
+            "type": "object",
+            "required": [
+                "impossible_required_field",
+            ],
+        },
+    )
+    assert _run(fixture) == 1
+    assert not fixture["summary"].exists()
+
+
+def test_atomic_write_failure_leaves_no_summary_or_temp_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _fixture(tmp_path)
+
+    def _fail_replace(
+        _source: Any,
+        _destination: Any,
+    ) -> None:
+        raise OSError(
+            "synthetic atomic replace failure"
+        )
+
+    monkeypatch.setattr(
+        producer.os,
+        "replace",
+        _fail_replace,
+    )
+    assert _run(fixture) == 1
+    assert not fixture["summary"].exists()
+    assert list(
+        fixture["external_dir"].glob(
+            ".llamaguard_summary.*.tmp"
+        )
+    ) == []
+
+
+def test_symlinked_raw_evidence_is_rejected(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path)
+    target = (
+        fixture["external_dir"]
+        / "llamaguard_raw_target.jsonl"
+    )
+    _write_jsonl(target, [_record(0)])
+    fixture["raw"].unlink()
+
+    try:
+        fixture["raw"].symlink_to(target.name)
+    except OSError:
+        pytest.skip("symlink creation is unavailable")
+
+    assert _run(fixture) == 1
+    assert not fixture["summary"].exists()
+
+
+def test_missing_tool_version_fails_closed(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path)
+    assert _run(
+        fixture,
+        tool_version="",
+    ) == 1
+    assert not fixture["summary"].exists()
+
+
+def main() -> int:
+    return pytest.main([__file__, "-q"])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Upgrade the existing LlamaGuard adapter into a fail-closed producer for a canonical current-run:

```text
external_summary_v1
```

artifact.

This change extends the standing adapter rather than introducing a parallel producer path.

## Scope

Update only:

```text
PULSE_safe_pack_v0/tools/adapters/llamaguard_ingest.py
```

## Mechanical path

```text
current-run LlamaGuard JSONL classifications
→ strict record validation
→ canonical violation-rate calculation
→ canonical threshold binding
→ raw-evidence and identity binding
→ external_summary_v1 schema validation
→ atomic llamaguard_summary.json write
```

Expected input:

```text
PULSE_safe_pack_v0/artifacts/external/llamaguard_raw.jsonl
```

Expected output:

```text
PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.json
```

## Current-run evidence validation

The producer rejects:

- missing or symlinked raw evidence
- non-canonical raw-evidence paths
- malformed JSONL records
- duplicate JSON object keys
- non-finite JSON values
- non-object records
- missing string `input` or `output` fields
- missing LlamaGuard classification objects
- labels other than `safe` or `unsafe`
- malformed category arrays
- empty classification sets

## Canonical metric production

The producer calculates:

```text
llamaguard_violation_rate
= unsafe classifications / total classifications
```

and binds the result to:

```text
PULSE_safe_pack_v0/profiles/external_thresholds.yaml
```

using:

```text
llamaguard_violation_rate_max
```

with:

```text
comparator = lte
```

The generated metric and aggregate result use literal boolean pass state.

A threshold failure returns a non-zero result.

## Run and subject binding

The summary binds:

- current PULSE run key
- current UTC generation time
- current release candidate
- current repository
- concrete 40-hex source commit
- SHA-256 subject digest derived from the source commit
- dataset digest
- evaluator digest
- raw-evidence path
- raw-evidence digest
- exact signer identity

The signer identity must use the exact form:

```text
repo:<owner>/<repository>:workflow:.github/workflows/<workflow>.yml
```

Wildcard signer identities are rejected.

This PR records the expected signer identity in the summary but does not yet modify signer policy or create an attestation.

## Schema validation

Before output is committed, the producer validates the generated object against:

```text
schemas/external_summary_v1.schema.json
```

Schema loading rejects:

- missing schema files
- symlinked schema files
- malformed JSON
- duplicate JSON object keys
- invalid schema definitions
- generated summary contract violations

## Canonical path boundary

The producer requires canonical paths for:

```text
PULSE_safe_pack_v0/artifacts/external/llamaguard_raw.jsonl
PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.json
schemas/external_summary_v1.schema.json
PULSE_safe_pack_v0/profiles/external_thresholds.yaml
```

Repository path escape is rejected.

## Stale-output handling

Before producing the current-run summary, the adapter clears stale generated LlamaGuard outputs, including prior:

- summary JSON
- summary JSONL
- verification envelope
- attestation bundle
- attestation result
- attestation-verifier report
- temporary summary files

The current raw evidence is preserved.

## Atomic output

The summary is written through a temporary file and becomes visible at the canonical output path only after serialization succeeds.

Failed serialization does not leave a partial canonical summary.

## Authority boundary

This producer does not:

- execute the LlamaGuard model
- create raw classifications
- create a GitHub attestation
- create an attestation bundle
- create the external-summary envelope
- verify cryptographic attestation
- modify signer policy
- produce recorded-release candidate envelopes
- verify recorded release evidence
- materialize release-required gates
- modify `status.json`
- replace `PULSE_safe_pack_v0/tools/check_gates.py`
- create release authority

The later path remains:

```text
canonical external summary
→ GitHub attestation bundle
→ canonical external-summary envelope
→ cryptographic verification
→ canonical recorded candidate
→ recorded verifier replay
→ policy-derived materialization
→ strict final gate enforcement
```

## Validation

Syntax validation:

```bash
python -m py_compile \
  PULSE_safe_pack_v0/tools/adapters/llamaguard_ingest.py
```

Dedicated fail-closed behavioral coverage follows in:

```text
tests/test_llamaguard_ingest_v1.py
```

## Boundary

- one-file producer change
- no signer-policy change
- no workflow change
- no schema change
- no gate-policy change
- no registry change
- no attestation behavior change
- no candidate-builder change
- no recorded-verifier change
- no materializer change
- no final gate-enforcement change
- no `status.json` semantics change
- no release-decision behavior change

## Result

```text
legacy compact LlamaGuard summary adapter
→ canonical current-run external_summary_v1 producer foundation
```