### PR TITLE
fix(break-glass): repair override schema and clarify exception boundary

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -47,6 +47,7 @@ tests/test_build_release_authority_manifest_v0.py
 tests/test_release_authority_manifest_non_interference.py
 tests/test_release_decision_v0_smoke.py
 tests/test_release_decision_v0_schema_smoke.py
+tests/test_break_glass_override_v0_smoke.py
 tests/test_release_grade_status_contract_schema.py
 tests/test_release_evidence_verifier_report_schema_v0.py
 tests/test_release_evidence_input_manifest_v0.py

--- a/docs/BREAK_GLASS_OVERRIDE_v0.md
+++ b/docs/BREAK_GLASS_OVERRIDE_v0.md
@@ -3,8 +3,8 @@
 ## Purpose
 
 `break_glass_override_v0` defines the audited exception mechanism for rare
-situations where a human operator authorizes an operational release despite a
-non-passing release decision.
+situations where a human operator records acceptance of a temporary operational
+exception attached to a non-passing release decision.
 
 Break-glass is not a hidden pass.
 
@@ -74,8 +74,9 @@ release_decision_v0.json
 + exception ledger rendering
 ```
 
-Break-glass may authorize an operational exception, but it must not mutate the
-underlying release-decision artifact.
+Break-glass may record acceptance of a temporary operational exception attached
+to a non-passing release decision, but it must not mutate the underlying
+release-decision artifact.
 
 ## Non-goals
 

--- a/schemas/break_glass_override_v0.schema.json
+++ b/schemas/break_glass_override_v0.schema.json
@@ -398,10 +398,7 @@
               }
             }
           },
-          HKati-patch-958740
-           "expires_utc": {
           "expires_utc": {
- main
             "type": "string",
             "format": "date-time"
           },

--- a/tests/test_break_glass_override_v0_smoke.py
+++ b/tests/test_break_glass_override_v0_smoke.py
@@ -7,7 +7,16 @@ from jsonschema import Draft202012Validator
 SCHEMA_PATH = Path("schemas/break_glass_override_v0.schema.json")
 
 
-def test_break_glass_override_schema_is_draft_2020_12_valid() -> None:
+def check_break_glass_override_schema_is_draft_2020_12_valid() -> None:
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
 
     Draft202012Validator.check_schema(schema)
+
+
+def test_break_glass_override_schema_is_draft_2020_12_valid() -> None:
+    check_break_glass_override_schema_is_draft_2020_12_valid()
+
+
+if __name__ == "__main__":
+    check_break_glass_override_schema_is_draft_2020_12_valid()
+    print("OK: break_glass_override_v0 schema is valid Draft 2020-12 JSON Schema")

--- a/tests/test_break_glass_override_v0_smoke.py
+++ b/tests/test_break_glass_override_v0_smoke.py
@@ -1,0 +1,13 @@
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+SCHEMA_PATH = Path("schemas/break_glass_override_v0.schema.json")
+
+
+def test_break_glass_override_schema_is_draft_2020_12_valid() -> None:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    Draft202012Validator.check_schema(schema)


### PR DESCRIPTION
## Summary

This PR repairs the real break-glass issues without broadening, weakening, or softening the PULSE release-authority model.

The change is intentionally narrow:

- It fixes the corrupted `revoked` branch in `schemas/break_glass_override_v0.schema.json`.
- It clarifies the break-glass documentation so break-glass records acceptance of a temporary operational exception attached to a non-passing release decision.
- It preserves the invariant that accepted break-glass does not convert `FAIL` into `PROD-PASS` or `STAGE-PASS`.
- It adds a minimal schema validity regression test using `Draft202012Validator.check_schema`.

This PR does not change the normal PULSE release-authority path.

## What changed

### Schema repair

Fixed the corrupted `revoked` branch in:

```text
schemas/break_glass_override_v0.schema.json
```

The corrupted stray tokens were removed while preserving the intended revoked semantics.

For `status = revoked`, the schema continues to require:

```text
review
risk_acceptance
expires_utc
revocation
followups
```

The following semantics are preserved:

```text
review.decision = accepted
expires_utc = string date-time
followups minItems = 1
```

### Documentation clarification

Updated:

```text
docs/BREAK_GLASS_OVERRIDE_v0.md
```

The documentation now says that break-glass records acceptance of a temporary operational exception attached to a non-passing release decision.

It no longer suggests that an operational release is authorized through a separate break-glass release path.

### Regression coverage

Added a minimal schema validity regression test in:

```text
tests/test_break_glass_override_v0_smoke.py
```

The test verifies that the break-glass override schema is valid Draft 2020-12 JSON Schema.

## Authority boundary

This PR does not introduce an independent break-glass release-authority path.

Break-glass remains an audited operational-exception artifact.

It may record human acceptance of a temporary operational exception, but it must not mutate, override, or reinterpret the underlying release-decision artifact.

The invariant remains:

```text
release decision = FAIL
break_glass_status = accepted
```

This must not become:

```text
release decision = PROD-PASS
```

or:

```text
release decision = STAGE-PASS
```

Accepted break-glass records exception accountability.

It does not create release authority.

## Preserved invariants

This PR preserves the following PULSE invariants:

```text
FAIL + accepted break-glass remains FAIL.
```

```text
Break-glass is not a hidden PASS.
```

```text
Break-glass is not a shadow release signal.
```

```text
Break-glass does not rewrite release_decision_v0.json.
```

```text
Break-glass does not mutate status.json.
```

```text
Break-glass does not alter required gates.
```

```text
Break-glass does not override check_gates.py.
```

```text
Break-glass does not promote STAGE-PASS or PROD-PASS.
```

## Out of scope

This PR intentionally does not change:

```text
README.md
check_gates.py
pulse_gate_policy_v0.yml
release_decision_v0 semantics
DOI metadata
Zenodo metadata
CITATION.cff
release tags
normal PULSE release-authority behavior
unrelated documentation
```

This is a narrow integrity fix only.

## Testing

The following checks passed:

```text
python -m json.tool schemas/break_glass_override_v0.schema.json >/tmp/break_glass_override_v0.schema.json.formatted
```

```text
python - <<'PY'
import json
from pathlib import Path
from jsonschema import Draft202012Validator

schema = json.loads(Path("schemas/break_glass_override_v0.schema.json").read_text())
Draft202012Validator.check_schema(schema)
PY
```

```text
python -m pytest tests/test_break_glass_override_v0_smoke.py
```

```text
git diff --check
```

## Files changed

```text
docs/BREAK_GLASS_OVERRIDE_v0.md
schemas/break_glass_override_v0.schema.json
tests/test_break_glass_override_v0_smoke.py
```

## Merge rationale

This is a narrow integrity and clarity fix.

It repairs a real schema corruption and removes a documentation ambiguity that could make break-glass look like an independent release-authority path.

The PULSE release-authority model remains unchanged:

```text
recorded evidence
→ status.json
→ declared policy
→ materialized required gates
→ check_gates.py
→ primary CI allow/block decision
```

Break-glass remains outside the normal release-authority path as an audited operational-exception artifact.

The system may record both facts:

```text
release decision = FAIL
break_glass_status = accepted
```

But only the release decision remains normative.

Therefore this PR strengthens the authority boundary without flattening or weakening PULSE.