### PR TITLE
ci(ref): preserve release-grade required-gate diagnostics

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -422,6 +422,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          set +e
           python "${PACK_DIR}/tools/run_recorded_required_gate_evaluations_v0.py" \
             --repo-root "${GITHUB_WORKSPACE}" \
             --git-sha "${GITHUB_SHA}" \
@@ -429,6 +430,60 @@ jobs:
             --repository "${GITHUB_REPOSITORY}" \
             --release-candidate "${GITHUB_REF_NAME}" \
             --out "${PACK_DIR}/artifacts/required_gate_evidence_v0.json"
+          REQUIRED_GATE_RC=$?
+          set -e
+
+          EVIDENCE="${PACK_DIR}/artifacts/required_gate_evidence_v0.json"
+
+          if [[ -f "${EVIDENCE}" && ! -L "${EVIDENCE}" ]]; then
+            echo "----- release-grade required-gate evidence summary -----"
+            python - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("PULSE_safe_pack_v0/artifacts/required_gate_evidence_v0.json")
+          payload = json.loads(path.read_text(encoding="utf-8"))
+
+          gates = payload.get("gates") or {}
+          failed = []
+          passed = []
+
+          for gate_id, gate in sorted(gates.items()):
+              if isinstance(gate, dict) and gate.get("status") == "passed":
+                  passed.append(gate_id)
+              else:
+                  failed.append(gate_id)
+
+          print(f"required_gate_evidence: {path}")
+          print(f"passed gates: {len(passed)}")
+          print(f"failed gates: {len(failed)}")
+
+          if failed:
+              print("failed gate IDs:")
+              for gate_id in failed:
+                  print(f" - {gate_id}")
+                  diagnostics = gates.get(gate_id, {}).get("diagnostics") or []
+                  for item in diagnostics:
+                      print(f"   diagnostic: {item}")
+          PY
+            echo "--------------------------------------------------------"
+          else
+            echo "::warning::required_gate_evidence_v0.json was not produced"
+          fi
+
+          exit "${REQUIRED_GATE_RC}"
+
+      - name: Upload release-grade required-gate diagnostics
+        if: ${{ always() && steps.release_mode.outputs.is_release == '1' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        with:
+          name: release-grade-required-gate-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            PULSE_safe_pack_v0/artifacts/required_gate_evidence_v0.json
+            PULSE_safe_pack_v0/artifacts/required_gate_inputs/**
+            PULSE_safe_pack_v0/artifacts/required_gate_evidence_logs/**
+          if-no-files-found: warn
+          retention-days: 30
 
       - name: release-grade build non-stubbed prod candidate status
         if: ${{ steps.release_mode.outputs.is_release == '1' }}


### PR DESCRIPTION
## Summary

Preserve diagnostics from the release-grade required-gate bootstrap step.

The controlled strict release-grade run stopped at:

```text
release-grade record current-run required-gate evidence
```

The producer wrote:

```text
PULSE_safe_pack_v0/artifacts/required_gate_evidence_v0.json
```

but returned non-zero because one or more required gates failed:

```text
one or more gates failed
```

Since the diagnostic evidence was not uploaded, the failed gate IDs and per-gate diagnostics were not visible from the run artifacts.

This PR preserves those diagnostics while keeping the release-grade bootstrap fail-closed.

## Changes

- capture the required-gate producer exit code;
- print a summary of passed and failed required gates when `required_gate_evidence_v0.json` exists;
- print failed gate IDs;
- print available diagnostics for failed gates;
- upload required-gate evidence, gate inputs, and evaluator logs as a diagnostic artifact;
- preserve the original fail-closed exit code from the required-gate evidence producer.

## Mechanical path

```text
release-grade required-gate producer
→ required_gate_evidence_v0.json
→ failed gate summary in log
→ required-gate diagnostic artifact upload
→ original exit code preserved
→ release-grade run remains fail-closed
```

## Diagnostic artifact

The workflow uploads:

```text
PULSE_safe_pack_v0/artifacts/required_gate_evidence_v0.json
PULSE_safe_pack_v0/artifacts/required_gate_inputs/**
PULSE_safe_pack_v0/artifacts/required_gate_evidence_logs/**
```

under a run-scoped artifact name:

```text
release-grade-required-gate-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
```

This gives the next controlled run enough evidence to identify the exact failed required gate without weakening the gate path.

## Authority boundary

This PR does not:

- change gate policy;
- change release decision semantics;
- materialize gates;
- create release authority;
- bypass `check_gates.py`;
- bypass the recorded verifier;
- bypass the materializer;
- allow a failed required-gate run to continue as passing;
- make diagnostic artifacts authoritative.

```text
diagnostics preserved
≠ release authorized
```

The required-gate producer remains fail-closed. If one or more required gates fail, the workflow still fails.

## Why this is needed

The strict release-grade run currently fails before `status.json` is produced, because the required-gate evidence producer returns non-zero after recording candidate evidence.

Without uploading the recorded evidence and logs, the run only shows that one or more gates failed, but not which gate failed or why.

This PR makes the failure inspectable while preserving the same release-blocking behavior.

## Validation

Expected validation:

- Tools smoke tests;
- PULSE CI;
- controlled `workflow_dispatch` release-grade run still fails closed if a required gate fails;
- failed required-gate IDs and diagnostics are visible in the job log;
- `release-grade-required-gate-diagnostics-*` artifact is uploaded even when the required-gate producer exits non-zero.