### PR TITLE
ci(ref): make hosted LlamaGuard runtime opt-in

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -29,6 +29,14 @@ on:
         options:
           - "false"
           - "true"
+      llamaguard_evidence_mode:
+        description: "LlamaGuard evidence lane"
+        required: false
+        default: "tier0_not_required"
+        type: choice
+        options:
+          - "tier0_not_required"
+          - "hosted_full_runtime"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -338,11 +346,12 @@ jobs:
           PULSE_IS_RELEASE=0
           PULSE_MODE="core"
           PULSE_POLICY_SET="core_required"
-
+          PULSE_LLAMAGUARD_EVIDENCE_MODE="tier0_not_required"
           if [[ "${GITHUB_REF:-}" == refs/tags/v* || "${GITHUB_REF:-}" == refs/tags/V* ]]; then
             PULSE_IS_RELEASE=1
             PULSE_MODE="prod"
             PULSE_POLICY_SET="required"
+            PULSE_LLAMAGUARD_EVIDENCE_MODE="hosted_full_runtime"
           fi
 
           if [[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]]; then
@@ -352,6 +361,17 @@ jobs:
               PULSE_MODE="prod"
               PULSE_POLICY_SET="required"
             fi
+         
+            RAW_LLAMAGUARD_MODE="$(jq -r '.inputs.llamaguard_evidence_mode // "tier0_not_required"' "$GITHUB_EVENT_PATH")"
+            case "$RAW_LLAMAGUARD_MODE" in
+              tier0_not_required|hosted_full_runtime)
+                PULSE_LLAMAGUARD_EVIDENCE_MODE="$RAW_LLAMAGUARD_MODE"
+                ;;
+              *)
+                echo "::error::invalid llamaguard_evidence_mode: ${RAW_LLAMAGUARD_MODE}"
+                exit 1
+                ;;
+            esac 
           fi
 
           PULSE_RUN_KEY="GITHUB_RUN_ID=${GITHUB_RUN_ID:?}|GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT:?}|GITHUB_WORKFLOW=${GITHUB_WORKFLOW:?}"
@@ -359,10 +379,13 @@ jobs:
           echo "PULSE_IS_RELEASE=${PULSE_IS_RELEASE}" >> "$GITHUB_ENV"
           echo "PULSE_MODE=${PULSE_MODE}" >> "$GITHUB_ENV"
           echo "PULSE_POLICY_SET=${PULSE_POLICY_SET}" >> "$GITHUB_ENV"
-                    echo "PULSE_RUN_KEY=${PULSE_RUN_KEY}" >> "$GITHUB_ENV"
+          echo "PULSE_LLAMAGUARD_EVIDENCE_MODE=${PULSE_LLAMAGUARD_EVIDENCE_MODE}" >> "$GITHUB_ENV"
+          echo "PULSE_RUN_KEY=${PULSE_RUN_KEY}" >> "$GITHUB_ENV"
+         
           echo "is_release=${PULSE_IS_RELEASE}" >> "$GITHUB_OUTPUT"
-
-          echo "Computed flags: IS_RELEASE=$PULSE_IS_RELEASE MODE=$PULSE_MODE POLICY_SET=$PULSE_POLICY_SET"
+          echo "llamaguard_evidence_mode=${PULSE_LLAMAGUARD_EVIDENCE_MODE}" >> "$GITHUB_OUTPUT"
+         
+          echo "Computed flags: IS_RELEASE=$PULSE_IS_RELEASE MODE=$PULSE_MODE POLICY_SET=$PULSE_POLICY_SET LLAMAGUARD_EVIDENCE_MODE=$PULSE_LLAMAGUARD_EVIDENCE_MODE"
 
           EXTRA=()
           if (( PULSE_IS_RELEASE )); then
@@ -596,7 +619,7 @@ jobs:
           retention-days: 30
 
       - name: release-grade initialize LlamaGuard runtime identity
-        if: ${{ steps.release_mode.outputs.is_release == '1' }}
+        if: ${{ steps.release_mode.outputs.is_release == '1' && steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -621,7 +644,7 @@ jobs:
           python -m pip check
 
       - name: release-grade produce current-run LlamaGuard raw evidence
-        if: ${{ steps.release_mode.outputs.is_release == '1' }}
+        if: ${{ steps.release_mode.outputs.is_release == '1' && steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime' }}
         shell: bash
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -659,7 +682,7 @@ jobs:
           done
 
       - name: release-grade build canonical LlamaGuard summary
-        if: ${{ steps.release_mode.outputs.is_release == '1' }}
+        if: ${{ steps.release_mode.outputs.is_release == '1' && steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -688,7 +711,7 @@ jobs:
           fi
 
       - name: release-grade upload current-run LlamaGuard evidence
-        if: ${{ steps.release_mode.outputs.is_release == '1' }}
+        if: ${{ steps.release_mode.outputs.is_release == '1' && steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: llamaguard-current-run-${{ github.run_id }}-${{ github.run_attempt }}
@@ -908,7 +931,7 @@ jobs:
           echo "-------------------------------------"
 
       - name: "Strict external evidence: require external summaries present (pre-augment, fail-closed)"
-        if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') }}
+        if: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V')) && steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/tests/test_llamaguard_current_run_workflow_wiring_v0.py
+++ b/tests/test_llamaguard_current_run_workflow_wiring_v0.py
@@ -13,21 +13,28 @@ RUNTIME_REQUIREMENTS = (
     / "requirements-llamaguard-v0.txt"
 )
 
-RELEASE_ONLY = (
-    "if: ${{ steps.release_mode.outputs.is_release == '1' }}"
+RELEASE_TOKEN = "steps.release_mode.outputs.is_release == '1'"
+HOSTED_MODE_TOKEN = (
+    "steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime'"
 )
 
 MODEL_REVISION = (
     "acf7aafa60f0410f8f42b1fa35e077d705892029"
 )
 
-STEP_NAMES = (
-    "release-grade reset candidate evidence outputs",
-    "release-grade initialize current-run LlamaGuard identity",
+LLAMAGUARD_STEPS = (
+    "release-grade initialize LlamaGuard runtime identity",
     "release-grade install pinned LlamaGuard runtime",
     "release-grade produce current-run LlamaGuard raw evidence",
     "release-grade build canonical LlamaGuard summary",
     "release-grade upload current-run LlamaGuard evidence",
+)
+
+ORDERED_STEPS = (
+    "release-grade initialize current-run evidence identity",
+    "release-grade build self-contained PULSE evidence floor",
+    "upload self-contained PULSE evidence floor",
+    *LLAMAGUARD_STEPS,
     (
         '"Strict external evidence: require external summaries '
         'present (pre-augment, fail-closed)"'
@@ -75,11 +82,44 @@ def _step_block(text: str, name: str) -> str:
     raise AssertionError(f"workflow step not found: {name}")
 
 
+def test_llamaguard_mode_input_defaults_to_tier0_not_required() -> None:
+    text = _workflow_text()
+
+    assert "llamaguard_evidence_mode:" in text
+    assert 'description: "LlamaGuard evidence lane"' in text
+    assert 'default: "tier0_not_required"' in text
+    assert 'type: choice' in text
+    assert '- "tier0_not_required"' in text
+    assert '- "hosted_full_runtime"' in text
+
+
+def test_preflight_exports_llamaguard_evidence_mode() -> None:
+    text = _workflow_text()
+    block = _step_block(
+        text,
+        "CI pack layout preflight (fail-closed on release-grade)",
+    )
+
+    assert "PULSE_LLAMAGUARD_EVIDENCE_MODE" in block
+    assert "tier0_not_required" in block
+    assert "hosted_full_runtime" in block
+    assert ".inputs.llamaguard_evidence_mode" in block
+    assert "invalid llamaguard_evidence_mode" in block
+    assert (
+        "PULSE_LLAMAGUARD_EVIDENCE_MODE=${PULSE_LLAMAGUARD_EVIDENCE_MODE}"
+        in block
+    )
+    assert (
+        "llamaguard_evidence_mode=${PULSE_LLAMAGUARD_EVIDENCE_MODE}"
+        in block
+    )
+
+
 def test_llamaguard_release_steps_exist_in_mechanical_order() -> None:
     text = _workflow_text()
     positions = []
 
-    for name in STEP_NAMES:
+    for name in ORDERED_STEPS:
         marker = f"- name: {name}"
         position = text.find(marker)
 
@@ -87,19 +127,38 @@ def test_llamaguard_release_steps_exist_in_mechanical_order() -> None:
         positions.append(position)
 
     assert positions == sorted(positions), (
-        "LlamaGuard workflow steps are out of mechanical order"
+        "Tier 0 floor and LlamaGuard workflow steps are out of mechanical order"
     )
 
 
-def test_llamaguard_runtime_steps_are_release_grade_only() -> None:
+def test_llamaguard_runtime_steps_are_hosted_mode_opt_in() -> None:
     text = _workflow_text()
 
-    for name in STEP_NAMES[1:6]:
+    for name in LLAMAGUARD_STEPS:
         block = _step_block(text, name)
 
-        assert RELEASE_ONLY in block, (
-            f"{name!r} must be conditional on release mode"
+        assert RELEASE_TOKEN in block, (
+            f"{name!r} must remain conditional on release mode"
         )
+        assert HOSTED_MODE_TOKEN in block, (
+            f"{name!r} must require hosted_full_runtime opt-in"
+        )
+
+
+def test_strict_external_summary_precheck_is_hosted_mode_only() -> None:
+    text = _workflow_text()
+    block = _step_block(
+        text,
+        (
+            '"Strict external evidence: require external summaries '
+            'present (pre-augment, fail-closed)"'
+        ),
+    )
+
+    assert "strict_external_evidence == 'true'" in block
+    assert "startsWith(github.ref, 'refs/tags/v')" in block
+    assert "startsWith(github.ref, 'refs/tags/V')" in block
+    assert HOSTED_MODE_TOKEN in block
 
 
 def test_hugging_face_secret_is_scoped_to_inference_step() -> None:
@@ -114,7 +173,9 @@ def test_hugging_face_secret_is_scoped_to_inference_step() -> None:
     assert '--token-env "HF_TOKEN"' in producer
 
     for name in (
-        "release-grade initialize current-run LlamaGuard identity",
+        "release-grade initialize current-run evidence identity",
+        "release-grade build self-contained PULSE evidence floor",
+        "release-grade initialize LlamaGuard runtime identity",
         "release-grade install pinned LlamaGuard runtime",
         "release-grade build canonical LlamaGuard summary",
         "release-grade upload current-run LlamaGuard evidence",
@@ -127,9 +188,13 @@ def test_hugging_face_secret_is_scoped_to_inference_step() -> None:
 
 def test_producer_uses_current_run_identity_and_canonical_paths() -> None:
     text = _workflow_text()
-    identity = _step_block(
+    shared_identity = _step_block(
         text,
-        "release-grade initialize current-run LlamaGuard identity",
+        "release-grade initialize current-run evidence identity",
+    )
+    runtime_identity = _step_block(
+        text,
+        "release-grade initialize LlamaGuard runtime identity",
     )
     producer = _step_block(
         text,
@@ -140,8 +205,12 @@ def test_producer_uses_current_run_identity_and_canonical_paths() -> None:
         "PULSE_EXTERNAL_SIGNER_IDENTITY="
         '"repo:${GITHUB_REPOSITORY:?}:workflow:'
         '.github/workflows/pulse_ci.yml"'
-    ) in identity
-    assert f'LLAMAGUARD_VERSION="{MODEL_REVISION}"' in identity
+    ) in shared_identity
+    assert "PULSE_CREATED_UTC" in shared_identity
+    assert "PULSE_RELEASE_CANDIDATE" in shared_identity
+    assert "LLAMAGUARD_VERSION" not in shared_identity
+
+    assert f'LLAMAGUARD_VERSION="{MODEL_REVISION}"' in runtime_identity
 
     required_tokens = (
         'tools/run_llamaguard_current_evidence_v0.py',
@@ -301,3 +370,24 @@ def test_current_run_artifacts_are_archived_fail_closed() -> None:
         "llamaguard_summary.json"
     ) in upload
     assert "if-no-files-found: error" in upload
+
+
+def main() -> int:
+    test_llamaguard_mode_input_defaults_to_tier0_not_required()
+    test_preflight_exports_llamaguard_evidence_mode()
+    test_llamaguard_release_steps_exist_in_mechanical_order()
+    test_llamaguard_runtime_steps_are_hosted_mode_opt_in()
+    test_strict_external_summary_precheck_is_hosted_mode_only()
+    test_hugging_face_secret_is_scoped_to_inference_step()
+    test_producer_uses_current_run_identity_and_canonical_paths()
+    test_existing_adapter_consumes_current_run_outputs()
+    test_lane_does_not_directly_mutate_release_authority()
+    test_standing_candidate_verifier_materializer_path_remains()
+    test_runtime_requirements_are_exactly_pinned()
+    test_current_run_artifacts_are_archived_fail_closed()
+    print("OK: LlamaGuard hosted runtime workflow opt-in wiring locked")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Make the hosted LlamaGuard runtime lane explicit opt-in.

The controlled release-grade run now proves that the Tier 0 self-contained PULSE floor can run before the hosted external model lane. The remaining failure is the hosted/gated provider path:

```text
meta-llama/Llama-Guard-3-1B
→ HF_TOKEN
→ gated access / provider authorization
```

This PR keeps that hosted lane available, but stops making it the default bottleneck for manual release-grade runs.

## Changes

- add `llamaguard_evidence_mode` workflow input;
- default manual workflow runs to:

```text
tier0_not_required
```

- keep explicit full hosted mode available:

```text
hosted_full_runtime
```

- export `PULSE_LLAMAGUARD_EVIDENCE_MODE`;
- expose `llamaguard_evidence_mode` as a `release_mode` step output;
- gate the hosted LlamaGuard runtime identity, install, producer, summary, and upload steps on `hosted_full_runtime`;
- gate the strict external summary precheck on `hosted_full_runtime`;
- update `tests/test_llamaguard_current_run_workflow_wiring_v0.py` to lock the opt-in boundary.

## Tier behavior

Default manual release-grade run:

```text
strict_external_evidence=true
llamaguard_evidence_mode=tier0_not_required
```

Expected behavior:

```text
required_gate_evidence_v0.json
→ status.json
→ self_contained_pulse_evidence_floor_v0.json
→ skip hosted LlamaGuard lane
```

Full hosted external model run:

```text
strict_external_evidence=true
llamaguard_evidence_mode=hosted_full_runtime
```

Expected behavior:

```text
Tier 0 floor
→ hosted LlamaGuard runtime install
→ LlamaGuard raw evidence
→ canonical LlamaGuard summary
→ strict external summary precheck
```

## Authority boundary

This PR does not:

- remove the LlamaGuard producer;
- mark missing external model evidence as passed;
- claim LlamaGuard or any external model passed in Tier 0 mode;
- bypass `check_gates.py`;
- bypass the recorded verifier;
- bypass the materializer;
- write `status.json`;
- materialize `release_required`;
- create attestation;
- create release authority;
- authorize release.

```text
Tier 0 self-contained floor
≠ hosted external model evidence
≠ release authorization
```

Hosted LlamaGuard remains a separate Tier 2 lane.