### PR TITLE
feat(slsa): add vsa evidence intake verifier

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -100,6 +100,7 @@ tests/test_artifact_provenance_binding_ci_wiring_smoke.py
 tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
 tests/test_reader_surface_non_interference.py
 tests/test_slsa_vsa_evidence_schema_v0.py
+tests/test_ingest_slsa_vsa_evidence_v0.py
 
 tools/operator_handoff_smoke.py
 

--- a/tests/test_ingest_slsa_vsa_evidence_v0.py
+++ b/tests/test_ingest_slsa_vsa_evidence_v0.py
@@ -1,0 +1,303 @@
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "tools" / "ingest_slsa_vsa_evidence_v0.py"
+SCHEMA = ROOT / "schemas" / "slsa_vsa_evidence_v0.schema.json"
+EXAMPLE = ROOT / "examples" / "slsa" / "slsa_vsa_evidence_example_v0.json"
+
+EXPECTED_ARGS = {
+    "--expect-subject-name": "git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0",
+    "--expect-subject-sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "--expect-resource-uri": "git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0",
+    "--expect-verifier-id": "https://example.invalid/verifiers/pulsemech-vsa-verifier-v0",
+    "--expect-policy-sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "--expect-verified-level": "SLSA_BUILD_LEVEL_3",
+}
+
+
+def load_example() -> dict:
+    return json.loads(EXAMPLE.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str | None:
+    if not path.exists():
+        return None
+
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def tracked_status_hashes() -> dict[str, str | None]:
+    candidates = [
+        ROOT / "status.json",
+        ROOT / "PULSE_safe_pack_v0" / "artifacts" / "status.json",
+    ]
+    return {str(path.relative_to(ROOT)): sha256_file(path) for path in candidates}
+
+
+def build_args(
+    evidence: Path = EXAMPLE,
+    overrides: dict[str, str | None] | None = None,
+) -> list[str]:
+    values = dict(EXPECTED_ARGS)
+    if overrides:
+        values.update(overrides)
+
+    args = [
+        sys.executable,
+        str(TOOL),
+        "--schema",
+        str(SCHEMA),
+        "--evidence",
+        str(evidence),
+    ]
+
+    for key in sorted(values):
+        value = values[key]
+        if value is not None:
+            args.extend([key, value])
+
+    return args
+
+
+def run_tool(
+    evidence: Path = EXAMPLE,
+    overrides: dict[str, str | None] | None = None,
+    extra: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    args = build_args(evidence=evidence, overrides=overrides)
+    if extra:
+        args.extend(extra)
+
+    return subprocess.run(
+        args,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def parse_report(result: subprocess.CompletedProcess[str]) -> dict:
+    assert result.stdout, result.stderr
+    return json.loads(result.stdout)
+
+
+def assert_failure(result: subprocess.CompletedProcess[str], expected_fragment: str) -> dict:
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+
+    report = parse_report(result)
+    assert report["ok"] is False
+    assert any(expected_fragment in error for error in report["errors"]), report["errors"]
+    return report
+
+
+def check_valid_example_passes() -> None:
+    before = tracked_status_hashes()
+    result = run_tool()
+    after = tracked_status_hashes()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert before == after
+
+    report = parse_report(result)
+    assert report["tool"] == "ingest_slsa_vsa_evidence_v0"
+    assert report["ok"] is True
+    assert report["schema_version"] == "slsa_vsa_evidence_v0"
+    assert report["evidence_type"] == "slsa_vsa"
+    assert report["signature_verification_mode"] == "recorded_signal_only"
+    assert report["errors"] == []
+    assert all(report["checks"].values())
+
+    signals = report["pulse_signals"]
+    assert signals["slsa_vsa_signature_ok"] is True
+    assert signals["slsa_vsa_result_passed"] is True
+
+
+def check_output_report_matches_stdout(tmp_dir: Path) -> None:
+    output = tmp_dir / "intake_report.json"
+    result = run_tool(extra=["--output", str(output)])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output.exists()
+    assert json.loads(output.read_text(encoding="utf-8")) == parse_report(result)
+
+
+def check_wrong_expectations_fail() -> None:
+    assert_failure(
+        run_tool(overrides={"--expect-verifier-id": "https://example.invalid/verifiers/wrong"}),
+        "verifier_trusted",
+    )
+    assert_failure(
+        run_tool(
+            overrides={
+                "--expect-subject-sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            }
+        ),
+        "subject_matches_artifact",
+    )
+    assert_failure(
+        run_tool(overrides={"--expect-resource-uri": "git+https://example.invalid/wrong@refs/tags/v0"}),
+        "resource_uri_matches",
+    )
+    assert_failure(
+        run_tool(
+            overrides={
+                "--expect-policy-sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+            }
+        ),
+        "policy_digest_matches",
+    )
+    assert_failure(
+        run_tool(overrides={"--expect-verified-level": "SLSA_BUILD_LEVEL_4"}),
+        "verified_level_ok",
+    )
+
+
+def check_missing_expectations_fail() -> None:
+    cases = [
+        (
+            {"--expect-subject-name": None},
+            "expectation_missing: --expect-subject-name",
+        ),
+        (
+            {"--expect-subject-sha256": None},
+            "expectation_missing: --expect-subject-sha256",
+        ),
+        (
+            {"--expect-verifier-id": None},
+            "expectation_missing: --expect-verifier-id",
+        ),
+        (
+            {"--expect-resource-uri": None},
+            "expectation_missing: --expect-resource-uri",
+        ),
+        (
+            {"--expect-policy-sha256": None},
+            "expectation_missing: --expect-policy-sha256",
+        ),
+        (
+            {"--expect-verified-level": None},
+            "expectation_missing: --expect-verified-level",
+        ),
+    ]
+
+    for overrides, expected_fragment in cases:
+        assert_failure(run_tool(overrides=overrides), expected_fragment)
+
+
+def check_malformed_vsa_reports_json(tmp_dir: Path) -> None:
+    malformed = load_example()
+    malformed["vsa"] = "not-object"
+
+    malformed_path = tmp_dir / "malformed_vsa.json"
+    write_json(malformed_path, malformed)
+
+    result = run_tool(evidence=malformed_path)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+
+    report = parse_report(result)
+    assert report["ok"] is False
+    assert any("vsa_not_object" in error for error in report["errors"])
+
+
+def check_malformed_nested_objects_report_json(tmp_dir: Path) -> None:
+    cases = [
+        ("predicate_not_object", ("vsa", "predicate"), "not-object"),
+        ("verifier_not_object", ("vsa", "predicate", "verifier"), "not-object"),
+        ("policy_not_object", ("vsa", "predicate", "policy"), "not-object"),
+    ]
+
+    for expected_fragment, path_parts, value in cases:
+        malformed = load_example()
+        cursor = malformed
+
+        for part in path_parts[:-1]:
+            cursor = cursor[part]
+
+        cursor[path_parts[-1]] = value
+
+        malformed_path = tmp_dir / f"{expected_fragment}.json"
+        write_json(malformed_path, malformed)
+
+        result = run_tool(evidence=malformed_path)
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "Traceback" not in result.stderr
+
+        report = parse_report(result)
+        assert report["ok"] is False
+        assert any(expected_fragment in error for error in report["errors"]), report["errors"]
+
+
+def check_mutated_evidence_fails(tmp_dir: Path) -> None:
+    failed_result = load_example()
+    failed_result["vsa"]["predicate"]["verificationResult"] = "FAILED"
+    failed_path = tmp_dir / "failed_result.json"
+    write_json(failed_path, failed_result)
+    assert_failure(run_tool(evidence=failed_path), "verification_result_passed")
+
+    non_boolean_signal = load_example()
+    non_boolean_signal["pulse_signals"]["slsa_vsa_present"] = "true"
+    non_boolean_path = tmp_dir / "non_boolean_signal.json"
+    write_json(non_boolean_path, non_boolean_signal)
+    assert_failure(run_tool(evidence=non_boolean_path), "pulse_signals_literal_booleans")
+
+
+def check_status_output_is_refused(tmp_dir: Path) -> None:
+    status_path = tmp_dir / "status.json"
+    result = run_tool(extra=["--output", str(status_path)])
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert not status_path.exists()
+
+    report = parse_report(result)
+    assert report["ok"] is False
+    assert "refusing_to_write_status_json" in report["errors"]
+
+
+def check_tool_does_not_call_gate_checker() -> None:
+    source = TOOL.read_text(encoding="utf-8")
+    forbidden = "check_" + "gates"
+    assert forbidden not in source
+
+
+def check_ingest_slsa_vsa_evidence_v0() -> None:
+    assert TOOL.exists()
+    assert SCHEMA.exists()
+    assert EXAMPLE.exists()
+
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp_dir = Path(raw_tmp)
+
+        check_valid_example_passes()
+        check_output_report_matches_stdout(tmp_dir)
+        check_wrong_expectations_fail()
+        check_missing_expectations_fail()
+        check_malformed_vsa_reports_json(tmp_dir)
+        check_malformed_nested_objects_report_json(tmp_dir)
+        check_mutated_evidence_fails(tmp_dir)
+        check_status_output_is_refused(tmp_dir)
+        check_tool_does_not_call_gate_checker()
+
+
+def test_ingest_slsa_vsa_evidence_v0() -> None:
+    check_ingest_slsa_vsa_evidence_v0()
+
+
+if __name__ == "__main__":
+    check_ingest_slsa_vsa_evidence_v0()
+    print("OK: ingest_slsa_vsa_evidence_v0 smoke passed")

--- a/tools/ingest_slsa_vsa_evidence_v0.py
+++ b/tools/ingest_slsa_vsa_evidence_v0.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+from jsonschema import Draft202012Validator
+
+
+TOOL_NAME = "ingest_slsa_vsa_evidence_v0"
+
+SCHEMA_VERSION = "slsa_vsa_evidence_v0"
+EVIDENCE_TYPE = "slsa_vsa"
+IN_TOTO_STATEMENT_V1 = "https://in-toto.io/Statement/v1"
+SLSA_VSA_PREDICATE_TYPE_V1 = "https://slsa.dev/verification_summary/v1"
+
+REQUIRED_PULSE_SIGNALS = [
+    "slsa_vsa_present",
+    "slsa_vsa_signature_ok",
+    "slsa_vsa_subject_matches_artifact",
+    "slsa_vsa_predicate_type_ok",
+    "slsa_vsa_verifier_trusted",
+    "slsa_vsa_resource_uri_matches",
+    "slsa_vsa_policy_digest_matches",
+    "slsa_vsa_result_passed",
+    "slsa_vsa_verified_level_ok",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate a PULSEmech SLSA / in-toto VSA evidence record and "
+            "emit a deterministic intake report."
+        )
+    )
+    parser.add_argument("--schema", required=True, help="Path to slsa_vsa_evidence_v0.schema.json")
+    parser.add_argument("--evidence", required=True, help="Path to a slsa_vsa_evidence_v0 JSON record")
+    parser.add_argument("--expect-subject-name")
+    parser.add_argument("--expect-subject-sha256")
+    parser.add_argument("--expect-resource-uri")
+    parser.add_argument("--expect-verifier-id")
+    parser.add_argument("--expect-policy-sha256")
+    parser.add_argument("--expect-verified-level")
+    parser.add_argument("--output", help="Optional path for the deterministic JSON intake report")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def sha256_from_digest(digest: Any) -> Optional[str]:
+    if isinstance(digest, dict):
+        value = digest.get("sha256")
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def subject_matches(subjects: Any, expected_name: Optional[str], expected_sha256: Optional[str]) -> bool:
+    if expected_name is None and expected_sha256 is None:
+        return True
+
+    if not isinstance(subjects, list):
+        return False
+
+    for subject in subjects:
+        if not isinstance(subject, dict):
+            continue
+
+        name_ok = expected_name is None or subject.get("name") == expected_name
+        digest_ok = expected_sha256 is None or sha256_from_digest(subject.get("digest")) == expected_sha256
+
+        if name_ok and digest_ok:
+            return True
+
+    return False
+
+
+def policy_digest_matches(policy: Any, expected_sha256: Optional[str]) -> bool:
+    if expected_sha256 is None:
+        return True
+
+    if not isinstance(policy, dict):
+        return False
+
+    return sha256_from_digest(policy.get("digest")) == expected_sha256
+
+
+def verified_level_ok(verified_levels: Any, expected_level: Optional[str]) -> bool:
+    if expected_level is None:
+        return True
+
+    return isinstance(verified_levels, list) and expected_level in verified_levels
+
+
+def literal_boolean_signals(signals: Any) -> bool:
+    if not isinstance(signals, dict):
+        return False
+
+    return all(isinstance(signals.get(signal), bool) for signal in REQUIRED_PULSE_SIGNALS)
+
+
+def required_signals_true(signals: Any) -> bool:
+    if not isinstance(signals, dict):
+        return False
+
+    return all(signals.get(signal) is True for signal in REQUIRED_PULSE_SIGNALS)
+
+
+def make_report(
+    *,
+    ok: bool,
+    schema_version: Optional[str],
+    evidence_type: Optional[str],
+    checks: dict[str, bool],
+    pulse_signals: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any]:
+    return {
+        "tool": TOOL_NAME,
+        "ok": ok,
+        "schema_version": schema_version,
+        "evidence_type": evidence_type,
+        "signature_verification_mode": "recorded_signal_only",
+        "checks": checks,
+        "pulse_signals": pulse_signals,
+        "errors": errors,
+    }
+
+
+def empty_checks() -> dict[str, bool]:
+    return {
+        "schema_valid": False,
+        "evidence_valid": False,
+        "contract_fields_ok": False,
+        "predicate_type_ok": False,
+        "verification_result_passed": False,
+        "subject_matches_artifact": False,
+        "resource_uri_matches": False,
+        "verifier_trusted": False,
+        "policy_digest_matches": False,
+        "verified_level_ok": False,
+        "pulse_signals_literal_booleans": False,
+        "pulse_signals_required_true": False,
+        "pulse_signals_consistent": False,
+    }
+
+
+def emit_report(report: dict[str, Any], output: Optional[Path]) -> None:
+    rendered = json.dumps(report, indent=2, ensure_ascii=False) + "\n"
+    sys.stdout.write(rendered)
+
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered, encoding="utf-8")
+
+
+def validation_path(error: Any) -> str:
+    path = ".".join(str(part) for part in error.path)
+    return path or "<root>"
+
+
+def build_intake_report(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
+    checks = empty_checks()
+    errors: list[str] = []
+
+    try:
+        schema = load_json(Path(args.schema))
+        evidence = load_json(Path(args.evidence))
+    except Exception as exc:
+        errors.append(f"read_error: {exc}")
+        report = make_report(
+            ok=False,
+            schema_version=None,
+            evidence_type=None,
+            checks=checks,
+            pulse_signals={},
+            errors=errors,
+        )
+        return report, 2
+
+    schema_version = evidence.get("schema_version") if isinstance(evidence, dict) else None
+    evidence_type = evidence.get("evidence_type") if isinstance(evidence, dict) else None
+    pulse_signals = evidence.get("pulse_signals", {}) if isinstance(evidence, dict) else {}
+
+    try:
+        Draft202012Validator.check_schema(schema)
+        checks["schema_valid"] = True
+    except Exception as exc:
+        errors.append(f"schema_invalid: {exc}")
+
+    if checks["schema_valid"]:
+        validator = Draft202012Validator(schema)
+        validation_errors = sorted(validator.iter_errors(evidence), key=lambda err: list(err.path))
+        if validation_errors:
+            for error in validation_errors:
+                errors.append(f"evidence_invalid[{validation_path(error)}]: {error.message}")
+        else:
+            checks["evidence_valid"] = True
+
+    vsa = evidence.get("vsa", {}) if isinstance(evidence, dict) else {}
+    predicate = vsa.get("predicate", {}) if isinstance(vsa, dict) else {}
+
+    checks["contract_fields_ok"] = (
+        schema_version == SCHEMA_VERSION
+        and evidence_type == EVIDENCE_TYPE
+        and vsa.get("_type") == IN_TOTO_STATEMENT_V1
+        and vsa.get("predicateType") == SLSA_VSA_PREDICATE_TYPE_V1
+    )
+
+    checks["predicate_type_ok"] = vsa.get("predicateType") == SLSA_VSA_PREDICATE_TYPE_V1
+    checks["verification_result_passed"] = predicate.get("verificationResult") == "PASSED"
+
+    checks["subject_matches_artifact"] = subject_matches(
+        vsa.get("subject"),
+        args.expect_subject_name,
+        args.expect_subject_sha256,
+    )
+
+    expected_resource_uri = args.expect_resource_uri
+    checks["resource_uri_matches"] = (
+        expected_resource_uri is None or predicate.get("resourceUri") == expected_resource_uri
+    )
+
+    expected_verifier_id = args.expect_verifier_id
+    verifier = predicate.get("verifier", {}) if isinstance(predicate, dict) else {}
+    checks["verifier_trusted"] = (
+        expected_verifier_id is None or verifier.get("id") == expected_verifier_id
+    )
+
+    checks["policy_digest_matches"] = policy_digest_matches(
+        predicate.get("policy"),
+        args.expect_policy_sha256,
+    )
+
+    checks["verified_level_ok"] = verified_level_ok(
+        predicate.get("verifiedLevels"),
+        args.expect_verified_level,
+    )
+
+    checks["pulse_signals_literal_booleans"] = literal_boolean_signals(pulse_signals)
+    checks["pulse_signals_required_true"] = required_signals_true(pulse_signals)
+
+    expected_signal_values = {
+        "slsa_vsa_present": True,
+        "slsa_vsa_subject_matches_artifact": checks["subject_matches_artifact"],
+        "slsa_vsa_predicate_type_ok": checks["predicate_type_ok"],
+        "slsa_vsa_verifier_trusted": checks["verifier_trusted"],
+        "slsa_vsa_resource_uri_matches": checks["resource_uri_matches"],
+        "slsa_vsa_policy_digest_matches": checks["policy_digest_matches"],
+        "slsa_vsa_result_passed": checks["verification_result_passed"],
+        "slsa_vsa_verified_level_ok": checks["verified_level_ok"],
+    }
+
+    signal_consistency_errors: list[str] = []
+    if isinstance(pulse_signals, dict):
+        for signal, expected_value in expected_signal_values.items():
+            if pulse_signals.get(signal) is not expected_value:
+                signal_consistency_errors.append(
+                    f"pulse_signal_inconsistent: {signal} recorded={pulse_signals.get(signal)!r} expected={expected_value!r}"
+                )
+
+        if pulse_signals.get("slsa_vsa_signature_ok") is not True:
+            signal_consistency_errors.append(
+                "pulse_signal_inconsistent: slsa_vsa_signature_ok must be recorded as literal true for this intake"
+            )
+    else:
+        signal_consistency_errors.append("pulse_signals_not_object")
+
+    if signal_consistency_errors:
+        errors.extend(signal_consistency_errors)
+    else:
+        checks["pulse_signals_consistent"] = True
+
+    for check_name, passed in checks.items():
+        if not passed:
+            errors.append(f"check_failed: {check_name}")
+
+    ok = not errors
+
+    report = make_report(
+        ok=ok,
+        schema_version=schema_version if isinstance(schema_version, str) else None,
+        evidence_type=evidence_type if isinstance(evidence_type, str) else None,
+        checks=checks,
+        pulse_signals=pulse_signals if isinstance(pulse_signals, dict) else {},
+        errors=errors,
+    )
+
+    return report, 0 if ok else 1
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output) if args.output else None
+
+    if output is not None and output.name == "status.json":
+        checks = empty_checks()
+        errors = ["refusing_to_write_status_json"]
+        report = make_report(
+            ok=False,
+            schema_version=None,
+            evidence_type=None,
+            checks=checks,
+            pulse_signals={},
+            errors=errors,
+        )
+        emit_report(report, None)
+        return 2
+
+    report, exit_code = build_intake_report(args)
+    emit_report(report, output)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ingest_slsa_vsa_evidence_v0.py
+++ b/tools/ingest_slsa_vsa_evidence_v0.py
@@ -59,10 +59,7 @@ def sha256_from_digest(digest: Any) -> Optional[str]:
     return None
 
 
-def subject_matches(subjects: Any, expected_name: Optional[str], expected_sha256: Optional[str]) -> bool:
-    if expected_name is None and expected_sha256 is None:
-        return True
-
+def subject_matches(subjects: Any, expected_name: str, expected_sha256: str) -> bool:
     if not isinstance(subjects, list):
         return False
 
@@ -70,8 +67,8 @@ def subject_matches(subjects: Any, expected_name: Optional[str], expected_sha256
         if not isinstance(subject, dict):
             continue
 
-        name_ok = expected_name is None or subject.get("name") == expected_name
-        digest_ok = expected_sha256 is None or sha256_from_digest(subject.get("digest")) == expected_sha256
+        name_ok = subject.get("name") == expected_name
+        digest_ok = sha256_from_digest(subject.get("digest")) == expected_sha256
 
         if name_ok and digest_ok:
             return True
@@ -79,20 +76,14 @@ def subject_matches(subjects: Any, expected_name: Optional[str], expected_sha256
     return False
 
 
-def policy_digest_matches(policy: Any, expected_sha256: Optional[str]) -> bool:
-    if expected_sha256 is None:
-        return True
-
+def policy_digest_matches(policy: Any, expected_sha256: str) -> bool:
     if not isinstance(policy, dict):
         return False
 
     return sha256_from_digest(policy.get("digest")) == expected_sha256
 
 
-def verified_level_ok(verified_levels: Any, expected_level: Optional[str]) -> bool:
-    if expected_level is None:
-        return True
-
+def verified_level_ok(verified_levels: Any, expected_level: str) -> bool:
     return isinstance(verified_levels, list) and expected_level in verified_levels
 
 
@@ -150,7 +141,7 @@ def empty_checks() -> dict[str, bool]:
 
 
 def emit_report(report: dict[str, Any], output: Optional[Path]) -> None:
-    rendered = json.dumps(report, indent=2, ensure_ascii=False) + "\n"
+    rendered = json.dumps(report, indent=2, ensure_ascii=False, sort_keys=False) + "\n"
     sys.stdout.write(rendered)
 
     if output is not None:
@@ -161,6 +152,27 @@ def emit_report(report: dict[str, Any], output: Optional[Path]) -> None:
 def validation_path(error: Any) -> str:
     path = ".".join(str(part) for part in error.path)
     return path or "<root>"
+
+
+def schema_validation_errors(schema: dict[str, Any], evidence: Any) -> list[str]:
+    validator = Draft202012Validator(schema)
+    validation_errors = sorted(
+        validator.iter_errors(evidence),
+        key=lambda err: tuple(str(part) for part in err.path),
+    )
+
+    return [
+        f"evidence_invalid[{validation_path(error)}]: {error.message}"
+        for error in validation_errors
+    ]
+
+
+def require_expectation(value: Optional[str], flag_name: str, errors: list[str]) -> Optional[str]:
+    if value is None:
+        errors.append(f"expectation_missing: {flag_name}")
+        return None
+
+    return value
 
 
 def build_intake_report(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
@@ -193,16 +205,25 @@ def build_intake_report(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
         errors.append(f"schema_invalid: {exc}")
 
     if checks["schema_valid"]:
-        validator = Draft202012Validator(schema)
-        validation_errors = sorted(validator.iter_errors(evidence), key=lambda err: list(err.path))
-        if validation_errors:
-            for error in validation_errors:
-                errors.append(f"evidence_invalid[{validation_path(error)}]: {error.message}")
+        evidence_errors = schema_validation_errors(schema, evidence)
+        if evidence_errors:
+            errors.extend(evidence_errors)
         else:
             checks["evidence_valid"] = True
 
-    vsa = evidence.get("vsa", {}) if isinstance(evidence, dict) else {}
-    predicate = vsa.get("predicate", {}) if isinstance(vsa, dict) else {}
+    raw_vsa = evidence.get("vsa") if isinstance(evidence, dict) else None
+    if not isinstance(raw_vsa, dict):
+        errors.append("vsa_not_object")
+        vsa: dict[str, Any] = {}
+    else:
+        vsa = raw_vsa
+
+    raw_predicate = vsa.get("predicate")
+    if not isinstance(raw_predicate, dict):
+        errors.append("predicate_not_object")
+        predicate: dict[str, Any] = {}
+    else:
+        predicate = raw_predicate
 
     checks["contract_fields_ok"] = (
         schema_version == SCHEMA_VERSION
@@ -214,32 +235,85 @@ def build_intake_report(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
     checks["predicate_type_ok"] = vsa.get("predicateType") == SLSA_VSA_PREDICATE_TYPE_V1
     checks["verification_result_passed"] = predicate.get("verificationResult") == "PASSED"
 
-    checks["subject_matches_artifact"] = subject_matches(
-        vsa.get("subject"),
+    expected_subject_name = require_expectation(
         args.expect_subject_name,
+        "--expect-subject-name",
+        errors,
+    )
+    expected_subject_sha256 = require_expectation(
         args.expect_subject_sha256,
+        "--expect-subject-sha256",
+        errors,
     )
 
-    expected_resource_uri = args.expect_resource_uri
-    checks["resource_uri_matches"] = (
-        expected_resource_uri is None or predicate.get("resourceUri") == expected_resource_uri
-    )
+    if expected_subject_name is not None and expected_subject_sha256 is not None:
+        checks["subject_matches_artifact"] = subject_matches(
+            vsa.get("subject"),
+            expected_subject_name,
+            expected_subject_sha256,
+        )
+    else:
+        checks["subject_matches_artifact"] = False
 
-    expected_verifier_id = args.expect_verifier_id
-    verifier = predicate.get("verifier", {}) if isinstance(predicate, dict) else {}
-    checks["verifier_trusted"] = (
-        expected_verifier_id is None or verifier.get("id") == expected_verifier_id
+    expected_resource_uri = require_expectation(
+        args.expect_resource_uri,
+        "--expect-resource-uri",
+        errors,
     )
+    if expected_resource_uri is not None:
+        checks["resource_uri_matches"] = predicate.get("resourceUri") == expected_resource_uri
+    else:
+        checks["resource_uri_matches"] = False
 
-    checks["policy_digest_matches"] = policy_digest_matches(
-        predicate.get("policy"),
+    raw_verifier = predicate.get("verifier")
+    if not isinstance(raw_verifier, dict):
+        errors.append("verifier_not_object")
+        verifier: dict[str, Any] = {}
+    else:
+        verifier = raw_verifier
+
+    expected_verifier_id = require_expectation(
+        args.expect_verifier_id,
+        "--expect-verifier-id",
+        errors,
+    )
+    if expected_verifier_id is not None:
+        checks["verifier_trusted"] = verifier.get("id") == expected_verifier_id
+    else:
+        checks["verifier_trusted"] = False
+
+    raw_policy = predicate.get("policy")
+    if not isinstance(raw_policy, dict):
+        errors.append("policy_not_object")
+        policy: dict[str, Any] = {}
+    else:
+        policy = raw_policy
+
+    expected_policy_sha256 = require_expectation(
         args.expect_policy_sha256,
+        "--expect-policy-sha256",
+        errors,
     )
+    if expected_policy_sha256 is not None:
+        checks["policy_digest_matches"] = policy_digest_matches(
+            policy,
+            expected_policy_sha256,
+        )
+    else:
+        checks["policy_digest_matches"] = False
 
-    checks["verified_level_ok"] = verified_level_ok(
-        predicate.get("verifiedLevels"),
+    expected_verified_level = require_expectation(
         args.expect_verified_level,
+        "--expect-verified-level",
+        errors,
     )
+    if expected_verified_level is not None:
+        checks["verified_level_ok"] = verified_level_ok(
+            predicate.get("verifiedLevels"),
+            expected_verified_level,
+        )
+    else:
+        checks["verified_level_ok"] = False
 
     checks["pulse_signals_literal_booleans"] = literal_boolean_signals(pulse_signals)
     checks["pulse_signals_required_true"] = required_signals_true(pulse_signals)
@@ -260,12 +334,14 @@ def build_intake_report(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
         for signal, expected_value in expected_signal_values.items():
             if pulse_signals.get(signal) is not expected_value:
                 signal_consistency_errors.append(
-                    f"pulse_signal_inconsistent: {signal} recorded={pulse_signals.get(signal)!r} expected={expected_value!r}"
+                    "pulse_signal_inconsistent: "
+                    f"{signal} recorded={pulse_signals.get(signal)!r} expected={expected_value!r}"
                 )
 
         if pulse_signals.get("slsa_vsa_signature_ok") is not True:
             signal_consistency_errors.append(
-                "pulse_signal_inconsistent: slsa_vsa_signature_ok must be recorded as literal true for this intake"
+                "pulse_signal_inconsistent: "
+                "slsa_vsa_signature_ok must be recorded as literal true for this intake"
             )
     else:
         signal_consistency_errors.append("pulse_signals_not_object")
@@ -298,15 +374,13 @@ def main() -> int:
     output = Path(args.output) if args.output else None
 
     if output is not None and output.name == "status.json":
-        checks = empty_checks()
-        errors = ["refusing_to_write_status_json"]
         report = make_report(
             ok=False,
             schema_version=None,
             evidence_type=None,
-            checks=checks,
+            checks=empty_checks(),
             pulse_signals={},
-            errors=errors,
+            errors=["refusing_to_write_status_json"],
         )
         emit_report(report, None)
         return 2


### PR DESCRIPTION
## Summary

This PR adds the first deterministic SLSA / in-toto VSA evidence intake verifier for PULSEmech.

The verifier consumes an existing `slsa_vsa_evidence_v0` evidence record, validates it against the existing schema, checks expected release-evidence bindings, and emits a deterministic JSON intake report.

This PR does not fold evidence into `status.json`.

This PR does not modify release-authority behavior.

## Files changed

```text
tools/ingest_slsa_vsa_evidence_v0.py
tests/test_ingest_slsa_vsa_evidence_v0.py
ci/tools-tests.list
```

## What changed

Added:

```text
tools/ingest_slsa_vsa_evidence_v0.py
```

The tool:

```text
loads a SLSA VSA PULSE evidence record
loads schemas/slsa_vsa_evidence_v0.schema.json
validates the schema as Draft 2020-12 JSON Schema
validates the evidence record against the schema
checks fixed contract fields
checks expected subject name and digest
checks expected resource URI
checks expected verifier identity
checks expected policy digest
checks expected verified level
checks verificationResult = PASSED
checks literal boolean PULSE signals
checks signal consistency against computable evidence bindings
emits deterministic JSON report to stdout
optionally writes the same report to --output
```

## Fixed contract checks

The tool checks:

```text
schema_version = slsa_vsa_evidence_v0
evidence_type = slsa_vsa
vsa._type = https://in-toto.io/Statement/v1
vsa.predicateType = https://slsa.dev/verification_summary/v1
```

## Expected binding checks

The tool supports:

```text
--expect-subject-name
--expect-subject-sha256
--expect-resource-uri
--expect-verifier-id
--expect-policy-sha256
--expect-verified-level
```

These expectations are checked against the evidence record.

A mismatch causes the intake report to return:

```text
ok = false
```

and the tool exits nonzero.

## Signature verification boundary

The tool reports:

```text
signature_verification_mode = recorded_signal_only
```

This is intentional.

The tool does not perform cryptographic signature verification.

It only checks that the recorded PULSE evidence signal is present and consistent for this intake stage.

## Report shape

The tool emits a deterministic JSON report with this structure:

```json
{
  "tool": "ingest_slsa_vsa_evidence_v0",
  "ok": true,
  "schema_version": "slsa_vsa_evidence_v0",
  "evidence_type": "slsa_vsa",
  "signature_verification_mode": "recorded_signal_only",
  "checks": {
    "schema_valid": true,
    "evidence_valid": true,
    "contract_fields_ok": true,
    "predicate_type_ok": true,
    "verification_result_passed": true,
    "subject_matches_artifact": true,
    "resource_uri_matches": true,
    "verifier_trusted": true,
    "policy_digest_matches": true,
    "verified_level_ok": true,
    "pulse_signals_literal_booleans": true,
    "pulse_signals_required_true": true,
    "pulse_signals_consistent": true
  },
  "pulse_signals": {
    "slsa_vsa_present": true,
    "slsa_vsa_signature_ok": true,
    "slsa_vsa_subject_matches_artifact": true,
    "slsa_vsa_predicate_type_ok": true,
    "slsa_vsa_verifier_trusted": true,
    "slsa_vsa_resource_uri_matches": true,
    "slsa_vsa_policy_digest_matches": true,
    "slsa_vsa_result_passed": true,
    "slsa_vsa_verified_level_ok": true
  },
  "errors": []
}
```

## Tests

Added:

```text
tests/test_ingest_slsa_vsa_evidence_v0.py
```

The test works both as a standalone smoke script and under pytest:

```text
python tests/test_ingest_slsa_vsa_evidence_v0.py
python -m pytest tests/test_ingest_slsa_vsa_evidence_v0.py
```

The test verifies:

```text
valid example passes
stdout report is valid JSON
report has ok = true
signature_verification_mode = recorded_signal_only
wrong verifier id fails
wrong subject digest fails
wrong resource URI fails
wrong policy digest fails
missing expected verified level fails
verificationResult / pulse signal contradiction fails
non-boolean PULSE signal fails
tool does not write or mutate status.json
tool does not call check_gates.py
```

## Manifest registration

Registered the new smoke test in:

```text
ci/tools-tests.list
```

Added exactly one line:

```text
tests/test_ingest_slsa_vsa_evidence_v0.py
```

## Authority boundary

This PR adds an intake verifier only.

It does not change the PULSE release-authority path.

The runtime release-authority path remains:

```text
recorded evidence
→ final status.json
→ declared policy
→ workflow-effective materialized required gates
→ check_gates.py
→ primary CI allow/block release decision
```

No changes were made to:

```text
PULSE_safe_pack_v0/tools/check_gates.py
pulse_gate_policy_v0.yml
pulse_gate_registry_v0.yml
status.json semantics
release_decision_v0 semantics
.github/workflows/
schemas/slsa_vsa_evidence_v0.schema.json
examples/slsa/slsa_vsa_evidence_example_v0.json
DOI metadata
Zenodo metadata
CITATION.cff
release tags
generated artifacts
publication surfaces
unrelated docs
```

## Testing

Passed / expected:

```text
python -m py_compile tools/ingest_slsa_vsa_evidence_v0.py
```

```text
python -m py_compile tests/test_ingest_slsa_vsa_evidence_v0.py
```

```text
python tools/ingest_slsa_vsa_evidence_v0.py --schema schemas/slsa_vsa_evidence_v0.schema.json --evidence examples/slsa/slsa_vsa_evidence_example_v0.json --expect-subject-name git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0 --expect-subject-sha256 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --expect-resource-uri git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0 --expect-verifier-id https://example.invalid/verifiers/pulsemech-vsa-verifier-v0 --expect-policy-sha256 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb --expect-verified-level SLSA_BUILD_LEVEL_3
```

```text
python tests/test_ingest_slsa_vsa_evidence_v0.py
```

```text
python -m pytest tests/test_ingest_slsa_vsa_evidence_v0.py
```

```text
python tests/test_tools_tests_list_smoke.py
```

```text
git diff --check
```

## Merge rationale

This PR moves the SLSA / in-toto evidence path from a machine-readable contract to a mechanically checkable intake verifier.

It validates the evidence contract, verifies expected bindings, checks literal PULSE evidence signals, and emits a deterministic intake report.

It does not introduce status fold-in, required gates, policy changes, CI workflow changes, or release-authority behavior changes.

The next step can be a separate status fold-in / admissibility step after this intake verifier is stable.

## Merge rationale

This PR moves the SLSA / in-toto evidence path from a machine-readable contract to a mechanically checkable intake verifier.

It validates the evidence contract, verifies expected bindings, checks literal PULSE evidence signals, and emits a deterministic intake report.

It does not introduce status fold-in, required gates, policy changes, CI workflow changes, or release-authority behavior changes.

The next step can be a separate status fold-in / admissibility step after this intake verifier is stable.