### PR TITLE
feat(slsa): add vsa trusted producer report contract

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -104,7 +104,7 @@ tests/test_ingest_slsa_vsa_evidence_v0.py
 tests/test_fold_slsa_vsa_intake_into_status_v0.py
 tests/test_slsa_vsa_advisory_policy_gates_v0.py
 tests/test_slsa_vsa_recorded_intake_candidate_v0.py
-
+tests/test_slsa_vsa_trusted_evidence_producer_report_schema_v0.py
 
 tools/operator_handoff_smoke.py
 

--- a/examples/slsa/slsa_vsa_trusted_evidence_producer_report_example_v0.json
+++ b/examples/slsa/slsa_vsa_trusted_evidence_producer_report_example_v0.json
@@ -34,6 +34,7 @@
     "expected_policy_id": "pulse-gate-policy-v0",
     "expected_policy_uri": "pulse_gate_policy_v0.yml",
     "expected_policy_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "evidence_policy_id": "pulse-gate-policy-v0",
     "evidence_policy_uri": "pulse_gate_policy_v0.yml",
     "evidence_policy_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
     "policy_identity_matches": true,

--- a/examples/slsa/slsa_vsa_trusted_evidence_producer_report_example_v0.json
+++ b/examples/slsa/slsa_vsa_trusted_evidence_producer_report_example_v0.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "slsa_vsa_trusted_evidence_producer_report_v0",
+  "report_type": "slsa_vsa_trusted_evidence_producer_report",
+  "created_utc": "2026-07-07T00:00:00Z",
+  "producer": {
+    "producer_id": "pulse_slsa_vsa_trusted_evidence_producer_v0",
+    "producer_name": "PULSE SLSA VSA trusted evidence producer",
+    "producer_version": "0.1.0",
+    "producer_source": "github-actions",
+    "ci_workflow_or_job_identity": "PULSE CI / SLSA VSA trusted evidence producer"
+  },
+  "run_binding": {
+    "current_run_id": "1234567890",
+    "current_run_number": "2692",
+    "current_run_attempt": "1",
+    "current_run_key": "GITHUB_RUN_ID=1234567890|GITHUB_RUN_NUMBER=2692|GITHUB_RUN_ATTEMPT=1|GITHUB_WORKFLOW=PULSE CI",
+    "workflow_name": "PULSE CI",
+    "job_name": "slsa-vsa-trusted-evidence-producer",
+    "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "release_candidate_id": "pulse-release-gates-0.1-candidate-v0"
+  },
+  "artifact_binding": {
+    "subject_name": "git+https://github.com/HKati/pulse-release-gates-0.1@refs/heads/main",
+    "subject_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "resource_uri": "git+https://github.com/HKati/pulse-release-gates-0.1@refs/heads/main",
+    "release_candidate_id": "pulse-release-gates-0.1-candidate-v0",
+    "artifact_digest_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "subject_digest_matches": true,
+    "resource_uri_matches": true,
+    "release_candidate_matches": true,
+    "artifact_digest_matches": true
+  },
+  "policy_binding": {
+    "expected_policy_id": "pulse-gate-policy-v0",
+    "expected_policy_uri": "pulse_gate_policy_v0.yml",
+    "expected_policy_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "evidence_policy_uri": "pulse_gate_policy_v0.yml",
+    "evidence_policy_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "policy_identity_matches": true,
+    "policy_digest_matches": true
+  },
+  "verifier_binding": {
+    "expected_verifier_id": "https://example.invalid/verifiers/pulsemech-vsa-verifier-v0",
+    "evidence_verifier_id": "https://example.invalid/verifiers/pulsemech-vsa-verifier-v0",
+    "verifier_trusted": true
+  },
+  "evidence": {
+    "evidence_path": "examples/slsa/slsa_vsa_evidence_example_v0.json",
+    "evidence_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "evidence_schema_version": "slsa_vsa_evidence_v0",
+    "evidence_type": "slsa_vsa",
+    "time_verified": "2026-07-07T00:00:00Z",
+    "verification_result": "PASSED",
+    "expected_verified_level": "SLSA_BUILD_LEVEL_3",
+    "evidence_verified_levels": [
+      "SLSA_BUILD_LEVEL_3"
+    ],
+    "verified_level_ok": true
+  },
+  "freshness": {
+    "freshness_result": "fresh_current_run",
+    "stale_vsa_evidence": false,
+    "previous_run_artifact_reuse": false,
+    "time_verified_current_run_match": true,
+    "current_run_binding_ok": true
+  },
+  "recorded_signal_mode": "recorded_signal_only",
+  "candidate_set": "slsa_vsa_recorded_intake_candidate",
+  "producer_decision": "TRUSTED_EVIDENCE_ACCEPTED",
+  "ok": true,
+  "failed_checks": [],
+  "warnings": []
+}

--- a/schemas/slsa_vsa_trusted_evidence_producer_report_v0.schema.json
+++ b/schemas/slsa_vsa_trusted_evidence_producer_report_v0.schema.json
@@ -1,0 +1,464 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/HKati/pulse-release-gates-0.1/schemas/slsa_vsa_trusted_evidence_producer_report_v0.schema.json",
+  "title": "PULSE SLSA VSA trusted evidence producer report v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "report_type",
+    "created_utc",
+    "producer",
+    "run_binding",
+    "artifact_binding",
+    "policy_binding",
+    "verifier_binding",
+    "evidence",
+    "freshness",
+    "recorded_signal_mode",
+    "candidate_set",
+    "producer_decision",
+    "ok",
+    "failed_checks",
+    "warnings"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "slsa_vsa_trusted_evidence_producer_report_v0"
+    },
+    "report_type": {
+      "const": "slsa_vsa_trusted_evidence_producer_report"
+    },
+    "created_utc": {
+      "type": "string",
+      "minLength": 1
+    },
+    "producer": {
+      "$ref": "#/$defs/producer"
+    },
+    "run_binding": {
+      "$ref": "#/$defs/run_binding"
+    },
+    "artifact_binding": {
+      "$ref": "#/$defs/artifact_binding"
+    },
+    "policy_binding": {
+      "$ref": "#/$defs/policy_binding"
+    },
+    "verifier_binding": {
+      "$ref": "#/$defs/verifier_binding"
+    },
+    "evidence": {
+      "$ref": "#/$defs/evidence"
+    },
+    "freshness": {
+      "$ref": "#/$defs/freshness"
+    },
+    "recorded_signal_mode": {
+      "const": "recorded_signal_only"
+    },
+    "candidate_set": {
+      "const": "slsa_vsa_recorded_intake_candidate"
+    },
+    "producer_decision": {
+      "type": "string",
+      "enum": [
+        "TRUSTED_EVIDENCE_ACCEPTED",
+        "TRUSTED_EVIDENCE_REJECTED"
+      ]
+    },
+    "ok": {
+      "type": "boolean"
+    },
+    "failed_checks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$"
+    },
+    "sha40": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{40}$"
+    },
+    "non_empty_string": {
+      "type": "string",
+      "minLength": 1
+    },
+    "producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "producer_id",
+        "producer_name",
+        "producer_version",
+        "producer_source",
+        "ci_workflow_or_job_identity"
+      ],
+      "properties": {
+        "producer_id": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "producer_name": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "producer_version": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "producer_source": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "ci_workflow_or_job_identity": {
+          "$ref": "#/$defs/non_empty_string"
+        }
+      }
+    },
+    "run_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "current_run_id",
+        "current_run_number",
+        "current_run_attempt",
+        "current_run_key",
+        "workflow_name",
+        "job_name",
+        "commit_sha",
+        "release_candidate_id"
+      ],
+      "properties": {
+        "current_run_id": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "current_run_number": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "current_run_attempt": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "current_run_key": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "workflow_name": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "job_name": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "commit_sha": {
+          "$ref": "#/$defs/sha40"
+        },
+        "release_candidate_id": {
+          "$ref": "#/$defs/non_empty_string"
+        }
+      }
+    },
+    "artifact_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "subject_name",
+        "subject_sha256",
+        "resource_uri",
+        "release_candidate_id",
+        "artifact_digest_sha256",
+        "subject_digest_matches",
+        "resource_uri_matches",
+        "release_candidate_matches",
+        "artifact_digest_matches"
+      ],
+      "properties": {
+        "subject_name": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "subject_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "resource_uri": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "release_candidate_id": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "artifact_digest_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "subject_digest_matches": {
+          "type": "boolean"
+        },
+        "resource_uri_matches": {
+          "type": "boolean"
+        },
+        "release_candidate_matches": {
+          "type": "boolean"
+        },
+        "artifact_digest_matches": {
+          "type": "boolean"
+        }
+      }
+    },
+    "policy_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "expected_policy_id",
+        "expected_policy_uri",
+        "expected_policy_sha256",
+        "evidence_policy_uri",
+        "evidence_policy_sha256",
+        "policy_identity_matches",
+        "policy_digest_matches"
+      ],
+      "properties": {
+        "expected_policy_id": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "expected_policy_uri": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "expected_policy_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "evidence_policy_uri": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "evidence_policy_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "policy_identity_matches": {
+          "type": "boolean"
+        },
+        "policy_digest_matches": {
+          "type": "boolean"
+        }
+      }
+    },
+    "verifier_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "expected_verifier_id",
+        "evidence_verifier_id",
+        "verifier_trusted"
+      ],
+      "properties": {
+        "expected_verifier_id": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "evidence_verifier_id": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "verifier_trusted": {
+          "type": "boolean"
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evidence_path",
+        "evidence_sha256",
+        "evidence_schema_version",
+        "evidence_type",
+        "time_verified",
+        "verification_result",
+        "expected_verified_level",
+        "evidence_verified_levels",
+        "verified_level_ok"
+      ],
+      "properties": {
+        "evidence_path": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "evidence_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "evidence_schema_version": {
+          "const": "slsa_vsa_evidence_v0"
+        },
+        "evidence_type": {
+          "const": "slsa_vsa"
+        },
+        "time_verified": {
+          "type": "string",
+          "minLength": 1
+        },
+        "verification_result": {
+          "enum": [
+            "PASSED",
+            "FAILED"
+          ]
+        },
+        "expected_verified_level": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "evidence_verified_levels": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/non_empty_string"
+          }
+        },
+        "verified_level_ok": {
+          "type": "boolean"
+        }
+      }
+    },
+    "freshness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "freshness_result",
+        "stale_vsa_evidence",
+        "previous_run_artifact_reuse",
+        "time_verified_current_run_match",
+        "current_run_binding_ok"
+      ],
+      "properties": {
+        "freshness_result": {
+          "enum": [
+            "fresh_current_run",
+            "rejected_stale_vsa",
+            "rejected_previous_run_artifact",
+            "rejected_time_verified_current_run_mismatch",
+            "rejected_ambiguous_freshness"
+          ]
+        },
+        "stale_vsa_evidence": {
+          "type": "boolean"
+        },
+        "previous_run_artifact_reuse": {
+          "type": "boolean"
+        },
+        "time_verified_current_run_match": {
+          "type": "boolean"
+        },
+        "current_run_binding_ok": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "ok": {
+            "const": true
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      },
+      "then": {
+        "properties": {
+          "producer_decision": {
+            "const": "TRUSTED_EVIDENCE_ACCEPTED"
+          },
+          "failed_checks": {
+            "maxItems": 0
+          },
+          "artifact_binding": {
+            "properties": {
+              "subject_digest_matches": {
+                "const": true
+              },
+              "resource_uri_matches": {
+                "const": true
+              },
+              "release_candidate_matches": {
+                "const": true
+              },
+              "artifact_digest_matches": {
+                "const": true
+              }
+            }
+          },
+          "policy_binding": {
+            "properties": {
+              "policy_identity_matches": {
+                "const": true
+              },
+              "policy_digest_matches": {
+                "const": true
+              }
+            }
+          },
+          "verifier_binding": {
+            "properties": {
+              "verifier_trusted": {
+                "const": true
+              }
+            }
+          },
+          "evidence": {
+            "properties": {
+              "verification_result": {
+                "const": "PASSED"
+              },
+              "verified_level_ok": {
+                "const": true
+              }
+            }
+          },
+          "freshness": {
+            "properties": {
+              "freshness_result": {
+                "const": "fresh_current_run"
+              },
+              "stale_vsa_evidence": {
+                "const": false
+              },
+              "previous_run_artifact_reuse": {
+                "const": false
+              },
+              "time_verified_current_run_match": {
+                "const": true
+              },
+              "current_run_binding_ok": {
+                "const": true
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "ok": {
+            "const": false
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      },
+      "then": {
+        "properties": {
+          "producer_decision": {
+            "const": "TRUSTED_EVIDENCE_REJECTED"
+          },
+          "failed_checks": {
+            "minItems": 1
+          }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/slsa_vsa_trusted_evidence_producer_report_v0.schema.json
+++ b/schemas/slsa_vsa_trusted_evidence_producer_report_v0.schema.json
@@ -114,6 +114,7 @@
     "date_time": {
       "type": "string",
       "format": "date-time",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$",
       "minLength": 1
     },
     "nullable_date_time": {
@@ -121,7 +122,8 @@
         "string",
         "null"
       ],
-      "format": "date-time"
+      "format": "date-time",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$"
     },
     "producer": {
       "type": "object",

--- a/schemas/slsa_vsa_trusted_evidence_producer_report_v0.schema.json
+++ b/schemas/slsa_vsa_trusted_evidence_producer_report_v0.schema.json
@@ -30,8 +30,7 @@
       "const": "slsa_vsa_trusted_evidence_producer_report"
     },
     "created_utc": {
-      "type": "string",
-      "minLength": 1
+      "$ref": "#/$defs/date_time"
     },
     "producer": {
       "$ref": "#/$defs/producer"
@@ -90,6 +89,13 @@
       "type": "string",
       "pattern": "^[0-9a-fA-F]{64}$"
     },
+    "nullable_sha256": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[0-9a-fA-F]{64}$"
+    },
     "sha40": {
       "type": "string",
       "pattern": "^[0-9a-fA-F]{40}$"
@@ -97,6 +103,25 @@
     "non_empty_string": {
       "type": "string",
       "minLength": 1
+    },
+    "nullable_non_empty_string": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1
+    },
+    "date_time": {
+      "type": "string",
+      "format": "date-time",
+      "minLength": 1
+    },
+    "nullable_date_time": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
     },
     "producer": {
       "type": "object",
@@ -217,6 +242,7 @@
         "expected_policy_id",
         "expected_policy_uri",
         "expected_policy_sha256",
+        "evidence_policy_id",
         "evidence_policy_uri",
         "evidence_policy_sha256",
         "policy_identity_matches",
@@ -232,11 +258,14 @@
         "expected_policy_sha256": {
           "$ref": "#/$defs/sha256"
         },
+        "evidence_policy_id": {
+          "$ref": "#/$defs/nullable_non_empty_string"
+        },
         "evidence_policy_uri": {
-          "$ref": "#/$defs/non_empty_string"
+          "$ref": "#/$defs/nullable_non_empty_string"
         },
         "evidence_policy_sha256": {
-          "$ref": "#/$defs/sha256"
+          "$ref": "#/$defs/nullable_sha256"
         },
         "policy_identity_matches": {
           "type": "boolean"
@@ -259,7 +288,7 @@
           "$ref": "#/$defs/non_empty_string"
         },
         "evidence_verifier_id": {
-          "$ref": "#/$defs/non_empty_string"
+          "$ref": "#/$defs/nullable_non_empty_string"
         },
         "verifier_trusted": {
           "type": "boolean"
@@ -282,36 +311,49 @@
       ],
       "properties": {
         "evidence_path": {
-          "$ref": "#/$defs/non_empty_string"
+          "$ref": "#/$defs/nullable_non_empty_string"
         },
         "evidence_sha256": {
-          "$ref": "#/$defs/sha256"
+          "$ref": "#/$defs/nullable_sha256"
         },
         "evidence_schema_version": {
-          "const": "slsa_vsa_evidence_v0"
+          "enum": [
+            "slsa_vsa_evidence_v0",
+            null
+          ]
         },
         "evidence_type": {
-          "const": "slsa_vsa"
+          "enum": [
+            "slsa_vsa",
+            null
+          ]
         },
         "time_verified": {
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/$defs/nullable_date_time"
         },
         "verification_result": {
           "enum": [
             "PASSED",
-            "FAILED"
+            "FAILED",
+            null
           ]
         },
         "expected_verified_level": {
           "$ref": "#/$defs/non_empty_string"
         },
         "evidence_verified_levels": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "$ref": "#/$defs/non_empty_string"
-          }
+          "anyOf": [
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/non_empty_string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "verified_level_ok": {
           "type": "boolean"
@@ -332,6 +374,8 @@
         "freshness_result": {
           "enum": [
             "fresh_current_run",
+            "rejected_missing_vsa_evidence",
+            "rejected_unreadable_vsa_evidence",
             "rejected_stale_vsa",
             "rejected_previous_run_artifact",
             "rejected_time_verified_current_run_mismatch",
@@ -391,6 +435,15 @@
           },
           "policy_binding": {
             "properties": {
+              "evidence_policy_id": {
+                "$ref": "#/$defs/non_empty_string"
+              },
+              "evidence_policy_uri": {
+                "$ref": "#/$defs/non_empty_string"
+              },
+              "evidence_policy_sha256": {
+                "$ref": "#/$defs/sha256"
+              },
               "policy_identity_matches": {
                 "const": true
               },
@@ -401,6 +454,9 @@
           },
           "verifier_binding": {
             "properties": {
+              "evidence_verifier_id": {
+                "$ref": "#/$defs/non_empty_string"
+              },
               "verifier_trusted": {
                 "const": true
               }
@@ -408,8 +464,30 @@
           },
           "evidence": {
             "properties": {
+              "evidence_path": {
+                "$ref": "#/$defs/non_empty_string"
+              },
+              "evidence_sha256": {
+                "$ref": "#/$defs/sha256"
+              },
+              "evidence_schema_version": {
+                "const": "slsa_vsa_evidence_v0"
+              },
+              "evidence_type": {
+                "const": "slsa_vsa"
+              },
+              "time_verified": {
+                "$ref": "#/$defs/date_time"
+              },
               "verification_result": {
                 "const": "PASSED"
+              },
+              "evidence_verified_levels": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/$defs/non_empty_string"
+                }
               },
               "verified_level_ok": {
                 "const": true

--- a/tests/test_slsa_vsa_trusted_evidence_producer_report_schema_v0.py
+++ b/tests/test_slsa_vsa_trusted_evidence_producer_report_schema_v0.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+SCHEMA_PATH = ROOT / "schemas" / "slsa_vsa_trusted_evidence_producer_report_v0.schema.json"
+EXAMPLE_PATH = ROOT / "examples" / "slsa" / "slsa_vsa_trusted_evidence_producer_report_example_v0.json"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _schema() -> dict[str, Any]:
+    return _load_json(SCHEMA_PATH)
+
+
+def _accepted_report() -> dict[str, Any]:
+    return _load_json(EXAMPLE_PATH)
+
+
+def _validator() -> jsonschema.Draft202012Validator:
+    schema = _schema()
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(
+        schema,
+        format_checker=jsonschema.FormatChecker(),
+    )
+
+
+def _validate(instance: dict[str, Any]) -> None:
+    _validator().validate(instance)
+
+
+def _validation_errors(instance: dict[str, Any]) -> list[str]:
+    return [error.message for error in _validator().iter_errors(instance)]
+
+
+def _rejected_report(failed_check: str) -> dict[str, Any]:
+    report = _accepted_report()
+    report["ok"] = False
+    report["producer_decision"] = "TRUSTED_EVIDENCE_REJECTED"
+    report["failed_checks"] = [failed_check]
+    return report
+
+
+def test_schema_and_example_exist() -> None:
+    assert SCHEMA_PATH.exists()
+    assert EXAMPLE_PATH.exists()
+
+
+def test_example_validates() -> None:
+    _validate(_accepted_report())
+
+
+def test_schema_version_and_report_type_are_locked() -> None:
+    report = _accepted_report()
+    report["schema_version"] = "wrong"
+    assert _validation_errors(report)
+
+    report = _accepted_report()
+    report["report_type"] = "wrong"
+    assert _validation_errors(report)
+
+
+def test_created_utc_requires_date_time() -> None:
+    report = _accepted_report()
+    report["created_utc"] = "unknown"
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_candidate_set_and_recorded_signal_mode_are_locked() -> None:
+    report = _accepted_report()
+    report["candidate_set"] = "slsa_vsa_release_required_candidate"
+    assert _validation_errors(report)
+
+    report = _accepted_report()
+    report["recorded_signal_mode"] = "cryptographic_signature_verified"
+    assert _validation_errors(report)
+
+
+def test_ok_true_requires_accepted_decision_and_no_failed_checks() -> None:
+    report = _accepted_report()
+    report["producer_decision"] = "TRUSTED_EVIDENCE_REJECTED"
+    assert _validation_errors(report)
+
+    report = _accepted_report()
+    report["failed_checks"] = ["synthetic_failure"]
+    assert _validation_errors(report)
+
+
+def test_rejected_report_requires_failed_checks() -> None:
+    report = _rejected_report("synthetic_failure")
+
+    _validate(report)
+
+    report["failed_checks"] = []
+    assert _validation_errors(report)
+
+
+def test_release_authority_words_are_not_producer_decisions() -> None:
+    for bad_decision in ["PASS", "ALLOW", "PROD-PASS", "VERIFIED", "FAILED"]:
+        report = _accepted_report()
+        report["producer_decision"] = bad_decision
+        assert _validation_errors(report), bad_decision
+
+
+def test_policy_digest_binding_is_required() -> None:
+    for field in ["expected_policy_sha256", "evidence_policy_sha256"]:
+        report = _accepted_report()
+        del report["policy_binding"][field]
+        assert _validation_errors(report), field
+
+
+def test_evidence_policy_identity_is_required() -> None:
+    report = _accepted_report()
+    del report["policy_binding"]["evidence_policy_id"]
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_policy_uri_only_binding_is_rejected() -> None:
+    report = _accepted_report()
+    report["policy_binding"]["evidence_policy_id"] = None
+    report["policy_binding"]["evidence_policy_sha256"] = None
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_policy_digest_mismatch_cannot_be_accepted() -> None:
+    report = _accepted_report()
+    report["policy_binding"]["policy_digest_matches"] = False
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_policy_identity_mismatch_cannot_be_accepted() -> None:
+    report = _accepted_report()
+    report["policy_binding"]["policy_identity_matches"] = False
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_time_verified_requires_date_time() -> None:
+    report = _accepted_report()
+    report["evidence"]["time_verified"] = "unknown"
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_stale_vsa_evidence_cannot_be_accepted() -> None:
+    report = _accepted_report()
+    report["freshness"]["freshness_result"] = "rejected_stale_vsa"
+    report["freshness"]["stale_vsa_evidence"] = True
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_previous_run_artifact_reuse_cannot_be_accepted() -> None:
+    report = _accepted_report()
+    report["freshness"]["freshness_result"] = "rejected_previous_run_artifact"
+    report["freshness"]["previous_run_artifact_reuse"] = True
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_time_verified_current_run_mismatch_cannot_be_accepted() -> None:
+    report = _accepted_report()
+    report["freshness"]["freshness_result"] = "rejected_time_verified_current_run_mismatch"
+    report["freshness"]["time_verified_current_run_match"] = False
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_artifact_binding_mismatches_cannot_be_accepted() -> None:
+    for field in [
+        "subject_digest_matches",
+        "resource_uri_matches",
+        "release_candidate_matches",
+        "artifact_digest_matches",
+    ]:
+        report = _accepted_report()
+        report["artifact_binding"][field] = False
+        assert _validation_errors(report), field
+
+
+def test_unknown_verifier_cannot_be_accepted() -> None:
+    report = _accepted_report()
+    report["verifier_binding"]["verifier_trusted"] = False
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_failed_vsa_verification_result_cannot_be_accepted() -> None:
+    report = _accepted_report()
+    report["evidence"]["verification_result"] = "FAILED"
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_missing_verified_level_cannot_be_accepted() -> None:
+    report = _accepted_report()
+    report["evidence"]["verified_level_ok"] = False
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_required_sha_fields_use_expected_lengths() -> None:
+    bad_values = [
+        ("run_binding", "commit_sha", "a" * 39),
+        ("artifact_binding", "subject_sha256", "b" * 63),
+        ("artifact_binding", "artifact_digest_sha256", "b" * 63),
+        ("policy_binding", "expected_policy_sha256", "c" * 63),
+        ("policy_binding", "evidence_policy_sha256", "c" * 63),
+        ("evidence", "evidence_sha256", "d" * 63),
+    ]
+
+    for section, field, value in bad_values:
+        report = _accepted_report()
+        report[section][field] = value
+        assert _validation_errors(report), f"{section}.{field}"
+
+
+def test_manual_status_boolean_input_is_not_allowed() -> None:
+    report = _accepted_report()
+    report["status_gates"] = {
+        "slsa_vsa_present": True
+    }
+
+    errors = _validation_errors(report)
+
+    assert errors
+
+
+def test_release_required_activation_fields_are_not_allowed() -> None:
+    for field in [
+        "required",
+        "core_required",
+        "release_required",
+        "prod_required",
+        "stage_required",
+        "blocking",
+        "release_blocking",
+        "gate_materialization",
+    ]:
+        report = _accepted_report()
+        report[field] = ["slsa_vsa_present"]
+        assert _validation_errors(report), field
+
+
+def test_nested_extra_properties_are_rejected() -> None:
+    sections = [
+        "producer",
+        "run_binding",
+        "artifact_binding",
+        "policy_binding",
+        "verifier_binding",
+        "evidence",
+        "freshness",
+    ]
+
+    for section in sections:
+        report = _accepted_report()
+        report[section]["extra"] = "not allowed"
+        assert _validation_errors(report), section
+
+
+def test_rejected_report_allows_missing_evidence_digest() -> None:
+    report = _rejected_report("missing_vsa_evidence")
+    report["evidence"]["evidence_path"] = None
+    report["evidence"]["evidence_sha256"] = None
+    report["evidence"]["evidence_schema_version"] = None
+    report["evidence"]["evidence_type"] = None
+    report["evidence"]["time_verified"] = None
+    report["evidence"]["verification_result"] = None
+    report["evidence"]["evidence_verified_levels"] = None
+    report["evidence"]["verified_level_ok"] = False
+    report["freshness"]["freshness_result"] = "rejected_missing_vsa_evidence"
+    report["freshness"]["current_run_binding_ok"] = False
+
+    _validate(report)
+
+
+def test_rejected_report_allows_unreadable_evidence_digest_absence() -> None:
+    report = _rejected_report("unreadable_vsa_evidence")
+    report["evidence"]["evidence_sha256"] = None
+    report["evidence"]["time_verified"] = None
+    report["freshness"]["freshness_result"] = "rejected_unreadable_vsa_evidence"
+    report["freshness"]["current_run_binding_ok"] = False
+
+    _validate(report)
+
+
+def test_rejected_stale_report_shape_validates_when_failed_checks_exist() -> None:
+    report = _rejected_report("stale_vsa_evidence")
+    report["freshness"]["freshness_result"] = "rejected_stale_vsa"
+    report["freshness"]["stale_vsa_evidence"] = True
+
+    _validate(report)
+
+
+def test_rejected_policy_digest_mismatch_report_shape_validates_when_failed_checks_exist() -> None:
+    report = _rejected_report("policy_digest_mismatch")
+    report["policy_binding"]["policy_digest_matches"] = False
+
+    _validate(report)
+
+
+def test_rejected_policy_identity_absent_report_shape_validates_when_failed_checks_exist() -> None:
+    report = _rejected_report("missing_evidence_policy_identity")
+    report["policy_binding"]["evidence_policy_id"] = None
+    report["policy_binding"]["policy_identity_matches"] = False
+
+    _validate(report)
+
+
+def test_example_has_no_release_required_activation_surface() -> None:
+    report = _accepted_report()
+    forbidden = {
+        "required",
+        "core_required",
+        "release_required",
+        "prod_required",
+        "stage_required",
+        "blocking",
+        "release_blocking",
+        "gate_materialization",
+        "status_gates",
+    }
+
+    assert forbidden.isdisjoint(report.keys())
+
+
+def check_slsa_vsa_trusted_evidence_producer_report_schema_v0() -> None:
+    test_schema_and_example_exist()
+    test_example_validates()
+    test_schema_version_and_report_type_are_locked()
+    test_created_utc_requires_date_time()
+    test_candidate_set_and_recorded_signal_mode_are_locked()
+    test_ok_true_requires_accepted_decision_and_no_failed_checks()
+    test_rejected_report_requires_failed_checks()
+    test_release_authority_words_are_not_producer_decisions()
+    test_policy_digest_binding_is_required()
+    test_evidence_policy_identity_is_required()
+    test_policy_uri_only_binding_is_rejected()
+    test_policy_digest_mismatch_cannot_be_accepted()
+    test_policy_identity_mismatch_cannot_be_accepted()
+    test_time_verified_requires_date_time()
+    test_stale_vsa_evidence_cannot_be_accepted()
+    test_previous_run_artifact_reuse_cannot_be_accepted()
+    test_time_verified_current_run_mismatch_cannot_be_accepted()
+    test_artifact_binding_mismatches_cannot_be_accepted()
+    test_unknown_verifier_cannot_be_accepted()
+    test_failed_vsa_verification_result_cannot_be_accepted()
+    test_missing_verified_level_cannot_be_accepted()
+    test_required_sha_fields_use_expected_lengths()
+    test_manual_status_boolean_input_is_not_allowed()
+    test_release_required_activation_fields_are_not_allowed()
+    test_nested_extra_properties_are_rejected()
+    test_rejected_report_allows_missing_evidence_digest()
+    test_rejected_report_allows_unreadable_evidence_digest_absence()
+    test_rejected_stale_report_shape_validates_when_failed_checks_exist()
+    test_rejected_policy_digest_mismatch_report_shape_validates_when_failed_checks_exist()
+    test_rejected_policy_identity_absent_report_shape_validates_when_failed_checks_exist()
+    test_example_has_no_release_required_activation_surface()
+
+
+def test_slsa_vsa_trusted_evidence_producer_report_schema_v0() -> None:
+    check_slsa_vsa_trusted_evidence_producer_report_schema_v0()
+
+
+if __name__ == "__main__":
+    check_slsa_vsa_trusted_evidence_producer_report_schema_v0()
+    print("OK: SLSA VSA trusted evidence producer report schema passed")


### PR DESCRIPTION
## Summary

This PR adds the SLSA VSA trusted evidence producer report contract.

New files:

```text
schemas/slsa_vsa_trusted_evidence_producer_report_v0.schema.json
examples/slsa/slsa_vsa_trusted_evidence_producer_report_example_v0.json
tests/test_slsa_vsa_trusted_evidence_producer_report_schema_v0.py
```

Updated manifest:

```text
ci/tools-tests.list
```

## Why

The trusted evidence producer design has been documented, but there is not yet a machine-readable report contract.

This PR adds that contract before any producer implementation, CI wiring, or release-required promotion.

## Scope

This PR adds:

```text
schema
example
schema validation test
tools-tests manifest registration
```

## Contract coverage

The producer report contract records:

```text
producer identity
current-run binding
artifact binding
policy identity and policy digest binding
verifier trust boundary
evidence identity and digest
freshness result
recorded_signal_only mode
candidate set identity
producer decision
fail-closed errors
warnings
```

## Non-goals

This PR does not modify:

```text
pulse_gate_policy_v0.yml
tools/policy_to_require_args.py
PULSE_safe_pack_v0/tools/check_gates.py
tools/ingest_slsa_vsa_evidence_v0.py
tools/fold_slsa_vsa_intake_into_status_v0.py
.github/workflows/
pulse_gate_registry_v0.yml
README.md
DOI / Zenodo / CITATION metadata
```

This PR does not implement the trusted evidence producer.

This PR does not change release-authority behavior.

This PR does not activate SLSA VSA as:

```text
required
core_required
release_required
prod_required
stage_required
blocking
release_blocking
```

## Validation

Expected validation:

```text
python -m py_compile tests/test_slsa_vsa_trusted_evidence_producer_report_schema_v0.py
python tests/test_slsa_vsa_trusted_evidence_producer_report_schema_v0.py
python -m pytest tests/test_slsa_vsa_trusted_evidence_producer_report_schema_v0.py
python tests/test_tools_tests_list_smoke.py
git diff --check
```

## Follow-up

Future PRs may add:

```text
trusted producer report validator/tool
trusted producer CI wiring
release-required promotion
```

Each remains separate.