### PR TITLE
feat(slsa): add vsa trusted producer report validator

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -105,6 +105,7 @@ tests/test_fold_slsa_vsa_intake_into_status_v0.py
 tests/test_slsa_vsa_advisory_policy_gates_v0.py
 tests/test_slsa_vsa_recorded_intake_candidate_v0.py
 tests/test_slsa_vsa_trusted_evidence_producer_report_schema_v0.py
+tests/test_check_slsa_vsa_trusted_evidence_producer_report_v0.py
 
 tools/operator_handoff_smoke.py
 

--- a/tests/test_check_slsa_vsa_trusted_evidence_producer_report_v0.py
+++ b/tests/test_check_slsa_vsa_trusted_evidence_producer_report_v0.py
@@ -18,6 +18,14 @@ EXAMPLE = ROOT / "examples" / "slsa" / "slsa_vsa_trusted_evidence_producer_repor
 EXPECTED_ARGS = [
     "--expect-producer-id",
     "pulse_slsa_vsa_trusted_evidence_producer_v0",
+    "--expect-producer-name",
+    "PULSE SLSA VSA trusted evidence producer",
+    "--expect-producer-version",
+    "0.1.0",
+    "--expect-producer-source",
+    "github-actions",
+    "--expect-ci-workflow-or-job-identity",
+    "PULSE CI / SLSA VSA trusted evidence producer",
     "--expect-current-run-id",
     "1234567890",
     "--expect-current-run-key",
@@ -36,6 +44,8 @@ EXPECTED_ARGS = [
     "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
     "--expect-verifier-id",
     "https://example.invalid/verifiers/pulsemech-vsa-verifier-v0",
+    "--expect-verified-level",
+    "SLSA_BUILD_LEVEL_3",
     "--expect-candidate-set",
     "slsa_vsa_recorded_intake_candidate",
 ]
@@ -46,7 +56,10 @@ def read_json(path: Path) -> dict[str, Any]:
 
 
 def write_json(path: Path, data: dict[str, Any]) -> None:
-    path.write_text(json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 
 
 def run_tool(
@@ -140,7 +153,7 @@ def test_wrong_policy_digest_fails_closed(tmp_path: Path) -> None:
     report_path = tmp_path / "wrong_policy_digest.json"
     write_json(report_path, report)
 
-    assert_failure(run_tool(report_path), "check_failed: policy_sha256_matches")
+    assert_failure(run_tool(report_path), "check_failed: evidence_policy_sha256_matches")
 
 
 def test_policy_digest_mismatch_flag_fails_closed(tmp_path: Path) -> None:
@@ -160,7 +173,111 @@ def test_wrong_evidence_policy_id_fails_closed(tmp_path: Path) -> None:
     report_path = tmp_path / "wrong_policy_id.json"
     write_json(report_path, report)
 
-    assert_failure(run_tool(report_path), "check_failed: policy_id_matches")
+    assert_failure(run_tool(report_path), "check_failed: evidence_policy_id_matches")
+
+
+def test_wrong_embedded_expected_policy_id_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["policy_binding"]["expected_policy_id"] = "wrong-policy-id"
+
+    report_path = tmp_path / "wrong_expected_policy_id.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "check_failed: expected_policy_id_matches")
+
+
+def test_wrong_embedded_expected_policy_sha256_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["policy_binding"]["expected_policy_sha256"] = "e" * 64
+
+    report_path = tmp_path / "wrong_expected_policy_sha256.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "check_failed: expected_policy_sha256_matches")
+
+
+def test_wrong_embedded_expected_verifier_id_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["verifier_binding"]["expected_verifier_id"] = "https://example.invalid/verifiers/wrong"
+
+    report_path = tmp_path / "wrong_expected_verifier_id.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "check_failed: expected_verifier_id_matches")
+
+
+def test_wrong_artifact_release_candidate_id_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["artifact_binding"]["release_candidate_id"] = "wrong-candidate"
+    report["artifact_binding"]["release_candidate_matches"] = True
+
+    report_path = tmp_path / "wrong_artifact_release_candidate.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "check_failed: artifact_release_candidate_id_matches")
+
+
+def test_wrong_artifact_digest_sha256_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["artifact_binding"]["artifact_digest_sha256"] = "e" * 64
+    report["artifact_binding"]["artifact_digest_matches"] = True
+
+    report_path = tmp_path / "wrong_artifact_digest.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "check_failed: artifact_digest_sha256_matches")
+
+
+def test_wrong_producer_name_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["producer"]["producer_name"] = "Wrong producer"
+
+    report_path = tmp_path / "wrong_producer_name.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "check_failed: producer_name_matches")
+
+
+def test_wrong_producer_version_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["producer"]["producer_version"] = "9.9.9"
+
+    report_path = tmp_path / "wrong_producer_version.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "check_failed: producer_version_matches")
+
+
+def test_wrong_producer_source_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["producer"]["producer_source"] = "manual-local"
+
+    report_path = tmp_path / "wrong_producer_source.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "check_failed: producer_source_matches")
+
+
+def test_wrong_producer_ci_identity_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["producer"]["ci_workflow_or_job_identity"] = "Wrong CI / job"
+
+    report_path = tmp_path / "wrong_producer_ci_identity.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "check_failed: producer_ci_identity_matches")
+
+
+def test_weaker_verified_level_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["evidence"]["expected_verified_level"] = "SLSA_BUILD_LEVEL_1"
+    report["evidence"]["evidence_verified_levels"] = ["SLSA_BUILD_LEVEL_1"]
+    report["evidence"]["verified_level_ok"] = True
+
+    report_path = tmp_path / "weaker_verified_level.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "check_failed: expected_verified_level_matches")
 
 
 def test_stale_vsa_evidence_fails_closed(tmp_path: Path) -> None:
@@ -237,7 +354,8 @@ def test_expectation_mismatch_fails_closed() -> None:
 
     diagnostic = parse_diagnostic(result)
     assert diagnostic["ok"] is False
-    assert "check_failed: policy_sha256_matches" in diagnostic["errors"]
+    assert "check_failed: expected_policy_sha256_matches" in diagnostic["errors"]
+    assert "check_failed: evidence_policy_sha256_matches" in diagnostic["errors"]
 
 
 def test_missing_report_file_returns_read_error(tmp_path: Path) -> None:
@@ -292,6 +410,16 @@ def check_check_slsa_vsa_trusted_evidence_producer_report_v0() -> None:
         test_wrong_policy_digest_fails_closed(tmp_path)
         test_policy_digest_mismatch_flag_fails_closed(tmp_path)
         test_wrong_evidence_policy_id_fails_closed(tmp_path)
+        test_wrong_embedded_expected_policy_id_fails_closed(tmp_path)
+        test_wrong_embedded_expected_policy_sha256_fails_closed(tmp_path)
+        test_wrong_embedded_expected_verifier_id_fails_closed(tmp_path)
+        test_wrong_artifact_release_candidate_id_fails_closed(tmp_path)
+        test_wrong_artifact_digest_sha256_fails_closed(tmp_path)
+        test_wrong_producer_name_fails_closed(tmp_path)
+        test_wrong_producer_version_fails_closed(tmp_path)
+        test_wrong_producer_source_fails_closed(tmp_path)
+        test_wrong_producer_ci_identity_fails_closed(tmp_path)
+        test_weaker_verified_level_fails_closed(tmp_path)
         test_stale_vsa_evidence_fails_closed(tmp_path)
         test_previous_run_artifact_reuse_fails_closed(tmp_path)
         test_time_verified_current_run_mismatch_fails_closed(tmp_path)

--- a/tests/test_check_slsa_vsa_trusted_evidence_producer_report_v0.py
+++ b/tests/test_check_slsa_vsa_trusted_evidence_producer_report_v0.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+TOOL = ROOT / "tools" / "check_slsa_vsa_trusted_evidence_producer_report_v0.py"
+SCHEMA = ROOT / "schemas" / "slsa_vsa_trusted_evidence_producer_report_v0.schema.json"
+EXAMPLE = ROOT / "examples" / "slsa" / "slsa_vsa_trusted_evidence_producer_report_example_v0.json"
+
+EXPECTED_ARGS = [
+    "--expect-producer-id",
+    "pulse_slsa_vsa_trusted_evidence_producer_v0",
+    "--expect-current-run-id",
+    "1234567890",
+    "--expect-current-run-key",
+    "GITHUB_RUN_ID=1234567890|GITHUB_RUN_NUMBER=2692|GITHUB_RUN_ATTEMPT=1|GITHUB_WORKFLOW=PULSE CI",
+    "--expect-commit-sha",
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "--expect-release-candidate-id",
+    "pulse-release-gates-0.1-candidate-v0",
+    "--expect-artifact-subject-name",
+    "git+https://github.com/HKati/pulse-release-gates-0.1@refs/heads/main",
+    "--expect-artifact-sha256",
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "--expect-policy-id",
+    "pulse-gate-policy-v0",
+    "--expect-policy-sha256",
+    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "--expect-verifier-id",
+    "https://example.invalid/verifiers/pulsemech-vsa-verifier-v0",
+    "--expect-candidate-set",
+    "slsa_vsa_recorded_intake_candidate",
+]
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def run_tool(
+    report_path: Path = EXAMPLE,
+    extra: list[str] | None = None,
+    omit_expected: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        sys.executable,
+        str(TOOL),
+        "--schema",
+        str(SCHEMA),
+        "--report",
+        str(report_path),
+    ]
+
+    if not omit_expected:
+        cmd.extend(EXPECTED_ARGS)
+
+    if extra:
+        cmd.extend(extra)
+
+    return subprocess.run(
+        cmd,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def parse_diagnostic(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    assert result.stdout, result.stderr
+    return json.loads(result.stdout)
+
+
+def assert_failure(
+    result: subprocess.CompletedProcess[str],
+    expected_fragment: str,
+) -> dict[str, Any]:
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+
+    diagnostic = parse_diagnostic(result)
+    assert diagnostic["ok"] is False
+    assert any(expected_fragment in error for error in diagnostic["errors"]), diagnostic["errors"]
+    return diagnostic
+
+
+def test_valid_example_passes() -> None:
+    result = run_tool()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    diagnostic = parse_diagnostic(result)
+    assert diagnostic["tool"] == "check_slsa_vsa_trusted_evidence_producer_report_v0"
+    assert diagnostic["ok"] is True
+    assert diagnostic["schema_valid"] is True
+    assert diagnostic["errors"] == []
+    assert all(diagnostic["checks"].values())
+
+
+def test_output_report_matches_stdout(tmp_path: Path) -> None:
+    output = tmp_path / "diagnostic.json"
+    result = run_tool(extra=["--output", str(output)])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output.exists()
+    assert read_json(output) == parse_diagnostic(result)
+
+
+def test_rejected_report_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["ok"] = False
+    report["producer_decision"] = "TRUSTED_EVIDENCE_REJECTED"
+    report["failed_checks"] = ["stale_vsa_evidence"]
+    report["freshness"]["freshness_result"] = "rejected_stale_vsa"
+    report["freshness"]["stale_vsa_evidence"] = True
+
+    report_path = tmp_path / "rejected_report.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "check_failed: producer_report_ok")
+
+
+def test_wrong_policy_digest_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["policy_binding"]["evidence_policy_sha256"] = "e" * 64
+
+    report_path = tmp_path / "wrong_policy_digest.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "check_failed: policy_sha256_matches")
+
+
+def test_policy_digest_mismatch_flag_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["policy_binding"]["policy_digest_matches"] = False
+
+    report_path = tmp_path / "policy_digest_mismatch.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "check_failed: policy_digest_matches")
+
+
+def test_wrong_evidence_policy_id_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["policy_binding"]["evidence_policy_id"] = "wrong-policy-id"
+
+    report_path = tmp_path / "wrong_policy_id.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "check_failed: policy_id_matches")
+
+
+def test_stale_vsa_evidence_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["freshness"]["freshness_result"] = "rejected_stale_vsa"
+    report["freshness"]["stale_vsa_evidence"] = True
+
+    report_path = tmp_path / "stale_vsa.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "schema_error")
+
+
+def test_previous_run_artifact_reuse_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["freshness"]["freshness_result"] = "rejected_previous_run_artifact"
+    report["freshness"]["previous_run_artifact_reuse"] = True
+
+    report_path = tmp_path / "previous_run_artifact.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "schema_error")
+
+
+def test_time_verified_current_run_mismatch_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["freshness"]["freshness_result"] = "rejected_time_verified_current_run_mismatch"
+    report["freshness"]["time_verified_current_run_match"] = False
+
+    report_path = tmp_path / "time_verified_mismatch.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "schema_error")
+
+
+def test_missing_evidence_digest_rejected_report_fails_but_does_not_need_fake_digest(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["ok"] = False
+    report["producer_decision"] = "TRUSTED_EVIDENCE_REJECTED"
+    report["failed_checks"] = ["missing_vsa_evidence"]
+    report["evidence"]["evidence_path"] = None
+    report["evidence"]["evidence_sha256"] = None
+    report["evidence"]["evidence_schema_version"] = None
+    report["evidence"]["evidence_type"] = None
+    report["evidence"]["time_verified"] = None
+    report["evidence"]["verification_result"] = None
+    report["evidence"]["evidence_verified_levels"] = None
+    report["evidence"]["verified_level_ok"] = False
+    report["freshness"]["freshness_result"] = "rejected_missing_vsa_evidence"
+    report["freshness"]["current_run_binding_ok"] = False
+
+    report_path = tmp_path / "missing_evidence.json"
+    write_json(report_path, report)
+
+    diagnostic = assert_failure(run_tool(report_path), "check_failed: producer_report_ok")
+    assert diagnostic["schema_valid"] is True
+
+
+def test_schema_invalid_report_fails_closed(tmp_path: Path) -> None:
+    report = read_json(EXAMPLE)
+    report["created_utc"] = "unknown"
+
+    report_path = tmp_path / "schema_invalid.json"
+    write_json(report_path, report)
+
+    assert_failure(run_tool(report_path), "schema_error")
+
+
+def test_expectation_mismatch_fails_closed() -> None:
+    result = run_tool(extra=["--expect-policy-sha256", "e" * 64])
+
+    assert result.returncode != 0
+    assert "Traceback" not in result.stderr
+
+    diagnostic = parse_diagnostic(result)
+    assert diagnostic["ok"] is False
+    assert "check_failed: policy_sha256_matches" in diagnostic["errors"]
+
+
+def test_missing_report_file_returns_read_error(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.json"
+
+    result = run_tool(report_path=missing)
+
+    assert result.returncode == 2
+    diagnostic = parse_diagnostic(result)
+    assert diagnostic["ok"] is False
+    assert any("read_error:" in error for error in diagnostic["errors"])
+
+
+def test_refuses_to_write_status_json(tmp_path: Path) -> None:
+    status_path = tmp_path / "status.json"
+    result = run_tool(extra=["--output", str(status_path)])
+
+    assert result.returncode == 2
+    assert not status_path.exists()
+
+    diagnostic = parse_diagnostic(result)
+    assert diagnostic["ok"] is False
+    assert "refusing_to_write_status_json" in diagnostic["errors"]
+
+
+def test_tool_does_not_call_gate_checker() -> None:
+    source = TOOL.read_text(encoding="utf-8")
+    forbidden = "check_" + "gates"
+
+    assert forbidden not in source
+
+
+def test_tool_does_not_write_status_gates() -> None:
+    source = TOOL.read_text(encoding="utf-8")
+
+    assert "status_gates" not in source
+    assert "release_required" not in source
+    assert "gate_materialization" not in source
+
+
+def check_check_slsa_vsa_trusted_evidence_producer_report_v0() -> None:
+    assert TOOL.exists()
+    assert SCHEMA.exists()
+    assert EXAMPLE.exists()
+
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp_path = Path(raw_tmp)
+
+        test_valid_example_passes()
+        test_output_report_matches_stdout(tmp_path)
+        test_rejected_report_fails_closed(tmp_path)
+        test_wrong_policy_digest_fails_closed(tmp_path)
+        test_policy_digest_mismatch_flag_fails_closed(tmp_path)
+        test_wrong_evidence_policy_id_fails_closed(tmp_path)
+        test_stale_vsa_evidence_fails_closed(tmp_path)
+        test_previous_run_artifact_reuse_fails_closed(tmp_path)
+        test_time_verified_current_run_mismatch_fails_closed(tmp_path)
+        test_missing_evidence_digest_rejected_report_fails_but_does_not_need_fake_digest(tmp_path)
+        test_schema_invalid_report_fails_closed(tmp_path)
+        test_expectation_mismatch_fails_closed()
+        test_missing_report_file_returns_read_error(tmp_path)
+        test_refuses_to_write_status_json(tmp_path)
+        test_tool_does_not_call_gate_checker()
+        test_tool_does_not_write_status_gates()
+
+
+def test_check_slsa_vsa_trusted_evidence_producer_report_v0() -> None:
+    check_check_slsa_vsa_trusted_evidence_producer_report_v0()
+
+
+if __name__ == "__main__":
+    check_check_slsa_vsa_trusted_evidence_producer_report_v0()
+    print("OK: check_slsa_vsa_trusted_evidence_producer_report_v0 passed")

--- a/tools/check_slsa_vsa_trusted_evidence_producer_report_v0.py
+++ b/tools/check_slsa_vsa_trusted_evidence_producer_report_v0.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+
+TOOL_NAME = "check_slsa_vsa_trusted_evidence_producer_report_v0"
+SCHEMA_VERSION = "slsa_vsa_trusted_evidence_producer_report_v0"
+REPORT_TYPE = "slsa_vsa_trusted_evidence_producer_report"
+ACCEPTED_DECISION = "TRUSTED_EVIDENCE_ACCEPTED"
+CANDIDATE_SET = "slsa_vsa_recorded_intake_candidate"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate a SLSA VSA trusted evidence producer report."
+    )
+    parser.add_argument("--schema", required=True, help="Path to producer report schema")
+    parser.add_argument("--report", required=True, help="Path to producer report JSON")
+    parser.add_argument("--expect-producer-id", required=True)
+    parser.add_argument("--expect-current-run-id", required=True)
+    parser.add_argument("--expect-current-run-key", required=True)
+    parser.add_argument("--expect-commit-sha", required=True)
+    parser.add_argument("--expect-release-candidate-id", required=True)
+    parser.add_argument("--expect-artifact-subject-name", required=True)
+    parser.add_argument("--expect-artifact-sha256", required=True)
+    parser.add_argument("--expect-policy-id", required=True)
+    parser.add_argument("--expect-policy-sha256", required=True)
+    parser.add_argument("--expect-verifier-id", required=True)
+    parser.add_argument("--expect-candidate-set", default=CANDIDATE_SET)
+    parser.add_argument("--output", help="Optional path for deterministic diagnostic report")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def nested_get(data: Any, path: list[str]) -> Any:
+    cursor = data
+    for key in path:
+        if not isinstance(cursor, dict):
+            return None
+        cursor = cursor.get(key)
+    return cursor
+
+
+def make_diagnostic(*, ok: bool, schema_valid: bool, checks: dict[str, bool], errors: list[str]) -> dict[str, Any]:
+    return {
+        "tool": TOOL_NAME,
+        "ok": ok,
+        "schema_version": SCHEMA_VERSION,
+        "report_type": REPORT_TYPE,
+        "schema_valid": schema_valid,
+        "checks": checks,
+        "errors": errors,
+    }
+
+
+def emit_report(report: dict[str, Any], output: Path | None) -> None:
+    rendered = json.dumps(report, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+    sys.stdout.write(rendered)
+
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered, encoding="utf-8")
+
+
+def validation_errors(schema: dict[str, Any], report: Any) -> list[str]:
+    validator = jsonschema.Draft202012Validator(
+        schema,
+        format_checker=jsonschema.FormatChecker(),
+    )
+    return [
+        f"schema_error[{list(error.path)}]: {error.message}"
+        for error in sorted(validator.iter_errors(report), key=lambda err: list(err.path))
+    ]
+
+
+def build_checks(args: argparse.Namespace, report: dict[str, Any]) -> dict[str, bool]:
+    return {
+        "schema_version_ok": report.get("schema_version") == SCHEMA_VERSION,
+        "report_type_ok": report.get("report_type") == REPORT_TYPE,
+        "producer_report_ok": report.get("ok") is True,
+        "producer_decision_accepted": report.get("producer_decision") == ACCEPTED_DECISION,
+        "producer_id_matches": nested_get(report, ["producer", "producer_id"]) == args.expect_producer_id,
+        "current_run_id_matches": nested_get(report, ["run_binding", "current_run_id"]) == args.expect_current_run_id,
+        "current_run_key_matches": nested_get(report, ["run_binding", "current_run_key"]) == args.expect_current_run_key,
+        "commit_sha_matches": nested_get(report, ["run_binding", "commit_sha"]) == args.expect_commit_sha,
+        "release_candidate_matches": nested_get(report, ["run_binding", "release_candidate_id"]) == args.expect_release_candidate_id,
+        "artifact_subject_name_matches": nested_get(report, ["artifact_binding", "subject_name"]) == args.expect_artifact_subject_name,
+        "artifact_subject_sha256_matches": nested_get(report, ["artifact_binding", "subject_sha256"]) == args.expect_artifact_sha256,
+        "artifact_digest_matches": nested_get(report, ["artifact_binding", "artifact_digest_matches"]) is True,
+        "policy_id_matches": nested_get(report, ["policy_binding", "evidence_policy_id"]) == args.expect_policy_id,
+        "policy_sha256_matches": nested_get(report, ["policy_binding", "evidence_policy_sha256"]) == args.expect_policy_sha256,
+        "policy_identity_matches": nested_get(report, ["policy_binding", "policy_identity_matches"]) is True,
+        "policy_digest_matches": nested_get(report, ["policy_binding", "policy_digest_matches"]) is True,
+        "verifier_id_matches": nested_get(report, ["verifier_binding", "evidence_verifier_id"]) == args.expect_verifier_id,
+        "verifier_trusted": nested_get(report, ["verifier_binding", "verifier_trusted"]) is True,
+        "candidate_set_matches": report.get("candidate_set") == args.expect_candidate_set,
+        "recorded_signal_mode_ok": report.get("recorded_signal_mode") == "recorded_signal_only",
+        "freshness_current_run": nested_get(report, ["freshness", "freshness_result"]) == "fresh_current_run",
+        "not_stale_vsa_evidence": nested_get(report, ["freshness", "stale_vsa_evidence"]) is False,
+        "no_previous_run_artifact_reuse": nested_get(report, ["freshness", "previous_run_artifact_reuse"]) is False,
+        "time_verified_current_run_matches": nested_get(report, ["freshness", "time_verified_current_run_match"]) is True,
+        "current_run_binding_ok": nested_get(report, ["freshness", "current_run_binding_ok"]) is True,
+        "evidence_sha256_present": isinstance(nested_get(report, ["evidence", "evidence_sha256"]), str),
+        "evidence_time_verified_present": isinstance(nested_get(report, ["evidence", "time_verified"]), str),
+        "vsa_verification_passed": nested_get(report, ["evidence", "verification_result"]) == "PASSED",
+        "verified_level_ok": nested_get(report, ["evidence", "verified_level_ok"]) is True,
+        "no_failed_checks": report.get("failed_checks") == [],
+    }
+
+
+def build_report(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
+    try:
+        schema = load_json(Path(args.schema))
+        producer_report = load_json(Path(args.report))
+    except Exception as exc:
+        diagnostic = make_diagnostic(
+            ok=False,
+            schema_valid=False,
+            checks={},
+            errors=[f"read_error: {exc}"],
+        )
+        return diagnostic, 2
+
+    try:
+        jsonschema.Draft202012Validator.check_schema(schema)
+    except Exception as exc:
+        diagnostic = make_diagnostic(
+            ok=False,
+            schema_valid=False,
+            checks={},
+            errors=[f"schema_invalid: {exc}"],
+        )
+        return diagnostic, 2
+
+    errors = validation_errors(schema, producer_report)
+    schema_valid = not errors
+
+    if not isinstance(producer_report, dict):
+        diagnostic = make_diagnostic(
+            ok=False,
+            schema_valid=schema_valid,
+            checks={},
+            errors=errors + ["producer_report_not_object"],
+        )
+        return diagnostic, 1
+
+    checks = build_checks(args, producer_report)
+
+    for check_name, passed in checks.items():
+        if not passed:
+            errors.append(f"check_failed: {check_name}")
+
+    ok = schema_valid and not errors
+
+    diagnostic = make_diagnostic(
+        ok=ok,
+        schema_valid=schema_valid,
+        checks=checks,
+        errors=errors,
+    )
+
+    return diagnostic, 0 if ok else 1
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output) if args.output else None
+
+    if output is not None and output.name == "status.json":
+        report = make_diagnostic(
+            ok=False,
+            schema_valid=False,
+            checks={},
+            errors=["refusing_to_write_status_json"],
+        )
+        emit_report(report, None)
+        return 2
+
+    report, exit_code = build_report(args)
+    emit_report(report, output)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_slsa_vsa_trusted_evidence_producer_report_v0.py
+++ b/tools/check_slsa_vsa_trusted_evidence_producer_report_v0.py
@@ -23,16 +23,27 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--schema", required=True, help="Path to producer report schema")
     parser.add_argument("--report", required=True, help="Path to producer report JSON")
+
     parser.add_argument("--expect-producer-id", required=True)
+    parser.add_argument("--expect-producer-name", required=True)
+    parser.add_argument("--expect-producer-version", required=True)
+    parser.add_argument("--expect-producer-source", required=True)
+    parser.add_argument("--expect-ci-workflow-or-job-identity", required=True)
+
     parser.add_argument("--expect-current-run-id", required=True)
     parser.add_argument("--expect-current-run-key", required=True)
     parser.add_argument("--expect-commit-sha", required=True)
     parser.add_argument("--expect-release-candidate-id", required=True)
+
     parser.add_argument("--expect-artifact-subject-name", required=True)
     parser.add_argument("--expect-artifact-sha256", required=True)
+
     parser.add_argument("--expect-policy-id", required=True)
     parser.add_argument("--expect-policy-sha256", required=True)
+
     parser.add_argument("--expect-verifier-id", required=True)
+    parser.add_argument("--expect-verified-level", required=True)
+
     parser.add_argument("--expect-candidate-set", default=CANDIDATE_SET)
     parser.add_argument("--output", help="Optional path for deterministic diagnostic report")
     return parser.parse_args()
@@ -51,7 +62,13 @@ def nested_get(data: Any, path: list[str]) -> Any:
     return cursor
 
 
-def make_diagnostic(*, ok: bool, schema_valid: bool, checks: dict[str, bool], errors: list[str]) -> dict[str, Any]:
+def make_diagnostic(
+    *,
+    ok: bool,
+    schema_valid: bool,
+    checks: dict[str, bool],
+    errors: list[str],
+) -> dict[str, Any]:
     return {
         "tool": TOOL_NAME,
         "ok": ok,
@@ -83,37 +100,126 @@ def validation_errors(schema: dict[str, Any], report: Any) -> list[str]:
     ]
 
 
+def _verified_level_list_contains(report: dict[str, Any], expected_level: str) -> bool:
+    levels = nested_get(report, ["evidence", "evidence_verified_levels"])
+    return isinstance(levels, list) and expected_level in levels
+
+
 def build_checks(args: argparse.Namespace, report: dict[str, Any]) -> dict[str, bool]:
+    expected_policy_uri = nested_get(report, ["policy_binding", "expected_policy_uri"])
+    evidence_policy_uri = nested_get(report, ["policy_binding", "evidence_policy_uri"])
+
     return {
         "schema_version_ok": report.get("schema_version") == SCHEMA_VERSION,
         "report_type_ok": report.get("report_type") == REPORT_TYPE,
         "producer_report_ok": report.get("ok") is True,
         "producer_decision_accepted": report.get("producer_decision") == ACCEPTED_DECISION,
+
         "producer_id_matches": nested_get(report, ["producer", "producer_id"]) == args.expect_producer_id,
+        "producer_name_matches": nested_get(report, ["producer", "producer_name"]) == args.expect_producer_name,
+        "producer_version_matches": nested_get(report, ["producer", "producer_version"]) == args.expect_producer_version,
+        "producer_source_matches": nested_get(report, ["producer", "producer_source"]) == args.expect_producer_source,
+        "producer_ci_identity_matches": (
+            nested_get(report, ["producer", "ci_workflow_or_job_identity"])
+            == args.expect_ci_workflow_or_job_identity
+        ),
+
         "current_run_id_matches": nested_get(report, ["run_binding", "current_run_id"]) == args.expect_current_run_id,
         "current_run_key_matches": nested_get(report, ["run_binding", "current_run_key"]) == args.expect_current_run_key,
         "commit_sha_matches": nested_get(report, ["run_binding", "commit_sha"]) == args.expect_commit_sha,
-        "release_candidate_matches": nested_get(report, ["run_binding", "release_candidate_id"]) == args.expect_release_candidate_id,
-        "artifact_subject_name_matches": nested_get(report, ["artifact_binding", "subject_name"]) == args.expect_artifact_subject_name,
-        "artifact_subject_sha256_matches": nested_get(report, ["artifact_binding", "subject_sha256"]) == args.expect_artifact_sha256,
-        "artifact_digest_matches": nested_get(report, ["artifact_binding", "artifact_digest_matches"]) is True,
-        "policy_id_matches": nested_get(report, ["policy_binding", "evidence_policy_id"]) == args.expect_policy_id,
-        "policy_sha256_matches": nested_get(report, ["policy_binding", "evidence_policy_sha256"]) == args.expect_policy_sha256,
-        "policy_identity_matches": nested_get(report, ["policy_binding", "policy_identity_matches"]) is True,
-        "policy_digest_matches": nested_get(report, ["policy_binding", "policy_digest_matches"]) is True,
-        "verifier_id_matches": nested_get(report, ["verifier_binding", "evidence_verifier_id"]) == args.expect_verifier_id,
+        "run_release_candidate_matches": (
+            nested_get(report, ["run_binding", "release_candidate_id"])
+            == args.expect_release_candidate_id
+        ),
+
+        "artifact_subject_name_matches": (
+            nested_get(report, ["artifact_binding", "subject_name"])
+            == args.expect_artifact_subject_name
+        ),
+        "artifact_subject_sha256_matches": (
+            nested_get(report, ["artifact_binding", "subject_sha256"])
+            == args.expect_artifact_sha256
+        ),
+        "artifact_release_candidate_id_matches": (
+            nested_get(report, ["artifact_binding", "release_candidate_id"])
+            == args.expect_release_candidate_id
+        ),
+        "artifact_digest_sha256_matches": (
+            nested_get(report, ["artifact_binding", "artifact_digest_sha256"])
+            == args.expect_artifact_sha256
+        ),
+        "artifact_subject_digest_flag_matches": (
+            nested_get(report, ["artifact_binding", "subject_digest_matches"]) is True
+        ),
+        "artifact_resource_uri_flag_matches": (
+            nested_get(report, ["artifact_binding", "resource_uri_matches"]) is True
+        ),
+        "artifact_release_candidate_flag_matches": (
+            nested_get(report, ["artifact_binding", "release_candidate_matches"]) is True
+        ),
+        "artifact_digest_flag_matches": (
+            nested_get(report, ["artifact_binding", "artifact_digest_matches"]) is True
+        ),
+
+        "expected_policy_id_matches": (
+            nested_get(report, ["policy_binding", "expected_policy_id"])
+            == args.expect_policy_id
+        ),
+        "expected_policy_sha256_matches": (
+            nested_get(report, ["policy_binding", "expected_policy_sha256"])
+            == args.expect_policy_sha256
+        ),
+        "evidence_policy_id_matches": (
+            nested_get(report, ["policy_binding", "evidence_policy_id"])
+            == args.expect_policy_id
+        ),
+        "evidence_policy_sha256_matches": (
+            nested_get(report, ["policy_binding", "evidence_policy_sha256"])
+            == args.expect_policy_sha256
+        ),
+        "policy_uri_self_consistent": (
+            isinstance(expected_policy_uri, str)
+            and isinstance(evidence_policy_uri, str)
+            and expected_policy_uri == evidence_policy_uri
+        ),
+        "policy_identity_matches": (
+            nested_get(report, ["policy_binding", "policy_identity_matches"]) is True
+        ),
+        "policy_digest_matches": (
+            nested_get(report, ["policy_binding", "policy_digest_matches"]) is True
+        ),
+
+        "expected_verifier_id_matches": (
+            nested_get(report, ["verifier_binding", "expected_verifier_id"])
+            == args.expect_verifier_id
+        ),
+        "evidence_verifier_id_matches": (
+            nested_get(report, ["verifier_binding", "evidence_verifier_id"])
+            == args.expect_verifier_id
+        ),
         "verifier_trusted": nested_get(report, ["verifier_binding", "verifier_trusted"]) is True,
+
         "candidate_set_matches": report.get("candidate_set") == args.expect_candidate_set,
         "recorded_signal_mode_ok": report.get("recorded_signal_mode") == "recorded_signal_only",
+
         "freshness_current_run": nested_get(report, ["freshness", "freshness_result"]) == "fresh_current_run",
         "not_stale_vsa_evidence": nested_get(report, ["freshness", "stale_vsa_evidence"]) is False,
         "no_previous_run_artifact_reuse": nested_get(report, ["freshness", "previous_run_artifact_reuse"]) is False,
-        "time_verified_current_run_matches": nested_get(report, ["freshness", "time_verified_current_run_match"]) is True,
+        "time_verified_current_run_matches": (
+            nested_get(report, ["freshness", "time_verified_current_run_match"]) is True
+        ),
         "current_run_binding_ok": nested_get(report, ["freshness", "current_run_binding_ok"]) is True,
+
         "evidence_sha256_present": isinstance(nested_get(report, ["evidence", "evidence_sha256"]), str),
         "evidence_time_verified_present": isinstance(nested_get(report, ["evidence", "time_verified"]), str),
         "vsa_verification_passed": nested_get(report, ["evidence", "verification_result"]) == "PASSED",
+        "expected_verified_level_matches": (
+            nested_get(report, ["evidence", "expected_verified_level"])
+            == args.expect_verified_level
+        ),
+        "expected_verified_level_listed": _verified_level_list_contains(report, args.expect_verified_level),
         "verified_level_ok": nested_get(report, ["evidence", "verified_level_ok"]) is True,
+
         "no_failed_checks": report.get("failed_checks") == [],
     }
 


### PR DESCRIPTION
## Summary

This PR adds a validator for the SLSA VSA trusted evidence producer report contract.

New files:

```text
tools/check_slsa_vsa_trusted_evidence_producer_report_v0.py
tests/test_check_slsa_vsa_trusted_evidence_producer_report_v0.py
```

Updated manifest:

```text
ci/tools-tests.list
```

## Why

The trusted producer report contract now exists as schema + example + schema test.

This PR adds the next narrow layer: a validator that checks a report against the schema and explicit expected bindings.

This is still not a producer implementation and not release-required activation.

## Scope

The validator checks:

```text
schema validity
producer identity
current-run identity
current-run key
commit SHA
release candidate ID
artifact subject name
artifact subject digest
policy identity
policy digest
verifier identity
candidate set
accepted producer decision
fresh current-run evidence
```

It emits a deterministic diagnostic report.

## Non-goals

This PR does not modify:

```text
pulse_gate_policy_v0.yml
tools/policy_to_require_args.py
PULSE_safe_pack_v0/tools/check_gates.py
tools/ingest_slsa_vsa_evidence_v0.py
tools/fold_slsa_vsa_intake_into_status_v0.py
.github/workflows/
pulse_gate_registry_v0.yml
README.md
DOI / Zenodo / CITATION metadata
```

This PR does not implement the trusted evidence producer.

This PR does not change release-authority behavior.

This PR does not activate SLSA VSA as:

```text
required
core_required
release_required
prod_required
stage_required
blocking
release_blocking
```

## Validation

Expected validation:

```text
python -m py_compile tools/check_slsa_vsa_trusted_evidence_producer_report_v0.py
python -m py_compile tests/test_check_slsa_vsa_trusted_evidence_producer_report_v0.py
python tests/test_check_slsa_vsa_trusted_evidence_producer_report_v0.py
python -m pytest tests/test_check_slsa_vsa_trusted_evidence_producer_report_v0.py
python tests/test_tools_tests_list_smoke.py
git diff --check
```

## Follow-up

Future PRs may add:

```text
trusted producer report builder
trusted producer CI wiring
release-required promotion
```

Each remains separate.