### PR TITLE
feat(slsa): register vsa advisory policy gates

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -102,6 +102,7 @@ tests/test_reader_surface_non_interference.py
 tests/test_slsa_vsa_evidence_schema_v0.py
 tests/test_ingest_slsa_vsa_evidence_v0.py
 tests/test_fold_slsa_vsa_intake_into_status_v0.py
+tests/test_slsa_vsa_advisory_policy_gates_v0.py
 
 tools/operator_handoff_smoke.py
 

--- a/pulse_gate_policy_v0.yml
+++ b/pulse_gate_policy_v0.yml
@@ -69,3 +69,14 @@ gates:
   advisory:
     - external_summaries_present
     - external_all_pass
+    # SLSA / in-toto VSA evidence gates.
+    # Advisory-only in v0; not release-blocking.
+    - slsa_vsa_present
+    - slsa_vsa_signature_ok
+    - slsa_vsa_subject_matches_artifact
+    - slsa_vsa_predicate_type_ok
+    - slsa_vsa_verifier_trusted
+    - slsa_vsa_resource_uri_matches
+    - slsa_vsa_policy_digest_matches
+    - slsa_vsa_result_passed
+    - slsa_vsa_verified_level_ok

--- a/pulse_gate_registry_v0.yml
+++ b/pulse_gate_registry_v0.yml
@@ -130,6 +130,60 @@ gates:
     stability: experimental
     default_normative: false
 
+  # --- SLSA / in-toto VSA evidence gates (advisory by default) ---
+  slsa_vsa_present:
+    category: external
+    intent: "SLSA / in-toto VSA evidence record is present in the folded status surface."
+    stability: experimental
+    default_normative: false
+
+  slsa_vsa_signature_ok:
+    category: external
+    intent: "SLSA / in-toto VSA signature verification is recorded as an evidence signal."
+    stability: experimental
+    default_normative: false
+
+  slsa_vsa_subject_matches_artifact:
+    category: external
+    intent: "SLSA / in-toto VSA subject digest matches the expected release artifact identity."
+    stability: experimental
+    default_normative: false
+
+  slsa_vsa_predicate_type_ok:
+    category: external
+    intent: "SLSA / in-toto VSA predicate type matches the expected verification summary contract."
+    stability: experimental
+    default_normative: false
+
+  slsa_vsa_verifier_trusted:
+    category: external
+    intent: "SLSA / in-toto VSA verifier identity matches the declared trust expectation."
+    stability: experimental
+    default_normative: false
+
+  slsa_vsa_resource_uri_matches:
+    category: external
+    intent: "SLSA / in-toto VSA resource URI matches the expected release resource binding."
+    stability: experimental
+    default_normative: false
+
+  slsa_vsa_policy_digest_matches:
+    category: external
+    intent: "SLSA / in-toto VSA policy digest matches the expected verification policy digest."
+    stability: experimental
+    default_normative: false
+
+  slsa_vsa_result_passed:
+    category: external
+    intent: "SLSA / in-toto VSA verification result is recorded as PASSED."
+    stability: experimental
+    default_normative: false
+
+  slsa_vsa_verified_level_ok:
+    category: external
+    intent: "SLSA / in-toto VSA verified level satisfies the declared intake expectation."
+    stability: experimental
+    default_normative: false
 
   # --- Diagnostics (must remain non-normative unless explicitly promoted) ---
   epf_hazard_ok:

--- a/tests/fixtures/core_baseline_v0/status.normalized.json
+++ b/tests/fixtures/core_baseline_v0/status.normalized.json
@@ -32,7 +32,7 @@
     "RDSI": 0.92,
     "build_time": "1970-01-01T00:00:00Z",
     "gate_policy_path": "pulse_gate_policy_v0.yml",
-    "gate_policy_sha256": "b15b322c6af73a95d5e1f4912b790d62a64ddb95db48afe7ca5a791c67e284d9",
+    "gate_policy_sha256": "294ec583934a1aaeec42140de5f4e92709895e5b6374a0bdea4e6807eb3a2a17",
     "git_sha": "<GIT_SHA>",
     "hazard_D": 0.0,
     "hazard_E": 0.07999999999999996,

--- a/tests/test_slsa_vsa_advisory_policy_gates_v0.py
+++ b/tests/test_slsa_vsa_advisory_policy_gates_v0.py
@@ -1,0 +1,232 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+POLICY = ROOT / "pulse_gate_policy_v0.yml"
+REGISTRY = ROOT / "pulse_gate_registry_v0.yml"
+POLICY_TO_REQUIRE_ARGS = ROOT / "tools" / "policy_to_require_args.py"
+
+SLSA_VSA_GATES = [
+    "slsa_vsa_present",
+    "slsa_vsa_signature_ok",
+    "slsa_vsa_subject_matches_artifact",
+    "slsa_vsa_predicate_type_ok",
+    "slsa_vsa_verifier_trusted",
+    "slsa_vsa_resource_uri_matches",
+    "slsa_vsa_policy_digest_matches",
+    "slsa_vsa_result_passed",
+    "slsa_vsa_verified_level_ok",
+]
+
+REQUIRED_LIKE_SETS = [
+    "required",
+    "core_required",
+    "release_required",
+]
+
+FORBIDDEN_BLOCKING_SET_NAMES = [
+    "required",
+    "core_required",
+    "release_required",
+    "prod_required",
+    "stage_required",
+    "blocking",
+    "release_blocking",
+]
+
+
+def _strip_inline_comment(text: str) -> str:
+    return text.split("#", 1)[0].strip()
+
+
+def _parse_inline_list(value: str) -> list[str]:
+    value = value.strip()
+    if not (value.startswith("[") and value.endswith("]")):
+        return []
+
+    inner = value[1:-1].strip()
+    if not inner:
+        return []
+
+    return [part.strip() for part in inner.split(",") if part.strip()]
+
+
+def _extract_gate_set(text: str, gate_set: str) -> tuple[bool, list[str]]:
+    lines = text.splitlines()
+
+    in_gates = False
+    in_set = False
+    gates_indent = None
+    set_indent = None
+    found_set = False
+    out: list[str] = []
+
+    for raw in lines:
+        line = raw.rstrip("\n")
+        stripped = line.strip()
+
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        clean = _strip_inline_comment(stripped)
+        if not clean:
+            continue
+
+        indent = len(line) - len(line.lstrip(" "))
+
+        if clean == "gates:":
+            in_gates = True
+            in_set = False
+            gates_indent = indent
+            set_indent = None
+            continue
+
+        if in_gates and gates_indent is not None and indent <= gates_indent and ":" in clean and clean != "gates:":
+            in_gates = False
+            in_set = False
+            gates_indent = None
+            set_indent = None
+
+        if not in_gates:
+            continue
+
+        if in_set and set_indent is not None and indent == set_indent and ":" in clean and not clean.startswith("-"):
+            key = clean.split(":", 1)[0].strip()
+            if key and key != gate_set:
+                in_set = False
+                set_indent = None
+
+        if ":" in clean and not clean.startswith("-"):
+            key, rest = clean.split(":", 1)
+            key = key.strip()
+            rest = rest.strip()
+
+            if key == gate_set:
+                found_set = True
+                set_indent = indent
+
+                if rest.startswith("[") and rest.endswith("]"):
+                    out.extend(_parse_inline_list(rest))
+                    in_set = False
+                    continue
+
+                in_set = True
+                continue
+
+        if not in_set:
+            continue
+
+        if clean.startswith("- "):
+            gate_id = _strip_inline_comment(clean[2:])
+            if gate_id:
+                out.append(gate_id)
+
+    return found_set, out
+
+
+def _extract_registry_gate_block(text: str, gate_id: str) -> str:
+    lines = text.splitlines()
+    marker = f"  {gate_id}:"
+
+    start = None
+    for index, line in enumerate(lines):
+        if line.rstrip() == marker:
+            start = index
+            break
+
+    if start is None:
+        return ""
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        stripped = line.strip()
+
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if line.startswith("  ") and not line.startswith("    ") and stripped.endswith(":"):
+            end = index
+            break
+
+    return "\n".join(lines[start:end])
+
+
+def _policy_to_require_args(gate_set: str) -> list[str]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(POLICY_TO_REQUIRE_ARGS),
+            "--policy",
+            str(POLICY),
+            "--set",
+            gate_set,
+            "--format",
+            "newline",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def check_slsa_vsa_advisory_policy_gates_v0() -> None:
+    assert POLICY.exists()
+    assert REGISTRY.exists()
+    assert POLICY_TO_REQUIRE_ARGS.exists()
+
+    policy_text = POLICY.read_text(encoding="utf-8")
+    registry_text = REGISTRY.read_text(encoding="utf-8")
+
+    found_advisory, advisory_gates = _extract_gate_set(policy_text, "advisory")
+    assert found_advisory, "advisory gate set is missing from pulse_gate_policy_v0.yml"
+
+    missing_from_advisory = [gate for gate in SLSA_VSA_GATES if gate not in advisory_gates]
+    assert not missing_from_advisory, f"SLSA VSA gates missing from advisory set: {missing_from_advisory}"
+
+    for gate in SLSA_VSA_GATES:
+        block = _extract_registry_gate_block(registry_text, gate)
+
+        assert block, f"{gate} missing from pulse_gate_registry_v0.yml"
+        assert "category: external" in block, f"{gate} must be an external evidence gate"
+        assert "default_normative: false" in block, f"{gate} must remain non-normative by default"
+
+    for gate_set in FORBIDDEN_BLOCKING_SET_NAMES:
+        found_set, gates = _extract_gate_set(policy_text, gate_set)
+        if not found_set:
+            continue
+
+        leaked = [gate for gate in SLSA_VSA_GATES if gate in gates]
+        assert not leaked, f"SLSA VSA gates must not appear in {gate_set}: {leaked}"
+
+    for gate_set in REQUIRED_LIKE_SETS:
+        materialized = _policy_to_require_args(gate_set)
+        leaked = [gate for gate in SLSA_VSA_GATES if gate in materialized]
+        assert not leaked, f"policy_to_require_args materialized advisory SLSA VSA gates for {gate_set}: {leaked}"
+
+    materialized_advisory = _policy_to_require_args("advisory")
+    missing_from_materialized_advisory = [
+        gate for gate in SLSA_VSA_GATES if gate not in materialized_advisory
+    ]
+    assert not missing_from_materialized_advisory, (
+        "SLSA VSA gates missing from materialized advisory set: "
+        f"{missing_from_materialized_advisory}"
+    )
+
+
+def test_slsa_vsa_advisory_policy_gates_v0() -> None:
+    check_slsa_vsa_advisory_policy_gates_v0()
+
+
+if __name__ == "__main__":
+    check_slsa_vsa_advisory_policy_gates_v0()
+    print("OK: SLSA VSA gates are registered and advisory-only")


### PR DESCRIPTION
## Summary

This PR registers the SLSA / in-toto VSA evidence gates as advisory-only PULSE policy gates.

The gates are produced by the existing SLSA VSA evidence path:

```text
SLSA VSA evidence contract
→ SLSA VSA intake verifier
→ SLSA VSA status fold-in
→ slsa_vsa_* signals in status["gates"]
```

This PR makes those `slsa_vsa_*` signals known to the registry and visible on the policy surface.

This PR does not make them release-required.

This PR does not make them release-blocking.

This PR does not change release-authority behavior.

## Files changed

```text
pulse_gate_registry_v0.yml
pulse_gate_policy_v0.yml
tests/test_slsa_vsa_advisory_policy_gates_v0.py
ci/tools-tests.list
```

## Registered SLSA VSA gates

```text
slsa_vsa_present
slsa_vsa_signature_ok
slsa_vsa_subject_matches_artifact
slsa_vsa_predicate_type_ok
slsa_vsa_verifier_trusted
slsa_vsa_resource_uri_matches
slsa_vsa_policy_digest_matches
slsa_vsa_result_passed
slsa_vsa_verified_level_ok
```

## What changed

Updated:

```text
pulse_gate_registry_v0.yml
```

to register all nine `slsa_vsa_*` gate identifiers as external advisory evidence gates.

Updated:

```text
pulse_gate_policy_v0.yml
```

to expose all nine `slsa_vsa_*` gates on the advisory SLSA VSA evidence surface.

Added:

```text
tests/test_slsa_vsa_advisory_policy_gates_v0.py
```

to prove that the gates are registered and advisory-only.

Updated:

```text
ci/tools-tests.list
```

to register the new smoke test exactly once.

## Advisory-only boundary

These gates are advisory evidence gates in this PR.

They are not added to any release-blocking gate set.

They are not added to:

```text
required
core_required
release_required
prod_required
stage_required
blocking
release_blocking
```

They are not release-required.

They are not policy-blocking.

They do not change `check_gates.py`.

They do not change CI workflow behavior.

They do not change release-decision semantics.

## Policy behavior

The `slsa_vsa_*` gates are visible as advisory policy gates.

They must not be materialized by current required release gate sets.

The smoke test verifies that `policy_to_require_args.py` does not materialize any `slsa_vsa_*` gate for current required-like sets.

Required-like sets checked:

```text
required
core_required
release_required
```

Forbidden blocking-style sets checked where present:

```text
required
core_required
release_required
prod_required
stage_required
blocking
release_blocking
```

## Authority boundary

This PR does not change the PULSE release-authority path.

The runtime release-authority path remains:

```text
recorded evidence
→ final status.json
→ declared policy
→ workflow-effective materialized required gates
→ check_gates.py
→ primary CI allow/block release decision
```

No changes were made to:

```text
PULSE_safe_pack_v0/tools/check_gates.py
.github/workflows/
release_decision_v0 semantics
status.json semantics
schemas/slsa_vsa_evidence_v0.schema.json
examples/slsa/slsa_vsa_evidence_example_v0.json
tools/ingest_slsa_vsa_evidence_v0.py
tools/fold_slsa_vsa_intake_into_status_v0.py
DOI metadata
Zenodo metadata
CITATION.cff
release tags
generated artifacts
publication surfaces
unrelated docs
```

## Tests

Added:

```text
tests/test_slsa_vsa_advisory_policy_gates_v0.py
```

The test verifies:

```text
all nine slsa_vsa_* gates are present in pulse_gate_registry_v0.yml
all nine slsa_vsa_* gates are present in the advisory policy surface
all nine slsa_vsa_* gates are category external in the registry
all nine slsa_vsa_* gates have default_normative: false
none of the nine gates appear in required/core_required/release_required/prod_required/stage_required/blocking/release_blocking sets
policy_to_require_args.py does not materialize any slsa_vsa_* gate for current required-like gate sets
policy_to_require_args.py does materialize the slsa_vsa_* gates for the advisory set
```

The test works both ways:

```text
python tests/test_slsa_vsa_advisory_policy_gates_v0.py
```

```text
python -m pytest tests/test_slsa_vsa_advisory_policy_gates_v0.py
```

## Manifest registration

Registered the new smoke test in:

```text
ci/tools-tests.list
```

Added exactly one line:

```text
tests/test_slsa_vsa_advisory_policy_gates_v0.py
```

## Testing

Passed / expected:

```text
python -m py_compile tests/test_slsa_vsa_advisory_policy_gates_v0.py
```

```text
python tests/test_slsa_vsa_advisory_policy_gates_v0.py
```

```text
python -m pytest tests/test_slsa_vsa_advisory_policy_gates_v0.py
```

```text
python tests/test_tools_tests_list_smoke.py
```

```text
git diff --check
```

## Merge rationale

This PR completes the advisory policy-surface step after the SLSA VSA evidence contract, intake verifier, and status fold-in path.

The repository now recognizes the folded `slsa_vsa_*` evidence signals as registered advisory policy gates.

This keeps the SLSA VSA lane visible and mechanically named without making it release-required.

This PR does not introduce a release-required SLSA lane.

The next step remains separate:

```text
release-required SLSA lane
```

That step should only be introduced after this advisory policy surface remains stable.