### PR TITLE
docs(slsa): define PULSEmech evidence intake mechanics

### DIFF
--- a/docs/PULSE_SLSA_EVIDENCE_INTAKE_v0.md
+++ b/docs/PULSE_SLSA_EVIDENCE_INTAKE_v0.md
@@ -1,0 +1,144 @@
+# PULSEmech SLSA / in-toto evidence intake v0
+
+## Function
+
+This document defines how SLSA / in-toto verification output enters the PULSEmech release-authority path as recorded evidence.
+
+SLSA / in-toto verification produces provenance and verification evidence.
+
+PULSEmech records that evidence, binds it to declared policy, materializes required gates, and enforces the release transition through `check_gates.py`.
+
+## Release-authority path
+
+```text
+SLSA / in-toto verification output
+→ recorded PULSE evidence
+→ final status.json
+→ declared PULSE policy
+→ workflow-effective materialized required gates
+→ strict enforcement by check_gates.py
+→ primary CI allow/block release decision
+```
+
+## Input evidence contract
+
+A SLSA / in-toto evidence intake record carries the following fields when available:
+
+```text
+subject.digest
+predicateType
+verifier.id
+verifier.version
+timeVerified
+resourceUri
+policy.uri
+policy.digest
+inputAttestations[].uri
+inputAttestations[].digest
+verificationResult
+verifiedLevels
+dependencyLevels
+slsaVersion
+```
+
+## Evidence role
+
+The SLSA / in-toto verification result enters PULSE as evidence state.
+
+The evidence state is recorded into the PULSE artifact chain and evaluated by declared PULSE policy.
+
+Release authority is materialized by the PULSE path:
+
+```text
+recorded evidence
+→ policy binding
+→ gate materialization
+→ fail-closed gate enforcement
+→ CI allow/block result
+```
+
+## VSA-to-PULSE signal mapping
+
+| SLSA / in-toto VSA field | PULSE evidence signal |
+| --- | --- |
+| `subject.digest` | artifact identity binding |
+| `predicateType` | evidence format contract |
+| `verifier.id` | verifier identity binding |
+| `verifier.version` | verifier implementation record |
+| `timeVerified` | verification timestamp |
+| `resourceUri` | artifact resource binding |
+| `policy.uri` | verification policy identity |
+| `policy.digest` | verification policy version binding |
+| `inputAttestations[].digest` | evidence-chain digest binding |
+| `verificationResult` | verification result evidence |
+| `verifiedLevels` | verified SLSA level evidence |
+| `dependencyLevels` | dependency verification summary |
+| `slsaVersion` | SLSA specification version record |
+
+## Gate materialization
+
+A PULSE policy may declare SLSA / in-toto evidence as required release evidence.
+
+When required, the materialized gate set may include signals such as:
+
+```text
+slsa_vsa_present
+slsa_vsa_signature_ok
+slsa_vsa_subject_matches_artifact
+slsa_vsa_predicate_type_ok
+slsa_vsa_verifier_trusted
+slsa_vsa_resource_uri_matches
+slsa_vsa_policy_digest_matches
+slsa_vsa_result_passed
+slsa_vsa_verified_level_ok
+```
+
+Each signal is recorded as a literal boolean gate value in `status.json`.
+
+## Enforcement table
+
+| Condition | Recorded PULSE signal | Release effect when required |
+| --- | --- | --- |
+| VSA artifact present | `slsa_vsa_present=true` | gate can pass |
+| VSA artifact absent | `slsa_vsa_present=false` | fail-closed |
+| VSA signature verified | `slsa_vsa_signature_ok=true` | gate can pass |
+| VSA signature mismatch | `slsa_vsa_signature_ok=false` | fail-closed |
+| Subject digest matches release artifact | `slsa_vsa_subject_matches_artifact=true` | gate can pass |
+| Subject digest mismatch | `slsa_vsa_subject_matches_artifact=false` | fail-closed |
+| Predicate type matches expected VSA type | `slsa_vsa_predicate_type_ok=true` | gate can pass |
+| Predicate type mismatch | `slsa_vsa_predicate_type_ok=false` | fail-closed |
+| Verifier identity matches declared trust policy | `slsa_vsa_verifier_trusted=true` | gate can pass |
+| Verifier identity outside declared trust policy | `slsa_vsa_verifier_trusted=false` | fail-closed |
+| Resource URI matches expected artifact URI | `slsa_vsa_resource_uri_matches=true` | gate can pass |
+| Resource URI mismatch | `slsa_vsa_resource_uri_matches=false` | fail-closed |
+| Policy digest matches expected policy digest | `slsa_vsa_policy_digest_matches=true` | gate can pass |
+| Policy digest mismatch | `slsa_vsa_policy_digest_matches=false` | fail-closed |
+| Verification result is `PASSED` | `slsa_vsa_result_passed=true` | gate can pass |
+| Verification result is `FAILED` | `slsa_vsa_result_passed=false` | fail-closed |
+| Verified level matches declared PULSE requirement | `slsa_vsa_verified_level_ok=true` | gate can pass |
+| Verified level below declared PULSE requirement | `slsa_vsa_verified_level_ok=false` | fail-closed |
+
+## Decision materialization
+
+A passing SLSA / in-toto verification result records evidence.
+
+PULSE release authority is produced when the recorded evidence satisfies declared PULSE policy and all workflow-effective required gates pass under `check_gates.py`.
+
+## Minimal v0 implementation path
+
+```text
+schemas/slsa_vsa_evidence_v0.schema.json
+examples/slsa/slsa_vsa_evidence_example_v0.json
+tools/ingest_slsa_vsa_evidence_v0.py
+tests/test_ingest_slsa_vsa_evidence_v0.py
+```
+
+## Mechanical invariant
+
+```text
+verified provenance evidence
+→ recorded PULSE evidence
+→ materialized required gate
+→ strict fail-closed enforcement
+→ release allow/block
+```


### PR DESCRIPTION
## Summary

This PR adds a technical SLSA / in-toto evidence intake document for PULSEmech.

New document:

```text
docs/PULSE_SLSA_EVIDENCE_INTAKE_v0.md
```

The document defines how SLSA / in-toto verification output enters the PULSEmech release-authority path as recorded evidence.

## Mechanical path

The document describes this evidence-to-decision path:

```text
SLSA / in-toto verification output
→ recorded PULSE evidence
→ final status.json
→ declared PULSE policy
→ workflow-effective materialized required gates
→ strict enforcement by check_gates.py
→ primary CI allow/block release decision
```

## What the document defines

The document defines the mechanical intake surface for SLSA / in-toto verification output.

It covers:

```text
SLSA / in-toto verification output as PULSE evidence input
VSA field-to-PULSE evidence signal mapping
gate materialization examples for SLSA / in-toto evidence
fail-closed enforcement behavior for missing or mismatched required evidence
the mechanical invariant from verified provenance evidence to release allow/block
```

## Evidence intake fields

The document records the expected SLSA / in-toto evidence intake fields when available:

```text
subject.digest
predicateType
verifier.id
verifier.version
timeVerified
resourceUri
policy.uri
policy.digest
inputAttestations[].uri
inputAttestations[].digest
verificationResult
verifiedLevels
dependencyLevels
slsaVersion
```

## VSA-to-PULSE signal mapping

The document maps SLSA / in-toto VSA fields into PULSE evidence signals.

Examples:

```text
subject.digest → artifact identity binding
predicateType → evidence format contract
verifier.id → verifier identity binding
verifier.version → verifier implementation record
timeVerified → verification timestamp
resourceUri → artifact resource binding
policy.uri → verification policy identity
policy.digest → verification policy version binding
inputAttestations[].digest → evidence-chain digest binding
verificationResult → verification result evidence
verifiedLevels → verified SLSA level evidence
dependencyLevels → dependency verification summary
slsaVersion → SLSA specification version record
```

## Gate materialization examples

The document gives example PULSE gate signals for SLSA / in-toto evidence intake:

```text
slsa_vsa_present
slsa_vsa_signature_ok
slsa_vsa_subject_matches_artifact
slsa_vsa_predicate_type_ok
slsa_vsa_verifier_trusted
slsa_vsa_resource_uri_matches
slsa_vsa_policy_digest_matches
slsa_vsa_result_passed
slsa_vsa_verified_level_ok
```

These signals are documented as evidence-intake mechanics and future implementation guidance.

## Enforcement mechanics

When a PULSE policy declares SLSA / in-toto evidence as required release evidence, the materialized gate set carries the relevant boolean signals into `status.json`.

Examples:

```text
VSA artifact present → slsa_vsa_present=true
VSA artifact absent → slsa_vsa_present=false

VSA signature verified → slsa_vsa_signature_ok=true
VSA signature mismatch → slsa_vsa_signature_ok=false

Subject digest matches release artifact → slsa_vsa_subject_matches_artifact=true
Subject digest mismatch → slsa_vsa_subject_matches_artifact=false

Verification result is PASSED → slsa_vsa_result_passed=true
Verification result is FAILED → slsa_vsa_result_passed=false
```

Required evidence failures remain fail-closed through the normal PULSE gate path.

## Authority boundary

This PR is documentation-only.

The PULSE release-authority path remains:

```text
recorded evidence
→ final status.json
→ declared policy
→ workflow-effective materialized required gates
→ check_gates.py
→ primary CI allow/block release decision
```

The document describes an evidence intake interface.

Runtime enforcement remains unchanged.

The following remain unchanged:

```text
gate policy
schemas
CI workflows
release decisions
generated artifacts
DOI metadata
Zenodo metadata
citation files
release tags
publication surfaces
```

## Files changed

```text
docs/PULSE_SLSA_EVIDENCE_INTAKE_v0.md
```

## Testing

Recommended check:

```text
git diff --check
```

Optional documentation sanity checks:

```text
grep -n "SLSA / in-toto verification output" docs/PULSE_SLSA_EVIDENCE_INTAKE_v0.md
grep -n "strict enforcement by check_gates.py" docs/PULSE_SLSA_EVIDENCE_INTAKE_v0.md
grep -n "primary CI allow/block release decision" docs/PULSE_SLSA_EVIDENCE_INTAKE_v0.md
```

## Merge rationale

This PR adds a clear mechanical interface between SLSA / in-toto verification output and the PULSEmech release-authority path.

The document keeps the language technical and positive:

```text
verification output enters as evidence
evidence is recorded
policy declares requirements
gates are materialized
check_gates.py enforces
CI returns allow/block
```

The change prepares the repository for a later SLSA / in-toto evidence schema or intake tool while keeping this PR documentation-only.

Release-authority behavior remains unchanged.