### PR TITLE
fix(citation): repair ORCID software work metadata v0

### DIFF
--- a/ORCID_add_work.json
+++ b/ORCID_add_work.json
@@ -1,5 +1,5 @@
 {
-  "title": "PULSE: Deterministic Release Gates for Safe & Useful AI (Software, v1.0.2)"
+  "title": "PULSE: Artifact-Bound Release Authority for AI Release Decisions (Software, v1.0.2)",
   "type": "software",
   "doi": "10.5281/zenodo.17373002",
   "year": 2025,


### PR DESCRIPTION
## Summary

Repair `ORCID_add_work.json` so it is valid JSON and matches the canonical PULSE software citation metadata.

- add the missing comma after the `title` field
- update the software title to `PULSE: Artifact-Bound Release Authority for AI Release Decisions`
- preserve the retained versioned software citation DOI: `10.5281/zenodo.17373002`
- preserve the software type: `software`

## Boundary

No concept DOI is changed.

No Zenodo software identity is changed.

No gate policy, runtime code, release workflow, verifier, materializer, status artifact, or release-authority semantics are changed.

This is a metadata syntax and citation-title repair only.