### PR TITLE
feat(ref): wire attested LlamaGuard evidence into release-grade path

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -874,47 +874,6 @@ jobs:
 
           "${AUGMENT_CMD[@]}"
 
-      - name: release-grade build verifier-facing candidate envelopes
-        if: ${{ steps.release_mode.outputs.is_release == '1' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          python "${PACK_DIR}/tools/build_recorded_release_candidates_v0.py" \
-            --repo-root "${GITHUB_WORKSPACE}"
-
-      - name: release-grade build release-evidence input manifest
-        if: ${{ steps.release_mode.outputs.is_release == '1' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          python "${PACK_DIR}/tools/build_release_evidence_input_manifest_v0.py" \
-            --repo-root "${GITHUB_WORKSPACE}"
-      
-      - name: release-grade verify recorded release evidence
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          python "${PACK_DIR}/tools/check_recorded_release_evidence_v0.py" \
-            --manifest "${PACK_DIR}/artifacts/release_evidence_input_manifest_v0.json" \
-            --repo-root "${GITHUB_WORKSPACE}" \
-            --out-json "${PACK_DIR}/artifacts/recorded_release_evidence_verifier_v0.json"
-
-      - name: release-grade materialize release-required from verifier
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          python "${PACK_DIR}/tools/materialize_release_required_from_verifier_v0.py" \
-            --status "${PACK_DIR}/artifacts/status.json" \
-            --verifier-report "${PACK_DIR}/artifacts/recorded_release_evidence_verifier_v0.json" \
-            --manifest "${PACK_DIR}/artifacts/release_evidence_input_manifest_v0.json" \
-            --repo-root "${GITHUB_WORKSPACE}" \
-            --policy "${GITHUB_WORKSPACE}/pulse_gate_policy_v0.yml" \
-            --registry "${GITHUB_WORKSPACE}/pulse_gate_registry_v0.yml" \
-            --out "${PACK_DIR}/artifacts/status.json"
       
       - name: "ci: schema validate status.json (status_v1)"
         shell: bash
@@ -1226,7 +1185,6 @@ jobs:
 
           POLICY_SET="${PULSE_POLICY_SET:-core_required}"
 
-          # Canonical helper (fail-closed, no PyYAML dependency)
           REQ_STR="$(python tools/policy_to_require_args.py \
             --policy pulse_gate_policy_v0.yml \
             --set "$POLICY_SET" \
@@ -1239,26 +1197,7 @@ jobs:
             exit 1
           fi
 
-          EFFECTIVE_SET="${POLICY_SET}"
-
-          if [[ "${PULSE_IS_RELEASE:-0}" == "1" ]]; then
-            RELEASE_REQ_STR="$(python tools/policy_to_require_args.py \
-              --policy pulse_gate_policy_v0.yml \
-              --set release_required \
-              --format space)"
-
-            read -r -a RELEASE_REQ <<< "$RELEASE_REQ_STR"
-
-            if (( ${#RELEASE_REQ[@]} == 0 )); then
-              echo "::error::derived gate set is empty: release_required"
-              exit 1
-            fi
-
-            REQ+=("${RELEASE_REQ[@]}")
-            EFFECTIVE_SET="${POLICY_SET}+release_required"
-          fi
-
-          echo "Enforcing materialized gate set: ${EFFECTIVE_SET} (${#REQ[@]} gates)"
+          echo "Enforcing materialized core gate set: ${POLICY_SET} (${#REQ[@]} gates)"
           printf '%s\n' "${REQ[@]}" | sed 's/^/ - /'
 
           python "${{ env.PACK_DIR }}/tools/check_gates.py" \
@@ -2358,8 +2297,272 @@ jobs:
           if-no-files-found: error
           retention-days: 30
   
+  release_grade_recorded_path:
+    name: "Release-grade recorded path: attested evidence to gates"
+    needs: attest_llamaguard_current_run_summary
+    if: ${{ github.event_name != 'pull_request' && needs.attest_llamaguard_current_run_summary.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true')) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      actions: read
+
+    env:
+      PACK_DIR: ${{ github.workspace }}/PULSE_safe_pack_v0
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pinned
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # pinned
+        with:
+          python-version: "3.11"
+
+      - name: Install Python deps for release-grade recorded path
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install jsonschema
+
+      - name: Download baseline pulse artifacts
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          DOWNLOAD_DIR="${RUNNER_TEMP}/pulse-report"
+          CANONICAL_ARTIFACTS="${GITHUB_WORKSPACE}/PULSE_safe_pack_v0/artifacts"
+
+          rm -rf "${DOWNLOAD_DIR}"
+          mkdir -p "${DOWNLOAD_DIR}" "${CANONICAL_ARTIFACTS}"
+
+          gh run download "${GITHUB_RUN_ID}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --name "pulse-report" \
+            --dir "${DOWNLOAD_DIR}"
+
+          copy_required_artifact () {
+            local name="$1"
+            local src
+
+            src="$(find "${DOWNLOAD_DIR}" -type f -name "${name}" | head -n 1 || true)"
+
+            if [[ -z "${src}" ]]; then
+              echo "::error::pulse-report artifact is missing ${name}"
+              exit 1
+            fi
+
+            if [[ -L "${src}" ]]; then
+              echo "::error::pulse-report artifact must not be a symlink: ${src}"
+              exit 1
+            fi
+
+            cp "${src}" "${CANONICAL_ARTIFACTS}/${name}"
+          }
+
+          copy_required_artifact "status.json"
+          copy_required_artifact "status_baseline.json"
+          copy_required_artifact "required_gate_evidence_v0.json"
+          copy_required_artifact "refusal_delta_summary.json"
+
+          for artifact in \
+            "${CANONICAL_ARTIFACTS}/status.json" \
+            "${CANONICAL_ARTIFACTS}/status_baseline.json" \
+            "${CANONICAL_ARTIFACTS}/required_gate_evidence_v0.json" \
+            "${CANONICAL_ARTIFACTS}/refusal_delta_summary.json"
+          do
+            if [[ ! -f "${artifact}" || -L "${artifact}" ]]; then
+              echo "::error::Restored baseline artifact is not a regular non-symlink file: ${artifact}"
+              exit 1
+            fi
+
+            sha256sum "${artifact}"
+          done
+
+      - name: Download attested LlamaGuard external evidence
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          DOWNLOAD_DIR="${RUNNER_TEMP}/llamaguard-attested-current-run"
+          CANONICAL_EXTERNAL="${GITHUB_WORKSPACE}/PULSE_safe_pack_v0/artifacts/external"
+
+          rm -rf "${DOWNLOAD_DIR}"
+          mkdir -p "${DOWNLOAD_DIR}" "${CANONICAL_EXTERNAL}"
+
+          gh run download "${GITHUB_RUN_ID}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --name "llamaguard-attested-current-run-${{ github.run_id }}-${{ github.run_attempt }}" \
+            --dir "${DOWNLOAD_DIR}"
+
+          restore_external_artifact () {
+            local name="$1"
+            local dst="$2"
+            local src
+
+            src="$(find "${DOWNLOAD_DIR}" -type f -name "${name}" | head -n 1 || true)"
+
+            if [[ -z "${src}" ]]; then
+              echo "::error::attested LlamaGuard artifact is missing ${name}"
+              exit 1
+            fi
+
+            if [[ -L "${src}" ]]; then
+              echo "::error::attested LlamaGuard artifact must not be a symlink: ${src}"
+              exit 1
+            fi
+
+            cp "${src}" "${dst}"
+          }
+
+          restore_external_artifact \
+            "llamaguard_raw.jsonl" \
+            "PULSE_safe_pack_v0/artifacts/external/llamaguard_raw.jsonl"
+
+          restore_external_artifact \
+            "llamaguard_evaluator_manifest_v0.json" \
+            "PULSE_safe_pack_v0/artifacts/external/llamaguard_evaluator_manifest_v0.json"
+
+          restore_external_artifact \
+            "llamaguard_summary.json" \
+            "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.json"
+
+          restore_external_artifact \
+            "llamaguard_summary.bundle.json" \
+            "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.bundle.json"
+
+          restore_external_artifact \
+            "llamaguard_summary.envelope.json" \
+            "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.envelope.json"
+
+          restore_external_artifact \
+            "llamaguard_attestation_verifier_v1.json" \
+            "PULSE_safe_pack_v0/artifacts/external/llamaguard_attestation_verifier_v1.json"
+
+          for artifact in \
+            "PULSE_safe_pack_v0/artifacts/external/llamaguard_raw.jsonl" \
+            "PULSE_safe_pack_v0/artifacts/external/llamaguard_evaluator_manifest_v0.json" \
+            "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.json" \
+            "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.bundle.json" \
+            "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.envelope.json" \
+            "PULSE_safe_pack_v0/artifacts/external/llamaguard_attestation_verifier_v1.json"
+          do
+            if [[ ! -f "${artifact}" || -L "${artifact}" ]]; then
+              echo "::error::Restored attested LlamaGuard artifact is not a regular non-symlink file: ${artifact}"
+              exit 1
+            fi
+
+            sha256sum "${artifact}"
+          done
+
+      - name: release-grade build verifier-facing candidate envelopes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          python "${PACK_DIR}/tools/build_recorded_release_candidates_v0.py" \
+            --repo-root "${GITHUB_WORKSPACE}"
+
+      - name: release-grade build release-evidence input manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python "${PACK_DIR}/tools/build_release_evidence_input_manifest_v0.py" \
+            --repo-root "${GITHUB_WORKSPACE}"
+
+      - name: release-grade verify recorded release evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python "${PACK_DIR}/tools/check_recorded_release_evidence_v0.py" \
+            --manifest "${PACK_DIR}/artifacts/release_evidence_input_manifest_v0.json" \
+            --repo-root "${GITHUB_WORKSPACE}" \
+            --out-json "${PACK_DIR}/artifacts/recorded_release_evidence_verifier_v0.json"
+
+      - name: release-grade materialize release-required from verifier
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python "${PACK_DIR}/tools/materialize_release_required_from_verifier_v0.py" \
+            --status "${PACK_DIR}/artifacts/status.json" \
+            --verifier-report "${PACK_DIR}/artifacts/recorded_release_evidence_verifier_v0.json" \
+            --manifest "${PACK_DIR}/artifacts/release_evidence_input_manifest_v0.json" \
+            --repo-root "${GITHUB_WORKSPACE}" \
+            --policy "${GITHUB_WORKSPACE}/pulse_gate_policy_v0.yml" \
+            --registry "${GITHUB_WORKSPACE}/pulse_gate_registry_v0.yml" \
+            --out "${PACK_DIR}/artifacts/status.json"
+
+      - name: release-grade enforce release-required gates via check_gates
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          STATUS="PULSE_safe_pack_v0/artifacts/status.json"
+
+          if [[ ! -f "${STATUS}" || -L "${STATUS}" ]]; then
+            echo "::error::release-grade status is missing or symlinked: ${STATUS}"
+            exit 1
+          fi
+
+          RELEASE_REQ_STR="$(python tools/policy_to_require_args.py \
+            --policy pulse_gate_policy_v0.yml \
+            --set release_required \
+            --format space)"
+
+          read -r -a RELEASE_REQ <<< "$RELEASE_REQ_STR"
+
+          if (( ${#RELEASE_REQ[@]} == 0 )); then
+            echo "::error::derived gate set is empty: release_required"
+            exit 1
+          fi
+
+          echo "Enforcing release_required gate set (${#RELEASE_REQ[@]} gates)"
+          printf '%s\n' "${RELEASE_REQ[@]}" | sed 's/^/ - /'
+
+          python "${PACK_DIR}/tools/check_gates.py" \
+            --status "${STATUS}" \
+            --require "${RELEASE_REQ[@]}"
+
+      - name: Upload release-grade recorded path artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        with:
+          name: release-grade-recorded-path-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            PULSE_safe_pack_v0/artifacts/status.json
+            PULSE_safe_pack_v0/artifacts/status_baseline.json
+            PULSE_safe_pack_v0/artifacts/required_gate_evidence_v0.json
+            PULSE_safe_pack_v0/artifacts/refusal_delta_summary.json
+            PULSE_safe_pack_v0/artifacts/recorded_release_candidates/**
+            PULSE_safe_pack_v0/artifacts/recorded_release_candidate_index_v0.json
+            PULSE_safe_pack_v0/artifacts/release_evidence_input_manifest_v0.json
+            PULSE_safe_pack_v0/artifacts/recorded_release_evidence_verifier_v0.json
+            PULSE_safe_pack_v0/artifacts/external/llamaguard_raw.jsonl
+            PULSE_safe_pack_v0/artifacts/external/llamaguard_evaluator_manifest_v0.json
+            PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.json
+            PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.bundle.json
+            PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.envelope.json
+            PULSE_safe_pack_v0/artifacts/external/llamaguard_attestation_verifier_v1.json
+          if-no-files-found: error
+          retention-days: 30
+  
   tools-tests:
     name: Tools smoke tests
+    needs: release_grade_recorded_path
+    if: ${{ always() && (needs.release_grade_recorded_path.result == 'success' || needs.release_grade_recorded_path.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -19,6 +19,7 @@ tests/test_augment_status_strict_external_evidence.py
 tests/test_llamaguard_ingest_v1.py
 tests/test_run_llamaguard_current_evidence_v0.py
 tests/test_llamaguard_current_run_workflow_wiring_v0.py
+tests/test_llamaguard_current_run_workflow_wiring_v0.py
 tests/test_run_all_mode_contract.py
 tests/test_validate_status_schema_tool.py
 tests/test_validate_space_relation_map_tool.py

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -18,7 +18,7 @@ tests/test_augment_status_smoke.py
 tests/test_augment_status_strict_external_evidence.py
 tests/test_llamaguard_ingest_v1.py
 tests/test_run_llamaguard_current_evidence_v0.py
-tests/test_llamaguard_current_run_workflow_wiring_v0.py
+tests/test_llamaguard_attested_release_path_wiring_v0.py
 tests/test_llamaguard_current_run_workflow_wiring_v0.py
 tests/test_run_all_mode_contract.py
 tests/test_validate_status_schema_tool.py

--- a/tests/test_llamaguard_attested_release_path_wiring_v0.py
+++ b/tests/test_llamaguard_attested_release_path_wiring_v0.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pulse_ci.yml"
+TOOLS_TESTS_LIST = REPO_ROOT / "ci" / "tools-tests.list"
+
+ATTEST_JOB = "attest_llamaguard_current_run_summary"
+RELEASE_PATH_JOB = "release_grade_recorded_path"
+ATTESTED_ARTIFACT = (
+    "llamaguard-attested-current-run-"
+    "${{ github.run_id }}-${{ github.run_attempt }}"
+)
+
+STRICT_RELEASE_GUARD_TOKENS = (
+    "github.event_name != 'pull_request'",
+    "needs.attest_llamaguard_current_run_summary.result == 'success'",
+    "strict_external_evidence == 'true'",
+)
+
+STANDING_RELEASE_TOOLS = (
+    "tools/build_recorded_release_candidates_v0.py",
+    "tools/build_release_evidence_input_manifest_v0.py",
+    "tools/check_recorded_release_evidence_v0.py",
+    "tools/materialize_release_required_from_verifier_v0.py",
+    "tools/check_gates.py",
+)
+
+ATTESTED_EXTERNAL_ARTIFACTS = (
+    "llamaguard_raw.jsonl",
+    "llamaguard_evaluator_manifest_v0.json",
+    "llamaguard_summary.json",
+    "llamaguard_summary.bundle.json",
+    "llamaguard_summary.envelope.json",
+    "llamaguard_attestation_verifier_v1.json",
+)
+
+
+def _read_workflow() -> str:
+    if not WORKFLOW.is_file():
+        raise AssertionError(f"missing workflow: {WORKFLOW}")
+
+    return WORKFLOW.read_text(
+        encoding="utf-8",
+        errors="strict",
+    )
+
+
+def _read_tools_manifest() -> str:
+    if not TOOLS_TESTS_LIST.is_file():
+        raise AssertionError(
+            f"missing tools manifest: {TOOLS_TESTS_LIST}"
+        )
+
+    return TOOLS_TESTS_LIST.read_text(
+        encoding="utf-8",
+        errors="strict",
+    )
+
+
+def _top_level_job_blocks(text: str) -> dict[str, str]:
+    starts: list[tuple[str, int]] = []
+    offset = 0
+
+    for line in text.splitlines(keepends=True):
+        if (
+            line.startswith("  ")
+            and not line.startswith("    ")
+            and line.strip().endswith(":")
+        ):
+            starts.append((line.strip()[:-1], offset))
+
+        offset += len(line)
+
+    blocks: dict[str, str] = {}
+
+    for index, (name, start) in enumerate(starts):
+        end = (
+            starts[index + 1][1]
+            if index + 1 < len(starts)
+            else len(text)
+        )
+        blocks[name] = text[start:end]
+
+    return blocks
+
+
+def _job_field(job_block: str, field_name: str) -> str:
+    prefix = f"    {field_name}:"
+
+    for line in job_block.splitlines():
+        if line.startswith(prefix):
+            return line.split(":", 1)[1].strip()
+
+    raise AssertionError(f"missing job field: {field_name}")
+
+
+def _workflow_and_jobs() -> tuple[str, dict[str, str]]:
+    text = _read_workflow()
+    blocks = _top_level_job_blocks(text)
+
+    for name in (
+        "pulse",
+        ATTEST_JOB,
+        RELEASE_PATH_JOB,
+        "tools-tests",
+    ):
+        if name not in blocks:
+            raise AssertionError(f"missing workflow job: {name}")
+
+    return text, blocks
+
+
+def test_attested_release_path_job_order() -> None:
+    text, _blocks = _workflow_and_jobs()
+
+    pulse_index = text.index("  pulse:")
+    attest_index = text.index(f"  {ATTEST_JOB}:")
+    release_path_index = text.index(
+        f"  {RELEASE_PATH_JOB}:"
+    )
+    tools_index = text.index("  tools-tests:")
+
+    assert (
+        pulse_index
+        < attest_index
+        < release_path_index
+        < tools_index
+    )
+
+
+def test_release_path_depends_on_attested_llamaguard_job() -> None:
+    _text, blocks = _workflow_and_jobs()
+    job = blocks[RELEASE_PATH_JOB]
+
+    assert _job_field(job, "needs") == ATTEST_JOB
+
+    guard = _job_field(job, "if")
+
+    for token in STRICT_RELEASE_GUARD_TOKENS:
+        assert token in guard, token
+
+
+def test_standing_release_tools_move_out_of_pulse_job() -> None:
+    _text, blocks = _workflow_and_jobs()
+    pulse = blocks["pulse"]
+
+    for tool in STANDING_RELEASE_TOOLS:
+        if tool in pulse:
+            raise AssertionError(
+                "standing release-grade candidate/verifier/"
+                "materializer/check_gates path must not run in "
+                f"the pre-attestation pulse job: {tool}"
+            )
+
+
+def test_release_path_downloads_attested_external_evidence_first() -> None:
+    _text, blocks = _workflow_and_jobs()
+    job = blocks[RELEASE_PATH_JOB]
+
+    download_index = job.index(
+        "Download attested LlamaGuard external evidence"
+    )
+    artifact_index = job.index(ATTESTED_ARTIFACT)
+
+    assert download_index < artifact_index
+
+    for artifact in ATTESTED_EXTERNAL_ARTIFACTS:
+        assert artifact in job, artifact
+
+    first_standing_tool_index = min(
+        job.index(tool)
+        for tool in STANDING_RELEASE_TOOLS
+    )
+
+    assert artifact_index < first_standing_tool_index
+
+
+def test_release_path_uses_existing_standing_tools_in_order() -> None:
+    _text, blocks = _workflow_and_jobs()
+    job = blocks[RELEASE_PATH_JOB]
+
+    positions = [
+        job.index(tool)
+        for tool in STANDING_RELEASE_TOOLS
+    ]
+
+    assert positions == sorted(positions), positions
+
+
+def test_release_path_does_not_introduce_parallel_engines() -> None:
+    _text, blocks = _workflow_and_jobs()
+    job = blocks[RELEASE_PATH_JOB]
+
+    forbidden = (
+        "new_release_decision",
+        "parallel_decision",
+        "alternate_check_gates",
+        "llamaguard_materializer",
+        "llamaguard_verifier",
+    )
+
+    for token in forbidden:
+        assert token not in job, token
+
+
+def test_release_path_keeps_check_gates_as_final_enforcement() -> None:
+    _text, blocks = _workflow_and_jobs()
+    job = blocks[RELEASE_PATH_JOB]
+
+    materializer_index = job.index(
+        "tools/materialize_release_required_from_verifier_v0.py"
+    )
+    check_gates_index = job.index("tools/check_gates.py")
+
+    assert materializer_index < check_gates_index
+    assert "--status" in job
+    assert "PULSE_safe_pack_v0/artifacts/status.json" in job
+    assert "--require" in job
+
+
+def test_pr3_workflow_wiring_smoke_registered() -> None:
+    manifest = _read_tools_manifest()
+
+    assert (
+        "tests/test_llamaguard_attested_release_path_wiring_v0.py"
+        in manifest
+    )
+
+
+def main() -> int:
+    test_attested_release_path_job_order()
+    test_release_path_depends_on_attested_llamaguard_job()
+    test_standing_release_tools_move_out_of_pulse_job()
+    test_release_path_downloads_attested_external_evidence_first()
+    test_release_path_uses_existing_standing_tools_in_order()
+    test_release_path_does_not_introduce_parallel_engines()
+    test_release_path_keeps_check_gates_as_final_enforcement()
+    test_pr3_workflow_wiring_smoke_registered()
+    print(
+        "LlamaGuard attested release-path workflow wiring "
+        "smoke passed"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_llamaguard_attested_release_path_wiring_v0.py
+++ b/tests/test_llamaguard_attested_release_path_wiring_v0.py
@@ -19,23 +19,35 @@ STRICT_RELEASE_GUARD_TOKENS = (
     "github.event_name != 'pull_request'",
     "needs.attest_llamaguard_current_run_summary.result == 'success'",
     "strict_external_evidence == 'true'",
+    "startsWith(github.ref, 'refs/tags/v')",
+    "startsWith(github.ref, 'refs/tags/V')",
 )
 
-STANDING_RELEASE_TOOLS = (
+PRE_ATTESTATION_RELEASE_TOOLS = (
     "tools/build_recorded_release_candidates_v0.py",
     "tools/build_release_evidence_input_manifest_v0.py",
     "tools/check_recorded_release_evidence_v0.py",
     "tools/materialize_release_required_from_verifier_v0.py",
+)
+
+RELEASE_PATH_TOOLS = (
+    *PRE_ATTESTATION_RELEASE_TOOLS,
     "tools/check_gates.py",
 )
 
-ATTESTED_EXTERNAL_ARTIFACTS = (
-    "llamaguard_raw.jsonl",
-    "llamaguard_evaluator_manifest_v0.json",
-    "llamaguard_summary.json",
-    "llamaguard_summary.bundle.json",
-    "llamaguard_summary.envelope.json",
-    "llamaguard_attestation_verifier_v1.json",
+ATTESTED_EXTERNAL_ARTIFACT_PATHS = (
+    "PULSE_safe_pack_v0/artifacts/external/llamaguard_raw.jsonl",
+    (
+        "PULSE_safe_pack_v0/artifacts/external/"
+        "llamaguard_evaluator_manifest_v0.json"
+    ),
+    "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.json",
+    "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.bundle.json",
+    "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.envelope.json",
+    (
+        "PULSE_safe_pack_v0/artifacts/external/"
+        "llamaguard_attestation_verifier_v1.json"
+    ),
 )
 
 
@@ -144,17 +156,33 @@ def test_release_path_depends_on_attested_llamaguard_job() -> None:
         assert token in guard, token
 
 
-def test_standing_release_tools_move_out_of_pulse_job() -> None:
+def test_tools_tests_depends_on_release_path_job() -> None:
+    _text, blocks = _workflow_and_jobs()
+
+    assert _job_field(blocks["tools-tests"], "needs") == (
+        RELEASE_PATH_JOB
+    )
+
+
+def test_release_grade_candidate_path_runs_only_after_attestation() -> None:
     _text, blocks = _workflow_and_jobs()
     pulse = blocks["pulse"]
 
-    for tool in STANDING_RELEASE_TOOLS:
+    for tool in PRE_ATTESTATION_RELEASE_TOOLS:
         if tool in pulse:
             raise AssertionError(
-                "standing release-grade candidate/verifier/"
-                "materializer/check_gates path must not run in "
-                f"the pre-attestation pulse job: {tool}"
+                "release-grade candidate/verifier/materializer "
+                "path must not run in the pre-attestation pulse "
+                f"job: {tool}"
             )
+
+
+def test_core_check_gates_remains_allowed_in_pulse_job() -> None:
+    _text, blocks = _workflow_and_jobs()
+    pulse = blocks["pulse"]
+
+    assert "tools/check_gates.py" in pulse
+    assert "ci: enforce gates via check_gates (policy-derived)" in pulse
 
 
 def test_release_path_downloads_attested_external_evidence_first() -> None:
@@ -168,15 +196,17 @@ def test_release_path_downloads_attested_external_evidence_first() -> None:
 
     assert download_index < artifact_index
 
-    for artifact in ATTESTED_EXTERNAL_ARTIFACTS:
-        assert artifact in job, artifact
+    for artifact_path in ATTESTED_EXTERNAL_ARTIFACT_PATHS:
+        restored_index = job.index(artifact_path)
+        assert artifact_index < restored_index
 
-    first_standing_tool_index = min(
+    first_release_tool_index = min(
         job.index(tool)
-        for tool in STANDING_RELEASE_TOOLS
+        for tool in RELEASE_PATH_TOOLS
     )
 
-    assert artifact_index < first_standing_tool_index
+    for artifact_path in ATTESTED_EXTERNAL_ARTIFACT_PATHS:
+        assert job.index(artifact_path) < first_release_tool_index
 
 
 def test_release_path_uses_existing_standing_tools_in_order() -> None:
@@ -185,7 +215,7 @@ def test_release_path_uses_existing_standing_tools_in_order() -> None:
 
     positions = [
         job.index(tool)
-        for tool in STANDING_RELEASE_TOOLS
+        for tool in RELEASE_PATH_TOOLS
     ]
 
     assert positions == sorted(positions), positions
@@ -207,19 +237,22 @@ def test_release_path_does_not_introduce_parallel_engines() -> None:
         assert token not in job, token
 
 
-def test_release_path_keeps_check_gates_as_final_enforcement() -> None:
+def test_release_path_keeps_policy_derived_check_gates_enforcement() -> None:
     _text, blocks = _workflow_and_jobs()
     job = blocks[RELEASE_PATH_JOB]
 
     materializer_index = job.index(
         "tools/materialize_release_required_from_verifier_v0.py"
     )
+    helper_index = job.index("tools/policy_to_require_args.py")
+    set_index = job.index("--set release_required")
     check_gates_index = job.index("tools/check_gates.py")
 
-    assert materializer_index < check_gates_index
+    assert materializer_index < helper_index < set_index < check_gates_index
+    assert "RELEASE_REQ_STR" in job
+    assert '"${RELEASE_REQ[@]}"' in job
     assert "--status" in job
     assert "PULSE_safe_pack_v0/artifacts/status.json" in job
-    assert "--require" in job
 
 
 def test_pr3_workflow_wiring_smoke_registered() -> None:
@@ -234,11 +267,13 @@ def test_pr3_workflow_wiring_smoke_registered() -> None:
 def main() -> int:
     test_attested_release_path_job_order()
     test_release_path_depends_on_attested_llamaguard_job()
-    test_standing_release_tools_move_out_of_pulse_job()
+    test_tools_tests_depends_on_release_path_job()
+    test_release_grade_candidate_path_runs_only_after_attestation()
+    test_core_check_gates_remains_allowed_in_pulse_job()
     test_release_path_downloads_attested_external_evidence_first()
     test_release_path_uses_existing_standing_tools_in_order()
     test_release_path_does_not_introduce_parallel_engines()
-    test_release_path_keeps_check_gates_as_final_enforcement()
+    test_release_path_keeps_policy_derived_check_gates_enforcement()
     test_pr3_workflow_wiring_smoke_registered()
     print(
         "LlamaGuard attested release-path workflow wiring "

--- a/tests/test_release_authority_audit_bundle_workflow_neutrality_v0.py
+++ b/tests/test_release_authority_audit_bundle_workflow_neutrality_v0.py
@@ -7,6 +7,16 @@ traceability surface.
 It does not change workflow behavior. It statically verifies that the
 primary workflow keeps audit-bundle staging/upload separate from the
 artifact-bound release-authority path.
+
+The workflow may contain more than one policy-derived check_gates.py
+enforcement step. For example:
+
+- core gate enforcement in the pulse job;
+- release_required enforcement in the attested release-grade path.
+
+That is valid. The invariant here is not "exactly one enforcement step".
+The invariant is that no policy-derived check_gates enforcement step may
+consume the audit bundle as a release-authority carrier.
 """
 
 from __future__ import annotations
@@ -30,6 +40,7 @@ def _extract_step(workflow: str, step_name: str) -> str:
         rf"(?=^\s*-\s+name:\s+|\Z)"
     )
     match = pattern.search(workflow)
+
     assert match is not None, f"Missing workflow step: {step_name}"
     return match.group(0)
 
@@ -55,7 +66,11 @@ def _extract_steps_containing(
     return matches
 
 
-def _assert_contains_all(text: str, required: list[str], label: str) -> None:
+def _assert_contains_all(
+    text: str,
+    required: list[str],
+    label: str,
+) -> None:
     missing = [item for item in required if item not in text]
     assert not missing, f"{label} is missing expected tokens: {missing}"
 
@@ -83,11 +98,10 @@ def test_release_authority_audit_bundle_workflow_neutrality_v0() -> None:
         workflow,
         "Upload release authority audit bundle (audit-only)",
     )
-        enforcement_steps = _extract_steps_containing(
+    enforcement_steps = _extract_steps_containing(
         workflow,
         ["policy_to_require_args.py", "check_gates.py"],
         "policy-derived check_gates enforcement",
-    )
     )
 
     _assert_contains_all(
@@ -151,7 +165,7 @@ def test_release_authority_audit_bundle_workflow_neutrality_v0() -> None:
             f"token: {token}"
         )
 
-        forbidden_enforcement_tokens = [
+    forbidden_enforcement_tokens = [
         "release_authority_audit_bundle",
         "release-authority-audit-bundle",
         "--audit-bundle-dir",

--- a/tests/test_release_authority_audit_bundle_workflow_neutrality_v0.py
+++ b/tests/test_release_authority_audit_bundle_workflow_neutrality_v0.py
@@ -34,11 +34,11 @@ def _extract_step(workflow: str, step_name: str) -> str:
     return match.group(0)
 
 
-def _extract_step_containing(
+def _extract_steps_containing(
     workflow: str,
     required_tokens: list[str],
     label: str,
-) -> str:
+) -> list[str]:
     step_pattern = re.compile(
         r"(?ms)^\s*-\s+name:\s+.*?$.*?(?=^\s*-\s+name:\s+|\Z)"
     )
@@ -48,11 +48,11 @@ def _extract_step_containing(
         if all(token in match.group(0) for token in required_tokens)
     ]
 
-    assert len(matches) == 1, (
-        f"Expected exactly one {label} step containing {required_tokens}, "
-        f"found {len(matches)}"
+    assert matches, (
+        f"Expected at least one {label} step containing {required_tokens}, "
+        "found 0"
     )
-    return matches[0]
+    return matches
 
 
 def _assert_contains_all(text: str, required: list[str], label: str) -> None:
@@ -83,10 +83,11 @@ def test_release_authority_audit_bundle_workflow_neutrality_v0() -> None:
         workflow,
         "Upload release authority audit bundle (audit-only)",
     )
-    enforcement_step = _extract_step_containing(
+        enforcement_steps = _extract_steps_containing(
         workflow,
         ["policy_to_require_args.py", "check_gates.py"],
         "policy-derived check_gates enforcement",
+    )
     )
 
     _assert_contains_all(
@@ -150,17 +151,18 @@ def test_release_authority_audit_bundle_workflow_neutrality_v0() -> None:
             f"token: {token}"
         )
 
-    forbidden_enforcement_tokens = [
+        forbidden_enforcement_tokens = [
         "release_authority_audit_bundle",
         "release-authority-audit-bundle",
         "--audit-bundle-dir",
     ]
 
-    for token in forbidden_enforcement_tokens:
-        assert token not in enforcement_step, (
-            "policy-derived check_gates enforcement must not consume the "
-            f"audit bundle as a release-authority carrier: {token}"
-        )
+    for enforcement_step in enforcement_steps:
+        for token in forbidden_enforcement_tokens:
+            assert token not in enforcement_step, (
+                "policy-derived check_gates enforcement must not consume the "
+                f"audit bundle as a release-authority carrier: {token}"
+            )
 
     assert "name: release-authority-audit-bundle" in upload_step
     assert "name: status.json" not in upload_step

--- a/tests/test_release_grade_reference_qualification_advisory_boundary_v0.py
+++ b/tests/test_release_grade_reference_qualification_advisory_boundary_v0.py
@@ -7,6 +7,17 @@ non-normative / non-blocking review support.
 It does not change workflow behavior. It statically verifies that the
 qualification step does not become the primary artifact-bound
 release-authority path.
+
+The workflow may contain more than one real policy-derived check_gates.py
+enforcement step. For example:
+
+- core gate enforcement in the pulse job;
+- release_required enforcement in the attested release-grade recorded path.
+
+That is valid. The invariant here is not "exactly one enforcement step".
+The invariant is that the advisory qualification step must not become an
+enforcement path, and no real policy-derived check_gates.py enforcement step
+may consume the qualification/audit bundle as a release-authority carrier.
 """
 
 from __future__ import annotations
@@ -52,7 +63,11 @@ def _assert_contains_all(text: str, required: list[str], label: str) -> None:
     assert not missing, f"{label} is missing expected tokens: {missing}"
 
 
-def _assert_not_contains_any(text: str, forbidden: list[str], label: str) -> None:
+def _assert_not_contains_any(
+    text: str,
+    forbidden: list[str],
+    label: str,
+) -> None:
     present = [item for item in forbidden if item in text]
     assert not present, f"{label} contains forbidden tokens: {present}"
 
@@ -185,20 +200,25 @@ def _step_has_non_summary_token(step: str, token: str) -> bool:
     return any(token in line for line in _non_summary_lines(step))
 
 
-def _extract_policy_derived_check_gates_enforcement_step(workflow: str) -> str:
-    """Find the real policy-derived check_gates.py enforcement step.
+def _extract_policy_derived_check_gates_enforcement_steps(
+    workflow: str,
+) -> list[str]:
+    """Find real policy-derived check_gates.py enforcement steps.
 
-    The test must not depend on an exact workflow step name because the
-    workflow name may change. It must also avoid matching summary/export steps
-    that merely mention check_gates.py in text.
+    The test must not depend on an exact workflow step name because workflow
+    names may change. It must also avoid matching summary/export steps that
+    merely mention check_gates.py in text.
 
     The mechanical shape required here is:
 
-    - policy_to_require_args.py is present in non-summary content
-    - check_gates.py is present in non-summary content
-    - --status and --require are present in non-summary content
+    - policy_to_require_args.py is present in non-summary content;
+    - check_gates.py is present in non-summary content;
+    - --status and --require are present in non-summary content;
     - both tools are invoked through Python, either directly or through
-      variables assigned to those tool paths
+      variables assigned to those tool paths.
+
+    More than one matching enforcement step is allowed, because PR3 separates
+    core enforcement from release_required enforcement.
     """
 
     candidates: list[str] = []
@@ -228,12 +248,12 @@ def _extract_policy_derived_check_gates_enforcement_step(workflow: str) -> str:
         if has_policy_invocation and has_check_gates_invocation:
             candidates.append(step)
 
-    assert len(candidates) == 1, (
-        "Expected exactly one real policy-derived check_gates.py enforcement "
-        f"step, found {len(candidates)}"
+    assert candidates, (
+        "Expected at least one real policy-derived check_gates.py enforcement "
+        "step, found 0"
     )
 
-    return candidates[0]
+    return candidates
 
 
 def _assert_failure_branch_exits_zero(qualification_step: str) -> None:
@@ -301,7 +321,7 @@ def _assert_failure_branch_exits_zero(qualification_step: str) -> None:
 
 
 def _assert_actual_check_gates_enforcement_step(enforcement_step: str) -> None:
-    """Lock the real policy-derived check_gates enforcement step.
+    """Lock a real policy-derived check_gates enforcement step.
 
     This must not accidentally match a later reporting/export step that only
     mentions check_gates.py in summary text.
@@ -340,7 +360,7 @@ def test_release_grade_reference_qualification_is_advisory_boundary_v0() -> None
         workflow,
         "Check release-grade reference run qualification (advisory)",
     )
-    enforcement_step = _extract_policy_derived_check_gates_enforcement_step(
+    enforcement_steps = _extract_policy_derived_check_gates_enforcement_steps(
         workflow,
     )
 
@@ -392,18 +412,21 @@ def test_release_grade_reference_qualification_is_advisory_boundary_v0() -> None
         "release-grade reference qualification step",
     )
 
-    _assert_actual_check_gates_enforcement_step(enforcement_step)
+    forbidden_enforcement_tokens = [
+        "release_authority_audit_bundle",
+        "release-authority-audit-bundle",
+        "--audit-bundle-dir",
+        "check_release_grade_reference_run_v0.py",
+    ]
 
-    _assert_not_contains_any(
-        enforcement_step,
-        [
-            "release_authority_audit_bundle",
-            "release-authority-audit-bundle",
-            "--audit-bundle-dir",
-            "check_release_grade_reference_run_v0.py",
-        ],
-        "policy-derived check_gates.py enforcement step",
-    )
+    for enforcement_step in enforcement_steps:
+        _assert_actual_check_gates_enforcement_step(enforcement_step)
+
+        _assert_not_contains_any(
+            enforcement_step,
+            forbidden_enforcement_tokens,
+            "policy-derived check_gates.py enforcement step",
+        )
 
     _assert_contains_all(
         workflow,


### PR DESCRIPTION
## Summary

Wire the attested current-run LlamaGuard evidence into the standing release-grade candidate, verifier, materializer, and gate-enforcement path.

This PR continues after:

```text
PR #2629
current-run LlamaGuard raw-evidence lane

PR #2630
exact LlamaGuard workflow identity
→ GitHub attestation
→ persisted bundle
→ canonical envelope
→ attestation verifier report path
```

The purpose of this PR is not to build a new decision engine. The purpose is to make the already-attested LlamaGuard external evidence available before the existing recorded release path runs.

## Mechanical path

```text
current-run LlamaGuard raw evidence
→ canonical LlamaGuard summary
→ exact workflow attestation
→ persisted bundle and envelope
→ verified attestation report
→ existing recorded candidate builder
→ existing input manifest builder
→ existing recorded verifier
→ existing release-required materializer
→ existing check_gates.py
```

## Required workflow order

```text
pulse
→ attest_llamaguard_current_run_summary
→ release_grade_recorded_path
→ tools-tests
```

## Changes

- add a workflow-wiring smoke test for the attested LlamaGuard release path;
- require the release-grade recorded path to depend on the attested LlamaGuard job;
- require the attested LlamaGuard artifact to be downloaded before candidate building;
- ensure the restored attested artifacts include:

```text
llamaguard_raw.jsonl
llamaguard_evaluator_manifest_v0.json
llamaguard_summary.json
llamaguard_summary.bundle.json
llamaguard_summary.envelope.json
llamaguard_attestation_verifier_v1.json
```

- keep the standing release-grade tool order:

```text
build_recorded_release_candidates_v0.py
→ build_release_evidence_input_manifest_v0.py
→ check_recorded_release_evidence_v0.py
→ materialize_release_required_from_verifier_v0.py
→ check_gates.py
```

- prevent the pre-attestation `pulse` job from running the standing release-grade candidate/verifier/materializer/check_gates path too early;
- register the new workflow-wiring smoke test in the tools-test manifest.

## Authority boundary

This PR does not:

- create a new external evidence producer;
- create a new verifier;
- create a new materializer;
- create a new gate checker;
- create a new release-decision engine;
- directly authorize a release;
- bypass the recorded verifier;
- bypass `check_gates.py`.

```text
attested external evidence
≠ release authorization
```

The attested LlamaGuard evidence only becomes useful through the existing recorded candidate, verifier, materializer, and strict gate-enforcement path.

## Validation

- new attested release-path workflow-wiring smoke test;
- existing LlamaGuard current-run producer tests;
- existing LlamaGuard attestation-envelope tests;
- existing external-summary attestation verifier tests;
- existing recorded release evidence tests;
- existing materializer tests;
- Tools smoke tests;
- PULSE CI.

## Expected intermediate state

After the first test-only commit, the new wiring smoke test may fail until the workflow is updated.

That failure is expected because the test locks the intended PR3 wiring before the workflow move is implemented.