### PR TITLE
docs: remove non-technical surface term from SLSA alignment note

### DIFF
--- a/docs/PULSEMECH_SLSA_PROVENANCE_TO_TRANSITION_v0.md
+++ b/docs/PULSEMECH_SLSA_PROVENANCE_TO_TRANSITION_v0.md
@@ -630,7 +630,6 @@ Examples:
 ```text
 README
 dashboard
-badge
 release note
 publication page
 status page


### PR DESCRIPTION
Updated after review.

The only failing review criterion was the presence of one forbidden non-technical term in the informational surfaces example list.

Removed that term.

No other content changed.
No workflow, runtime, gate policy, verifier, materializer, schema, or release-authority semantics changed.