### PR TITLE
fix(ci): always export release-grade final status summary

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1057,23 +1057,51 @@ jobs:
           echo "OK: re-rendered Quality Ledger from final status.json"
       
       - name: Export final summary (post-augment)
+        if: always()
         shell: bash
         run: |
           set -euo pipefail
           SCRIPT="${{ env.PACK_DIR }}/tools/status_to_summary.py"
           STATUS="${{ env.PACK_DIR }}/artifacts/status.json"
+          OUT_MD="${{ env.PACK_DIR }}/artifacts/status_summary.md"
+          OUT_JSON="${{ env.PACK_DIR }}/artifacts/status_summary.json"
 
           if [ ! -f "$SCRIPT" ]; then
+            if [[ "${PULSE_IS_RELEASE:-0}" == "1" ]]; then
+          
+              echo "::error::status_to_summary.py not found at $SCRIPT on release-grade run"
+              exit 1
+            fi
+       
             echo "::notice::SKIP: status_to_summary.py not found at $SCRIPT (optional)"
             exit 0
           fi
+      
           if [ ! -f "$STATUS" ]; then
+            if [[ "${PULSE_IS_RELEASE:-0}" == "1" ]]; then
+              echo "::error::status.json not found at $STATUS; cannot export release-grade final summary"
+              exit 1
+            fi    
+          
             echo "::notice::SKIP: status.json not found at $STATUS; skipping final summary (optional)"
             exit 0
           fi
 
-          # Default outputs: artifacts/status_summary.md + artifacts/status_summary.json
-          python "$SCRIPT" --status "$STATUS"
+              python "$SCRIPT" \
+            --status "$STATUS" \
+            --out_md "$OUT_MD" \
+            --out_json "$OUT_JSON"
+
+          if [[ "${PULSE_IS_RELEASE:-0}" == "1" ]]; then
+            for artifact in "$OUT_MD" "$OUT_JSON"; do
+              if [[ ! -f "$artifact" || -L "$artifact" ]]; then
+                echo "::error::release-grade final summary missing or symlinked: $artifact"
+                exit 1
+              fi
+
+              sha256sum "$artifact"
+            done
+          fi
 
       - name: "ci: forbid demo status on version tags"
         if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V')


### PR DESCRIPTION
## Summary

Make final status summary export align with release-grade artifact postconditions.

The controlled Tier 0 release-grade run reached artifact postconditions with:

```text
PULSE_LLAMAGUARD_EVIDENCE_MODE=tier0_not_required
```

but failed because:

```text
PULSE_safe_pack_v0/artifacts/status_summary.json
```

was missing.

Release-grade postconditions already require:

```text
status_baseline.json
status.json
status_summary_baseline.json
status_summary.json
```

so the final summary export must be guaranteed whenever release-grade status exists.

## Changes

- run `Export final summary (post-augment)` under `if: always()`;
- write explicit outputs:
  - `PULSE_safe_pack_v0/artifacts/status_summary.md`;
  - `PULSE_safe_pack_v0/artifacts/status_summary.json`;
- fail closed on release-grade runs if the summary tool, `status.json`, or final summary artifacts are missing;
- hash the final summary artifacts after creation.

## Why

This keeps the release-grade artifact contract consistent:

```text
status.json
→ final status_summary.json
→ release-grade artifact postconditions
```

The fix does not change gate policy, LlamaGuard mode, external evidence behavior, release authority, or package assembly.

## Authority boundary

This PR does not:

- run an external model;
- claim LlamaGuard or any external model passed;
- bypass `check_gates.py`;
- bypass the recorded verifier;
- bypass the materializer;
- write or materialize `release_required`;
- create release authority;
- authorize release.

```text
final summary export
≠ release authorization
```

## Expected result

The next Tier 0 controlled run should not fail at:

```text
Release-grade artifact postconditions
```

because of missing:

```text
status_summary.json
```