### PR TITLE
feat(slsa): build vsa trusted producer report

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -106,6 +106,7 @@ tests/test_slsa_vsa_advisory_policy_gates_v0.py
 tests/test_slsa_vsa_recorded_intake_candidate_v0.py
 tests/test_slsa_vsa_trusted_evidence_producer_report_schema_v0.py
 tests/test_check_slsa_vsa_trusted_evidence_producer_report_v0.py
+tests/test_build_slsa_vsa_trusted_evidence_producer_report_v0.py
 
 tools/operator_handoff_smoke.py
 

--- a/tests/test_build_slsa_vsa_trusted_evidence_producer_report_v0.py
+++ b/tests/test_build_slsa_vsa_trusted_evidence_producer_report_v0.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+TOOL = ROOT / "tools" / "build_slsa_vsa_trusted_evidence_producer_report_v0.py"
+CHECKER = ROOT / "tools" / "check_slsa_vsa_trusted_evidence_producer_report_v0.py"
+REPORT_SCHEMA = ROOT / "schemas" / "slsa_vsa_trusted_evidence_producer_report_v0.schema.json"
+EVIDENCE_EXAMPLE = ROOT / "examples" / "slsa" / "slsa_vsa_evidence_example_v0.json"
+
+SUBJECT_NAME = "git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0"
+SUBJECT_SHA256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+POLICY_URI = "https://example.invalid/policies/pulse-slsa-vsa-policy-v0.json"
+POLICY_SHA256 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+VERIFIER_ID = "https://example.invalid/verifiers/pulsemech-vsa-verifier-v0"
+VERIFIED_LEVEL = "SLSA_BUILD_LEVEL_3"
+
+BUILDER_ARGS = {
+    "--created-utc": "2026-07-07T00:00:00Z",
+    "--producer-id": "pulse_slsa_vsa_trusted_evidence_producer_v0",
+    "--producer-name": "PULSE SLSA VSA trusted evidence producer",
+    "--producer-version": "0.1.0",
+    "--producer-source": "github-actions",
+    "--ci-workflow-or-job-identity": "PULSE CI / SLSA VSA trusted evidence producer",
+    "--current-run-id": "1234567890",
+    "--current-run-number": "2692",
+    "--current-run-attempt": "1",
+    "--workflow-name": "PULSE CI",
+    "--job-name": "slsa-vsa-trusted-evidence-producer",
+    "--commit-sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "--release-candidate-id": "pulse-release-gates-0.1-candidate-v0",
+    "--artifact-subject-name": SUBJECT_NAME,
+    "--artifact-sha256": SUBJECT_SHA256,
+    "--artifact-resource-uri": SUBJECT_NAME,
+    "--policy-id": "pulse-gate-policy-v0",
+    "--policy-uri": POLICY_URI,
+    "--policy-sha256": POLICY_SHA256,
+    "--verifier-id": VERIFIER_ID,
+    "--expected-verified-level": VERIFIED_LEVEL,
+    "--expect-time-verified": "2026-07-04T00:00:00Z",
+}
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def expected_current_run_key() -> str:
+    return (
+        "GITHUB_RUN_ID=1234567890"
+        "|GITHUB_RUN_NUMBER=2692"
+        "|GITHUB_RUN_ATTEMPT=1"
+        "|GITHUB_WORKFLOW=PULSE CI"
+    )
+
+
+def build_args(
+    evidence: Path = EVIDENCE_EXAMPLE,
+    overrides: dict[str, str | None] | None = None,
+) -> list[str]:
+    values = dict(BUILDER_ARGS)
+    if overrides:
+        values.update(overrides)
+
+    args = [
+        sys.executable,
+        str(TOOL),
+        "--evidence",
+        str(evidence),
+    ]
+
+    for key in sorted(values):
+        value = values[key]
+        if value is not None:
+            args.extend([key, value])
+
+    return args
+
+
+def run_builder(
+    evidence: Path = EVIDENCE_EXAMPLE,
+    overrides: dict[str, str | None] | None = None,
+    extra: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    args = build_args(evidence=evidence, overrides=overrides)
+    if extra:
+        args.extend(extra)
+
+    return subprocess.run(
+        args,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def checker_args(report: Path) -> list[str]:
+    return [
+        sys.executable,
+        str(CHECKER),
+        "--schema",
+        str(REPORT_SCHEMA),
+        "--report",
+        str(report),
+        "--expect-producer-id",
+        "pulse_slsa_vsa_trusted_evidence_producer_v0",
+        "--expect-producer-name",
+        "PULSE SLSA VSA trusted evidence producer",
+        "--expect-producer-version",
+        "0.1.0",
+        "--expect-producer-source",
+        "github-actions",
+        "--expect-ci-workflow-or-job-identity",
+        "PULSE CI / SLSA VSA trusted evidence producer",
+        "--expect-current-run-id",
+        "1234567890",
+        "--expect-current-run-key",
+        expected_current_run_key(),
+        "--expect-commit-sha",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "--expect-release-candidate-id",
+        "pulse-release-gates-0.1-candidate-v0",
+        "--expect-artifact-subject-name",
+        SUBJECT_NAME,
+        "--expect-artifact-sha256",
+        SUBJECT_SHA256,
+        "--expect-policy-id",
+        "pulse-gate-policy-v0",
+        "--expect-policy-sha256",
+        POLICY_SHA256,
+        "--expect-verifier-id",
+        VERIFIER_ID,
+        "--expect-verified-level",
+        VERIFIED_LEVEL,
+        "--expect-candidate-set",
+        "slsa_vsa_recorded_intake_candidate",
+    ]
+
+
+def run_checker(report: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        checker_args(report),
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def parse_report(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    assert result.stdout, result.stderr
+    return json.loads(result.stdout)
+
+
+def report_schema_validator() -> jsonschema.Draft202012Validator:
+    schema = read_json(REPORT_SCHEMA)
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(
+        schema,
+        format_checker=jsonschema.FormatChecker(),
+    )
+
+
+def assert_report_schema_valid(report: dict[str, Any]) -> None:
+    validator = report_schema_validator()
+    errors = sorted(
+        validator.iter_errors(report),
+        key=lambda error: list(error.path),
+    )
+    assert not errors, [error.message for error in errors]
+
+
+def assert_rejected(
+    result: subprocess.CompletedProcess[str],
+    expected_check: str,
+) -> dict[str, Any]:
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+
+    report = parse_report(result)
+    assert_report_schema_valid(report)
+
+    assert report["ok"] is False
+    assert report["producer_decision"] == "TRUSTED_EVIDENCE_REJECTED"
+    assert expected_check in report["failed_checks"], report["failed_checks"]
+    assert report["failed_checks"]
+
+    return report
+
+
+def mutated_evidence(tmp_dir: Path, name: str, patch: dict[str, Any]) -> Path:
+    evidence = read_json(EVIDENCE_EXAMPLE)
+
+    for dotted_path, value in patch.items():
+        cursor: Any = evidence
+        parts = dotted_path.split(".")
+        for part in parts[:-1]:
+            cursor = cursor[part]
+        cursor[parts[-1]] = value
+
+    path = tmp_dir / name
+    write_json(path, evidence)
+    return path
+
+
+def check_valid_evidence_builds_accepted_producer_report() -> None:
+    result = run_builder()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+
+    report = parse_report(result)
+    assert_report_schema_valid(report)
+
+    assert report["schema_version"] == "slsa_vsa_trusted_evidence_producer_report_v0"
+    assert report["report_type"] == "slsa_vsa_trusted_evidence_producer_report"
+    assert report["ok"] is True
+    assert report["producer_decision"] == "TRUSTED_EVIDENCE_ACCEPTED"
+    assert report["failed_checks"] == []
+    assert report["candidate_set"] == "slsa_vsa_recorded_intake_candidate"
+    assert report["recorded_signal_mode"] == "recorded_signal_only"
+    assert report["run_binding"]["current_run_key"] == expected_current_run_key()
+    assert report["freshness"]["freshness_result"] == "fresh_current_run"
+
+
+def check_accepted_report_passes_report_validator(tmp_dir: Path) -> None:
+    output = tmp_dir / "producer_report.json"
+    result = run_builder(extra=["--output", str(output)])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output.exists()
+
+    checker_result = run_checker(output)
+
+    assert checker_result.returncode == 0, checker_result.stdout + checker_result.stderr
+
+
+def check_output_report_matches_stdout(tmp_dir: Path) -> None:
+    output = tmp_dir / "producer_report.json"
+    result = run_builder(extra=["--output", str(output)])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output.exists()
+    assert read_json(output) == parse_report(result)
+
+
+def check_missing_evidence_returns_deterministic_rejected_report(tmp_dir: Path) -> None:
+    missing = tmp_dir / "missing_vsa.json"
+
+    first = run_builder(evidence=missing)
+    second = run_builder(evidence=missing)
+
+    first_report = assert_rejected(first, "evidence_readable")
+    second_report = assert_rejected(second, "evidence_readable")
+
+    assert first_report == second_report
+    assert first_report["freshness"]["freshness_result"] == "rejected_missing_vsa_evidence"
+    assert first_report["evidence"]["evidence_path"] is None
+    assert first_report["evidence"]["evidence_sha256"] is None
+
+
+def check_wrong_artifact_digest_rejects() -> None:
+    report = assert_rejected(
+        run_builder(overrides={"--artifact-sha256": "d" * 64}),
+        "subject_sha256_matches",
+    )
+
+    assert "artifact_digest_matches" in report["failed_checks"]
+
+
+def check_wrong_artifact_subject_rejects() -> None:
+    assert_rejected(
+        run_builder(overrides={"--artifact-subject-name": "git+https://example.invalid/wrong@refs/tags/v0"}),
+        "subject_name_matches",
+    )
+
+
+def check_wrong_resource_uri_rejects() -> None:
+    assert_rejected(
+        run_builder(overrides={"--artifact-resource-uri": "git+https://example.invalid/wrong@refs/tags/v0"}),
+        "resource_uri_matches",
+    )
+
+
+def check_wrong_policy_digest_rejects() -> None:
+    assert_rejected(
+        run_builder(overrides={"--policy-sha256": "e" * 64}),
+        "policy_digest_matches",
+    )
+
+
+def check_wrong_verifier_rejects() -> None:
+    assert_rejected(
+        run_builder(overrides={"--verifier-id": "https://example.invalid/verifiers/wrong"}),
+        "verifier_id_matches",
+    )
+
+
+def check_wrong_verified_level_rejects() -> None:
+    assert_rejected(
+        run_builder(overrides={"--expected-verified-level": "SLSA_BUILD_LEVEL_4"}),
+        "verified_level_ok",
+    )
+
+
+def check_failed_verification_result_rejects(tmp_dir: Path) -> None:
+    failed = mutated_evidence(
+        tmp_dir,
+        "failed_vsa.json",
+        {
+            "vsa.predicate.verificationResult": "FAILED",
+        },
+    )
+
+    assert_rejected(run_builder(evidence=failed), "verification_result_passed")
+
+
+def check_time_verified_current_run_mismatch_rejects() -> None:
+    report = assert_rejected(
+        run_builder(overrides={"--expect-time-verified": "2026-07-05T00:00:00Z"}),
+        "time_verified_current_run_match",
+    )
+
+    assert report["freshness"]["freshness_result"] == "rejected_time_verified_current_run_mismatch"
+
+
+def check_recorded_pulse_signal_mismatch_rejects(tmp_dir: Path) -> None:
+    mismatch = mutated_evidence(
+        tmp_dir,
+        "signal_mismatch.json",
+        {
+            "pulse_signals.slsa_vsa_policy_digest_matches": False,
+        },
+    )
+
+    assert_rejected(run_builder(evidence=mismatch), "pulse_signals_consistent")
+
+
+def check_status_output_is_refused(tmp_dir: Path) -> None:
+    status_path = tmp_dir / "status.json"
+    result = run_builder(extra=["--output", str(status_path)])
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+    assert not status_path.exists()
+
+    report = parse_report(result)
+    assert_report_schema_valid(report)
+    assert report["ok"] is False
+    assert report["producer_decision"] == "TRUSTED_EVIDENCE_REJECTED"
+    assert "refusing_to_write_status_json" in report["failed_checks"]
+
+
+def check_tool_does_not_call_gate_checker() -> None:
+    source = TOOL.read_text(encoding="utf-8")
+    forbidden = "check_" + "gates"
+
+    assert forbidden not in source
+
+
+def check_tool_does_not_write_status_gates_or_activate_release_sets() -> None:
+    source = TOOL.read_text(encoding="utf-8")
+    forbidden = [
+        "status_" + "gates",
+        "release_" + "required",
+        "release_" + "blocking",
+        "prod_" + "required",
+        "stage_" + "required",
+        "gate_" + "materialization",
+    ]
+
+    for marker in forbidden:
+        assert marker not in source, marker
+
+
+def check_build_slsa_vsa_trusted_evidence_producer_report_v0() -> None:
+    assert TOOL.exists()
+    assert CHECKER.exists()
+    assert REPORT_SCHEMA.exists()
+    assert EVIDENCE_EXAMPLE.exists()
+
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp_dir = Path(raw_tmp)
+
+        check_valid_evidence_builds_accepted_producer_report()
+        check_accepted_report_passes_report_validator(tmp_dir)
+        check_output_report_matches_stdout(tmp_dir)
+        check_missing_evidence_returns_deterministic_rejected_report(tmp_dir)
+        check_wrong_artifact_digest_rejects()
+        check_wrong_artifact_subject_rejects()
+        check_wrong_resource_uri_rejects()
+        check_wrong_policy_digest_rejects()
+        check_wrong_verifier_rejects()
+        check_wrong_verified_level_rejects()
+        check_failed_verification_result_rejects(tmp_dir)
+        check_time_verified_current_run_mismatch_rejects()
+        check_recorded_pulse_signal_mismatch_rejects(tmp_dir)
+        check_status_output_is_refused(tmp_dir)
+        check_tool_does_not_call_gate_checker()
+        check_tool_does_not_write_status_gates_or_activate_release_sets()
+
+
+def test_build_slsa_vsa_trusted_evidence_producer_report_v0() -> None:
+    check_build_slsa_vsa_trusted_evidence_producer_report_v0()
+
+
+if __name__ == "__main__":
+    check_build_slsa_vsa_trusted_evidence_producer_report_v0()
+    print("OK: build_slsa_vsa_trusted_evidence_producer_report_v0 smoke passed")

--- a/tools/build_slsa_vsa_trusted_evidence_producer_report_v0.py
+++ b/tools/build_slsa_vsa_trusted_evidence_producer_report_v0.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "slsa_vsa_trusted_evidence_producer_report_v0"
+REPORT_TYPE = "slsa_vsa_trusted_evidence_producer_report"
+ACCEPTED = "TRUSTED_EVIDENCE_ACCEPTED"
+REJECTED = "TRUSTED_EVIDENCE_REJECTED"
+RECORDED_MODE = "recorded_signal_only"
+CANDIDATE_SET = "slsa_vsa_recorded_intake_candidate"
+
+EVIDENCE_SCHEMA = "slsa_vsa_evidence_v0"
+EVIDENCE_TYPE = "slsa_vsa"
+IN_TOTO_V1 = "https://in-toto.io/Statement/v1"
+VSA_PREDICATE = "https://slsa.dev/verification_summary/v1"
+
+SHA256 = re.compile(r"^[0-9a-fA-F]{64}$")
+DATE_TIME = re.compile(
+    r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T"
+    r"[0-9]{2}:[0-9]{2}:[0-9]{2}"
+    r"(\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$"
+)
+
+REQUIRED_SIGNALS = [
+    "slsa_vsa_present",
+    "slsa_vsa_signature_ok",
+    "slsa_vsa_subject_matches_artifact",
+    "slsa_vsa_predicate_type_ok",
+    "slsa_vsa_verifier_trusted",
+    "slsa_vsa_resource_uri_matches",
+    "slsa_vsa_policy_digest_matches",
+    "slsa_vsa_result_passed",
+    "slsa_vsa_verified_level_ok",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Build a deterministic SLSA VSA trusted evidence producer report."
+    )
+    p.add_argument("--evidence", required=True)
+    p.add_argument("--created-utc", required=True)
+    p.add_argument("--producer-id", required=True)
+    p.add_argument("--producer-name", required=True)
+    p.add_argument("--producer-version", required=True)
+    p.add_argument("--producer-source", required=True)
+    p.add_argument("--ci-workflow-or-job-identity", required=True)
+    p.add_argument("--current-run-id", required=True)
+    p.add_argument("--current-run-number", required=True)
+    p.add_argument("--current-run-attempt", required=True)
+    p.add_argument("--workflow-name", required=True)
+    p.add_argument("--job-name", required=True)
+    p.add_argument("--commit-sha", required=True)
+    p.add_argument("--release-candidate-id", required=True)
+    p.add_argument("--artifact-subject-name", required=True)
+    p.add_argument("--artifact-sha256", required=True)
+    p.add_argument("--artifact-resource-uri", required=True)
+    p.add_argument("--policy-id", required=True)
+    p.add_argument("--policy-uri", required=True)
+    p.add_argument("--policy-sha256", required=True)
+    p.add_argument("--verifier-id", required=True)
+    p.add_argument("--expected-verified-level", required=True)
+    p.add_argument("--expect-time-verified", required=True)
+    p.add_argument("--output")
+    return p.parse_args()
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def is_sha256(value: Any) -> bool:
+    return isinstance(value, str) and SHA256.fullmatch(value) is not None
+
+
+def is_date_time(value: Any) -> bool:
+    return isinstance(value, str) and DATE_TIME.fullmatch(value) is not None
+
+
+def file_sha256(path: Path) -> str | None:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except Exception:
+        return None
+
+
+def digest_sha256(value: Any) -> str | None:
+    if isinstance(value, dict) and is_sha256(value.get("sha256")):
+        return value["sha256"]
+    return None
+
+
+def get(data: Any, *path: str) -> Any:
+    cur = data
+    for key in path:
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(key)
+    return cur
+
+
+def run_key(a: argparse.Namespace) -> str:
+    return (
+        f"GITHUB_RUN_ID={a.current_run_id}"
+        f"|GITHUB_RUN_NUMBER={a.current_run_number}"
+        f"|GITHUB_RUN_ATTEMPT={a.current_run_attempt}"
+        f"|GITHUB_WORKFLOW={a.workflow_name}"
+    )
+
+
+def first_subject(subjects: Any) -> dict[str, Any]:
+    if isinstance(subjects, list):
+        for subject in subjects:
+            if isinstance(subject, dict):
+                return subject
+    return {}
+
+
+def subject_named(subjects: Any, name: str) -> dict[str, Any]:
+    if isinstance(subjects, list):
+        for subject in subjects:
+            if isinstance(subject, dict) and subject.get("name") == name:
+                return subject
+    return {}
+
+
+def string_list(value: Any) -> list[str] | None:
+    if isinstance(value, list) and all(isinstance(item, str) and item for item in value):
+        return value
+    return None
+
+
+def signals_present(signals: Any) -> bool:
+    return isinstance(signals, dict) and all(name in signals for name in REQUIRED_SIGNALS)
+
+
+def signals_boolean(signals: Any) -> bool:
+    return isinstance(signals, dict) and all(isinstance(signals.get(name), bool) for name in REQUIRED_SIGNALS)
+
+
+def signals_match(signals: Any, expected: dict[str, bool]) -> bool:
+    if not isinstance(signals, dict):
+        return False
+    return all(signals.get(name) is value for name, value in expected.items())
+
+
+def evidence_parts(evidence: dict[str, Any] | None) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any], Any]:
+    vsa = evidence.get("vsa") if isinstance(evidence, dict) else None
+    vsa = vsa if isinstance(vsa, dict) else {}
+    predicate = vsa.get("predicate")
+    predicate = predicate if isinstance(predicate, dict) else {}
+    policy = predicate.get("policy")
+    policy = policy if isinstance(policy, dict) else {}
+    verifier = predicate.get("verifier")
+    verifier = verifier if isinstance(verifier, dict) else {}
+    return vsa, predicate, policy, verifier, evidence.get("pulse_signals") if isinstance(evidence, dict) else None
+
+
+def build_checks(a: argparse.Namespace, evidence: dict[str, Any] | None, readable: bool) -> dict[str, bool]:
+    vsa, pred, policy, verifier, signals = evidence_parts(evidence)
+    subject = subject_named(vsa.get("subject"), a.artifact_subject_name)
+    subject_sha = digest_sha256(subject.get("digest")) if subject else None
+    subject_ok = bool(subject) and subject_sha == a.artifact_sha256
+    levels = pred.get("verifiedLevels")
+    policy_uri = policy.get("uri")
+    policy_sha = digest_sha256(policy.get("digest"))
+
+    checks = {
+        "evidence_readable": readable,
+        "schema_version_ok": get(evidence, "schema_version") == EVIDENCE_SCHEMA,
+        "evidence_type_ok": get(evidence, "evidence_type") == EVIDENCE_TYPE,
+        "in_toto_statement_ok": vsa.get("_type") == IN_TOTO_V1,
+        "predicate_type_ok": vsa.get("predicateType") == VSA_PREDICATE,
+        "verification_result_passed": pred.get("verificationResult") == "PASSED",
+        "subject_name_matches": bool(subject),
+        "subject_sha256_matches": subject_sha == a.artifact_sha256,
+        "resource_uri_matches": pred.get("resourceUri") == a.artifact_resource_uri,
+        "release_candidate_present": bool(a.release_candidate_id),
+        "artifact_digest_matches": subject_ok,
+        "policy_id_bound": bool(a.policy_id) and policy_uri == a.policy_uri,
+        "policy_uri_matches": policy_uri == a.policy_uri,
+        "policy_digest_matches": policy_sha == a.policy_sha256,
+        "verifier_id_matches": verifier.get("id") == a.verifier_id,
+        "verified_level_present": isinstance(levels, list) and bool(levels),
+        "verified_level_ok": isinstance(levels, list) and a.expected_verified_level in levels,
+        "time_verified_present": is_date_time(pred.get("timeVerified")),
+        "time_verified_current_run_match": pred.get("timeVerified") == a.expect_time_verified,
+        "pulse_signals_present": signals_present(signals),
+        "pulse_signals_literal_booleans": signals_boolean(signals),
+    }
+
+    expected_signals = {
+        "slsa_vsa_present": True,
+        "slsa_vsa_signature_ok": True,
+        "slsa_vsa_subject_matches_artifact": subject_ok,
+        "slsa_vsa_predicate_type_ok": checks["predicate_type_ok"],
+        "slsa_vsa_verifier_trusted": checks["verifier_id_matches"],
+        "slsa_vsa_resource_uri_matches": checks["resource_uri_matches"],
+        "slsa_vsa_policy_digest_matches": checks["policy_digest_matches"],
+        "slsa_vsa_result_passed": checks["verification_result_passed"],
+        "slsa_vsa_verified_level_ok": checks["verified_level_ok"],
+    }
+
+    checks["pulse_signals_consistent"] = signals_match(signals, expected_signals)
+    checks["recorded_signal_mode_ok"] = RECORDED_MODE == "recorded_signal_only"
+    checks["candidate_set_ok"] = CANDIDATE_SET == "slsa_vsa_recorded_intake_candidate"
+    checks["current_run_binding_ok"] = (
+        checks["evidence_readable"]
+        and checks["time_verified_current_run_match"]
+        and checks["subject_name_matches"]
+        and checks["subject_sha256_matches"]
+        and checks["resource_uri_matches"]
+        and checks["artifact_digest_matches"]
+    )
+    return checks
+
+
+def freshness(path: Path, readable: bool, checks: dict[str, bool]) -> tuple[str, bool]:
+    if not readable:
+        return ("rejected_unreadable_vsa_evidence", False) if path.exists() else ("rejected_missing_vsa_evidence", False)
+    if not checks["time_verified_present"]:
+        return "rejected_ambiguous_freshness", False
+    if not checks["time_verified_current_run_match"]:
+        return "rejected_time_verified_current_run_mismatch", False
+    artifact_reuse = not (
+        checks["subject_name_matches"]
+        and checks["subject_sha256_matches"]
+        and checks["resource_uri_matches"]
+        and checks["artifact_digest_matches"]
+    )
+    return ("rejected_previous_run_artifact", True) if artifact_reuse else ("fresh_current_run", False)
+
+
+def report_value(value: Any, expected: str) -> str | None:
+    return value if value == expected else None
+
+
+def make_report(
+    a: argparse.Namespace,
+    evidence: dict[str, Any] | None,
+    path: str | None,
+    evidence_sha: str | None,
+    checks: dict[str, bool],
+    failed: list[str],
+    freshness_result: str,
+    artifact_reuse: bool,
+) -> dict[str, Any]:
+    vsa, pred, policy, verifier, _signals = evidence_parts(evidence)
+    subject = subject_named(vsa.get("subject"), a.artifact_subject_name) or first_subject(vsa.get("subject"))
+    subject_name = subject.get("name") if isinstance(subject.get("name"), str) and subject.get("name") else a.artifact_subject_name
+    subject_sha = digest_sha256(subject.get("digest")) or a.artifact_sha256
+    policy_uri = policy.get("uri") if isinstance(policy.get("uri"), str) and policy.get("uri") else None
+    policy_sha = digest_sha256(policy.get("digest"))
+    verifier_id = verifier.get("id") if isinstance(verifier.get("id"), str) and verifier.get("id") else None
+    time_verified = pred.get("timeVerified") if is_date_time(pred.get("timeVerified")) else None
+    result = pred.get("verificationResult") if pred.get("verificationResult") in ["PASSED", "FAILED"] else None
+
+    ok = not failed
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_type": REPORT_TYPE,
+        "created_utc": a.created_utc,
+        "producer": {
+            "producer_id": a.producer_id,
+            "producer_name": a.producer_name,
+            "producer_version": a.producer_version,
+            "producer_source": a.producer_source,
+            "ci_workflow_or_job_identity": a.ci_workflow_or_job_identity,
+        },
+        "run_binding": {
+            "current_run_id": a.current_run_id,
+            "current_run_number": a.current_run_number,
+            "current_run_attempt": a.current_run_attempt,
+            "current_run_key": run_key(a),
+            "workflow_name": a.workflow_name,
+            "job_name": a.job_name,
+            "commit_sha": a.commit_sha,
+            "release_candidate_id": a.release_candidate_id,
+        },
+        "artifact_binding": {
+            "subject_name": subject_name,
+            "subject_sha256": subject_sha,
+            "resource_uri": a.artifact_resource_uri,
+            "release_candidate_id": a.release_candidate_id,
+            "artifact_digest_sha256": a.artifact_sha256,
+            "subject_digest_matches": checks.get("subject_name_matches", False) and checks.get("subject_sha256_matches", False),
+            "resource_uri_matches": checks.get("resource_uri_matches", False),
+            "release_candidate_matches": checks.get("release_candidate_present", False),
+            "artifact_digest_matches": checks.get("artifact_digest_matches", False),
+        },
+        "policy_binding": {
+            "expected_policy_id": a.policy_id,
+            "expected_policy_uri": a.policy_uri,
+            "expected_policy_sha256": a.policy_sha256,
+            "evidence_policy_id": a.policy_id if checks.get("policy_id_bound", False) else None,
+            "evidence_policy_uri": policy_uri,
+            "evidence_policy_sha256": policy_sha,
+            "policy_identity_matches": checks.get("policy_id_bound", False) and checks.get("policy_uri_matches", False),
+            "policy_digest_matches": checks.get("policy_digest_matches", False),
+        },
+        "verifier_binding": {
+            "expected_verifier_id": a.verifier_id,
+            "evidence_verifier_id": verifier_id,
+            "verifier_trusted": checks.get("verifier_id_matches", False),
+        },
+        "evidence": {
+            "evidence_path": path,
+            "evidence_sha256": evidence_sha,
+            "evidence_schema_version": report_value(get(evidence, "schema_version"), EVIDENCE_SCHEMA),
+            "evidence_type": report_value(get(evidence, "evidence_type"), EVIDENCE_TYPE),
+            "time_verified": time_verified,
+            "verification_result": result,
+            "expected_verified_level": a.expected_verified_level,
+            "evidence_verified_levels": string_list(pred.get("verifiedLevels")),
+            "verified_level_ok": checks.get("verified_level_ok", False),
+        },
+        "freshness": {
+            "freshness_result": freshness_result,
+            "stale_vsa_evidence": freshness_result == "rejected_stale_vsa",
+            "previous_run_artifact_reuse": artifact_reuse,
+            "time_verified_current_run_match": checks.get("time_verified_current_run_match", False),
+            "current_run_binding_ok": checks.get("current_run_binding_ok", False),
+        },
+        "recorded_signal_mode": RECORDED_MODE,
+        "candidate_set": CANDIDATE_SET,
+        "producer_decision": ACCEPTED if ok else REJECTED,
+        "ok": ok,
+        "failed_checks": failed,
+        "warnings": [],
+    }
+
+
+def emit(report: dict[str, Any], output: Path | None) -> None:
+    text = json.dumps(report, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+    sys.stdout.write(text)
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(text, encoding="utf-8")
+
+
+def build_report(a: argparse.Namespace) -> tuple[dict[str, Any], int]:
+    evidence_path = Path(a.evidence)
+    evidence: dict[str, Any] | None = None
+    readable = False
+
+    try:
+        loaded = read_json(evidence_path)
+        if isinstance(loaded, dict):
+            evidence = loaded
+            readable = True
+    except Exception:
+        pass
+
+    checks = build_checks(a, evidence, readable)
+    failed = [name for name, passed in checks.items() if not passed]
+    freshness_result, artifact_reuse = freshness(evidence_path, readable, checks)
+    report = make_report(
+        a,
+        evidence,
+        str(evidence_path) if readable else None,
+        file_sha256(evidence_path) if readable else None,
+        checks,
+        failed,
+        freshness_result,
+        artifact_reuse,
+    )
+    return report, 0 if report["ok"] else 1
+
+
+def refusal_report(a: argparse.Namespace) -> dict[str, Any]:
+    checks = build_checks(a, None, False)
+    return make_report(
+        a,
+        None,
+        None,
+        None,
+        checks,
+        ["refusing_to_write_status_json"],
+        "rejected_missing_vsa_evidence",
+        False,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output) if args.output else None
+    if output is not None and output.name == "status.json":
+        emit(refusal_report(args), None)
+        return 2
+
+    report, code = build_report(args)
+    emit(report, output)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds a deterministic builder for the SLSA VSA trusted evidence producer report.

New files:

```text
tools/build_slsa_vsa_trusted_evidence_producer_report_v0.py
tests/test_build_slsa_vsa_trusted_evidence_producer_report_v0.py
```

Updated manifest:

```text
ci/tools-tests.list
```

## Why

The trusted producer design, report schema, example, and report validator now exist.

This PR adds the next narrow layer: a report builder that converts recorded SLSA VSA evidence plus explicit expected bindings into a deterministic trusted producer report.

This remains pre-promotion work.

## Scope

The builder checks explicit bindings for:

```text
producer identity
current-run identity
current-run key
commit SHA
release candidate ID
artifact subject name
artifact digest
resource URI
policy identity
policy URI
policy digest
verifier identity
verified level
timeVerified/current-run match
recorded pulse signal consistency
```

The builder emits a producer report matching:

```text
schemas/slsa_vsa_trusted_evidence_producer_report_v0.schema.json
```

It emits `TRUSTED_EVIDENCE_ACCEPTED` only when all checks pass.

It emits `TRUSTED_EVIDENCE_REJECTED` with deterministic `failed_checks` when any check fails.

It refuses to write any output file named:

```text
status.json
```

## Tests

The test covers:

```text
valid evidence builds accepted producer report
accepted report validates against the trusted producer report schema
accepted report passes the existing report validator
output report matches stdout
missing evidence returns deterministic rejected report
artifact digest mismatch rejects
artifact subject mismatch rejects
resource URI mismatch rejects
policy digest mismatch rejects
verifier mismatch rejects
verified level mismatch rejects
verificationResult != PASSED rejects
timeVerified/current-run mismatch rejects
recorded pulse signal mismatch rejects
status.json output is refused
builder does not call check_gates.py
builder does not write status.gates or activate release policy sets
```

## Non-goals

This PR does not modify:

```text
pulse_gate_policy_v0.yml
pulse_gate_registry_v0.yml
PULSE_safe_pack_v0/tools/check_gates.py
tools/policy_to_require_args.py
tools/ingest_slsa_vsa_evidence_v0.py
tools/fold_slsa_vsa_intake_into_status_v0.py
.github/workflows/
README.md
CITATION.cff
.zenodo.json
zenodo.preprint.json
ORCID_add_work.json
docs/policy/CHANGELOG.md
tests/fixtures/core_baseline_v0/status.normalized.json
```

This PR does not activate SLSA VSA as:

```text
required
core_required
release_required
prod_required
stage_required
blocking
release_blocking
```

This PR does not change release-authority behavior.

## Validation

Expected validation:

```text
python -m py_compile tools/build_slsa_vsa_trusted_evidence_producer_report_v0.py
python -m py_compile tests/test_build_slsa_vsa_trusted_evidence_producer_report_v0.py
python tests/test_build_slsa_vsa_trusted_evidence_producer_report_v0.py
python -m pytest tests/test_build_slsa_vsa_trusted_evidence_producer_report_v0.py
python tests/test_tools_tests_list_smoke.py
git diff --check
```

## Follow-up

Future PRs may add:

```text
trusted producer CI wiring
trusted producer evidence packet
release-required promotion
```

Each remains separate.