### PR TITLE
feat(slsa): add PULSEmech VSA evidence contract

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -99,6 +99,7 @@ tests/test_build_field_point_authority_map_v0.py
 tests/test_artifact_provenance_binding_ci_wiring_smoke.py
 tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
 tests/test_reader_surface_non_interference.py
+tests/test_slsa_vsa_evidence_schema_v0.py
 
 tools/operator_handoff_smoke.py
 

--- a/examples/slsa/slsa_vsa_evidence_example_v0.json
+++ b/examples/slsa/slsa_vsa_evidence_example_v0.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": "slsa_vsa_evidence_v0",
+  "evidence_type": "slsa_vsa",
+  "vsa": {
+    "_type": "https://in-toto.io/Statement/v1",
+    "subject": [
+      {
+        "name": "git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0",
+        "digest": {
+          "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+      }
+    ],
+    "predicateType": "https://slsa.dev/verification_summary/v1",
+    "predicate": {
+      "verifier": {
+        "id": "https://github.com/slsa-framework/slsa-verifier",
+        "version": {
+          "slsa-verifier": "v2.7.0"
+        }
+      },
+      "timeVerified": "2026-07-04T00:00:00Z",
+      "resourceUri": "git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0",
+      "policy": {
+        "uri": "https://example.invalid/policies/pulse-slsa-vsa-policy-v0.json",
+        "digest": {
+          "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+      },
+      "inputAttestations": [
+        {
+          "uri": "https://example.invalid/attestations/pulse-release-gates-v0.1.0.intoto.jsonl",
+          "digest": {
+            "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+          }
+        }
+      ],
+      "verificationResult": "PASSED",
+      "verifiedLevels": [
+        "SLSA_BUILD_LEVEL_3"
+      ],
+      "dependencyLevels": {
+        "SLSA_BUILD_LEVEL_3": 0
+      },
+      "slsaVersion": "1.2"
+    }
+  },
+  "pulse_signals": {
+    "slsa_vsa_present": true,
+    "slsa_vsa_signature_ok": true,
+    "slsa_vsa_subject_matches_artifact": true,
+    "slsa_vsa_predicate_type_ok": true,
+    "slsa_vsa_verifier_trusted": true,
+    "slsa_vsa_resource_uri_matches": true,
+    "slsa_vsa_policy_digest_matches": true,
+    "slsa_vsa_result_passed": true,
+    "slsa_vsa_verified_level_ok": true
+  }
+}

--- a/examples/slsa/slsa_vsa_evidence_example_v0.json
+++ b/examples/slsa/slsa_vsa_evidence_example_v0.json
@@ -14,7 +14,7 @@
     "predicateType": "https://slsa.dev/verification_summary/v1",
     "predicate": {
       "verifier": {
-        "id": "https://github.com/slsa-framework/slsa-verifier",
+        "id": "https://example.invalid/verifiers/pulsemech-vsa-verifier-v0",
         "version": {
           "slsa-verifier": "v2.7.0"
         }

--- a/schemas/slsa_vsa_evidence_v0.schema.json
+++ b/schemas/slsa_vsa_evidence_v0.schema.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/HKati/pulse-release-gates-0.1/schemas/slsa_vsa_evidence_v0.schema.json",
+  "title": "PULSEmech SLSA / in-toto VSA evidence contract v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "evidence_type",
+    "vsa",
+    "pulse_signals"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "slsa_vsa_evidence_v0"
+    },
+    "evidence_type": {
+      "const": "slsa_vsa"
+    },
+    "vsa": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "_type",
+        "subject",
+        "predicateType",
+        "predicate"
+      ],
+      "properties": {
+        "_type": {
+          "const": "https://in-toto.io/Statement/v1"
+        },
+        "subject": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "name",
+              "digest"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "digest": {
+                "$ref": "#/$defs/digestMap"
+              }
+            }
+          }
+        },
+        "predicateType": {
+          "const": "https://slsa.dev/verification_summary/v1"
+        },
+        "predicate": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [
+            "verifier",
+            "resourceUri",
+            "policy",
+            "verificationResult",
+            "verifiedLevels"
+          ],
+          "properties": {
+            "verifier": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "version": {
+                  "type": "object",
+                  "minProperties": 1,
+                  "propertyNames": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "additionalProperties": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            },
+            "timeVerified": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "resourceUri": {
+              "type": "string",
+              "minLength": 1
+            },
+            "policy": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": [
+                "uri"
+              ],
+              "properties": {
+                "uri": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "digest": {
+                  "$ref": "#/$defs/digestMap"
+                }
+              }
+            },
+            "inputAttestations": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true,
+                "required": [
+                  "digest"
+                ],
+                "properties": {
+                  "uri": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "digest": {
+                    "$ref": "#/$defs/digestMap"
+                  }
+                }
+              }
+            },
+            "verificationResult": {
+              "enum": [
+                "PASSED",
+                "FAILED"
+              ]
+            },
+            "verifiedLevels": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "dependencyLevels": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string",
+                "minLength": 1
+              },
+              "additionalProperties": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "slsaVersion": {
+              "type": "string",
+              "pattern": "^[0-9]+\\.[0-9]+$"
+            }
+          }
+        }
+      }
+    },
+    "pulse_signals": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "slsa_vsa_present",
+        "slsa_vsa_signature_ok",
+        "slsa_vsa_subject_matches_artifact",
+        "slsa_vsa_predicate_type_ok",
+        "slsa_vsa_verifier_trusted",
+        "slsa_vsa_resource_uri_matches",
+        "slsa_vsa_policy_digest_matches",
+        "slsa_vsa_result_passed",
+        "slsa_vsa_verified_level_ok"
+      ],
+      "properties": {
+        "slsa_vsa_present": {
+          "type": "boolean"
+        },
+        "slsa_vsa_signature_ok": {
+          "type": "boolean"
+        },
+        "slsa_vsa_subject_matches_artifact": {
+          "type": "boolean"
+        },
+        "slsa_vsa_predicate_type_ok": {
+          "type": "boolean"
+        },
+        "slsa_vsa_verifier_trusted": {
+          "type": "boolean"
+        },
+        "slsa_vsa_resource_uri_matches": {
+          "type": "boolean"
+        },
+        "slsa_vsa_policy_digest_matches": {
+          "type": "boolean"
+        },
+        "slsa_vsa_result_passed": {
+          "type": "boolean"
+        },
+        "slsa_vsa_verified_level_ok": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "digestMap": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9._+:-]+$"
+      },
+      "additionalProperties": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  }
+}

--- a/tests/test_slsa_vsa_evidence_schema_v0.py
+++ b/tests/test_slsa_vsa_evidence_schema_v0.py
@@ -1,0 +1,77 @@
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+SCHEMA_PATH = Path("schemas/slsa_vsa_evidence_v0.schema.json")
+EXAMPLE_PATH = Path("examples/slsa/slsa_vsa_evidence_example_v0.json")
+
+REQUIRED_PULSE_SIGNALS = [
+    "slsa_vsa_present",
+    "slsa_vsa_signature_ok",
+    "slsa_vsa_subject_matches_artifact",
+    "slsa_vsa_predicate_type_ok",
+    "slsa_vsa_verifier_trusted",
+    "slsa_vsa_resource_uri_matches",
+    "slsa_vsa_policy_digest_matches",
+    "slsa_vsa_result_passed",
+    "slsa_vsa_verified_level_ok"
+]
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def check_slsa_vsa_evidence_schema_v0() -> None:
+    schema = load_json(SCHEMA_PATH)
+    example = load_json(EXAMPLE_PATH)
+
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(example)
+
+    assert example["schema_version"] == "slsa_vsa_evidence_v0"
+    assert example["evidence_type"] == "slsa_vsa"
+
+    vsa = example["vsa"]
+    assert vsa["_type"] == "https://in-toto.io/Statement/v1"
+    assert vsa["predicateType"] == "https://slsa.dev/verification_summary/v1"
+
+    predicate = vsa["predicate"]
+    assert predicate["verificationResult"] == "PASSED"
+    assert "SLSA_BUILD_LEVEL_3" in predicate["verifiedLevels"]
+
+    verifier = predicate["verifier"]
+    assert verifier["id"] == "https://example.invalid/verifiers/pulsemech-vsa-verifier-v0"
+    assert verifier["id"] != "https://github.com/slsa-framework/slsa-verifier"
+    assert isinstance(verifier["version"], dict)
+    assert verifier["version"]["slsa-verifier"] == "v2.7.0"
+
+    input_attestations = predicate["inputAttestations"]
+    assert input_attestations
+    for attestation in input_attestations:
+        assert "digest" in attestation
+        assert "sha256" in attestation["digest"]
+        assert isinstance(attestation["digest"]["sha256"], str)
+        assert attestation["digest"]["sha256"]
+
+    dependency_levels = predicate["dependencyLevels"]
+    assert isinstance(dependency_levels, dict)
+    assert dependency_levels
+    assert all(isinstance(value, int) for value in dependency_levels.values())
+    assert all(value >= 0 for value in dependency_levels.values())
+
+    pulse_signals = example["pulse_signals"]
+    for signal in REQUIRED_PULSE_SIGNALS:
+        assert signal in pulse_signals
+        assert pulse_signals[signal] is True
+
+
+def test_slsa_vsa_evidence_schema_v0() -> None:
+    check_slsa_vsa_evidence_schema_v0()
+
+
+if __name__ == "__main__":
+    check_slsa_vsa_evidence_schema_v0()
+    print("OK: slsa_vsa_evidence_v0 schema and example are valid")


### PR DESCRIPTION
## Summary

This PR adds the first machine-readable PULSEmech evidence contract for SLSA / in-toto Verification Summary Attestations.

The contract records a SLSA VSA statement as PULSE evidence and maps it into literal boolean PULSE evidence signals for later gate materialization.

## Files changed

```text
schemas/slsa_vsa_evidence_v0.schema.json
examples/slsa/slsa_vsa_evidence_example_v0.json
tests/test_slsa_vsa_evidence_schema_v0.py
ci/tools-tests.list
```

## What changed

Added:

```text
schemas/slsa_vsa_evidence_v0.schema.json
```

This schema defines a PULSE evidence record with required top-level fields:

```text
schema_version
evidence_type
vsa
pulse_signals
```

Fixed values:

```text
schema_version = slsa_vsa_evidence_v0
evidence_type = slsa_vsa
```

The schema preserves the SLSA / in-toto VSA field names under:

```text
vsa._type
vsa.subject
vsa.predicateType
vsa.predicate
```

Required VSA values:

```text
_type = https://in-toto.io/Statement/v1
predicateType = https://slsa.dev/verification_summary/v1
```

## Example

Added:

```text
examples/slsa/slsa_vsa_evidence_example_v0.json
```

The example validates against the schema and records:

```text
predicateType = https://slsa.dev/verification_summary/v1
verificationResult = PASSED
verifiedLevels includes SLSA_BUILD_LEVEL_3
all required PULSE signals are literal true
```

The example also preserves SLSA VSA field shape:

```text
verifier.version = string map
inputAttestations[].digest = present
dependencyLevels = SLSA result key mapped to integer count
```

## PULSE signals

The contract requires these literal boolean PULSE signals:

```text
slsa_vsa_present
slsa_vsa_signature_ok
slsa_vsa_subject_matches_artifact
slsa_vsa_predicate_type_ok
slsa_vsa_verifier_trusted
slsa_vsa_resource_uri_matches
slsa_vsa_policy_digest_matches
slsa_vsa_result_passed
slsa_vsa_verified_level_ok
```

These are evidence signals only.

They do not change runtime release authority in this PR.

## Tests

Added:

```text
tests/test_slsa_vsa_evidence_schema_v0.py
```

The test runs both as a standalone smoke script and as a pytest test:

```text
python tests/test_slsa_vsa_evidence_schema_v0.py
python -m pytest tests/test_slsa_vsa_evidence_schema_v0.py
```

The test verifies:

```text
Draft 2020-12 schema validity
example validation against the schema
predicateType is https://slsa.dev/verification_summary/v1
verificationResult is PASSED
all required PULSE signals are literal true
verifier.version has the expected map shape
inputAttestations entries include digest binding
dependencyLevels values are integers
```

## Manifest registration

Registered the new smoke test in:

```text
ci/tools-tests.list
```

Added exactly one line:

```text
tests/test_slsa_vsa_evidence_schema_v0.py
```

## Authority boundary

This PR adds an evidence contract only.

It does not change PULSE release authority.

The runtime release-authority path remains:

```text
recorded evidence
→ final status.json
→ declared policy
→ workflow-effective materialized required gates
→ check_gates.py
→ primary CI allow/block release decision
```

No changes were made to:

```text
PULSE_safe_pack_v0/tools/check_gates.py
pulse_gate_policy_v0.yml
pulse_gate_registry_v0.yml
status.json semantics
release_decision_v0 semantics
.github/workflows/
DOI metadata
Zenodo metadata
CITATION.cff
release tags
generated artifacts
publication surfaces
```

## Testing

Passed:

```text
python -m json.tool schemas/slsa_vsa_evidence_v0.schema.json >/tmp/slsa_vsa_evidence_v0.schema.json.formatted
```

```text
python -m json.tool examples/slsa/slsa_vsa_evidence_example_v0.json >/tmp/slsa_vsa_evidence_example_v0.json.formatted
```

```text
python tests/test_slsa_vsa_evidence_schema_v0.py
```

```text
python -m pytest tests/test_slsa_vsa_evidence_schema_v0.py
```

```text
python tests/test_tools_tests_list_smoke.py
```

```text
git diff --check
```

## Merge rationale

This PR moves the SLSA / in-toto integration from documentation-only alignment into a first machine-readable evidence contract.

It establishes the shape of SLSA VSA evidence as PULSE recorded evidence, while keeping runtime enforcement unchanged.

The next step can build an intake tool on top of this contract.

Release-authority behavior remains unchanged.