### PR TITLE
feat(slsa): add vsa trusted producer input packet contract

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -106,6 +106,7 @@ tests/test_slsa_vsa_advisory_policy_gates_v0.py
 tests/test_slsa_vsa_recorded_intake_candidate_v0.py
 tests/test_slsa_vsa_trusted_evidence_producer_report_schema_v0.py
 tests/test_check_slsa_vsa_trusted_evidence_producer_report_v0.py
+tests/test_slsa_vsa_trusted_producer_input_packet_schema_v0.py
 
 tools/operator_handoff_smoke.py
 

--- a/examples/slsa/slsa_vsa_trusted_producer_input_packet_example_v0.json
+++ b/examples/slsa/slsa_vsa_trusted_producer_input_packet_example_v0.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "slsa_vsa_trusted_producer_input_packet_v0",
+  "packet_type": "slsa_vsa_trusted_producer_input_packet",
+  "created_utc": "2026-07-07T00:00:00Z",
+  "producer_identity": {
+    "producer_id": "pulse_slsa_vsa_trusted_evidence_producer_v0",
+    "producer_name": "PULSE SLSA VSA trusted evidence producer",
+    "producer_version": "0.1.0",
+    "producer_source": "github-actions",
+    "ci_workflow_or_job_identity": "PULSE CI / SLSA VSA trusted evidence producer"
+  },
+  "run_binding": {
+    "current_run_id": "1234567890",
+    "current_run_number": "2692",
+    "current_run_attempt": "1",
+    "current_run_key": "GITHUB_RUN_ID=1234567890|GITHUB_RUN_NUMBER=2692|GITHUB_RUN_ATTEMPT=1|GITHUB_WORKFLOW=PULSE CI",
+    "workflow_name": "PULSE CI",
+    "job_name": "slsa-vsa-trusted-evidence-producer",
+    "commit_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "release_candidate_id": "pulse-release-gates-0.1-candidate-v0"
+  },
+  "artifact_binding": {
+    "subject_name": "git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0",
+    "subject_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "resource_uri": "git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0",
+    "release_candidate_id": "pulse-release-gates-0.1-candidate-v0",
+    "artifact_digest_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "policy_binding": {
+    "expected_policy_id": "pulse-gate-policy-v0",
+    "expected_policy_uri": "https://example.invalid/policies/pulse-slsa-vsa-policy-v0.json",
+    "expected_policy_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "verifier_binding": {
+    "expected_verifier_id": "https://example.invalid/verifiers/pulsemech-vsa-verifier-v0"
+  },
+  "expected_verified_level": "SLSA_BUILD_LEVEL_3",
+  "freshness": {
+    "expected_time_verified": "2026-07-04T00:00:00Z",
+    "freshness_epoch": "current_run"
+  },
+  "recorded_signal_mode": "recorded_signal_only",
+  "candidate_set": "slsa_vsa_recorded_intake_candidate"
+}

--- a/schemas/slsa_vsa_trusted_producer_input_packet_v0.schema.json
+++ b/schemas/slsa_vsa_trusted_producer_input_packet_v0.schema.json
@@ -1,0 +1,225 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/HKati/pulse-release-gates-0.1/schemas/slsa_vsa_trusted_producer_input_packet_v0.schema.json",
+  "title": "PULSE SLSA VSA trusted producer input packet v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "packet_type",
+    "created_utc",
+    "producer_identity",
+    "run_binding",
+    "artifact_binding",
+    "policy_binding",
+    "verifier_binding",
+    "expected_verified_level",
+    "freshness",
+    "recorded_signal_mode",
+    "candidate_set"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "slsa_vsa_trusted_producer_input_packet_v0"
+    },
+    "packet_type": {
+      "const": "slsa_vsa_trusted_producer_input_packet"
+    },
+    "created_utc": {
+      "$ref": "#/$defs/date_time"
+    },
+    "producer_identity": {
+      "$ref": "#/$defs/producer_identity"
+    },
+    "run_binding": {
+      "$ref": "#/$defs/run_binding"
+    },
+    "artifact_binding": {
+      "$ref": "#/$defs/artifact_binding"
+    },
+    "policy_binding": {
+      "$ref": "#/$defs/policy_binding"
+    },
+    "verifier_binding": {
+      "$ref": "#/$defs/verifier_binding"
+    },
+    "expected_verified_level": {
+      "$ref": "#/$defs/non_empty_string"
+    },
+    "freshness": {
+      "$ref": "#/$defs/freshness"
+    },
+    "recorded_signal_mode": {
+      "const": "recorded_signal_only"
+    },
+    "candidate_set": {
+      "const": "slsa_vsa_recorded_intake_candidate"
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$"
+    },
+    "sha40": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{40}$"
+    },
+    "non_empty_string": {
+      "type": "string",
+      "minLength": 1
+    },
+    "date_time": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$",
+      "minLength": 1
+    },
+    "producer_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "producer_id",
+        "producer_name",
+        "producer_version",
+        "producer_source",
+        "ci_workflow_or_job_identity"
+      ],
+      "properties": {
+        "producer_id": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "producer_name": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "producer_version": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "producer_source": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "ci_workflow_or_job_identity": {
+          "$ref": "#/$defs/non_empty_string"
+        }
+      }
+    },
+    "run_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "current_run_id",
+        "current_run_number",
+        "current_run_attempt",
+        "current_run_key",
+        "workflow_name",
+        "job_name",
+        "commit_sha",
+        "release_candidate_id"
+      ],
+      "properties": {
+        "current_run_id": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "current_run_number": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "current_run_attempt": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "current_run_key": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^GITHUB_RUN_ID=.+\\|GITHUB_RUN_NUMBER=.+\\|GITHUB_RUN_ATTEMPT=.+\\|GITHUB_WORKFLOW=.+$"
+        },
+        "workflow_name": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "job_name": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "commit_sha": {
+          "$ref": "#/$defs/sha40"
+        },
+        "release_candidate_id": {
+          "$ref": "#/$defs/non_empty_string"
+        }
+      }
+    },
+    "artifact_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "subject_name",
+        "subject_sha256",
+        "resource_uri",
+        "release_candidate_id",
+        "artifact_digest_sha256"
+      ],
+      "properties": {
+        "subject_name": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "subject_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "resource_uri": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "release_candidate_id": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "artifact_digest_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "policy_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "expected_policy_id",
+        "expected_policy_uri",
+        "expected_policy_sha256"
+      ],
+      "properties": {
+        "expected_policy_id": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "expected_policy_uri": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "expected_policy_sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "verifier_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "expected_verifier_id"
+      ],
+      "properties": {
+        "expected_verifier_id": {
+          "$ref": "#/$defs/non_empty_string"
+        }
+      }
+    },
+    "freshness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "expected_time_verified",
+        "freshness_epoch"
+      ],
+      "properties": {
+        "expected_time_verified": {
+          "$ref": "#/$defs/date_time"
+        },
+        "freshness_epoch": {
+          "$ref": "#/$defs/non_empty_string"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_slsa_vsa_trusted_producer_input_packet_schema_v0.py
+++ b/tests/test_slsa_vsa_trusted_producer_input_packet_schema_v0.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+SCHEMA_PATH = ROOT / "schemas" / "slsa_vsa_trusted_producer_input_packet_v0.schema.json"
+EXAMPLE_PATH = ROOT / "examples" / "slsa" / "slsa_vsa_trusted_producer_input_packet_example_v0.json"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _schema() -> dict[str, Any]:
+    return _load_json(SCHEMA_PATH)
+
+
+def _packet() -> dict[str, Any]:
+    return _load_json(EXAMPLE_PATH)
+
+
+def _validator() -> jsonschema.Draft202012Validator:
+    schema = _schema()
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(
+        schema,
+        format_checker=jsonschema.FormatChecker(),
+    )
+
+
+def _validate(instance: dict[str, Any]) -> None:
+    _validator().validate(instance)
+
+
+def _validation_errors(instance: dict[str, Any]) -> list[str]:
+    return [
+        error.message
+        for error in _validator().iter_errors(instance)
+    ]
+
+
+def test_schema_and_example_exist() -> None:
+    assert SCHEMA_PATH.exists()
+    assert EXAMPLE_PATH.exists()
+
+
+def test_example_validates() -> None:
+    _validate(_packet())
+
+
+def test_schema_version_is_locked() -> None:
+    packet = _packet()
+    packet["schema_version"] = "wrong"
+
+    assert _validation_errors(packet)
+
+
+def test_packet_type_is_locked() -> None:
+    packet = _packet()
+    packet["packet_type"] = "wrong"
+
+    assert _validation_errors(packet)
+
+
+def test_created_utc_requires_date_time() -> None:
+    packet = _packet()
+    packet["created_utc"] = "unknown"
+
+    assert _validation_errors(packet)
+
+
+def test_recorded_signal_mode_is_locked() -> None:
+    packet = _packet()
+    packet["recorded_signal_mode"] = "cryptographic_signature_verified"
+
+    assert _validation_errors(packet)
+
+
+def test_candidate_set_is_locked() -> None:
+    packet = _packet()
+    packet["candidate_set"] = "slsa_vsa_release_required_candidate"
+
+    assert _validation_errors(packet)
+
+
+def test_producer_identity_fields_are_required() -> None:
+    required_fields = [
+        "producer_id",
+        "producer_name",
+        "producer_version",
+        "producer_source",
+        "ci_workflow_or_job_identity",
+    ]
+
+    for field in required_fields:
+        packet = _packet()
+        del packet["producer_identity"][field]
+
+        assert _validation_errors(packet), field
+
+
+def test_run_binding_fields_are_required() -> None:
+    required_fields = [
+        "current_run_id",
+        "current_run_number",
+        "current_run_attempt",
+        "current_run_key",
+        "workflow_name",
+        "job_name",
+        "commit_sha",
+        "release_candidate_id",
+    ]
+
+    for field in required_fields:
+        packet = _packet()
+        del packet["run_binding"][field]
+
+        assert _validation_errors(packet), field
+
+
+def test_current_run_key_has_expected_shape() -> None:
+    packet = _packet()
+    packet["run_binding"]["current_run_key"] = "1234567890"
+
+    assert _validation_errors(packet)
+
+
+def test_commit_sha_must_be_40_character_hex() -> None:
+    bad_values = [
+        "a" * 39,
+        "a" * 41,
+        "g" * 40,
+        "",
+    ]
+
+    for value in bad_values:
+        packet = _packet()
+        packet["run_binding"]["commit_sha"] = value
+
+        assert _validation_errors(packet), value
+
+
+def test_artifact_sha_fields_must_be_64_character_hex() -> None:
+    fields = [
+        "subject_sha256",
+        "artifact_digest_sha256",
+    ]
+
+    bad_values = [
+        "a" * 63,
+        "a" * 65,
+        "g" * 64,
+        "",
+    ]
+
+    for field in fields:
+        for value in bad_values:
+            packet = _packet()
+            packet["artifact_binding"][field] = value
+
+            assert _validation_errors(packet), f"{field}={value!r}"
+
+
+def test_artifact_binding_fields_are_required() -> None:
+    required_fields = [
+        "subject_name",
+        "subject_sha256",
+        "resource_uri",
+        "release_candidate_id",
+        "artifact_digest_sha256",
+    ]
+
+    for field in required_fields:
+        packet = _packet()
+        del packet["artifact_binding"][field]
+
+        assert _validation_errors(packet), field
+
+
+def test_policy_binding_fields_are_required() -> None:
+    required_fields = [
+        "expected_policy_id",
+        "expected_policy_uri",
+        "expected_policy_sha256",
+    ]
+
+    for field in required_fields:
+        packet = _packet()
+        del packet["policy_binding"][field]
+
+        assert _validation_errors(packet), field
+
+
+def test_policy_digest_must_be_64_character_hex() -> None:
+    bad_values = [
+        "b" * 63,
+        "b" * 65,
+        "g" * 64,
+        "",
+    ]
+
+    for value in bad_values:
+        packet = _packet()
+        packet["policy_binding"]["expected_policy_sha256"] = value
+
+        assert _validation_errors(packet), value
+
+
+def test_policy_uri_only_packet_is_rejected() -> None:
+    packet = _packet()
+    del packet["policy_binding"]["expected_policy_sha256"]
+
+    assert _validation_errors(packet)
+
+
+def test_verifier_identity_is_required() -> None:
+    packet = _packet()
+    del packet["verifier_binding"]["expected_verifier_id"]
+
+    assert _validation_errors(packet)
+
+
+def test_expected_verified_level_is_required() -> None:
+    packet = _packet()
+    del packet["expected_verified_level"]
+
+    assert _validation_errors(packet)
+
+
+def test_expected_time_verified_requires_date_time() -> None:
+    packet = _packet()
+    packet["freshness"]["expected_time_verified"] = "unknown"
+
+    assert _validation_errors(packet)
+
+
+def test_freshness_fields_are_required() -> None:
+    required_fields = [
+        "expected_time_verified",
+        "freshness_epoch",
+    ]
+
+    for field in required_fields:
+        packet = _packet()
+        del packet["freshness"][field]
+
+        assert _validation_errors(packet), field
+
+
+def test_extra_top_level_fields_are_rejected() -> None:
+    packet = _packet()
+    packet["extra"] = "not allowed"
+
+    assert _validation_errors(packet)
+
+
+def test_release_decision_fields_are_rejected() -> None:
+    forbidden_fields = [
+        "status",
+        "status_gates",
+        "required",
+        "core_required",
+        "release_required",
+        "prod_required",
+        "stage_required",
+        "blocking",
+        "release_blocking",
+        "gate_materialization",
+        "release_authority",
+        "producer_decision",
+        "ok",
+        "failed_checks",
+    ]
+
+    for field in forbidden_fields:
+        packet = _packet()
+        packet[field] = True
+
+        assert _validation_errors(packet), field
+
+
+def test_nested_extra_properties_are_rejected() -> None:
+    sections = [
+        "producer_identity",
+        "run_binding",
+        "artifact_binding",
+        "policy_binding",
+        "verifier_binding",
+        "freshness",
+    ]
+
+    for section in sections:
+        packet = _packet()
+        packet[section]["extra"] = "not allowed"
+
+        assert _validation_errors(packet), section
+
+
+def check_slsa_vsa_trusted_producer_input_packet_schema_v0() -> None:
+    test_schema_and_example_exist()
+    test_example_validates()
+    test_schema_version_is_locked()
+    test_packet_type_is_locked()
+    test_created_utc_requires_date_time()
+    test_recorded_signal_mode_is_locked()
+    test_candidate_set_is_locked()
+    test_producer_identity_fields_are_required()
+    test_run_binding_fields_are_required()
+    test_current_run_key_has_expected_shape()
+    test_commit_sha_must_be_40_character_hex()
+    test_artifact_sha_fields_must_be_64_character_hex()
+    test_artifact_binding_fields_are_required()
+    test_policy_binding_fields_are_required()
+    test_policy_digest_must_be_64_character_hex()
+    test_policy_uri_only_packet_is_rejected()
+    test_verifier_identity_is_required()
+    test_expected_verified_level_is_required()
+    test_expected_time_verified_requires_date_time()
+    test_freshness_fields_are_required()
+    test_extra_top_level_fields_are_rejected()
+    test_release_decision_fields_are_rejected()
+    test_nested_extra_properties_are_rejected()
+
+
+def test_slsa_vsa_trusted_producer_input_packet_schema_v0() -> None:
+    check_slsa_vsa_trusted_producer_input_packet_schema_v0()
+
+
+if __name__ == "__main__":
+    check_slsa_vsa_trusted_producer_input_packet_schema_v0()
+    print("OK: slsa_vsa_trusted_producer_input_packet_schema_v0 smoke passed")


### PR DESCRIPTION
## Summary

This PR adds a machine-readable input packet contract for any future SLSA VSA trusted producer report builder.

New files:

```text
schemas/slsa_vsa_trusted_producer_input_packet_v0.schema.json
examples/slsa/slsa_vsa_trusted_producer_input_packet_example_v0.json
tests/test_slsa_vsa_trusted_producer_input_packet_schema_v0.py
```

Updated manifest:

```text
ci/tools-tests.list
```

## Why

The previous builder attempt showed that a trusted producer report must not be built directly from arbitrary CLI expectations.

Before rebuilding the builder, the repository needs a schema-validated input packet that records the trusted producer inputs separately from the generated producer report.

This PR defines that input boundary only.

## Scope

The input packet records:

```text
producer identity
run binding
artifact binding
policy binding
verifier binding
expected verified level
freshness expectation
recorded signal mode
candidate set
```

The packet is an input contract.

It is not a producer report.

It is not a release decision.

It must not write `status.json`.

It must not contain `status.gates`.

It must not activate any release-required policy set.

## Contract

The schema locks:

```text
schema_version: slsa_vsa_trusted_producer_input_packet_v0
packet_type: slsa_vsa_trusted_producer_input_packet
recorded_signal_mode: recorded_signal_only
candidate_set: slsa_vsa_recorded_intake_candidate
```

The packet requires:

```text
producer_identity
run_binding
artifact_binding
policy_binding
verifier_binding
expected_verified_level
freshness
```

Policy digest is mandatory.

Policy URI-only binding is rejected.

Verifier identity is mandatory.

Commit SHA must be a 40-character hex SHA.

Artifact and policy digests must be 64-character SHA256 hex strings.

## Forbidden fields

The schema rejects release-decision and release-authority fields, including:

```text
status_gates
required
core_required
release_required
prod_required
stage_required
blocking
release_blocking
gate_materialization
release_authority
producer_decision
ok
failed_checks
```

## Tests

Added:

```text
tests/test_slsa_vsa_trusted_producer_input_packet_schema_v0.py
```

The test covers:

```text
schema and example exist
example validates
schema_version is locked
packet_type is locked
created_utc requires date-time
recorded_signal_mode is locked
candidate_set is locked
producer identity fields are required
run binding fields are required
commit_sha must be 40-character hex
artifact SHA fields must be 64-character hex
policy digest is required
policy URI-only packet is rejected
verifier identity is required
expected_time_verified requires date-time
extra top-level fields are rejected
status_gates is rejected
release_required is rejected
release_blocking is rejected
producer_decision is rejected
ok is rejected
failed_checks is rejected
```

## Non-goals

This PR does not add:

```text
tools/build_slsa_vsa_trusted_evidence_producer_report_v0.py
```

This PR does not modify:

```text
pulse_gate_policy_v0.yml
pulse_gate_registry_v0.yml
PULSE_safe_pack_v0/tools/check_gates.py
tools/policy_to_require_args.py
tools/ingest_slsa_vsa_evidence_v0.py
tools/fold_slsa_vsa_intake_into_status_v0.py
.github/workflows/
README.md
CITATION.cff
.zenodo.json
zenodo.preprint.json
ORCID_add_work.json
docs/policy/CHANGELOG.md
tests/fixtures/core_baseline_v0/status.normalized.json
```

This PR does not activate SLSA VSA as:

```text
required
core_required
release_required
prod_required
stage_required
blocking
release_blocking
```

This PR does not change release-authority behavior.

## Validation

Expected validation:

```text
python -m py_compile tests/test_slsa_vsa_trusted_producer_input_packet_schema_v0.py
python tests/test_slsa_vsa_trusted_producer_input_packet_schema_v0.py
python -m pytest tests/test_slsa_vsa_trusted_producer_input_packet_schema_v0.py
python tests/test_tools_tests_list_smoke.py
git diff --check
```

## Follow-up

A later PR may rebuild the builder.

That future builder must consume:

```text
schema-valid SLSA VSA evidence
schema-valid trusted producer input packet
existing trusted producer report schema
existing trusted producer report validator
```

The future builder must exit `0` only after:

```text
input packet schema validates
SLSA VSA evidence schema validates
generated producer report schema validates
existing producer report validator passes
```

Each step remains separate.