### PR TITLE
fix(citation): repair preprint software relation metadata v0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,6 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it."
+type: software
 title: "PULSE: Artifact-Bound Release Authority for AI Release Decisions"
 
 authors:
@@ -41,9 +42,6 @@ identifiers:
   - type: doi
     value: "10.5281/zenodo.17373002"
     description: "Versioned release DOI retained for citation-history and repository DOI-hygiene compatibility"
-  - type: url
-    value: "https://github.com/HKati/pulse-release-gates-0.1/releases/tag/pulsemech-tier0-floor-20260628-b"
-    description: "GitHub Tier 0 publication snapshot"
 
 preferred-citation:
   type: software

--- a/zenodo.preprint.json
+++ b/zenodo.preprint.json
@@ -25,12 +25,12 @@
   "related_identifiers": [
     {
       "identifier": "10.5281/zenodo.17214908",
-      "relation": "isVersionOf",
+      "relation": "documents",
       "scheme": "doi"
     },
     {
       "identifier": "https://github.com/HKati/pulse-release-gates-0.1",
-      "relation": "isDocumentedBy",
+      "relation": "documents",
       "scheme": "url"
     }
   ],


### PR DESCRIPTION
## Summary

Repair `zenodo.preprint.json` relation metadata.

- change the software concept DOI relation from `isVersionOf` to `documents`
- change the repository URL relation from `isDocumentedBy` to `documents`
- preserve the canonical software concept DOI: `10.5281/zenodo.17214908`
- preserve the canonical repository URL: `https://github.com/HKati/pulse-release-gates-0.1`

## Boundary

No DOI value is changed.

No concept DOI is changed.

No Zenodo software identity is changed.

No gate policy, runtime code, release workflow, verifier, materializer, status artifact, or release-authority semantics are changed.

This is a preprint relation-routing metadata repair only.