### PR TITLE
fix(ref): align floor with required-gate evidence value field

### DIFF
--- a/PULSE_safe_pack_v0/tools/build_self_contained_pulse_evidence_floor_v0.py
+++ b/PULSE_safe_pack_v0/tools/build_self_contained_pulse_evidence_floor_v0.py
@@ -377,17 +377,35 @@ def _check_required_evidence(
     if missing:
         raise FloorError(f"required-gate evidence is missing gates: {missing}")
 
-    failed = [
-        gate
-        for gate in required
-        if not (
-            isinstance(gates.get(gate), dict)
-            and gates[gate].get("status") == "passed"
-            and gates[gate].get("pass") is True
+    malformed: list[str] = []
+    failed: list[str] = []
+
+    for gate in required:
+        entry = gates.get(gate)
+
+        if not isinstance(entry, dict):
+            malformed.append(gate)
+            continue
+
+        if (
+            entry.get("value") is not True
+            or entry.get("status") != "passed"
+            or entry.get("diagnostics") != []
+        ):
+            failed.append(gate)
+
+    if malformed:
+        raise FloorError(
+            "required-gate evidence has malformed gate entries: "
+            f"{malformed}"
         )
-    ]
+   
     if failed:
-        raise FloorError(f"required-gate evidence has non-passing gates: {failed}")
+        raise FloorError(
+            "required-gate evidence has non-passing gates: "
+            f"{failed}"
+        )
+
 
 
 def _artifact(

--- a/tests/test_self_contained_pulse_evidence_floor_v0.py
+++ b/tests/test_self_contained_pulse_evidence_floor_v0.py
@@ -159,9 +159,22 @@ def _bootstrap(tmp_path: Path) -> dict[str, Path]:
         },
         "gates": {
             gate: {
-                "gate_id": gate,
-                "pass": True,
+                "value": True,
                 "status": "passed",
+                "evaluation_id": f"{gate}_unit_evaluation",
+                "evidence_artifacts": [
+                    {
+                        "path": (
+                            "PULSE_safe_pack_v0/artifacts/"
+                            f"required_gate_inputs/{gate}.json"
+                        ),
+                        "sha256": "a" * 64,
+                        "kind": "unit_fixture",
+                        "schema_version": (
+                            "required_gate_evaluation_result_v0"
+                        ),
+                    }
+                ],
                 "diagnostics": [],
             }
             for gate in required_gates
@@ -367,6 +380,24 @@ def test_build_self_contained_floor_rejects_run_key_mismatch(
     paths = _bootstrap(tmp_path)
     evidence = json.loads(paths["evidence"].read_text(encoding="utf-8"))
     evidence["run_identity"]["run_key"] = "other"
+    _write_json(paths["evidence"], evidence)
+
+    result = floor.main(_args(paths["repo"]))
+
+    assert result == 1
+    assert not paths["out"].exists()
+
+
+def test_build_self_contained_floor_rejects_legacy_pass_only_gate_evidence(
+    tmp_path: Path,
+) -> None:
+    paths = _bootstrap(tmp_path)
+    evidence = json.loads(paths["evidence"].read_text(encoding="utf-8"))
+
+    for entry in evidence["gates"].values():
+        entry.pop("value")
+        entry["pass"] = True
+
     _write_json(paths["evidence"], evidence)
 
     result = floor.main(_args(paths["repo"]))


### PR DESCRIPTION
## Summary

Align the self-contained PULSE evidence floor with the `required_gate_evidence_v0` contract.

The current release-grade run reached the Tier 0 floor builder, but the builder rejected all required gates because it checked a legacy/non-contract field:

```text
pass
```

The actual `required_gate_evidence_v0` gate entry uses:

```text
value
status
evaluation_id
evidence_artifacts
diagnostics
```

For passing gate evidence, the contract is:

```text
value: true
status: passed
diagnostics: []
```

## Changes

- update `build_self_contained_pulse_evidence_floor_v0.py` to validate:
  - `value is True`;
  - `status == "passed"`;
  - `diagnostics == []`;
- update the self-contained floor test fixture to emit schema-aligned `value: true` gate evidence;
- add a regression test rejecting legacy `pass: true` without `value: true`;
- update the emitted floor check description from `pass=true` to `value=true`.

## Why

The Tier 0 floor should prove the actual required-gate evidence contract, not a legacy or invented field.

Before this fix, real schema-aligned evidence could be rejected as non-passing because the builder looked for `pass`.

After this fix, the floor follows the implemented required-gate evidence contract:

```text
required_gate_evidence_v0.gates[*].value
→ true

required_gate_evidence_v0.gates[*].status
→ passed

required_gate_evidence_v0.gates[*].diagnostics
→ []
```

## Authority boundary

This PR does not:

- change gate policy;
- change required gates;
- run an external model;
- claim LlamaGuard or any external model passed;
- bypass `check_gates.py`;
- bypass the recorded verifier;
- bypass the materializer;
- write `status.json`;
- materialize `release_required`;
- create attestation;
- create release authority;
- authorize release.

```text
self-contained floor
≠ release authorization
```

This is a contract-alignment fix only.

## Expected result

The next controlled release-grade run should pass this step:

```text
release-grade build self-contained PULSE evidence floor
→ OK
```

and produce:

```text
PULSE_safe_pack_v0/artifacts/self_contained_pulse_evidence_floor_v0.json
```