### PR TITLE
docs(citation): add temporary DOI containment box

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,30 @@
 # PULSE — Artifact-Bound Release Authority for AI Release Decisions
 
+> [!CAUTION]
+> **Temporary DOI identity containment notice**
+>
+> This release/archive surface is non-canonical for PULSE/PULSEmech software identity.
+>
+> Do not cite `10.5281/zenodo.21031131` as the canonical PULSE/PULSEmech software identity.
+>
+> That Zenodo record was produced by an unintended GitHub release/archive path.
+>
+> Canonical software concept DOI / all versions:
+>
+> `10.5281/zenodo.17214908`
+>
+> Retained version-specific software citation DOI:
+>
+> `10.5281/zenodo.17373002`
+>
+> Canonical repository:
+>
+> `https://github.com/HKati/pulse-release-gates-0.1`
+>
+> This notice is temporary containment only. It is not a repository component, does not replace the existing concept DOI, does not establish a new software identity, and does not create release authority or release authorization.
+>
+> Remove this notice after Zenodo support has deleted, tombstoned, withdrawn, or clearly marked the unintended record as non-canonical.
+
 ## Canonical PULSEmech implementation path
 
 PULSEmech is the artifact-bound release-authority mechanism for AI release decisions.


### PR DESCRIPTION
## Summary

Adds a temporary DOI identity containment box for the unintended
Zenodo GitHub release/archive surface.

The notice explicitly states that `10.5281/zenodo.21031131`
is non-canonical and must not be cited as the canonical
PULSE/PULSEmech software identity.

Canonical DOI path remains unchanged:

- software concept DOI / all versions: `10.5281/zenodo.17214908`
- retained version-specific software citation DOI: `10.5281/zenodo.17373002`

## Purpose

This PR is a temporary containment measure.

It exists to prevent readers, bots, indexers, citation systems,
metadata harvesters, and downstream tools from treating the unintended
Zenodo record as the canonical PULSE/PULSEmech software identity while
the Zenodo correction request is pending.

## Boundary

Documentation-only change.

No code changed.  
No workflow changed.  
No gate policy changed.  
No verifier behavior changed.  
No release authority semantics changed.  
No canonical DOI changed.  
No new DOI created.  
No GitHub release created.  
No Zenodo version created.  
No tag changed.  
No repository history changed.

The containment notice is temporary only.

It is not a permanent repository component, not a release-authority
component, and not a new software identity.

## Removal condition

Remove the temporary containment box after Zenodo support has deleted,
tombstoned, withdrawn, or clearly marked the unintended Zenodo record
as non-canonical.