### PR TITLE
fix(pages): scope Pages artifact name to workflow attempt

### DIFF
--- a/.github/workflows/publish_report_pages.yml
+++ b/.github/workflows/publish_report_pages.yml
@@ -1020,11 +1020,14 @@ jobs:
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: _site
+          name: github-pages-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Deploy to GitHub Pages
         id: deploy
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
-
+        with:
+          artifact_name: github-pages-${{ github.run_id }}-${{ github.run_attempt }}
+    
       # Post-deploy: verify the *public* Pages site serves crawler-critical endpoints.
       - name: SEO smoke (post-deploy)
         if: ${{ steps.deploy.outcome == 'success' }}


### PR DESCRIPTION
## Summary

This PR fixes a GitHub Pages publication rerun issue without changing PULSE release-authority behavior.

The Pages deployment previously failed with:

```text
Multiple artifacts named "github-pages" were unexpectedly found for this workflow run.
Artifact count is 2.
```

The failure occurred after the Pages artifact was created and before deployment completion, because more than one artifact with the default Pages artifact name existed in the workflow run.

This PR scopes the Pages artifact name to the workflow run and run attempt:

```text
github-pages-${{ github.run_id }}-${{ github.run_attempt }}
```

The same value is now used consistently by both:

```text
actions/upload-pages-artifact
actions/deploy-pages
```

## What changed

Updated:

```text
.github/workflows/publish_report_pages.yml
```

Changes:

- The Pages upload step still publishes `_site`.
- The upload artifact name is now run-attempt scoped.
- The deploy step uses the exact same artifact name through `artifact_name`.
- Existing pinned action refs are preserved.
- Existing `_site` content checks are preserved.

## Why

GitHub Pages upload/deploy actions use the default artifact name:

```text
github-pages
```

When a workflow is rerun and multiple artifacts with that same default name exist in the workflow run, the deploy step may fail because it cannot disambiguate which artifact should be deployed.

Using a run-attempt scoped artifact name prevents that duplicate-name collision.

## Authority boundary

This PR is publication-only.

It does not change PULSE release authority.

No changes were made to:

```text
PULSE_safe_pack_v0/tools/check_gates.py
pulse_gate_policy_v0.yml
status.json gate semantics
release_decision_v0 semantics
break-glass semantics
DOI metadata
Zenodo metadata
CITATION.cff
release tags
PULSE core logic
```

The Pages workflow remains a publication surface.

It does not create, modify, or override release authority.

## Preserved behavior

The workflow still publishes:

```text
_site
```

The workflow still checks for publication content, including:

```text
_site/index.html
_site/sitemap.xml
_site/robots.txt
```

The Pages flow remains:

```text
actions/configure-pages
actions/upload-pages-artifact
actions/deploy-pages
```

The only behavior change is artifact naming hygiene for reruns.

## Testing

Passed:

```text
python3 - <<'PY'
from pathlib import Path
import yaml

path = Path(".github/workflows/publish_report_pages.yml")
with path.open() as f:
    yaml.safe_load(f)

print("OK: workflow YAML parses")
PY
```

```text
python3 - <<'PY'
from pathlib import Path

text = Path(".github/workflows/publish_report_pages.yml").read_text()
needle = "github-pages-${{ github.run_id }}-${{ github.run_attempt }}"

assert text.count(f" name: {needle}") == 1, "upload artifact name missing or duplicated"
assert text.count(f" artifact_name: {needle}") == 1, "deploy artifact_name missing or duplicated"
assert " path: _site" in text, "Pages artifact path _site missing"

print("OK: upload-pages-artifact name == deploy-pages artifact_name")
PY
```

```text
python3 - <<'PY'
from pathlib import Path

text = Path(".github/workflows/publish_report_pages.yml").read_text()
required = [
    'if [ ! -s "_site/sitemap.xml" ]; then',
    'if [ ! -s "_site/robots.txt" ]; then',
    'if [ -f "_site/index.html" ]; then',
]

missing = [item for item in required if item not in text]
assert not missing, missing

print("OK: _site index/sitemap/robots checks remain present")
PY
```

```text
git diff --check
```

## Files changed

```text
.github/workflows/publish_report_pages.yml
```

## Merge rationale

This is a narrow GitHub Pages publication hardening fix.

It addresses a concrete rerun failure caused by duplicate default-named Pages artifacts.

It does not alter PULSE release authority, gate enforcement, policy semantics, break-glass semantics, DOI metadata, Zenodo metadata, citation files, release tags, or unrelated documentation.