### PR TITLE
feat(slsa): add vsa intake status fold-in

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -101,6 +101,7 @@ tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
 tests/test_reader_surface_non_interference.py
 tests/test_slsa_vsa_evidence_schema_v0.py
 tests/test_ingest_slsa_vsa_evidence_v0.py
+tests/test_fold_slsa_vsa_intake_into_status_v0.py
 
 tools/operator_handoff_smoke.py
 

--- a/tests/test_fold_slsa_vsa_intake_into_status_v0.py
+++ b/tests/test_fold_slsa_vsa_intake_into_status_v0.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -44,7 +45,10 @@ EXPECTED_INGEST_ARGS = [
 
 def write_json(path: Path, data: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 
 
 def read_json(path: Path) -> dict:
@@ -195,6 +199,32 @@ def check_missing_signal_fails(tmp_dir: Path) -> None:
     assert not output_path.exists()
 
 
+def check_missing_signal_with_existing_slsa_gate_reports_json(tmp_dir: Path) -> None:
+    status_path = tmp_dir / "status_input_existing_slsa_gate.json"
+    intake_path = tmp_dir / "intake_report_missing_signal_existing_gate.json"
+    output_path = tmp_dir / "status_output_missing_signal_existing_gate.json"
+
+    write_json(
+        status_path,
+        {
+            "schema_version": "test_status_v0",
+            "run_id": "fold-slsa-vsa-intake-test",
+            "gates": {
+                "slsa_vsa_present": True
+            },
+        },
+    )
+
+    report = run_ingest_report(tmp_dir / "valid_intake_report_for_missing_signal.json")
+    del report["pulse_signals"]["slsa_vsa_present"]
+    write_json(intake_path, report)
+
+    result = run_fold(status_path, intake_path, output_path)
+
+    assert_failure(result, "pulse_signal_missing: slsa_vsa_present")
+    assert not output_path.exists()
+
+
 def check_non_boolean_signal_fails(tmp_dir: Path) -> None:
     status_path = tmp_dir / "status_input.json"
     intake_path = tmp_dir / "intake_report_non_boolean_signal.json"
@@ -306,6 +336,49 @@ def check_in_place_output_refused(tmp_dir: Path) -> None:
     assert base_hash_before == base_hash_after
 
 
+def check_hardlinked_output_refused(tmp_dir: Path) -> None:
+    status_path = tmp_dir / "status_input.json"
+    intake_path = tmp_dir / "intake_report.json"
+    hardlink_output_path = tmp_dir / "status_hardlink.json"
+
+    make_base_status(status_path)
+    base_hash_before = sha256_file(status_path)
+
+    try:
+        os.link(status_path, hardlink_output_path)
+    except (OSError, NotImplementedError):
+        return
+
+    run_ingest_report(intake_path)
+
+    result = run_fold(status_path, intake_path, hardlink_output_path)
+    assert_failure(result, "refusing_in_place_status_write")
+
+    base_hash_after = sha256_file(status_path)
+    assert base_hash_before == base_hash_after
+
+
+def check_output_write_failure_reports_json(tmp_dir: Path) -> None:
+    status_path = tmp_dir / "status_input.json"
+    intake_path = tmp_dir / "intake_report.json"
+    output_path = tmp_dir / "status_output_directory"
+
+    make_base_status(status_path)
+    run_ingest_report(intake_path)
+
+    output_path.mkdir()
+
+    result = run_fold(status_path, intake_path, output_path)
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+
+    report = parse_report(result)
+    assert report["ok"] is False
+    assert report["output_status_written"] is False
+    assert any("output_write_error:" in error for error in report["errors"]), report["errors"]
+
+
 def check_tool_does_not_call_gate_checker() -> None:
     source = FOLD_TOOL.read_text(encoding="utf-8")
     forbidden = "check_" + "gates"
@@ -324,12 +397,15 @@ def check_fold_slsa_vsa_intake_into_status_v0() -> None:
         check_valid_fold_in(tmp_dir)
         check_report_not_ok_fails(tmp_dir)
         check_missing_signal_fails(tmp_dir)
+        check_missing_signal_with_existing_slsa_gate_reports_json(tmp_dir)
         check_non_boolean_signal_fails(tmp_dir)
         check_false_signal_fails(tmp_dir)
         check_false_check_fails(tmp_dir)
         check_existing_gate_conflict_fails(tmp_dir)
         check_base_status_shape_failures(tmp_dir)
         check_in_place_output_refused(tmp_dir)
+        check_hardlinked_output_refused(tmp_dir)
+        check_output_write_failure_reports_json(tmp_dir)
         check_tool_does_not_call_gate_checker()
 
 

--- a/tests/test_fold_slsa_vsa_intake_into_status_v0.py
+++ b/tests/test_fold_slsa_vsa_intake_into_status_v0.py
@@ -1,0 +1,342 @@
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+INGEST_TOOL = ROOT / "tools" / "ingest_slsa_vsa_evidence_v0.py"
+FOLD_TOOL = ROOT / "tools" / "fold_slsa_vsa_intake_into_status_v0.py"
+
+SCHEMA = ROOT / "schemas" / "slsa_vsa_evidence_v0.schema.json"
+EXAMPLE = ROOT / "examples" / "slsa" / "slsa_vsa_evidence_example_v0.json"
+
+REQUIRED_PULSE_SIGNALS = [
+    "slsa_vsa_present",
+    "slsa_vsa_signature_ok",
+    "slsa_vsa_subject_matches_artifact",
+    "slsa_vsa_predicate_type_ok",
+    "slsa_vsa_verifier_trusted",
+    "slsa_vsa_resource_uri_matches",
+    "slsa_vsa_policy_digest_matches",
+    "slsa_vsa_result_passed",
+    "slsa_vsa_verified_level_ok",
+]
+
+EXPECTED_INGEST_ARGS = [
+    "--expect-subject-name",
+    "git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0",
+    "--expect-subject-sha256",
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "--expect-resource-uri",
+    "git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0",
+    "--expect-verifier-id",
+    "https://example.invalid/verifiers/pulsemech-vsa-verifier-v0",
+    "--expect-policy-sha256",
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "--expect-verified-level",
+    "SLSA_BUILD_LEVEL_3",
+]
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def make_base_status(path: Path) -> None:
+    write_json(
+        path,
+        {
+            "schema_version": "test_status_v0",
+            "run_id": "fold-slsa-vsa-intake-test",
+            "gates": {
+                "existing_gate": True
+            },
+        },
+    )
+
+
+def run_ingest_report(output: Path) -> dict:
+    cmd = [
+        sys.executable,
+        str(INGEST_TOOL),
+        "--schema",
+        str(SCHEMA),
+        "--evidence",
+        str(EXAMPLE),
+        *EXPECTED_INGEST_ARGS,
+        "--output",
+        str(output),
+    ]
+
+    result = subprocess.run(
+        cmd,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    report = json.loads(result.stdout)
+    assert report["ok"] is True
+    assert output.exists()
+    assert read_json(output) == report
+    return report
+
+
+def run_fold(status: Path, intake_report: Path, output: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(FOLD_TOOL),
+            "--status",
+            str(status),
+            "--intake-report",
+            str(intake_report),
+            "--output",
+            str(output),
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def parse_report(result: subprocess.CompletedProcess[str]) -> dict:
+    assert result.stdout, result.stderr
+    return json.loads(result.stdout)
+
+
+def assert_failure(result: subprocess.CompletedProcess[str], expected_fragment: str) -> dict:
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+
+    report = parse_report(result)
+    assert report["ok"] is False
+    assert report["output_status_written"] is False
+    assert any(expected_fragment in error for error in report["errors"]), report["errors"]
+    return report
+
+
+def check_valid_fold_in(tmp_dir: Path) -> None:
+    status_path = tmp_dir / "status_input.json"
+    intake_path = tmp_dir / "intake_report.json"
+    output_path = tmp_dir / "status_output.json"
+
+    make_base_status(status_path)
+    base_hash_before = sha256_file(status_path)
+
+    run_ingest_report(intake_path)
+
+    result = run_fold(status_path, intake_path, output_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    base_hash_after = sha256_file(status_path)
+    assert base_hash_before == base_hash_after
+
+    report = parse_report(result)
+    assert report["tool"] == "fold_slsa_vsa_intake_into_status_v0"
+    assert report["ok"] is True
+    assert report["output_status_written"] is True
+    assert report["errors"] == []
+    assert report["folded_gates"] == REQUIRED_PULSE_SIGNALS
+
+    folded_status = read_json(output_path)
+    assert folded_status["gates"]["existing_gate"] is True
+
+    for signal in REQUIRED_PULSE_SIGNALS:
+        assert folded_status["gates"][signal] is True
+
+
+def check_report_not_ok_fails(tmp_dir: Path) -> None:
+    status_path = tmp_dir / "status_input.json"
+    intake_path = tmp_dir / "intake_report_not_ok.json"
+    output_path = tmp_dir / "status_output_not_ok.json"
+
+    make_base_status(status_path)
+    report = run_ingest_report(tmp_dir / "valid_intake_report.json")
+    report["ok"] = False
+    report["errors"] = ["synthetic_error"]
+    write_json(intake_path, report)
+
+    result = run_fold(status_path, intake_path, output_path)
+    assert_failure(result, "intake_report_not_ok")
+    assert not output_path.exists()
+
+
+def check_missing_signal_fails(tmp_dir: Path) -> None:
+    status_path = tmp_dir / "status_input.json"
+    intake_path = tmp_dir / "intake_report_missing_signal.json"
+    output_path = tmp_dir / "status_output_missing_signal.json"
+
+    make_base_status(status_path)
+    report = run_ingest_report(tmp_dir / "valid_intake_report.json")
+    del report["pulse_signals"]["slsa_vsa_present"]
+    write_json(intake_path, report)
+
+    result = run_fold(status_path, intake_path, output_path)
+    assert_failure(result, "pulse_signal_missing: slsa_vsa_present")
+    assert not output_path.exists()
+
+
+def check_non_boolean_signal_fails(tmp_dir: Path) -> None:
+    status_path = tmp_dir / "status_input.json"
+    intake_path = tmp_dir / "intake_report_non_boolean_signal.json"
+    output_path = tmp_dir / "status_output_non_boolean_signal.json"
+
+    make_base_status(status_path)
+    report = run_ingest_report(tmp_dir / "valid_intake_report.json")
+    report["pulse_signals"]["slsa_vsa_present"] = "true"
+    write_json(intake_path, report)
+
+    result = run_fold(status_path, intake_path, output_path)
+    assert_failure(result, "pulse_signal_not_boolean: slsa_vsa_present")
+    assert not output_path.exists()
+
+
+def check_false_signal_fails(tmp_dir: Path) -> None:
+    status_path = tmp_dir / "status_input.json"
+    intake_path = tmp_dir / "intake_report_false_signal.json"
+    output_path = tmp_dir / "status_output_false_signal.json"
+
+    make_base_status(status_path)
+    report = run_ingest_report(tmp_dir / "valid_intake_report.json")
+    report["pulse_signals"]["slsa_vsa_present"] = False
+    write_json(intake_path, report)
+
+    result = run_fold(status_path, intake_path, output_path)
+    assert_failure(result, "pulse_signal_not_true: slsa_vsa_present")
+    assert not output_path.exists()
+
+
+def check_false_check_fails(tmp_dir: Path) -> None:
+    status_path = tmp_dir / "status_input.json"
+    intake_path = tmp_dir / "intake_report_false_check.json"
+    output_path = tmp_dir / "status_output_false_check.json"
+
+    make_base_status(status_path)
+    report = run_ingest_report(tmp_dir / "valid_intake_report.json")
+    report["checks"]["verified_level_ok"] = False
+    write_json(intake_path, report)
+
+    result = run_fold(status_path, intake_path, output_path)
+    assert_failure(result, "intake_check_not_true: verified_level_ok")
+    assert not output_path.exists()
+
+
+def check_existing_gate_conflict_fails(tmp_dir: Path) -> None:
+    status_path = tmp_dir / "status_input_conflict.json"
+    intake_path = tmp_dir / "intake_report_conflict.json"
+    output_path = tmp_dir / "status_output_conflict.json"
+
+    write_json(
+        status_path,
+        {
+            "schema_version": "test_status_v0",
+            "run_id": "fold-slsa-vsa-intake-test",
+            "gates": {
+                "slsa_vsa_present": False
+            },
+        },
+    )
+
+    run_ingest_report(intake_path)
+
+    result = run_fold(status_path, intake_path, output_path)
+    assert_failure(result, "existing_gate_conflict: slsa_vsa_present")
+    assert not output_path.exists()
+
+
+def check_base_status_shape_failures(tmp_dir: Path) -> None:
+    intake_path = tmp_dir / "valid_intake_report.json"
+    run_ingest_report(intake_path)
+
+    not_object_status = tmp_dir / "status_not_object.json"
+    not_object_output = tmp_dir / "status_not_object_output.json"
+    not_object_status.write_text('"not-object"\n', encoding="utf-8")
+
+    result = run_fold(not_object_status, intake_path, not_object_output)
+    assert_failure(result, "status_not_object")
+    assert not not_object_output.exists()
+
+    bad_gates_status = tmp_dir / "status_bad_gates.json"
+    bad_gates_output = tmp_dir / "status_bad_gates_output.json"
+    write_json(
+        bad_gates_status,
+        {
+            "schema_version": "test_status_v0",
+            "gates": "not-object",
+        },
+    )
+
+    result = run_fold(bad_gates_status, intake_path, bad_gates_output)
+    assert_failure(result, "status_gates_not_object")
+    assert not bad_gates_output.exists()
+
+
+def check_in_place_output_refused(tmp_dir: Path) -> None:
+    status_path = tmp_dir / "status_input.json"
+    intake_path = tmp_dir / "intake_report.json"
+
+    make_base_status(status_path)
+    base_hash_before = sha256_file(status_path)
+
+    run_ingest_report(intake_path)
+
+    result = run_fold(status_path, intake_path, status_path)
+    assert_failure(result, "refusing_in_place_status_write")
+
+    base_hash_after = sha256_file(status_path)
+    assert base_hash_before == base_hash_after
+
+
+def check_tool_does_not_call_gate_checker() -> None:
+    source = FOLD_TOOL.read_text(encoding="utf-8")
+    forbidden = "check_" + "gates"
+    assert forbidden not in source
+
+
+def check_fold_slsa_vsa_intake_into_status_v0() -> None:
+    assert INGEST_TOOL.exists()
+    assert FOLD_TOOL.exists()
+    assert SCHEMA.exists()
+    assert EXAMPLE.exists()
+
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp_dir = Path(raw_tmp)
+
+        check_valid_fold_in(tmp_dir)
+        check_report_not_ok_fails(tmp_dir)
+        check_missing_signal_fails(tmp_dir)
+        check_non_boolean_signal_fails(tmp_dir)
+        check_false_signal_fails(tmp_dir)
+        check_false_check_fails(tmp_dir)
+        check_existing_gate_conflict_fails(tmp_dir)
+        check_base_status_shape_failures(tmp_dir)
+        check_in_place_output_refused(tmp_dir)
+        check_tool_does_not_call_gate_checker()
+
+
+def test_fold_slsa_vsa_intake_into_status_v0() -> None:
+    check_fold_slsa_vsa_intake_into_status_v0()
+
+
+if __name__ == "__main__":
+    check_fold_slsa_vsa_intake_into_status_v0()
+    print("OK: fold_slsa_vsa_intake_into_status_v0 smoke passed")

--- a/tools/fold_slsa_vsa_intake_into_status_v0.py
+++ b/tools/fold_slsa_vsa_intake_into_status_v0.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+
+TOOL_NAME = "fold_slsa_vsa_intake_into_status_v0"
+INTAKE_TOOL_NAME = "ingest_slsa_vsa_evidence_v0"
+
+SCHEMA_VERSION = "slsa_vsa_evidence_v0"
+EVIDENCE_TYPE = "slsa_vsa"
+SIGNATURE_VERIFICATION_MODE = "recorded_signal_only"
+
+REQUIRED_PULSE_SIGNALS = [
+    "slsa_vsa_present",
+    "slsa_vsa_signature_ok",
+    "slsa_vsa_subject_matches_artifact",
+    "slsa_vsa_predicate_type_ok",
+    "slsa_vsa_verifier_trusted",
+    "slsa_vsa_resource_uri_matches",
+    "slsa_vsa_policy_digest_matches",
+    "slsa_vsa_result_passed",
+    "slsa_vsa_verified_level_ok",
+]
+
+REQUIRED_INTAKE_CHECKS = [
+    "schema_valid",
+    "evidence_valid",
+    "contract_fields_ok",
+    "predicate_type_ok",
+    "verification_result_passed",
+    "subject_matches_artifact",
+    "resource_uri_matches",
+    "verifier_trusted",
+    "policy_digest_matches",
+    "verified_level_ok",
+    "pulse_signals_literal_booleans",
+    "pulse_signals_required_true",
+    "pulse_signals_consistent",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fold a validated PULSEmech SLSA / in-toto VSA intake report "
+            "into a new output status JSON."
+        )
+    )
+    parser.add_argument("--status", required=True, help="Path to the base status JSON")
+    parser.add_argument("--intake-report", required=True, help="Path to the intake report JSON")
+    parser.add_argument("--output", required=True, help="Path for the new folded status JSON")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def same_resolved_path(left: Path, right: Path) -> bool:
+    return left.resolve() == right.resolve()
+
+
+def make_report(
+    *,
+    ok: bool,
+    output_status_written: bool,
+    folded_gates: list[str],
+    errors: list[str],
+) -> dict[str, Any]:
+    return {
+        "tool": TOOL_NAME,
+        "ok": ok,
+        "output_status_written": output_status_written,
+        "folded_gates": folded_gates,
+        "errors": errors,
+    }
+
+
+def emit_report(report: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(report, indent=2, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def validate_base_status(status: Any, errors: list[str]) -> Optional[dict[str, Any]]:
+    if not isinstance(status, dict):
+        errors.append("status_not_object")
+        return None
+
+    gates = status.get("gates")
+    if not isinstance(gates, dict):
+        errors.append("status_gates_not_object")
+        return None
+
+    return status
+
+
+def validate_intake_report(report: Any, errors: list[str]) -> Optional[dict[str, Any]]:
+    if not isinstance(report, dict):
+        errors.append("intake_report_not_object")
+        return None
+
+    if report.get("tool") != INTAKE_TOOL_NAME:
+        errors.append("intake_report_tool_mismatch")
+
+    if report.get("ok") is not True:
+        errors.append("intake_report_not_ok")
+
+    if report.get("schema_version") != SCHEMA_VERSION:
+        errors.append("intake_report_schema_version_mismatch")
+
+    if report.get("evidence_type") != EVIDENCE_TYPE:
+        errors.append("intake_report_evidence_type_mismatch")
+
+    if report.get("signature_verification_mode") != SIGNATURE_VERIFICATION_MODE:
+        errors.append("intake_report_signature_mode_mismatch")
+
+    report_errors = report.get("errors")
+    if report_errors != []:
+        errors.append("intake_report_errors_not_empty")
+
+    checks = report.get("checks")
+    if not isinstance(checks, dict):
+        errors.append("intake_report_checks_not_object")
+    else:
+        for check_name in REQUIRED_INTAKE_CHECKS:
+            if checks.get(check_name) is not True:
+                errors.append(f"intake_check_not_true: {check_name}")
+
+    pulse_signals = report.get("pulse_signals")
+    if not isinstance(pulse_signals, dict):
+        errors.append("intake_report_pulse_signals_not_object")
+    else:
+        for signal in REQUIRED_PULSE_SIGNALS:
+            if signal not in pulse_signals:
+                errors.append(f"pulse_signal_missing: {signal}")
+            elif not isinstance(pulse_signals[signal], bool):
+                errors.append(f"pulse_signal_not_boolean: {signal}")
+            elif pulse_signals[signal] is not True:
+                errors.append(f"pulse_signal_not_true: {signal}")
+
+    return report
+
+
+def validate_existing_gate_conflicts(status: dict[str, Any], pulse_signals: dict[str, Any], errors: list[str]) -> None:
+    gates = status["gates"]
+
+    for signal in REQUIRED_PULSE_SIGNALS:
+        if signal in gates and gates[signal] is not pulse_signals[signal]:
+            errors.append(f"existing_gate_conflict: {signal}")
+
+
+def fold_signals_into_status(status: dict[str, Any], pulse_signals: dict[str, Any]) -> dict[str, Any]:
+    folded = copy.deepcopy(status)
+    gates = folded["gates"]
+
+    for signal in REQUIRED_PULSE_SIGNALS:
+        gates[signal] = pulse_signals[signal]
+
+    return folded
+
+
+def build_folded_status(status_path: Path, intake_report_path: Path, output_path: Path) -> tuple[dict[str, Any], Optional[dict[str, Any]], int]:
+    errors: list[str] = []
+
+    if same_resolved_path(status_path, output_path):
+        errors.append("refusing_in_place_status_write")
+        return make_report(ok=False, output_status_written=False, folded_gates=[], errors=errors), None, 2
+
+    try:
+        status_raw = load_json(status_path)
+    except Exception as exc:
+        errors.append(f"status_read_error: {exc}")
+        return make_report(ok=False, output_status_written=False, folded_gates=[], errors=errors), None, 2
+
+    try:
+        intake_raw = load_json(intake_report_path)
+    except Exception as exc:
+        errors.append(f"intake_report_read_error: {exc}")
+        return make_report(ok=False, output_status_written=False, folded_gates=[], errors=errors), None, 2
+
+    status = validate_base_status(status_raw, errors)
+    intake_report = validate_intake_report(intake_raw, errors)
+
+    pulse_signals: dict[str, Any] = {}
+    if isinstance(intake_report, dict) and isinstance(intake_report.get("pulse_signals"), dict):
+        pulse_signals = intake_report["pulse_signals"]
+
+    if status is not None and pulse_signals:
+        validate_existing_gate_conflicts(status, pulse_signals, errors)
+
+    if errors:
+        return make_report(ok=False, output_status_written=False, folded_gates=[], errors=errors), None, 1
+
+    assert status is not None
+    folded_status = fold_signals_into_status(status, pulse_signals)
+
+    report = make_report(
+        ok=True,
+        output_status_written=True,
+        folded_gates=list(REQUIRED_PULSE_SIGNALS),
+        errors=[],
+    )
+    return report, folded_status, 0
+
+
+def main() -> int:
+    args = parse_args()
+
+    status_path = Path(args.status)
+    intake_report_path = Path(args.intake_report)
+    output_path = Path(args.output)
+
+    report, folded_status, exit_code = build_folded_status(status_path, intake_report_path, output_path)
+
+    if exit_code == 0:
+        assert folded_status is not None
+        write_json(output_path, folded_status)
+
+    emit_report(report)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/fold_slsa_vsa_intake_into_status_v0.py
+++ b/tools/fold_slsa_vsa_intake_into_status_v0.py
@@ -62,11 +62,23 @@ def load_json(path: Path) -> Any:
 
 def write_json(path: Path, data: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 
 
-def same_resolved_path(left: Path, right: Path) -> bool:
-    return left.resolve() == right.resolve()
+def same_status_target(left: Path, right: Path) -> bool:
+    if left.resolve() == right.resolve():
+        return True
+
+    try:
+        if left.exists() and right.exists() and left.samefile(right):
+            return True
+    except OSError:
+        pass
+
+    return False
 
 
 def make_report(
@@ -149,11 +161,22 @@ def validate_intake_report(report: Any, errors: list[str]) -> Optional[dict[str,
     return report
 
 
-def validate_existing_gate_conflicts(status: dict[str, Any], pulse_signals: dict[str, Any], errors: list[str]) -> None:
+def validate_existing_gate_conflicts(
+    status: dict[str, Any],
+    pulse_signals: dict[str, Any],
+    errors: list[str],
+) -> None:
     gates = status["gates"]
 
     for signal in REQUIRED_PULSE_SIGNALS:
-        if signal in gates and gates[signal] is not pulse_signals[signal]:
+        if signal not in gates:
+            continue
+
+        incoming = pulse_signals.get(signal)
+        if incoming is None:
+            continue
+
+        if gates[signal] is not incoming:
             errors.append(f"existing_gate_conflict: {signal}")
 
 
@@ -167,24 +190,43 @@ def fold_signals_into_status(status: dict[str, Any], pulse_signals: dict[str, An
     return folded
 
 
-def build_folded_status(status_path: Path, intake_report_path: Path, output_path: Path) -> tuple[dict[str, Any], Optional[dict[str, Any]], int]:
+def build_folded_status(
+    status_path: Path,
+    intake_report_path: Path,
+    output_path: Path,
+) -> tuple[dict[str, Any], Optional[dict[str, Any]], int]:
     errors: list[str] = []
 
-    if same_resolved_path(status_path, output_path):
+    if same_status_target(status_path, output_path):
         errors.append("refusing_in_place_status_write")
-        return make_report(ok=False, output_status_written=False, folded_gates=[], errors=errors), None, 2
+        return make_report(
+            ok=False,
+            output_status_written=False,
+            folded_gates=[],
+            errors=errors,
+        ), None, 2
 
     try:
         status_raw = load_json(status_path)
     except Exception as exc:
         errors.append(f"status_read_error: {exc}")
-        return make_report(ok=False, output_status_written=False, folded_gates=[], errors=errors), None, 2
+        return make_report(
+            ok=False,
+            output_status_written=False,
+            folded_gates=[],
+            errors=errors,
+        ), None, 2
 
     try:
         intake_raw = load_json(intake_report_path)
     except Exception as exc:
         errors.append(f"intake_report_read_error: {exc}")
-        return make_report(ok=False, output_status_written=False, folded_gates=[], errors=errors), None, 2
+        return make_report(
+            ok=False,
+            output_status_written=False,
+            folded_gates=[],
+            errors=errors,
+        ), None, 2
 
     status = validate_base_status(status_raw, errors)
     intake_report = validate_intake_report(intake_raw, errors)
@@ -193,11 +235,16 @@ def build_folded_status(status_path: Path, intake_report_path: Path, output_path
     if isinstance(intake_report, dict) and isinstance(intake_report.get("pulse_signals"), dict):
         pulse_signals = intake_report["pulse_signals"]
 
-    if status is not None and pulse_signals:
+    if not errors and status is not None and pulse_signals:
         validate_existing_gate_conflicts(status, pulse_signals, errors)
 
     if errors:
-        return make_report(ok=False, output_status_written=False, folded_gates=[], errors=errors), None, 1
+        return make_report(
+            ok=False,
+            output_status_written=False,
+            folded_gates=[],
+            errors=errors,
+        ), None, 1
 
     assert status is not None
     folded_status = fold_signals_into_status(status, pulse_signals)
@@ -218,11 +265,26 @@ def main() -> int:
     intake_report_path = Path(args.intake_report)
     output_path = Path(args.output)
 
-    report, folded_status, exit_code = build_folded_status(status_path, intake_report_path, output_path)
+    report, folded_status, exit_code = build_folded_status(
+        status_path,
+        intake_report_path,
+        output_path,
+    )
 
     if exit_code == 0:
         assert folded_status is not None
-        write_json(output_path, folded_status)
+
+        try:
+            write_json(output_path, folded_status)
+        except Exception as exc:
+            report = make_report(
+                ok=False,
+                output_status_written=False,
+                folded_gates=[],
+                errors=[f"output_write_error: {exc}"],
+            )
+            emit_report(report)
+            return 2
 
     emit_report(report)
     return exit_code


### PR DESCRIPTION
## Summary

This PR adds the first standalone SLSA / in-toto VSA intake status fold-in tool for PULSEmech.

The tool reads:

```text
base status JSON
deterministic SLSA VSA intake report
```

and writes a new output status JSON with the validated SLSA VSA evidence signals folded into:

```text
status["gates"]
```

This PR does not introduce a policy gate.

This PR does not make SLSA VSA evidence release-required.

This PR does not change release-authority behavior.

## Files changed

```text
tools/fold_slsa_vsa_intake_into_status_v0.py
tests/test_fold_slsa_vsa_intake_into_status_v0.py
ci/tools-tests.list
```

## What changed

Added:

```text
tools/fold_slsa_vsa_intake_into_status_v0.py
```

The tool:

```text
loads a base status JSON
loads a deterministic intake report from ingest_slsa_vsa_evidence_v0.py
requires the intake report to be ok
requires the intake report tool identity to match ingest_slsa_vsa_evidence_v0
requires signature_verification_mode = recorded_signal_only
requires all required intake checks to be literal true
requires all required SLSA VSA PULSE signals to be present
requires all required SLSA VSA PULSE signals to be literal boolean true
refuses in-place status writes
refuses existing gate conflicts
writes a new folded output status JSON
emits a deterministic JSON fold-in report to stdout
```

## Folded gate signals

The tool folds these SLSA VSA evidence signals into `status["gates"]`:

```text
slsa_vsa_present
slsa_vsa_signature_ok
slsa_vsa_subject_matches_artifact
slsa_vsa_predicate_type_ok
slsa_vsa_verifier_trusted
slsa_vsa_resource_uri_matches
slsa_vsa_policy_digest_matches
slsa_vsa_result_passed
slsa_vsa_verified_level_ok
```

These are evidence signals only in this PR.

They are not added to policy.

They are not made release-required.

## Fail-closed behavior

The fold-in fails without writing output status when:

```text
the base status is not an object
status["gates"] is not an object
the intake report is missing or invalid
the intake report tool name is wrong
the intake report is not ok
signature_verification_mode is not recorded_signal_only
any required intake check is not true
any required SLSA VSA PULSE signal is missing
any required SLSA VSA PULSE signal is not a boolean
any required SLSA VSA PULSE signal is false
an existing status gate conflicts with the incoming SLSA VSA signal
--output points to the same path as --status
```

## Output behavior

The tool writes a new output status JSON only when all fold-in checks pass.

It does not modify the input status file.

It refuses in-place writes.

It emits a deterministic fold-in report with:

```text
tool
ok
output_status_written
folded_gates
errors
```

## Tests

Added:

```text
tests/test_fold_slsa_vsa_intake_into_status_v0.py
```

The test works both as a standalone smoke script and under pytest:

```text
python tests/test_fold_slsa_vsa_intake_into_status_v0.py
python -m pytest tests/test_fold_slsa_vsa_intake_into_status_v0.py
```

The test verifies:

```text
valid intake report + valid status creates output status
all 9 slsa_vsa_* signals are folded into status["gates"]
all folded signals are literal true
input status hash is unchanged
report.ok=false fails
missing signal fails
non-boolean signal fails
false signal fails
false intake check fails
existing gate conflict fails
bad base status shape fails
bad status["gates"] shape fails
in-place output is refused
the tool does not call the gate checker
```

## Manifest registration

Registered the new smoke test in:

```text
ci/tools-tests.list
```

Added exactly one line:

```text
tests/test_fold_slsa_vsa_intake_into_status_v0.py
```

## Authority boundary

This PR adds status fold-in mechanics only.

It does not change the PULSE release-authority path.

The runtime release-authority path remains:

```text
recorded evidence
→ final status.json
→ declared policy
→ workflow-effective materialized required gates
→ check_gates.py
→ primary CI allow/block release decision
```

No changes were made to:

```text
PULSE_safe_pack_v0/tools/check_gates.py
pulse_gate_policy_v0.yml
pulse_gate_registry_v0.yml
release_decision_v0 semantics
.github/workflows/
schemas/slsa_vsa_evidence_v0.schema.json
examples/slsa/slsa_vsa_evidence_example_v0.json
DOI metadata
Zenodo metadata
CITATION.cff
release tags
generated artifacts
publication surfaces
unrelated docs
```

## Testing

Passed / expected:

```text
python -m py_compile tools/fold_slsa_vsa_intake_into_status_v0.py
```

```text
python -m py_compile tests/test_fold_slsa_vsa_intake_into_status_v0.py
```

```text
python tests/test_fold_slsa_vsa_intake_into_status_v0.py
```

```text
python -m pytest tests/test_fold_slsa_vsa_intake_into_status_v0.py
```

```text
python tests/test_tools_tests_list_smoke.py
```

```text
git diff --check
```

## Merge rationale

This PR completes the next mechanical step after the SLSA VSA evidence contract and intake verifier.

The repository now has:

```text
SLSA / in-toto evidence intake docs
SLSA VSA evidence contract
SLSA VSA intake verifier
SLSA VSA intake status fold-in
```

This PR keeps the fold-in non-normative with respect to release authority.

It records validated SLSA VSA intake signals into a new output status JSON, but it does not add policy requirements, does not change CI, and does not make these signals release-required.

The next steps remain separate:

```text
policy gate
release-required SLSA lane
```

Those should only be added after this fold-in path remains stable.