### PR TITLE
fix: remove legacy Zenodo latest DOI badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,6 @@ Required gates are explicit, materialized, and checked before release effects ca
 
 [![DOI](https://doi.org/badge/DOI/10.5281/zenodo.17373002.svg)](https://doi.org/10.5281/zenodo.17373002)
 
-[![DOI](https://zenodo.org/badge/1061766508.svg)](https://zenodo.org/badge/latestdoi/1061766508)
 ---
 
 <details>

--- a/tests/test_readme_doi_badge_contract.py
+++ b/tests/test_readme_doi_badge_contract.py
@@ -26,11 +26,12 @@ ACCIDENTAL_CURRENT_RELEASE_RECORD = (
     "- **Current release DOI / v1.1.1:** "
     "https://doi.org/10.5281/zenodo.18203404"
 )
+ACCIDENTAL_NEW_RELEASE_URL = "https://doi.org/10.5281/zenodo.21031131"
+ACCIDENTAL_NEW_RELEASE_BADGE = (
+    "https://doi.org/badge/DOI/10.5281/zenodo.21031131.svg"
+)
 LEGACY_REPOSITORY_LATESTDOI_ROUTE = "https://zenodo.org/badge/latestdoi/1061766508"
 LEGACY_REPOSITORY_BADGE = "https://zenodo.org/badge/1061766508.svg"
-LEGACY_REPOSITORY_MARKDOWN_BADGE = (
-    f"[![DOI]({LEGACY_REPOSITORY_BADGE})]({LEGACY_REPOSITORY_LATESTDOI_ROUTE})"
-)
 
 
 def _read(path: Path) -> str:
@@ -52,18 +53,14 @@ def test_readme_zenodo_records_match_april_known_good_release_identity() -> None
     assert PREPRINT_RECORD in text
 
 
-def test_readme_blocks_accidental_current_release_but_preserves_legacy_repository_badge_surface() -> None:
+def test_readme_blocks_accidental_current_release_and_legacy_latestdoi_routes() -> None:
     text = _read(README)
 
     assert ACCIDENTAL_CURRENT_RELEASE_RECORD not in text
-    assert LEGACY_REPOSITORY_MARKDOWN_BADGE in text
-
-
-def test_readme_exposes_legacy_repository_badge_routes_for_crawlers() -> None:
-    text = _read(README)
-
-    assert LEGACY_REPOSITORY_BADGE in text
-    assert LEGACY_REPOSITORY_LATESTDOI_ROUTE in text
+    assert ACCIDENTAL_NEW_RELEASE_URL not in text
+    assert ACCIDENTAL_NEW_RELEASE_BADGE not in text
+    assert LEGACY_REPOSITORY_BADGE not in text
+    assert LEGACY_REPOSITORY_LATESTDOI_ROUTE not in text
 
 
 def test_docs_index_doi_badge_uses_versioned_release_doi() -> None:


### PR DESCRIPTION
### Motivation

The README must not expose the Zenodo `latestdoi` repository route because
that route can redirect to the newest Zenodo DOI for the repository, including
an unintended or accidental release DOI.

The public README badge should remain pinned to the explicit, known-good
versioned DOI:

`10.5281/zenodo.17373002`

### Changes

- Removed the legacy Zenodo `latestdoi` badge/link from `README.md`.
- Kept the explicit fixed DOI badge:
  `[![DOI](https://doi.org/badge/DOI/10.5281/zenodo.17373002.svg)](https://doi.org/10.5281/zenodo.17373002)`
- Updated the README DOI badge contract test so it forbids:
  - `https://zenodo.org/badge/latestdoi/1061766508`
  - `https://zenodo.org/badge/1061766508.svg`
  - accidental DOI badge/URL surfaces for `10.5281/zenodo.21031131`

### Testing

- `pytest -q tests/test_readme_doi_badge_contract.py`
- `pytest -q`