### PR TITLE
feat(policy): allow materializing declared gate sets

### DIFF
--- a/tests/test_policy_to_require_args_smoke.py
+++ b/tests/test_policy_to_require_args_smoke.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """
-Smoke test for tools/policy_to_require_args.py
+Smoke test for tools/policy_to_require_args.py.
 
 Locks down:
 - multiline list parsing
 - inline list parsing
 - advisory optional behavior (missing/empty => rc 0, no output)
-- required/core_required fail-closed behavior (missing/empty => non-zero)
+- all non-advisory gate sets fail closed when missing/empty
+- arbitrary declared gate-set materialization
+- repository SLSA VSA candidate-set materialization
 - file-not-found exit code
 """
 
@@ -21,6 +23,19 @@ import textwrap
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 TOOL = ROOT / "tools" / "policy_to_require_args.py"
+REPO_POLICY = ROOT / "pulse_gate_policy_v0.yml"
+
+EXPECTED_SLSA_VSA_CANDIDATE = [
+    "slsa_vsa_present",
+    "slsa_vsa_signature_ok",
+    "slsa_vsa_subject_matches_artifact",
+    "slsa_vsa_predicate_type_ok",
+    "slsa_vsa_verifier_trusted",
+    "slsa_vsa_resource_uri_matches",
+    "slsa_vsa_policy_digest_matches",
+    "slsa_vsa_result_passed",
+    "slsa_vsa_verified_level_ok",
+]
 
 
 def _run(policy_path: pathlib.Path, gate_set: str, fmt: str = "newline") -> subprocess.CompletedProcess[str]:
@@ -60,10 +75,11 @@ def test_policy_to_require_args_smoke() -> None:
     assert TOOL.is_file(), f"Missing tool at: {TOOL}"
 
     with tempfile.TemporaryDirectory() as td:
-        td = pathlib.Path(td)
+        td_path = pathlib.Path(td)
 
-        # 1) Happy path: multiline required + inline core_required + inline release_required + empty advisory 
-        policy1 = td / "policy1.yml"
+        # 1) Happy path: multiline required + inline core_required +
+        # inline release_required + empty advisory + arbitrary declared set.
+        policy1 = td_path / "policy1.yml"
         policy1.write_text(
             textwrap.dedent(
                 """\
@@ -76,6 +92,10 @@ def test_policy_to_require_args_smoke() -> None:
                     - gate_b  # inline comment should be ignored
                   core_required: [gate_a]
                   release_required: [gate_rel_a, gate_rel_b]
+                  custom_candidate:
+                    - candidate_a
+                    - candidate_b
+                  inline_candidate: [inline_a, inline_b]
                   advisory: []
                 """
             ),
@@ -93,14 +113,21 @@ def test_policy_to_require_args_smoke() -> None:
         p = _run(policy1, "release_required", "newline")
         _assert_rc(p, 0)
         assert _stdout_lines(p) == ["gate_rel_a", "gate_rel_b"]
- 
-        
+
+        p = _run(policy1, "custom_candidate", "newline")
+        _assert_rc(p, 0)
+        assert _stdout_lines(p) == ["candidate_a", "candidate_b"]
+
+        p = _run(policy1, "inline_candidate", "space")
+        _assert_rc(p, 0)
+        assert (p.stdout or "").strip() == "inline_a inline_b"
+
         p = _run(policy1, "advisory", "newline")
         _assert_rc(p, 0)
         assert (p.stdout or "").strip() == ""
 
-        # 2) Advisory missing key is OK (rc 0, no output)
-        policy2 = td / "policy2.yml"
+        # 2) Advisory missing key is OK (rc 0, no output).
+        policy2 = td_path / "policy2.yml"
         policy2.write_text(
             textwrap.dedent(
                 """\
@@ -118,8 +145,8 @@ def test_policy_to_require_args_smoke() -> None:
         _assert_rc(p, 0)
         assert (p.stdout or "").strip() == ""
 
-        # 3) Required missing set => fail closed (non-zero)
-        policy3 = td / "policy3_missing_required.yml"
+        # 3) Missing non-advisory set => fail closed (non-zero).
+        policy3 = td_path / "policy3_missing_required.yml"
         policy3.write_text(
             textwrap.dedent(
                 """\
@@ -136,8 +163,12 @@ def test_policy_to_require_args_smoke() -> None:
         p = _run(policy3, "required", "newline")
         _assert_rc(p, 3)
 
-        # 4) Required empty => fail closed (non-zero)
-        policy4 = td / "policy4_empty_required.yml"
+        p = _run(policy3, "custom_candidate", "newline")
+        _assert_rc(p, 3)
+        assert "Gate set not found: custom_candidate" in (p.stderr or "")
+
+        # 4) Empty non-advisory set => fail closed (non-zero).
+        policy4 = td_path / "policy4_empty_required.yml"
         policy4.write_text(
             textwrap.dedent(
                 """\
@@ -147,6 +178,7 @@ def test_policy_to_require_args_smoke() -> None:
                 gates:
                   required: []
                   core_required: [gate_a]
+                  custom_candidate: []
                   advisory: []
                 """
             ),
@@ -155,8 +187,12 @@ def test_policy_to_require_args_smoke() -> None:
         p = _run(policy4, "required", "newline")
         _assert_rc(p, 3)
 
-         # 5) release_required missing set => fail closed (non-zero)
-        policy5 = td / "policy5_missing_release_required.yml"
+        p = _run(policy4, "custom_candidate", "newline")
+        _assert_rc(p, 3)
+        assert "Gate set is empty: custom_candidate" in (p.stderr or "")
+
+        # 5) release_required missing set => fail closed (non-zero).
+        policy5 = td_path / "policy5_missing_release_required.yml"
         policy5.write_text(
             textwrap.dedent(
                 """\
@@ -174,8 +210,8 @@ def test_policy_to_require_args_smoke() -> None:
         p = _run(policy5, "release_required", "newline")
         _assert_rc(p, 3)
 
-        # 6) release_required empty => fail closed (non-zero)
-        policy6 = td / "policy6_empty_release_required.yml"
+        # 6) release_required empty => fail closed (non-zero).
+        policy6 = td_path / "policy6_empty_release_required.yml"
         policy6.write_text(
             textwrap.dedent(
                 """\
@@ -194,15 +230,24 @@ def test_policy_to_require_args_smoke() -> None:
         p = _run(policy6, "release_required", "newline")
         _assert_rc(p, 3)
 
-        # 7) Policy file not found => rc 2
-        missing = td / "does_not_exist.yml"
+        # 7) Policy file not found => rc 2.
+        missing = td_path / "does_not_exist.yml"
         p = _run(missing, "required", "newline")
         _assert_rc(p, 2)
+
+
+def test_repository_slsa_vsa_candidate_set_materializes() -> None:
+    assert REPO_POLICY.is_file(), f"Missing policy at: {REPO_POLICY}"
+
+    p = _run(REPO_POLICY, "slsa_vsa_recorded_intake_candidate", "newline")
+    _assert_rc(p, 0)
+    assert _stdout_lines(p) == EXPECTED_SLSA_VSA_CANDIDATE
 
 
 def main() -> int:
     try:
         test_policy_to_require_args_smoke()
+        test_repository_slsa_vsa_candidate_set_materializes()
     except AssertionError as e:
         print(f"ERROR: {e}")
         return 1
@@ -211,7 +256,7 @@ def main() -> int:
 
 
 def test_smoke() -> None:
-    # optional pytest entrypoint
+    # Optional pytest entrypoint.
     assert main() == 0
 
 

--- a/tools/policy_to_require_args.py
+++ b/tools/policy_to_require_args.py
@@ -9,30 +9,22 @@ hardcode `--require ...` lists.
 
 Behavior
 --------
-- `--set required`:
-    - missing set OR empty set => error (non-zero)
-- `--set core_required`:
-    - missing set OR empty set => error (non-zero)
-- `--set release_required`:
-    - missing set OR empty set => error (non-zero)
 - `--set advisory`:
     - missing set OR empty set => valid (exit 0, print nothing)
+- `--set <any other declared gate set>`:
+    - missing set OR empty set => error (non-zero)
 
-Supports inline list forms:
+Supports inline list forms for any gate set declared under `gates:`:
   advisory: []
   required: [a, b, c]
-  core_required: [a, b, c]
-  release_required: [a, b, c]
+  custom_candidate: [a, b, c]
 
 Design constraints
 ------------------
 - No external dependencies (no PyYAML).
 - Minimal parsing tailored to the policy layout under:
     gates:
-      required: ...
-      core_required: ...
-      release_required: ...
-      advisory: ...
+      <gate_set>: ...
 """
 
 from __future__ import annotations
@@ -104,7 +96,7 @@ def _extract_gate_set(text: str, gate_set: str) -> Tuple[bool, List[str]]:
 
         indent = len(line) - len(line.lstrip(" "))
 
-        # Enter "gates:" block
+        # Enter "gates:" block.
         if clean == "gates:":
             in_gates = True
             in_set = False
@@ -112,7 +104,7 @@ def _extract_gate_set(text: str, gate_set: str) -> Tuple[bool, List[str]]:
             set_indent = None
             continue
 
-        # Leave "gates:" block when we hit a top-level (or same-level) mapping key
+        # Leave "gates:" block when we hit a top-level (or same-level) mapping key.
         if in_gates and gates_indent is not None and indent <= gates_indent and ":" in clean and clean != "gates:":
             in_gates = False
             in_set = False
@@ -122,15 +114,15 @@ def _extract_gate_set(text: str, gate_set: str) -> Tuple[bool, List[str]]:
         if not in_gates:
             continue
 
-        # If we are inside a set and hit a sibling key (including inline values), leave the set
+        # If we are inside a set and hit a sibling key, leave the set.
         if in_set and set_indent is not None and indent == set_indent and ":" in clean and not clean.startswith("-"):
             key = clean.split(":", 1)[0].strip()
             if key and key != gate_set:
                 in_set = False
                 set_indent = None
-                # do not continue; allow processing of the current line below
+                # Do not continue; allow processing of the current line below.
 
-        # Enter target set: "<gate_set>:" or "<gate_set>: []" or "<gate_set>: [a,b]"
+        # Enter target set: "<gate_set>:" or "<gate_set>: []" or "<gate_set>: [a,b]".
         if ":" in clean and not clean.startswith("-"):
             key, rest = clean.split(":", 1)
             key = key.strip()
@@ -140,20 +132,20 @@ def _extract_gate_set(text: str, gate_set: str) -> Tuple[bool, List[str]]:
                 found_set = True
                 set_indent = indent
 
-                # Inline list form
+                # Inline list form.
                 if rest.startswith("[") and rest.endswith("]"):
                     out.extend(_parse_inline_list(rest))
                     in_set = False
                     continue
 
-                # Multi-line list form
+                # Multi-line list form.
                 in_set = True
                 continue
 
         if not in_set:
             continue
 
-        # Capture list items "- gate_id"
+        # Capture list items "- gate_id".
         if clean.startswith("- "):
             gate_id = _strip_inline_comment(clean[2:])
             if gate_id:
@@ -172,8 +164,7 @@ def main() -> int:
     ap.add_argument(
         "--set",
         default="required",
-        choices=["required", "core_required", "release_required", "advisory"],
-        help="Which gate set to print (default: required)",
+        help="Which declared gate set under gates: to print (default: required)",
     )
     ap.add_argument(
         "--format",
@@ -196,8 +187,7 @@ def main() -> int:
         if not found_set or not gates:
             return 0
 
-    # Required-like sets (required, core_required, release_required)
-    # must exist and must be non-empty.
+    # Any non-advisory gate set must exist and must be non-empty.
     if not found_set:
         print(f"[policy_to_require_args] Gate set not found: {args.set}", file=sys.stderr)
         return 3


### PR DESCRIPTION
## Summary

This PR updates `tools/policy_to_require_args.py` so it can materialize any gate set declared under `gates:` in `pulse_gate_policy_v0.yml`.

Previously, `--set` was restricted to a hard-coded list:

```text
required
core_required
release_required
advisory
```

This PR removes that hard-coded `--set` restriction and allows declared non-active candidate sets, such as:

```text
slsa_vsa_recorded_intake_candidate
```

to be materialized through the normal policy materializer path.

## Why

PR #2689 registered the non-active SLSA VSA recorded-intake candidate gate set.

That registration intentionally did not add materializer support or end-to-end proof.

This PR is the next small step: it allows the existing materializer to read any declared gate set from the policy file without activating that set as release-required.

## Behavior preserved

This PR preserves the existing fail-closed behavior:

- `advisory` may be missing or empty and exits `0` with no output.
- Any other missing gate set exits non-zero.
- Any other empty gate set exits non-zero.
- Gate order is preserved.
- No external YAML dependency is added.
- No PyYAML dependency is added.

## Scope

Changed files:

```text
tools/policy_to_require_args.py
tests/test_policy_to_require_args_smoke.py
```

## Non-goals

This PR does not change:

```text
pulse_gate_policy_v0.yml
docs/policy/CHANGELOG.md
tests/fixtures/core_baseline_v0/status.normalized.json
PULSE_safe_pack_v0/tools/check_gates.py
.github/workflows/
pulse_gate_registry_v0.yml
ci/tools-tests.list
README.md
DOI / Zenodo / CITATION metadata
```

This PR does not add the end-to-end SLSA VSA recorded-intake proof.

This PR does not activate SLSA VSA as:

```text
required
core_required
release_required
prod_required
stage_required
blocking
release_blocking
```

This PR does not change release-authority behavior.

## Validation

Expected validation commands:

```text
python -m py_compile tools/policy_to_require_args.py
python -m py_compile tests/test_policy_to_require_args_smoke.py
python tests/test_policy_to_require_args_smoke.py
python -m pytest tests/test_policy_to_require_args_smoke.py
python tools/policy_to_require_args.py --policy pulse_gate_policy_v0.yml --set slsa_vsa_recorded_intake_candidate --format newline
python tools/policy_to_require_args.py --policy pulse_gate_policy_v0.yml --set required --format newline
python tools/policy_to_require_args.py --policy pulse_gate_policy_v0.yml --set core_required --format newline
python tools/policy_to_require_args.py --policy pulse_gate_policy_v0.yml --set release_required --format newline
git diff --check
```

## Follow-up

A later PR will add the end-to-end SLSA VSA recorded-intake candidate proof:

```text
ingest_slsa_vsa_evidence_v0.py
→ fold_slsa_vsa_intake_into_status_v0.py
→ slsa_vsa_recorded_intake_candidate materialization
→ check_gates.py PASS / FAIL proof
```

That proof remains intentionally out of scope here.