### PR TITLE
fix(ci): gate LlamaGuard consumers on hosted mode

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -387,9 +387,11 @@ jobs:
           echo "PULSE_MODE=${PULSE_MODE}" >> "$GITHUB_ENV"
           echo "PULSE_POLICY_SET=${PULSE_POLICY_SET}" >> "$GITHUB_ENV"
           echo "PULSE_LLAMAGUARD_EVIDENCE_MODE=${PULSE_LLAMAGUARD_EVIDENCE_MODE}" >> "$GITHUB_ENV"
-      
+          echo "PULSE_RUN_KEY=${PULSE_RUN_KEY}" >> "$GITHUB_ENV"
+        
           echo "is_release=${PULSE_IS_RELEASE}" >> "$GITHUB_OUTPUT"
           echo "llamaguard_evidence_mode=${PULSE_LLAMAGUARD_EVIDENCE_MODE}" >> "$GITHUB_OUTPUT"
+         
           echo "Computed flags: IS_RELEASE=$PULSE_IS_RELEASE MODE=$PULSE_MODE POLICY_SET=$PULSE_POLICY_SET LLAMAGUARD_EVIDENCE_MODE=$PULSE_LLAMAGUARD_EVIDENCE_MODE"
 
           EXTRA=()
@@ -624,7 +626,7 @@ jobs:
           retention-days: 30
 
       - name: release-grade initialize LlamaGuard runtime identity
-        if: ${{ steps.release_mode.outputs.is_release == '1' }}
+        if: ${{ steps.release_mode.outputs.is_release == '1' && steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -936,7 +938,7 @@ jobs:
           echo "-------------------------------------"
 
       - name: "Strict external evidence: require external summaries present (pre-augment, fail-closed)"
-        if: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') }}
+        if: ${{ ((github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') || startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V')) && steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -29,6 +29,14 @@ on:
         options:
           - "false"
           - "true"
+      llamaguard_evidence_mode:
+        description: "LlamaGuard evidence lane for release-grade runs"
+        required: false
+        default: "tier0_not_required"
+        type: choice
+        options:
+          - "tier0_not_required"
+          - "hosted_full_runtime"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -345,6 +353,25 @@ jobs:
             PULSE_POLICY_SET="required"
           fi
 
+          RAW_LLAMAGUARD_MODE="tier0_not_required"
+          if [[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]]; then
+            RAW_LLAMAGUARD_MODE="$(jq -r '.inputs.llamaguard_evidence_mode // "tier0_not_required"' "$GITHUB_EVENT_PATH")"
+            case "$RAW_LLAMAGUARD_MODE" in
+              tier0_not_required|hosted_full_runtime)
+                ;;
+              *)
+                echo "::error::invalid llamaguard_evidence_mode: ${RAW_LLAMAGUARD_MODE}"
+                exit 1
+                ;;
+            esac
+          fi
+
+          if [[ "${GITHUB_REF:-}" == refs/tags/v* || "${GITHUB_REF:-}" == refs/tags/V* ]]; then
+            PULSE_LLAMAGUARD_EVIDENCE_MODE="hosted_full_runtime"
+          else
+            PULSE_LLAMAGUARD_EVIDENCE_MODE="$RAW_LLAMAGUARD_MODE"
+          fi
+
           if [[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]]; then
             STRICT="$(jq -r '.inputs.strict_external_evidence // "false"' "$GITHUB_EVENT_PATH")"
             if [[ "$STRICT" == "true" ]]; then
@@ -359,10 +386,11 @@ jobs:
           echo "PULSE_IS_RELEASE=${PULSE_IS_RELEASE}" >> "$GITHUB_ENV"
           echo "PULSE_MODE=${PULSE_MODE}" >> "$GITHUB_ENV"
           echo "PULSE_POLICY_SET=${PULSE_POLICY_SET}" >> "$GITHUB_ENV"
-                    echo "PULSE_RUN_KEY=${PULSE_RUN_KEY}" >> "$GITHUB_ENV"
+          echo "PULSE_LLAMAGUARD_EVIDENCE_MODE=${PULSE_LLAMAGUARD_EVIDENCE_MODE}" >> "$GITHUB_ENV"
+      
           echo "is_release=${PULSE_IS_RELEASE}" >> "$GITHUB_OUTPUT"
-
-          echo "Computed flags: IS_RELEASE=$PULSE_IS_RELEASE MODE=$PULSE_MODE POLICY_SET=$PULSE_POLICY_SET"
+          echo "llamaguard_evidence_mode=${PULSE_LLAMAGUARD_EVIDENCE_MODE}" >> "$GITHUB_OUTPUT"
+          echo "Computed flags: IS_RELEASE=$PULSE_IS_RELEASE MODE=$PULSE_MODE POLICY_SET=$PULSE_POLICY_SET LLAMAGUARD_EVIDENCE_MODE=$PULSE_LLAMAGUARD_EVIDENCE_MODE"
 
           EXTRA=()
           if (( PULSE_IS_RELEASE )); then
@@ -608,7 +636,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: release-grade install pinned LlamaGuard runtime
-        if: ${{ steps.release_mode.outputs.is_release == '1' }}
+        if: ${{ steps.release_mode.outputs.is_release == '1' && steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -621,7 +649,7 @@ jobs:
           python -m pip check
 
       - name: release-grade produce current-run LlamaGuard raw evidence
-        if: ${{ steps.release_mode.outputs.is_release == '1' }}
+        if: ${{ steps.release_mode.outputs.is_release == '1' && steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime' }}
         shell: bash
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -659,7 +687,7 @@ jobs:
           done
 
       - name: release-grade build canonical LlamaGuard summary
-        if: ${{ steps.release_mode.outputs.is_release == '1' }}
+        if: ${{ steps.release_mode.outputs.is_release == '1' && steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -688,7 +716,7 @@ jobs:
           fi
 
       - name: release-grade upload current-run LlamaGuard evidence
-        if: ${{ steps.release_mode.outputs.is_release == '1' }}
+        if: ${{ steps.release_mode.outputs.is_release == '1' && steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime' }}       
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: llamaguard-current-run-${{ github.run_id }}-${{ github.run_attempt }}
@@ -2262,7 +2290,7 @@ jobs:
   attest_llamaguard_current_run_summary:
     name: "LlamaGuard current-run summary: attest and verify"
     needs: pulse
-    if: ${{ github.event_name != 'pull_request' && needs.pulse.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true')) }}
+    if: ${{ github.event_name != 'pull_request' && needs.pulse.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true' && github.event.inputs.llamaguard_evidence_mode == 'hosted_full_runtime')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -2405,7 +2433,7 @@ jobs:
   release_grade_recorded_path:
     name: "Release-grade recorded path: attested evidence to gates"
     needs: attest_llamaguard_current_run_summary
-    if: ${{ github.event_name != 'pull_request' && needs.attest_llamaguard_current_run_summary.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true')) }}
+    if: ${{ github.event_name != 'pull_request' && needs.attest_llamaguard_current_run_summary.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true' && github.event.inputs.llamaguard_evidence_mode == 'hosted_full_runtime')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -2667,7 +2695,7 @@ jobs:
   assemble_release_grade_reference_package:
     name: "Release-grade reference package: assemble complete package"
     needs: release_grade_recorded_path
-    if: ${{ github.event_name != 'pull_request' && needs.release_grade_recorded_path.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true')) }}
+    if: ${{ github.event_name != 'pull_request' && needs.release_grade_recorded_path.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true' && github.event.inputs.llamaguard_evidence_mode == 'hosted_full_runtime')) }}   
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -2813,7 +2841,7 @@ jobs:
   verify_release_grade_reference_package:
     name: "Release-grade reference package: verify complete package"
     needs: assemble_release_grade_reference_package
-    if: ${{ github.event_name != 'pull_request' && needs.assemble_release_grade_reference_package.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true')) }}
+    if: ${{ github.event_name != 'pull_request' && needs.assemble_release_grade_reference_package.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true' && github.event.inputs.llamaguard_evidence_mode == 'hosted_full_runtime')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/tests/test_llamaguard_attested_release_path_wiring_v0.py
+++ b/tests/test_llamaguard_attested_release_path_wiring_v0.py
@@ -16,6 +16,9 @@ ATTESTED_ARTIFACT = (
     "llamaguard-attested-current-run-"
     "${{ github.run_id }}-${{ github.run_attempt }}"
 )
+HOSTED_MODE_GUARD_TOKEN = (
+    "github.event.inputs.llamaguard_evidence_mode == 'hosted_full_runtime'"
+)
 
 STRICT_RELEASE_GUARD_TOKENS = (
     "github.event_name != 'pull_request'",
@@ -23,6 +26,7 @@ STRICT_RELEASE_GUARD_TOKENS = (
     "strict_external_evidence == 'true'",
     "startsWith(github.ref, 'refs/tags/v')",
     "startsWith(github.ref, 'refs/tags/V')",
+    HOSTED_MODE_GUARD_TOKEN,
 )
 
 PRE_ATTESTATION_RELEASE_TOOLS = (
@@ -150,6 +154,22 @@ def test_attested_release_path_job_order() -> None:
         < verify_index
         < tools_index
     )
+
+
+def test_attestation_job_is_hosted_external_model_only() -> None:
+    _text, blocks = _workflow_and_jobs()
+    job = blocks[ATTEST_JOB]
+    guard = _job_field(job, "if")
+
+    for token in (
+        "github.event_name != 'pull_request'",
+        "needs.pulse.result == 'success'",
+        "strict_external_evidence == 'true'",
+        "startsWith(github.ref, 'refs/tags/v')",
+        "startsWith(github.ref, 'refs/tags/V')",
+        HOSTED_MODE_GUARD_TOKEN,
+    ):
+        assert token in guard, token
 
 
 def test_release_path_depends_on_attested_llamaguard_job() -> None:
@@ -281,6 +301,7 @@ def test_pr3_workflow_wiring_smoke_registered() -> None:
 def main() -> int:
     test_attested_release_path_job_order()
     test_release_path_depends_on_attested_llamaguard_job()
+    test_attestation_job_is_hosted_external_model_only() 
     test_tools_tests_is_downstream_of_release_path_via_package_verifier()
     test_release_grade_candidate_path_runs_only_after_attestation()
     test_core_check_gates_remains_allowed_in_pulse_job()


### PR DESCRIPTION
## Summary

Gate the hosted LlamaGuard consumer path on `hosted_full_runtime`.

The previous opt-in change gated most hosted LlamaGuard producer steps, but downstream consumers could still run in the default Tier 0 mode and try to download missing LlamaGuard artifacts.

## Fixes

- gate `release-grade install pinned LlamaGuard runtime` on `hosted_full_runtime`;
- gate `attest_llamaguard_current_run_summary` on hosted mode;
- gate `release_grade_recorded_path` on hosted mode;
- gate `assemble_release_grade_reference_package` on hosted mode;
- gate `verify_release_grade_reference_package` on hosted mode;
- preserve hosted LlamaGuard behavior for version tag releases;
- keep default manual branch release-grade runs on `tier0_not_required`;
- add/update smoke coverage for the hosted-only attestation boundary.

## Expected Tier 0 behavior

```text
strict_external_evidence=true
llamaguard_evidence_mode=tier0_not_required
```

Expected:

```text
self-contained PULSE evidence floor
→ produced

hosted LlamaGuard runtime install
→ skipped

hosted LlamaGuard raw evidence
→ skipped

LlamaGuard attestation job
→ skipped

recorded path / package assembly / package verification
→ skipped
```

## Expected hosted behavior

```text
strict_external_evidence=true
llamaguard_evidence_mode=hosted_full_runtime
```

Expected:

```text
Tier 0 floor
→ hosted LlamaGuard runtime
→ LlamaGuard raw evidence
→ canonical summary
→ attestation
→ recorded path
→ package assembly
→ package verification
```

## Authority boundary

This PR does not:

- remove the LlamaGuard producer;
- mark missing external model evidence as passed;
- claim LlamaGuard or any external model passed in Tier 0 mode;
- bypass `check_gates.py`;
- bypass the recorded verifier;
- bypass the materializer;
- write `status.json`;
- materialize `release_required`;
- create release authority;
- authorize release.

```text
Tier 0 self-contained floor
≠ hosted external model evidence
≠ release authorization
```