### PR TITLE
docs(cite): refresh PULSEmech citation metadata v0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it."
-title: "PULSE: Deterministic Release Gates for Safe & Useful AI"
+title: "PULSE: Artifact-Bound Release Authority for AI Release Decisions"
 
 authors:
   - family-names: "Horvat"
@@ -10,37 +10,44 @@ authors:
   - name: "EPLabsAI"
 
 abstract: |
-  PULSE provides deterministic, fail-closed release authority for AI release
-  decisions across safety, utility, and SLO dimensions with auditable artifacts.
-  Each release produces recorded machine-readable state and reader surfaces.
-  Use this software before shipping models or services to evaluate recorded
-  release evidence through declared policy, materialized required gates, and
-  strict fail-closed CI enforcement.
+  PULSE is an artifact-bound release-authority system for AI release
+  decisions. It structures recorded safety, quality, detector, stability,
+  CI, and review evidence into deterministic, fail-closed CI allow/block
+  release decisions under declared policy. Release authority is bound to
+  recorded evidence, status.json, declared gate policy, a materialized
+  required gate set, and strict fail-closed CI enforcement.
 
 repository-code: "https://github.com/HKati/pulse-release-gates-0.1"
 url: "https://github.com/HKati/pulse-release-gates-0.1"
 
 keywords:
+  - "pulsemech"
   - "release-authority"
   - "artifact-bound"
   - "AI release decisions"
   - "fail-closed CI"
+  - "materialized gates"
   - "auditability"
 
-# The specific release you want others to cite
+# Versioned release DOI retained as the repository software citation target.
 doi: "10.5281/zenodo.17373002"
 version: "v1.0.2"
 date-released: "2025-10-18"
 
-# The all-versions (concept) DOI so the badge can stay stable across releases
 identifiers:
   - type: doi
     value: "10.5281/zenodo.17214908"
     description: "Concept DOI (all versions)"
+  - type: doi
+    value: "10.5281/zenodo.17373002"
+    description: "Versioned release DOI retained for citation-history and repository DOI-hygiene compatibility"
+  - type: url
+    value: "https://github.com/HKati/pulse-release-gates-0.1/releases/tag/pulsemech-tier0-floor-20260628-b"
+    description: "GitHub Tier 0 publication snapshot"
 
 preferred-citation:
   type: software
-  title: "PULSE: Deterministic Release Gates for Safe & Useful AI"
+  title: "PULSE: Artifact-Bound Release Authority for AI Release Decisions"
   authors:
     - family-names: "Horvat"
       given-names: "Katalin"
@@ -52,13 +59,24 @@ preferred-citation:
   url: "https://doi.org/10.5281/zenodo.17373002"
 
 references:
+  - type: article
+    title: "PULSE: Deterministic Release Gates for Safe & Useful AI"
+    authors:
+      - family-names: "Horvat"
+        given-names: "Katalin"
+        affiliation: "EPLabsAI"
+        orcid: "https://orcid.org/0009-0001-9745-3764"
+    year: 2025
+    doi: "10.5281/zenodo.17833583"
+    url: "https://doi.org/10.5281/zenodo.17833583"
+
   - type: dataset
     title: "PULSE EPF Shadow A/B artifacts (seeded)"
     authors:
       - family-names: "Horvat"
         given-names: "Katalin"
         affiliation: "EPLabsAI"
-        orcid: "https://orcid.org/0000-0001-9745-3764"
+        orcid: "https://orcid.org/0009-0001-9745-3764"
     year: 2025
     doi: "10.34740/KAGGLE/DSV/13571702"
     url: "https://www.kaggle.com/dsv/13571702"
@@ -73,4 +91,3 @@ references:
     year: 2025
     doi: "10.34740/KAGGLE/DSV/13571927"
     url: "https://www.kaggle.com/dsv/13571927"
-

--- a/docs/PULSEMECH_TIER0_PUBLICATION_SNAPSHOT_v0.md
+++ b/docs/PULSEMECH_TIER0_PUBLICATION_SNAPSHOT_v0.md
@@ -1,0 +1,117 @@
+# PULSEmech Tier 0 publication snapshot v0
+
+## Purpose
+
+This note records publication-surface identifiers for the controlled Tier 0 self-contained PULSE evidence-floor milestone.
+
+It does not change release authority, workflow enforcement, gate policy, verifier behavior, materializer behavior, schema behavior, hosted external-model lane behavior, or fail-closed CI enforcement.
+
+## Publication identifiers
+
+```text
+GitHub repository:
+https://github.com/HKati/pulse-release-gates-0.1
+
+GitHub Tier 0 publication snapshot:
+https://github.com/HKati/pulse-release-gates-0.1/releases/tag/pulsemech-tier0-floor-20260628-b
+
+Zenodo software concept DOI / all versions:
+https://doi.org/10.5281/zenodo.17214908
+
+Zenodo versioned release DOI retained for citation-history / DOI-hygiene compatibility:
+https://doi.org/10.5281/zenodo.17373002
+
+Zenodo preprint / documentation DOI:
+https://doi.org/10.5281/zenodo.17833583
+
+ORCID:
+https://orcid.org/0009-0001-9745-3764
+```
+
+## Citation target
+
+The repository software citation target remains the versioned release DOI:
+
+```text
+10.5281/zenodo.17373002
+```
+
+The stable all-versions DOI remains the Zenodo concept DOI:
+
+```text
+10.5281/zenodo.17214908
+```
+
+The GitHub Tier 0 release tag records the active Tier 0 publication snapshot:
+
+```text
+pulsemech-tier0-floor-20260628-b
+```
+
+## Tier 0 milestone
+
+The publication snapshot is tied to the controlled Tier 0 self-contained evidence-floor milestone.
+
+Controlled run mode:
+
+```text
+strict_external_evidence=true
+llamaguard_evidence_mode=tier0_not_required
+```
+
+Observed outcome:
+
+```text
+PULSE CI
+→ success
+
+self-contained PULSE evidence floor
+→ produced
+
+hosted LlamaGuard runtime lane
+→ skipped
+
+external model pass
+→ not claimed
+```
+
+## Authority boundary
+
+```text
+Tier 0 self-contained floor
+≠ hosted external model evidence
+≠ release authorization
+```
+
+This publication snapshot does not claim:
+
+- LlamaGuard passed;
+- external model evidence passed;
+- hosted evaluator evidence was produced;
+- `release_required` was bypassed;
+- release authority was created;
+- release was authorized;
+- a completed full public release-grade reference package exists.
+
+## Reader-surface boundary
+
+Public pages, status renderers, DOI records, ORCID records, ResearchGate entries, Google Scholar profiles, repository badges, release notes, and documentation records are publication, reader, citation, preservation, review, or discoverability surfaces.
+
+They do not independently produce release authority.
+
+Release authority remains bound to the connected declared-policy path:
+
+```text
+recorded release evidence
+→ status.json
+→ declared gate policy
+→ workflow-effective materialized required gate set
+→ PULSE_safe_pack_v0/tools/check_gates.py
+→ primary CI allow/block release decision
+```
+
+## Summary
+
+This note records publication metadata only.
+
+The Tier 0 milestone is externally anchored by GitHub, Zenodo, and ORCID surfaces, while the release-authority boundary remains unchanged.


### PR DESCRIPTION
## Summary

Refreshes repository citation metadata and adds a Tier 0 publication snapshot note.

This PR preserves both existing Zenodo DOI anchors:

```text
10.5281/zenodo.17214908
10.5281/zenodo.17373002
```

It also records the active Tier 0 GitHub publication tag:

```text
pulsemech-tier0-floor-20260628-b
```

## Scope

Documentation / citation metadata only.

No workflow, gate policy, verifier, materializer, schema, executable tool, hosted external-model lane, fail-closed CI, or release-authority semantics are changed.

## Authority boundary

```text
Tier 0 self-contained floor
≠ hosted external model evidence
≠ release authorization
```

## Files

- `CITATION.cff`
- `docs/PULSEMECH_TIER0_PUBLICATION_SNAPSHOT_v0.md`
