### PR TITLE
docs: add README public origin notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PULSE — Artifact-Bound Release Authority for AI Release Decisions
 
+> **Public origin / prior-art notice:** PULSE has a minimum public origin record. For the visible provenance anchors and attribution boundary, see the [Public Origin / Prior Art Notice](docs/quality_ledger.md#10-public-origin--prior-art-notice).
+
 > [!NOTE]
 > The following three Zenodo version records currently have incorrect DOI/citation routing metadata:
 >


### PR DESCRIPTION
## Summary

- Adds a short Public origin / prior-art notice near the top of the README.
- Links the README to the Public Origin / Prior Art Notice in `docs/quality_ledger.md`.
- Makes the minimum public origin record visible from the repository front page.

## Validation

- Documentation-only change.
- No code or runtime behavior changed.
- README link reviewed.