### PR TITLE
docs: clarify release proof artifact contracts

### DIFF
--- a/docs/PULSEMECH_DEPENDENCY_SINGLE_TRUTH_PLAN_v0.md
+++ b/docs/PULSEMECH_DEPENDENCY_SINGLE_TRUTH_PLAN_v0.md
@@ -1,0 +1,49 @@
+# PULSEmech dependency single-truth plan v0
+
+## Status
+
+Technical dependency-surface plan.
+
+This document does not change workflow behavior, runtime code, gate policy, verifier behavior, materializer behavior, schema behavior, fail-closed CI enforcement, branch protection settings, or release-authority semantics.
+
+## Purpose
+
+PULSEmech should keep dependency authority explicit so reviewers can distinguish the self-contained evidence-floor runtime from hosted external-runtime lanes.
+
+## Current dependency surfaces
+
+The current dependency surfaces are:
+
+```text
+requirements.txt
+environment.yml
+PULSE_safe_pack_v0/requirements-llamaguard-v0.txt
+```
+
+`requirements.txt` remains the current canonical core runtime dependency surface for the repository’s self-contained PULSE evidence floor.
+
+`environment.yml` is a broader convenience environment and must not be treated as the canonical core runtime definition by itself.
+
+`PULSE_safe_pack_v0/requirements-llamaguard-v0.txt` is part of the hosted external-runtime dependency surface for the `hosted_full_runtime` lane.
+
+It is not part of the Tier 0 self-contained evidence-floor dependency surface and must not be promoted to core runtime.
+
+## Hosted external-runtime boundary
+
+The hosted external-runtime dependency surface exists to support optional or policy-required hosted evidence lanes when the active workflow-effective policy requires them.
+
+It must remain separate from the Tier 0 self-contained evidence-floor dependency surface so that hosted model dependencies, provider credentials, provider availability, and external runtime authorization do not silently become core runtime requirements.
+
+## Single-truth rule
+
+Dependency documentation and workflow interpretation should preserve these boundaries:
+
+```text
+Tier 0 self-contained evidence floor
+→ core runtime dependency surface
+
+hosted_full_runtime lane
+→ hosted external-runtime dependency surface
+```
+
+A dependency may move between surfaces only through an explicit reviewed change that updates the workflow contract, documentation, and any affected tests.

--- a/docs/PULSEMECH_RELEASE_GRADE_REFERENCE_PROOF_PLAN_v0.md
+++ b/docs/PULSEMECH_RELEASE_GRADE_REFERENCE_PROOF_PLAN_v0.md
@@ -4,13 +4,15 @@
 
 Technical proof plan.
 
-This document defines the evidence, run conditions, artifacts, and review criteria required before a public non-stubbed release-grade reference run can be recorded for PULSEmech.
+This document defines the evidence, run conditions, artifact set, qualification criteria, and reproduction expectations required before a public non-stubbed PULSEmech release-grade reference run can be recorded.
 
-It is not a run record.
+This document is not a run record.
 
-It does not mark any pending implementation-state item as completed.
+This document does not claim that a completed public non-stubbed release-grade reference run already exists.
 
-It does not change workflow behavior, runtime code, gate policy, verifier behavior, materializer behavior, schema behavior, fail-closed CI enforcement, branch protection settings, or release-authority semantics.
+This document does not mark any pending implementation-state item as completed.
+
+This document does not change workflow behavior, runtime code, gate policy, verifier behavior, materializer behavior, schema behavior, fail-closed CI enforcement, branch protection settings, README state, release metadata, or release-authority semantics.
 
 ## Purpose
 
@@ -19,7 +21,7 @@ PULSEmech already has a self-contained Tier 0 evidence floor and a broad release
 The remaining release-grade maturity question is different:
 
 ```text
-Can a complete, public, non-stubbed release-grade reference run be reconstructed from recorded evidence, declared policy, materialized required gates, verifier replay, and CI enforcement?
+Can a complete, public, non-stubbed release-grade reference run be reconstructed from recorded evidence, declared policy, workflow-effective materialized gates, verifier replay, and CI enforcement?
 ```
 
 This proof plan defines the conditions for answering that question.
@@ -28,22 +30,22 @@ This proof plan defines the conditions for answering that question.
 
 PULSEmech has multiple evidence layers.
 
-They should not be collapsed into one status.
+These layers must not be collapsed into one status.
 
 ```text
 Tier 0 self-contained evidence floor
 → demonstrates that the base evidence path can run without hosted external model access
 
 Release-grade reference package tests
-→ demonstrate package, schema, verifier, and reference-bundle contracts
+→ demonstrate package, schema, verifier, wiring, and reference-bundle contracts
 
-Full public non-stubbed release-grade reference run
-→ requires an operational run record with non-stubbed status, materialized release-required gates, verifier replay, and enforceable allow/block result
+Completed public non-stubbed release-grade reference run
+→ requires an operational run record with ref + commit identity, run_mode = prod, non-stubbed status, materialized workflow-effective gates, verifier replay, strict check_gates.py enforcement, and reconstructible PASS / PROD-PASS qualification
 ```
 
-A passing test suite or reference fixture is necessary support.
+A passing test suite or reference fixture supports the release-grade path.
 
-It is not by itself the final public release-grade run record.
+It is not by itself the completed public release-grade reference run record.
 
 ## Proof target
 
@@ -52,29 +54,40 @@ The target proof is a public, reconstructible release-grade reference run.
 The proof should show:
 
 ```text
+recorded ref
+recorded commit
 run_mode = prod
 diagnostics.gates_stubbed = false
 diagnostics.scaffold = false
-release-required gate set materialized
+current-run required-gate evidence archived
+pre-materialization candidate snapshot preserved
+canonical recorded-release candidate envelopes present
+candidate index present
+workflow-effective materialized gate set recorded
 recorded release evidence verified
 release-grade status contract validated
-release-required gates enforced by check_gates.py
-release-authority manifest produced
+workflow-effective gates enforced by check_gates.py
+release_decision_v0.json produced
+artifact_provenance_binding_v0.json produced
+PULSE_safe_pack_v0/artifacts/release_authority_v0.json produced as audit/trace sidecar
 audit/review bundle assembled
 operator/reviewer can reconstruct the decision from recorded artifacts
+reference-run checker accepts the package as PASS / PROD-PASS
 ```
 
 ## Non-targets
 
-This plan does not require an immediate hosted external model run.
+This plan does not require immediate hosted external model execution.
 
-Hosted external evidence remains a separate operational lane.
+Hosted external evidence remains governed by the active policy and workflow-effective gate set.
 
-A hosted external runtime proof should be attempted only when suitable provider access, model authorization, cost conditions, and verification conditions are available.
+If active policy requires hosted external evidence, the qualifying run must include and verify the required external evidence artifacts.
+
+If active policy does not require hosted external evidence for the run mode, the run record must state that external evidence was not required for that run.
 
 This plan also does not treat reader surfaces as proof.
 
-The following surfaces may describe or summarize the proof, but they are not the proof itself:
+The following surfaces may describe or summarize proof state, but they are not the proof itself:
 
 ```text
 README
@@ -86,27 +99,62 @@ publication surface
 dashboard
 ```
 
-## Required proof inputs
+## Required proof identity
 
-A complete release-grade reference proof should identify the following inputs.
+A complete release-grade reference proof must identify the run by ref and commit.
+
+Required identity fields:
 
 ```text
 repository
-branch
+ref
 commit
 workflow name
 workflow run id or URL
 workflow run attempt
 workflow inputs
 run mode
+CI outcome
+```
+
+The ref may be a branch ref or a tag ref.
+
+Examples:
+
+```text
+refs/heads/main
+refs/tags/v...
+refs/tags/V...
+```
+
+A branch-only identity is not sufficient for the general release-grade proof model because version-tag release paths are valid release-grade lanes.
+
+## Required proof inputs
+
+A complete release-grade reference proof should identify the following inputs.
+
+```text
+repository
+ref
+commit
+workflow name
+workflow run id or URL
+workflow run attempt
+workflow inputs
+run_mode = prod
 declared gate policy
 gate registry
 status artifact
-recorded release evidence artifacts
+pre-materialization status candidate
+current-run required-gate evidence
+canonical recorded-release candidate envelopes
+candidate index
 release evidence input manifest
 recorded release evidence verifier report
-materialized required gate set
-release-authority manifest
+workflow-effective materialized gate set
+release decision artifact
+artifact provenance binding artifact
+audit/trace sidecar
 check_gates enforcement command
 CI outcome
 ```
@@ -115,72 +163,103 @@ Each evidence-bearing artifact should be identified by path and digest where pos
 
 ## Required run conditions
 
-The reference run should satisfy these conditions.
+A qualifying release-grade reference run should satisfy these conditions.
 
 ```text
-1. The run is produced from a known branch and commit.
+1. The run is produced from a recorded ref and commit.
 2. The run uses the intended release-grade path.
 3. The run records run_mode = prod.
 4. The run does not use stubbed gate state.
 5. The run does not use scaffold status for release-grade proof.
 6. The declared policy is known and recorded.
-7. The required release gate set is materialized from policy and verifier state.
-8. The recorded evidence verifier report is produced.
-9. The release-grade status schema validation passes.
-10. The release-required gate set is enforced by check_gates.py.
-11. The release-authority manifest is produced and reviewable.
-12. The final allow/block decision is reconstructible from artifacts.
+7. The workflow-effective materialized gate set is produced.
+8. The workflow-effective materialized gate set covers all gates required for the run, including required + release_required when both sets are active.
+9. Current-run required-gate evidence is archived.
+10. The pre-materialization candidate snapshot is preserved.
+11. Canonical recorded-release candidate envelopes are present.
+12. The candidate index is present.
+13. The recorded release evidence verifier report is produced.
+14. The release-grade status schema validation passes.
+15. check_gates.py enforces the workflow-effective materialized gate set.
+16. release_decision_v0.json is produced.
+17. artifact_provenance_binding_v0.json is produced.
+18. PULSE_safe_pack_v0/artifacts/release_authority_v0.json is produced as audit/trace sidecar.
+19. The final PASS / PROD-PASS qualification is reconstructible from artifacts.
 ```
 
 ## Required artifact set
 
-A release-grade reference proof should include or point to the following artifact classes.
+A completed release-grade reference proof must include or point to the following artifact classes.
 
 ```text
 status.json
-status_baseline.json, if applicable
-required_gate_evidence_v0.json, if applicable
+status_baseline.json
+required_gate_evidence_v0.json
+canonical recorded-release candidate envelopes
+recorded-release candidate index
 release_evidence_input_manifest_v0.json
 recorded_release_evidence_verifier_v0.json
-materialized_required_gates_v0.json, if produced as a separate artifact
-release_authority_manifest_v0.json
-release decision output, if separate
+workflow-effective materialized gate set
+release_decision_v0.json
+artifact_provenance_binding_v0.json
+PULSE_safe_pack_v0/artifacts/release_authority_v0.json
 release-authority audit bundle
-operator handoff report, if produced
+operator handoff report, when produced by the run
 CI logs or run link
 artifact digest list
 ```
 
-If external evidence is included, it must also include:
+Concrete PULSE-REF package contexts may use artifact names such as:
+
+```text
+gates/materialized_gate_sets.json
+```
+
+The implemented release-authority audit/trace sidecar is:
+
+```text
+PULSE_safe_pack_v0/artifacts/release_authority_v0.json
+```
+
+This sidecar supports review and traceability.
+
+It is not an independent release-authority engine.
+
+## Required external evidence artifacts
+
+External evidence is required when the active policy and workflow-effective gate set require it.
+
+When required, the release-grade reference proof must include the corresponding external evidence artifacts and verification reports.
+
+Required external evidence may include:
 
 ```text
 external summary
-external raw/evaluator artifact, if applicable
+external raw or evaluator artifact, when applicable
 external summary envelope
-attestation bundle, if applicable
+attestation bundle, when applicable
 external attestation verifier report
 signer identity or provenance identity
+summary digest
+subject digest
 fold-in admission result
 ```
 
+The external evidence must satisfy the applicable schema, semantic, signer, digest, subject, and cryptographic attestation verification requirements.
+
+If the active policy does not require external evidence for the run mode, the run record must state that external evidence was not required.
+
 ## Hosted external evidence lane
 
-The hosted external evidence lane is treated separately.
+The hosted external evidence lane is governed by workflow context and active policy.
 
-It may later produce:
+For workflow_dispatch runs, hosted external evidence may be selected through the hosted_full_runtime mode.
 
-```text
-current-run external evaluator output
-attested external summary
-attestation envelope
-cryptographic verification report
-attested external-evidence artifact package
-release-grade recorded path continuation
-```
+For version-tag release paths, hosted external evidence may be required when active policy and workflow-effective gates require it.
 
-A hosted external runtime proof is not required for Tier 0 self-contained operation.
+Therefore, hosted external evidence must not be described globally as optional.
 
-It should remain deferred until:
+A hosted external runtime proof should be attempted only when:
 
 ```text
 provider access is available
@@ -191,6 +270,8 @@ the workflow path can be run without changing release metadata
 the resulting evidence can be verified and reconstructed
 ```
 
+Tier 0 self-contained evidence-floor operation does not require hosted external runtime access.
+
 ## Self-contained release-grade preparation path
 
 Before attempting hosted runtime proof, PULSEmech should maintain a self-contained preparation path.
@@ -199,10 +280,16 @@ This path should verify:
 
 ```text
 policy-to-required-gate materialization
+workflow-effective gate set construction
+current-run required-gate evidence production
 recorded evidence verifier behavior
+canonical candidate production
+candidate index construction
 release-grade candidate evidence path
 release-grade status contract
-release-authority manifest construction
+release decision construction
+artifact provenance binding
+release-authority audit/trace sidecar construction
 reference package assembly
 reference package verification
 audit bundle neutrality
@@ -210,7 +297,7 @@ reader-surface non-interference
 operator handoff
 ```
 
-This preparation path reduces risk before any expensive or provider-dependent external runtime run.
+This preparation path reduces risk before any provider-dependent external runtime run.
 
 ## Evidence acceptance rules
 
@@ -227,6 +314,7 @@ verifier-checked
 non-stubbed
 non-scaffolded for release-grade proof
 traceable to run context
+connected to the workflow-effective materialized gate set
 ```
 
 External evidence additionally requires:
@@ -243,14 +331,19 @@ fold-in allowed only after verification
 
 The reference proof must preserve block semantics.
 
-The run should be considered not qualified if any of the following occur:
+A release transition should remain blocked if any of the following occur:
 
 ```text
 run_mode is not prod
 diagnostics.gates_stubbed is true
 diagnostics.scaffold is true
-release-required gate set is empty
-required evidence is missing
+workflow-effective materialized gate set is missing
+workflow-effective materialized gate set is empty
+current-run required-gate evidence is missing
+pre-materialization candidate snapshot is missing
+canonical recorded-release candidates are missing
+candidate index is missing
+recorded release evidence is missing
 required evidence is unverifiable
 required evidence digest does not match
 required gate is missing
@@ -258,64 +351,82 @@ required gate is not literal true
 verifier replay fails
 release-grade status schema validation fails
 check_gates.py fails
+release_decision_v0.json is missing
+artifact_provenance_binding_v0.json is missing
+required external evidence is omitted when active policy requires it
 external evidence is admitted without required verification
 reader surface is used as substitute for machine-readable evidence
 ```
 
-A block result is not a tooling failure if it is caused by missing or failed evidence.
+A block result is not a tooling failure when it is caused by missing or failed evidence.
 
-A block result is a valid release-transition decision.
+A block result is a valid fail-closed release-transition decision.
+
+A block result is not, by itself, a completed public non-stubbed release-grade reference proof.
 
 ## Qualification criteria
 
-A public release-grade reference run may be recorded only when the following criteria are met.
+A public release-grade reference run may be recorded as completed only when the following criteria are met.
 
 ```text
 1. The run is public or externally inspectable.
-2. The branch and commit are recorded.
+2. The ref and commit are recorded.
 3. The workflow run and attempt are recorded.
-4. The run mode is release-grade.
+4. The run records run_mode = prod.
 5. Stubbed/scaffolded release status is absent.
-6. Required gates are materialized from declared policy.
-7. Verifier replay is recorded.
-8. check_gates.py enforces the materialized required set.
-9. The decision is allow or block and is reconstructible.
-10. All required artifacts are present and digest-identifiable.
-11. The release-authority manifest is present.
-12. The audit/review bundle is present.
-13. The proof record states what was proven and what was not proven.
+6. The workflow-effective required gate set is materialized from declared policy and run context.
+7. Current-run required-gate evidence is present.
+8. Pre-materialization candidate status is preserved.
+9. Canonical recorded-release candidate envelopes are present.
+10. The candidate index is present.
+11. Verifier replay is recorded.
+12. check_gates.py enforces the workflow-effective materialized gate set.
+13. release_decision_v0.json is present.
+14. artifact_provenance_binding_v0.json is present.
+15. PULSE_safe_pack_v0/artifacts/release_authority_v0.json is present as audit/trace sidecar.
+16. Required external evidence is present and verified when active policy requires it.
+17. All required artifacts are present and digest-identifiable.
+18. The audit/review bundle is present.
+19. The proof record states what was proven and what was not proven.
+20. The reference-run checker accepts the package as PASS / PROD-PASS.
 ```
+
+A fail-closed block may be recorded as a valid blocked transition.
+
+It must not be recorded as a completed qualified release-grade reference proof unless the documented reference-run checker accepts it under the applicable contract.
 
 ## Proof record format
 
-After a qualifying run, create a separate run record.
-
-Candidate file:
+After a qualifying run, record the completed public run in the existing run-note file:
 
 ```text
-docs/PULSEMECH_RELEASE_GRADE_REFERENCE_RUN_RECORD_v0.md
+docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md
 ```
 
-The run record should contain:
+The run note should contain:
 
 ```text
 run identity
-branch
+repository
+ref
 commit
 workflow
 run id / URL
 run attempt
 inputs
-run mode
+run_mode = prod
 artifact list
 digest list
 status summary
 gate policy
-materialized required gates
+workflow-effective materialized gate set
 verifier result
 check_gates result
-decision
+release_decision_v0.json reference
+artifact_provenance_binding_v0.json reference
+release_authority_v0.json audit/trace sidecar reference
 audit bundle reference
+reference-run checker result
 known limitations
 non-claims
 reproduction steps
@@ -337,12 +448,20 @@ Minimum reproduction procedure:
 3. Verify artifact digests.
 4. Load the declared gate policy.
 5. Load the gate registry.
-6. Load the recorded release evidence.
-7. Run the recorded evidence verifier.
-8. Materialize the required release gate set.
-9. Validate the release-grade status contract.
-10. Run check_gates.py against the materialized required set.
-11. Compare the reproduced result with the recorded CI decision.
+6. Load current-run required-gate evidence.
+7. Load the pre-materialization candidate snapshot.
+8. Load canonical recorded-release candidate envelopes.
+9. Load the candidate index.
+10. Load the release evidence input manifest.
+11. Run the recorded evidence verifier.
+12. Materialize the workflow-effective required gate set.
+13. Validate the release-grade status contract.
+14. Run check_gates.py against the workflow-effective materialized gate set.
+15. Verify release_decision_v0.json.
+16. Verify artifact_provenance_binding_v0.json.
+17. Inspect release_authority_v0.json as audit/trace sidecar.
+18. Compare the reproduced result with the recorded CI decision.
+19. Confirm the reference-run checker result is PASS / PROD-PASS.
 ```
 
 The proof is stronger when the reviewer can reproduce the decision without relying on reader surfaces.
@@ -358,17 +477,19 @@ release evidence verifier tests
 recorded release evidence tests
 release evidence input manifest tests
 release evidence pre-materialization pipeline tests
+required-gate current-run evaluator coverage tests
 release-grade candidate evidence path tests
 release-grade status contract tests
 materialize release-required tests
-release-authority manifest tests
+release decision tests
+artifact provenance binding tests
+release-authority audit/trace sidecar tests
 release-grade reference run checker tests
 release-grade reference package tests
 reference package assembly wiring tests
 reference package verification wiring tests
 audit bundle workflow neutrality tests
 reader-surface non-interference tests
-artifact provenance binding tests
 ```
 
 Passing tests support confidence in the mechanism.
@@ -385,7 +506,7 @@ A PULSE-REF package can provide:
 minimal reference package layout
 manifest
 digest coverage
-materialized gate sets
+gates/materialized_gate_sets.json
 CI outcome
 operator handoff report
 publication snapshot
@@ -411,6 +532,12 @@ PULSEmech verifier and gate path
 → transition decision
 ```
 
+The artifact provenance binding artifact is part of the evidence chain:
+
+```text
+artifact_provenance_binding_v0.json
+```
+
 ## Relationship to developer-first adoption
 
 The release-grade proof should be readable by technical maintainers.
@@ -419,14 +546,16 @@ A developer, release engineer, or external technical reviewer should be able to 
 
 ```text
 What was run?
+Which ref and commit produced it?
 What evidence was used?
 Which policy applied?
-Which gates were required?
+Which gates were workflow-effective?
 Which verifier replay ran?
-Which gates passed or failed?
+Which gates passed?
 Which artifact digests bind the result?
 Where did CI enforce the decision?
 Can the decision be reconstructed?
+Did the reference-run checker accept it as PASS / PROD-PASS?
 ```
 
 If those questions cannot be answered from recorded artifacts, the proof is not complete.
@@ -461,12 +590,18 @@ That candidate should verify:
 
 ```text
 non-stubbed release-grade status path
+current-run required-gate evidence production
+canonical recorded-release candidate production
+candidate index production
 recorded evidence verifier replay
-release-required materialization
+workflow-effective gate materialization
 check_gates.py enforcement
-release-authority manifest construction
+release_decision_v0.json production
+artifact_provenance_binding_v0.json production
+release_authority_v0.json audit/trace sidecar production
 reference package assembly
 reference package verification
+reference-run checker qualification
 ```
 
 If the self-contained candidate cannot satisfy non-stubbed release-grade criteria, it should be recorded as a preparation milestone rather than a completed public release-grade reference run.
@@ -478,9 +613,9 @@ This proof plan defines the path from existing PULSEmech evidence mechanisms to 
 The plan preserves three boundaries:
 
 ```text
-Tier 0 self-contained evidence floor is valuable but not identical to full release-grade operational proof.
+Tier 0 self-contained evidence floor is valuable but not identical to a completed public non-stubbed release-grade reference run.
 
 Hosted external runtime proof is deferred until provider access, authorization, cost, and verification conditions are suitable.
 
-A completed release-grade reference run requires reconstructible recorded evidence, declared policy, materialized required gates, verifier replay, check_gates enforcement, and a public run record.
+A completed release-grade reference run requires ref + commit identity, run_mode = prod, current-run evidence, canonical candidates, workflow-effective materialized gates, verifier replay, check_gates enforcement, release decision artifact, provenance binding artifact, audit/trace sidecar, and PASS / PROD-PASS acceptance by the reference-run checker.
 ```

--- a/docs/PULSEMECH_REQUIRED_CHECKS_AND_WORKFLOW_AUTHORITY_v0.md
+++ b/docs/PULSEMECH_REQUIRED_CHECKS_AND_WORKFLOW_AUTHORITY_v0.md
@@ -383,7 +383,7 @@ The release decision should not be reconstructed from `release_required` alone i
 
 The repository contains a broad test surface.
 
-The tools-test manifest includes many release-authority, verifier, materializer, schema, evidence, attestation, reference-package, reader-surface, and fail-closed checks. This breadth is a strength, but it also requires clear authority mapping so that test outputs are not mistaken for release decisions by themselves. :contentReference[oaicite:1]{index=1}
+The tools-test manifest includes many release-authority, verifier, materializer, schema, evidence, attestation, reference-package, reader-surface, and fail-closed checks. This breadth is a strength, but it also requires clear authority mapping so that test outputs are not mistaken for release decisions by themselves.
 
 A test may prove a contract, workflow invariant, schema boundary, documentation constraint, or wiring condition.
 

--- a/docs/PULSEMECH_REQUIRED_CHECKS_AND_WORKFLOW_AUTHORITY_v0.md
+++ b/docs/PULSEMECH_REQUIRED_CHECKS_AND_WORKFLOW_AUTHORITY_v0.md
@@ -4,15 +4,15 @@
 
 Technical repository map.
 
-This document describes how PULSEmech release-authority, required checks, workflow families, and reader surfaces relate to one another.
+This document describes how PULSEmech release-authority, required checks, workflow families, evidence artifacts, and reader surfaces relate to one another.
 
-It does not change workflow behavior, runtime code, gate policy, verifier behavior, materializer behavior, schema behavior, fail-closed CI enforcement, branch protection settings, or release-authority semantics.
+It does not change workflow behavior, runtime code, gate policy, verifier behavior, materializer behavior, schema behavior, fail-closed CI enforcement, branch protection settings, platform required-check settings, or release-authority semantics.
 
 It is a documentation map for maintainers, reviewers, and external technical readers.
 
 ## Purpose
 
-PULSEmech contains several workflow families, test surfaces, documentation records, audit artifacts, and publication or reader surfaces.
+PULSEmech contains several workflow families, test surfaces, evidence artifacts, documentation records, audit artifacts, and publication or reader surfaces.
 
 These surfaces do not all carry the same authority.
 
@@ -20,15 +20,14 @@ This document defines the repository-level map between:
 
 ```text
 primary release authority
-core checks
-release-grade checks
-guardrail checks
-advisory / diagnostic checks
-publication / reader surfaces
-maintenance records
+core deterministic checks
+release-grade evidence and reference support
+guardrail / hygiene checks
+advisory / diagnostic / shadow surfaces
+reader / publication / maintenance surfaces
 ```
 
-The purpose is to make the authority boundary visible before a reviewer interprets a workflow result, report, dashboard, document, or artifact as a release decision.
+The purpose is to make the authority boundary visible before a reviewer interprets a workflow result, report, dashboard, document, sidecar, or artifact as a release decision.
 
 ## Core release-authority model
 
@@ -38,13 +37,13 @@ PULSEmech release authority is produced by the connected evidence and enforcemen
 recorded release evidence
 → status.json
 → declared gate policy
-→ workflow-effective materialized required gate set
+→ workflow-effective materialized gate set
 → verifier replay
 → check_gates.py
 → primary CI allow/block decision
 ```
 
-No single reader surface, report, dashboard, metadata record, release note, audit bundle, or documentation page independently creates release authority.
+No single reader surface, report, dashboard, metadata record, release note, audit bundle, sidecar, or documentation page independently creates release authority.
 
 Release authority depends on the connected path.
 
@@ -55,7 +54,7 @@ PULSEmech repository surfaces are grouped into six categories.
 ```text
 A. Primary release-authority path
 B. Core deterministic lane
-C. Release-grade evidence and reference path
+C. Release-grade evidence and reference support
 D. Guardrail / hygiene checks
 E. Advisory / diagnostic / shadow surfaces
 F. Reader / publication / maintenance surfaces
@@ -65,14 +64,14 @@ Each category has a different role.
 
 ## A. Primary release-authority path
 
-The primary release-authority path is the normative allow/block path for the repository.
+The primary release-authority path is the normative allow/block path for release-transition decisions.
 
 It is defined by the connection between:
 
 ```text
 status.json
 declared gate policy
-materialized required gate set
+workflow-effective materialized gate set
 verifier replay
 check_gates.py
 primary CI outcome
@@ -84,7 +83,7 @@ The primary path answers:
 May this release transition proceed under the declared policy and recorded evidence?
 ```
 
-The primary path is not replaced by documentation, reader surfaces, dashboards, external summaries, or publication metadata.
+The primary path is not replaced by documentation, reader surfaces, dashboards, external summaries, publication metadata, audit bundles, or trace sidecars.
 
 ### Primary components
 
@@ -94,15 +93,32 @@ pulse_gate_policy_v0.yml
 pulse_gate_registry_v0.yml
 PULSE_safe_pack_v0/tools/check_gates.py
 status.json
-release evidence verifier reports
-materialized required gate outputs
-release-authority manifest outputs
+workflow-effective materialized gate set
+recorded evidence verifier output when connected to the release path
+primary CI allow/block result
 ```
 
 ### Primary authority rule
 
 ```text
-If required release evidence is missing, stale, unverifiable, policy-incomplete, or fails required gates, the transition must remain blocked.
+If required release evidence is missing, stale, unverifiable, policy-incomplete, or fails the workflow-effective required gates, the transition must remain blocked.
+```
+
+### Primary-path boundary
+
+The primary release-authority path may use supporting artifacts.
+
+Supporting artifacts help reconstruct, review, or audit the decision.
+
+They do not replace:
+
+```text
+status.json
+declared gate policy
+workflow-effective materialized gate set
+verifier replay
+check_gates.py
+primary CI allow/block result
 ```
 
 ## B. Core deterministic lane
@@ -122,7 +138,7 @@ registry coherence
 deterministic tool behavior
 ```
 
-The core lane is important because it proves the basic PULSEmech mechanism can run without relying on optional external hosted evidence.
+The core lane is important because it proves the base PULSEmech mechanism can run without relying on optional hosted external evidence.
 
 ### Core lane examples
 
@@ -141,9 +157,9 @@ The core lane is not automatically the same as a completed full release-grade re
 
 A core pass proves the core mechanism.
 
-A release-grade pass requires the release-grade evidence path and release-grade gate requirements applicable to that run.
+A completed release-grade reference proof requires the release-grade evidence path, workflow-effective gate requirements, non-stubbed status, verifier replay, and qualification criteria applicable to that run.
 
-## C. Release-grade evidence and reference path
+## C. Release-grade evidence and reference support
 
 The release-grade evidence path evaluates a stronger release context.
 
@@ -152,13 +168,15 @@ It may include:
 ```text
 recorded release evidence
 release evidence input manifest
-release evidence verifier report
-materialized release-required gates
+recorded release evidence verifier report
+workflow-effective materialized gate set
 release-grade status validation
-release-authority manifest
-audit bundle
+release decision artifact
+artifact provenance binding artifact
+audit / trace sidecar
+audit / review bundle
 reference package
-attested external evidence where applicable
+operator handoff report
 ```
 
 ### Release-grade path components
@@ -167,30 +185,49 @@ attested external evidence where applicable
 PULSE_safe_pack_v0/tools/build_release_evidence_input_manifest_v0.py
 PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py
 PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
-PULSE_safe_pack_v0/tools/build_release_authority_manifest_v0.py
 PULSE_safe_pack_v0/tools/check_gates.py
 ```
 
-### Release-grade reference artifacts
+### Implemented release-grade support artifacts
 
-Typical release-grade or reference-path artifacts may include:
+Concrete artifact names should be taken from the workflow, package manifest, verifier output, or reference package being reviewed.
+
+Known implemented artifact names and paths include:
 
 ```text
+status.json
+status_baseline.json
+required_gate_evidence_v0.json
 release_evidence_input_manifest_v0.json
 recorded_release_evidence_verifier_v0.json
-materialized_required_gates_v0.json
-release_authority_manifest_v0.json
-release_authority_audit_bundle
-release-grade reference package
+release_decision_v0.json
+artifact_provenance_binding_v0.json
+PULSE_safe_pack_v0/artifacts/release_authority_v0.json
 ```
+
+PULSE-REF package contexts may include:
+
+```text
+gates/materialized_gate_sets.json
+```
+
+The following artifact is an audit / trace sidecar:
+
+```text
+PULSE_safe_pack_v0/artifacts/release_authority_v0.json
+```
+
+It supports review and traceability.
+
+It is not an independent release-authority engine.
 
 ### Release-grade boundary
 
-A reference artifact or audit bundle supports review.
+A reference artifact, audit sidecar, or audit bundle supports review.
 
 It does not replace the primary enforcement path.
 
-A release-grade reference record should be read as evidence of a run, not as a second release decision engine.
+A release-grade reference record should be read as evidence of a run and a reconstruction aid, not as a second release decision engine.
 
 ## D. Guardrail / hygiene checks
 
@@ -214,6 +251,8 @@ secret scanning
 repository hygiene checks
 DCO checks
 workflow lint checks
+attestation action pin checks
+reader-surface non-interference checks
 ```
 
 ### Guardrail boundary
@@ -224,7 +263,7 @@ A guardrail pass does not by itself authorize a release transition.
 
 Guardrails protect the conditions around the release-authority path.
 
-They are not a substitute for recorded evidence, declared policy, materialized gates, verifier replay, and check_gates enforcement.
+They are not a substitute for recorded evidence, declared policy, workflow-effective materialized gates, verifier replay, and check_gates enforcement.
 
 ## E. Advisory / diagnostic / shadow surfaces
 
@@ -278,6 +317,8 @@ metadata records
 recovery ledger
 developer positioning notes
 SLSA alignment notes
+proof plans
+authority maps
 ```
 
 These surfaces may describe or summarize the release-authority path.
@@ -317,68 +358,42 @@ This is a GitHub repository administration requirement.
 
 This document does not define platform branch protection.
 
-It maps the authority categories so that platform settings can be configured consistently with the mechanism.
+This document does not claim that any listed check is configured as a GitHub required check.
+
+This document maps authority categories so that platform settings can be configured consistently with the mechanism.
+
+## Workflow-effective gate set
+
+A release run may involve more than one policy set.
+
+For release-grade interpretation, reviewers should identify the workflow-effective materialized gate set for the run.
+
+That set may include:
+
+```text
+required
+release_required
+```
+
+when both sets are active for the run.
+
+The release decision should not be reconstructed from `release_required` alone if the workflow-effective enforcement path includes both base required gates and release-required gates.
 
 ## Test surfaces
 
 The repository contains a broad test surface.
 
-The tools-test manifest includes tests for:
+The tools-test manifest includes many release-authority, verifier, materializer, schema, evidence, attestation, reference-package, reader-surface, and fail-closed checks. This breadth is a strength, but it also requires clear authority mapping so that test outputs are not mistaken for release decisions by themselves. :contentReference[oaicite:1]{index=1}
 
-```text
-exporters
-manifest coherence
-workflow structure
-status conversion
-policy-to-require arguments
-fail-closed gate behavior
-external summary handling
-LlamaGuard current-run wiring
-status schema validation
-release evidence verifier reports
-recorded release evidence
-release-authority manifests
-release decision schemas
-release-grade status contract
-self-contained PULSE evidence floor
-release-grade reference packages
-PULSE-REF RA1 packages
-agent orchestration evidence
-artifact provenance binding
-reader-surface non-interference
-```
-
-This breadth is a strength, but it also requires clear authority mapping.
-
-A test may prove a contract, workflow invariant, schema boundary, or documentation constraint.
+A test may prove a contract, workflow invariant, schema boundary, documentation constraint, or wiring condition.
 
 A test pass is not automatically a release decision unless it participates in the connected release-authority path.
-
-## Current known CI interpretation rule
-
-When a prior CI log shows a failure, it must be interpreted in context.
-
-A failed run should be classified by:
-
-```text
-branch
-commit
-workflow
-job
-test
-current reproducibility
-relationship to active merge target
-```
-
-If a failure does not reproduce on the current branch and targeted test, it should not trigger speculative workflow changes.
-
-If it reproduces on the current branch or an active merge target, it should be fixed before merge.
 
 ## Workflow family map
 
 | Workflow or surface family | Primary role | Authority category |
 |---|---|---|
-| `pulse_ci.yml` | Main repository CI and release-gating workflow | Primary release-authority path when enforcing declared policy and materialized gates |
+| `pulse_ci.yml` | Main repository CI and release-gating workflow | Primary release-authority path when enforcing declared policy and workflow-effective materialized gates |
 | `pulse_core_ci.yml` | Deterministic core lane | Core deterministic lane |
 | workflow lint / repo hygiene workflows | Configuration and repository integrity | Guardrail / hygiene |
 | secret scan workflows | Security hygiene and advisory finding surface | Guardrail / advisory |
@@ -389,18 +404,20 @@ If it reproduces on the current branch or an active merge target, it should be f
 | recovery ledger | Record maintenance and recovery decisions | Maintenance surface, not release authority |
 | SLSA alignment note | Explain provenance-to-transition relationship | Technical alignment surface, not release authority |
 | developer-first positioning note | Define audience and adoption order | Technical positioning surface, not release authority |
+| release-grade proof plan | Define qualification requirements for future run records | Technical plan, not release authority |
 
 ## Check family map
 
 | Check family | Examples | Role | Release-authority status |
 |---|---|---|---|
-| Gate enforcement | `check_gates.py`, policy-derived required gates | Enforces allow/block decision | Normative when used in primary path |
-| Evidence verification | recorded release-evidence verifier, external summary attestation verifier | Verifies evidence admissibility | Normative only when connected to materialized release path |
+| Gate enforcement | `check_gates.py`, policy-derived required gates | Enforces allow/block decision | Normative when used in the primary path |
+| Evidence verification | recorded release-evidence verifier, external summary attestation verifier | Verifies evidence admissibility | Normative only when connected to the materialized release path |
 | Schema validation | status schema, release evidence schema, manifest schema | Ensures machine-readable contract validity | Supporting / guardrail |
 | Workflow wiring smoke tests | workflow structure and pinned action checks | Guards workflow semantics | Guardrail |
 | Reader non-interference tests | reader-surface non-authority checks | Prevents surface confusion | Guardrail / semantic protection |
 | Exporter tests | JUnit, SARIF, report generation | Publication/integration correctness | Supporting |
 | Shadow / diagnostic tests | EPF, recognition drift, HPC evidence, field-point maps | Diagnostic/research correctness | Advisory unless policy-promoted |
+| Audit sidecar checks | `release_authority_v0.json` structure and non-interference | Supports audit and reconstruction | Supporting; not an independent authority engine |
 
 ## Promotion rule for advisory evidence
 
@@ -414,7 +431,7 @@ schema-valid evidence
 digest-bound artifact identity
 signer or provenance requirement where applicable
 verifier replay
-materialized required gate connection
+workflow-effective materialized gate connection
 fail-closed enforcement
 ```
 
@@ -424,7 +441,11 @@ Without this path, advisory evidence remains advisory.
 
 External evidence may be used only under the declared policy and verifier requirements that apply to the run.
 
-A hosted external runtime lane may be present as an opt-in workflow path.
+For `workflow_dispatch` runs, hosted external evidence may be selected through the `hosted_full_runtime` mode.
+
+For version-tag release paths, hosted external evidence may be required when active policy and workflow-effective gates require it.
+
+Therefore, hosted external evidence must not be described globally as optional.
 
 If external evidence is missing, unverified, unsigned where signing is required, or not admitted by signer policy, it must not silently become release authority.
 
@@ -436,9 +457,18 @@ Artifact provenance and attestation checks can support release evidence.
 
 They should be interpreted as evidence-path controls.
 
+Relevant evidence artifacts may include:
+
+```text
+artifact_provenance_binding_v0.json
+attestation bundle
+attestation envelope
+external attestation verifier report
+```
+
 A passing provenance or attestation check can support a release decision.
 
-It is not sufficient alone unless the release policy, materialized gates, verifier replay, and CI enforcement also pass.
+It is not sufficient alone unless the release policy, workflow-effective materialized gates, verifier replay, and CI enforcement also pass.
 
 ## Reader-surface non-interference
 
@@ -453,10 +483,39 @@ They must not override or substitute:
 ```text
 status.json
 declared gate policy
-materialized required gate set
+workflow-effective materialized gate set
 verifier replay
 check_gates.py
 primary CI result
+```
+
+## Audit / trace sidecar interpretation
+
+Audit and trace sidecars help reviewers inspect the decision path.
+
+The implemented release-authority audit / trace sidecar is:
+
+```text
+PULSE_safe_pack_v0/artifacts/release_authority_v0.json
+```
+
+This sidecar may record or reference evidence needed for review.
+
+It does not independently authorize a release transition.
+
+If an audit sidecar is missing or malformed, the review package may be incomplete.
+
+That does not mean the sidecar itself is the primary release decision engine.
+
+The primary release decision remains tied to:
+
+```text
+status.json
+declared gate policy
+workflow-effective materialized gate set
+verifier replay
+check_gates.py
+primary CI allow/block result
 ```
 
 ## Maintainer interpretation checklist
@@ -465,15 +524,15 @@ Before treating a result as release-authoritative, a maintainer should ask:
 
 ```text
 1. Which workflow produced the result?
-2. Which branch and commit produced the result?
+2. Which ref and commit produced the result?
 3. Which run mode was used?
 4. Which gate policy was applied?
-5. Which required gate set was materialized?
+5. Which workflow-effective gate set was materialized?
 6. Which evidence artifacts were verified?
 7. Which verifier report was used?
 8. Which check_gates enforcement step ran?
 9. Did the primary CI path allow or block?
-10. Is this result a reader surface, advisory report, or maintenance record instead?
+10. Is this result a reader surface, advisory report, audit sidecar, or maintenance record instead?
 ```
 
 ## External reviewer interpretation checklist
@@ -496,7 +555,44 @@ release-authority path
 
 A technical review should identify the machine-readable artifacts that produced the decision.
 
-If a claim cannot be traced to recorded evidence, declared policy, materialized gates, verifier replay, and CI enforcement, it should not be treated as release authority.
+If a claim cannot be traced to recorded evidence, declared policy, workflow-effective materialized gates, verifier replay, and CI enforcement, it should not be treated as release authority.
+
+## CI failure interpretation rule
+
+When a CI log shows a failure, it must be interpreted in context.
+
+A failed run should be classified by:
+
+```text
+ref
+commit
+workflow
+job
+test
+current reproducibility
+relationship to active merge target
+```
+
+If a failure does not reproduce on the current branch and targeted test, it should not trigger speculative workflow changes.
+
+If it reproduces on the current branch or an active merge target, it should be fixed before merge.
+
+## Required artifact-name rule
+
+Documentation that guides release proof or evidence review should use implemented artifact names where known.
+
+Avoid invented placeholders when the repository already defines concrete artifacts.
+
+Examples of concrete names:
+
+```text
+release_decision_v0.json
+artifact_provenance_binding_v0.json
+PULSE_safe_pack_v0/artifacts/release_authority_v0.json
+gates/materialized_gate_sets.json
+```
+
+When a package manifest defines a more specific path, reviewers should follow the manifest.
 
 ## Recommended repository follow-up
 
@@ -508,17 +604,18 @@ Recommended follow-up work may include:
 
 ```text
 publish a concise required-checks table
-document branch-protection expectations
+document branch-protection expectations separately
 document which workflows are intended as required merge checks
 document which workflows are advisory only
 document the release-grade reference proof path separately
+document artifact-name expectations for release-grade packages
 ```
 
 These follow-up tasks should be implemented as documentation and repository settings updates only after the authority categories are stable.
 
 ## Summary
 
-PULSEmech contains multiple workflow and reader surfaces.
+PULSEmech contains multiple workflow, artifact, audit, diagnostic, and reader surfaces.
 
 Only the connected release-authority path produces an allow/block release-transition decision.
 
@@ -527,7 +624,7 @@ The durable interpretation is:
 ```text
 recorded evidence
 → declared policy
-→ materialized required gate set
+→ workflow-effective materialized gate set
 → verifier replay
 → check_gates.py
 → primary CI allow/block result
@@ -538,6 +635,7 @@ All other surfaces should be interpreted according to their category:
 ```text
 core proof
 release-grade evidence support
+audit / trace sidecar
 guardrail
 advisory diagnostic evidence
 reader surface


### PR DESCRIPTION
## Summary

Clarify release-grade proof, workflow-authority, and dependency documentation based on review feedback.

This PR updates:

```text
docs/PULSEMECH_REQUIRED_CHECKS_AND_WORKFLOW_AUTHORITY_v0.md
docs/PULSEMECH_RELEASE_GRADE_REFERENCE_PROOF_PLAN_v0.md
docs/maintenance/PULSEMECH_DEPENDENCY_SINGLE_TRUTH_PLAN_v0.md
```

## Changes

The update:

```text
- removes release-authority manifest outputs from the primary authority components;
- classifies release_authority_v0.json as an audit/trace sidecar;
- uses concrete reference artifact names such as gates/materialized_gate_sets.json;
- uses PULSE_safe_pack_v0/artifacts/release_authority_v0.json for the implemented release-authority artifact;
- clarifies hosted external evidence semantics for workflow_dispatch and version-tag release paths;
- records ref + commit instead of branch-only identity;
- uses run_mode = prod for release-grade proof qualification;
- requires workflow-effective materialized gate sets;
- requires current-run evidence artifacts for completed release-grade reference proof;
- includes canonical recorded-release candidates and candidate index;
- includes release_decision_v0.json and artifact_provenance_binding_v0.json;
- points completed run records to docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md;
- distinguishes valid fail-closed block decisions from completed qualified release-grade reference proofs;
- includes PULSE_safe_pack_v0/requirements-llamaguard-v0.txt as the hosted external-runtime dependency surface for hosted_full_runtime.
```

## Boundary

Documentation only.

No changes to:

```text
workflows
runtime code
dependency files
requirements.txt
requirements-analysis.txt
environment.yml
PULSE_safe_pack_v0/requirements-llamaguard-v0.txt
gate policy
verifier behavior
materializer behavior
schemas
fail-closed CI enforcement
release-authority semantics
README implementation-state table
DOI / Zenodo metadata
citation metadata
ORCID metadata
tags
release metadata
```

## Testing

```text
python -m pytest -q tests/test_release_grade_reference_package_verification_wiring_v0.py tests/test_build_pulse_ref_schema_aligned_pass_fixture_packet_v0.py
```

Result:

```text
PASS
```