### PR TITLE
fix(ci): validate release-grade status after materialization

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1021,20 +1021,6 @@ jobs:
           python tools/validate_status_schema.py \
             --schema "$SCHEMA" \
             --status "$STATUS"
-
-      - name: "ci: validate release-grade status contract"
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          STATUS="${{ env.PACK_DIR }}/artifacts/status.json"
-          SCHEMA="$GITHUB_WORKSPACE/schemas/status/release_grade_status_v1.schema.json"
-
-          python tools/validate_status_schema.py \
-            --schema "$SCHEMA" \
-            --status "$STATUS" \
-            --max-errors 20
       
       - name: Re-render Quality Ledger from final status
         id: quality_ledger_final_render
@@ -2669,6 +2655,19 @@ jobs:
             --registry "${GITHUB_WORKSPACE}/pulse_gate_registry_v0.yml" \
             --out "${PACK_DIR}/artifacts/status.json"
 
+      - name: "ci: validate release-grade status contract (post-materialization)"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          STATUS="${PACK_DIR}/artifacts/status.json"
+          SCHEMA="$GITHUB_WORKSPACE/schemas/status/release_grade_status_v1.schema.json"
+
+          python tools/validate_status_schema.py \
+            --schema "$SCHEMA" \
+            --status "$STATUS" \
+            --max-errors 20
+      
       - name: release-grade enforce release-required gates via check_gates
         shell: bash
         run: |

--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -1118,14 +1118,6 @@ jobs:
 
           print(f"OK: non-demo status.version on tag: {v}")
           PY
-
-      - name: "ci: forbid stubbed status on release-grade runs"
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          STATUS="${{ env.PACK_DIR }}/artifacts/status.json"
-          python ci/check_release_no_stub_status.py --status "$STATUS"
       
 
       - name: Build release authority manifest (audit-only)
@@ -2667,6 +2659,14 @@ jobs:
             --schema "$SCHEMA" \
             --status "$STATUS" \
             --max-errors 20
+      
+      - name: "ci: forbid stubbed status on release-grade runs (post-materialization)"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          STATUS="${PACK_DIR}/artifacts/status.json"
+          python ci/check_release_no_stub_status.py --status "$STATUS"
       
       - name: release-grade enforce release-required gates via check_gates
         shell: bash

--- a/tests/test_llamaguard_attested_release_path_wiring_v0.py
+++ b/tests/test_llamaguard_attested_release_path_wiring_v0.py
@@ -289,6 +289,22 @@ def test_release_path_keeps_policy_derived_check_gates_enforcement() -> None:
     assert "PULSE_safe_pack_v0/artifacts/status.json" in job
 
 
+def test_release_grade_status_contract_validates_after_materialization() -> None:
+    _text, blocks = _workflow_and_jobs()
+    pulse = blocks["pulse"]
+    job = blocks[RELEASE_PATH_JOB]
+
+    assert "release_grade_status_v1.schema.json" not in pulse
+
+    materializer_index = job.index(
+        "tools/materialize_release_required_from_verifier_v0.py"
+    )
+    schema_index = job.index("release_grade_status_v1.schema.json")
+    check_gates_index = job.index("tools/check_gates.py")
+
+    assert materializer_index < schema_index < check_gates_index
+
+
 def test_pr3_workflow_wiring_smoke_registered() -> None:
     manifest = _read_tools_manifest()
 
@@ -309,6 +325,7 @@ def main() -> int:
     test_release_path_uses_existing_standing_tools_in_order()
     test_release_path_does_not_introduce_parallel_engines()
     test_release_path_keeps_policy_derived_check_gates_enforcement()
+    test_release_grade_status_contract_validates_after_materialization()
     test_pr3_workflow_wiring_smoke_registered()
     print(
         "LlamaGuard attested release-path workflow wiring "

--- a/tests/test_llamaguard_attested_release_path_wiring_v0.py
+++ b/tests/test_llamaguard_attested_release_path_wiring_v0.py
@@ -305,6 +305,23 @@ def test_release_grade_status_contract_validates_after_materialization() -> None
     assert materializer_index < schema_index < check_gates_index
 
 
+def test_no_stub_guard_runs_after_materialization() -> None:
+    _text, blocks = _workflow_and_jobs()
+    pulse = blocks["pulse"]
+    job = blocks[RELEASE_PATH_JOB]
+
+    assert "check_release_no_stub_status.py" not in pulse
+
+    materializer_index = job.index(
+        "tools/materialize_release_required_from_verifier_v0.py"
+    )
+    schema_index = job.index("release_grade_status_v1.schema.json")
+    no_stub_index = job.index("ci/check_release_no_stub_status.py")
+    check_gates_index = job.index("tools/check_gates.py")
+
+    assert materializer_index < schema_index < no_stub_index < check_gates_index
+
+
 def test_pr3_workflow_wiring_smoke_registered() -> None:
     manifest = _read_tools_manifest()
 
@@ -326,6 +343,7 @@ def main() -> int:
     test_release_path_does_not_introduce_parallel_engines()
     test_release_path_keeps_policy_derived_check_gates_enforcement()
     test_release_grade_status_contract_validates_after_materialization()
+    test_no_stub_guard_runs_after_materialization()
     test_pr3_workflow_wiring_smoke_registered()
     print(
         "LlamaGuard attested release-path workflow wiring "


### PR DESCRIPTION
## Summary

Move `release_grade_status_v1` validation to the post-materialization release-grade recorded path.

The controlled Tier 0 run failed at:

```text
ci: validate release-grade status contract
```

with:

```text
gates: 'detectors_materialized_ok' is a required property
```

That schema expects a post-materialization release-grade status, because `detectors_materialized_ok` belongs to:

```text
gates.release_required
```

The candidate status produced in the `pulse` job intentionally contains only the `required` gate set and must not pre-materialize `release_required`.

## Changes

- remove early `release_grade_status_v1` validation from the `pulse` job;
- add `release_grade_status_v1` validation in `release_grade_recorded_path`;
- run it after:

```text
release-grade materialize release-required from verifier
```

- run it before:

```text
release-grade enforce release-required gates via check_gates
```

- add/update workflow smoke coverage so this ordering stays locked.

## Authority boundary

This PR does not:

- change gate policy;
- change required gates;
- pre-materialize `release_required` in candidate status;
- run an external model;
- claim LlamaGuard or any external model passed;
- bypass `check_gates.py`;
- bypass the recorded verifier;
- bypass the materializer;
- create release authority;
- authorize release.

```text
candidate status
≠ release_required materialized status
```

## Expected result

Tier 0 controlled run should no longer fail early because `detectors_materialized_ok` is absent from the candidate status.

Hosted full-runtime release-grade path should still validate `release_grade_status_v1` after release-required materialization and before release-required `check_gates.py`.