### PR TITLE
feat(slsa): add vsa trusted producer input packet validator

### DIFF
--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -107,6 +107,7 @@ tests/test_slsa_vsa_recorded_intake_candidate_v0.py
 tests/test_slsa_vsa_trusted_evidence_producer_report_schema_v0.py
 tests/test_check_slsa_vsa_trusted_evidence_producer_report_v0.py
 tests/test_slsa_vsa_trusted_producer_input_packet_schema_v0.py
+tests/test_check_slsa_vsa_trusted_producer_input_packet_v0.py
 
 tools/operator_handoff_smoke.py
 

--- a/tests/test_check_slsa_vsa_trusted_producer_input_packet_v0.py
+++ b/tests/test_check_slsa_vsa_trusted_producer_input_packet_v0.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+TOOL = ROOT / "tools" / "check_slsa_vsa_trusted_producer_input_packet_v0.py"
+SCHEMA = ROOT / "schemas" / "slsa_vsa_trusted_producer_input_packet_v0.schema.json"
+EXAMPLE = ROOT / "examples" / "slsa" / "slsa_vsa_trusted_producer_input_packet_example_v0.json"
+
+EXPECTED_ARGS = [
+    "--expect-producer-id",
+    "pulse_slsa_vsa_trusted_evidence_producer_v0",
+    "--expect-producer-name",
+    "PULSE SLSA VSA trusted evidence producer",
+    "--expect-producer-version",
+    "0.1.0",
+    "--expect-producer-source",
+    "github-actions",
+    "--expect-ci-workflow-or-job-identity",
+    "PULSE CI / SLSA VSA trusted evidence producer",
+    "--expect-current-run-id",
+    "1234567890",
+    "--expect-current-run-key",
+    "GITHUB_RUN_ID=1234567890|GITHUB_RUN_NUMBER=2692|GITHUB_RUN_ATTEMPT=1|GITHUB_WORKFLOW=PULSE CI",
+    "--expect-commit-sha",
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "--expect-release-candidate-id",
+    "pulse-release-gates-0.1-candidate-v0",
+    "--expect-artifact-subject-name",
+    "git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0",
+    "--expect-artifact-sha256",
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "--expect-artifact-resource-uri",
+    "git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0",
+    "--expect-policy-id",
+    "pulse-gate-policy-v0",
+    "--expect-policy-uri",
+    "https://example.invalid/policies/pulse-slsa-vsa-policy-v0.json",
+    "--expect-policy-sha256",
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "--expect-verifier-id",
+    "https://example.invalid/verifiers/pulsemech-vsa-verifier-v0",
+    "--expect-verified-level",
+    "SLSA_BUILD_LEVEL_3",
+    "--expect-time-verified",
+    "2026-07-04T00:00:00Z",
+    "--expect-candidate-set",
+    "slsa_vsa_recorded_intake_candidate",
+]
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def run_tool(
+    packet_path: Path = EXAMPLE,
+    extra: list[str] | None = None,
+    omit_expected: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        sys.executable,
+        str(TOOL),
+        "--schema",
+        str(SCHEMA),
+        "--packet",
+        str(packet_path),
+    ]
+
+    if not omit_expected:
+        cmd.extend(EXPECTED_ARGS)
+
+    if extra:
+        cmd.extend(extra)
+
+    return subprocess.run(
+        cmd,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def parse_diagnostic(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    assert result.stdout, result.stderr
+    return json.loads(result.stdout)
+
+
+def assert_failure(
+    result: subprocess.CompletedProcess[str],
+    expected_fragment: str,
+) -> dict[str, Any]:
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+
+    diagnostic = parse_diagnostic(result)
+    assert diagnostic["ok"] is False
+    assert any(expected_fragment in error for error in diagnostic["errors"]), diagnostic["errors"]
+
+    return diagnostic
+
+
+def mutated_packet(tmp_path: Path, name: str, path: list[str], value: Any) -> Path:
+    packet = read_json(EXAMPLE)
+    cursor: Any = packet
+
+    for part in path[:-1]:
+        cursor = cursor[part]
+
+    cursor[path[-1]] = value
+
+    packet_path = tmp_path / name
+    write_json(packet_path, packet)
+    return packet_path
+
+
+def test_valid_example_passes() -> None:
+    result = run_tool()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+
+    diagnostic = parse_diagnostic(result)
+    assert diagnostic["tool"] == "check_slsa_vsa_trusted_producer_input_packet_v0"
+    assert diagnostic["ok"] is True
+    assert diagnostic["schema_valid"] is True
+    assert diagnostic["errors"] == []
+    assert all(diagnostic["checks"].values())
+
+
+def test_output_report_matches_stdout(tmp_path: Path) -> None:
+    output = tmp_path / "diagnostic.json"
+    result = run_tool(extra=["--output", str(output)])
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert output.exists()
+    assert read_json(output) == parse_diagnostic(result)
+
+
+def test_schema_invalid_packet_fails_closed(tmp_path: Path) -> None:
+    path = mutated_packet(
+        tmp_path,
+        "schema_invalid.json",
+        ["created_utc"],
+        "unknown",
+    )
+
+    diagnostic = assert_failure(run_tool(path), "schema_error")
+    assert diagnostic["schema_valid"] is False
+
+
+def test_missing_packet_file_returns_read_error(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.json"
+    result = run_tool(packet_path=missing)
+
+    assert result.returncode == 2
+    diagnostic = parse_diagnostic(result)
+    assert diagnostic["ok"] is False
+    assert any("read_error:" in error for error in diagnostic["errors"])
+
+
+def test_wrong_producer_identity_fails_closed(tmp_path: Path) -> None:
+    cases = [
+        ("producer_id", "wrong-producer", "producer_id_matches"),
+        ("producer_name", "Wrong producer", "producer_name_matches"),
+        ("producer_version", "9.9.9", "producer_version_matches"),
+        ("producer_source", "manual-local", "producer_source_matches"),
+        ("ci_workflow_or_job_identity", "Wrong CI / job", "producer_ci_identity_matches"),
+    ]
+
+    for field, value, expected_error in cases:
+        path = mutated_packet(
+            tmp_path,
+            f"wrong_{field}.json",
+            ["producer_identity", field],
+            value,
+        )
+
+        assert_failure(run_tool(path), f"check_failed: {expected_error}")
+
+
+def test_wrong_current_run_binding_fails_closed(tmp_path: Path) -> None:
+    cases = [
+        ("current_run_id", "9999999999", "current_run_id_matches"),
+        (
+            "current_run_key",
+            "GITHUB_RUN_ID=9999999999|GITHUB_RUN_NUMBER=2692|GITHUB_RUN_ATTEMPT=1|GITHUB_WORKFLOW=PULSE CI",
+            "current_run_key_matches",
+        ),
+        ("commit_sha", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "commit_sha_matches"),
+        ("release_candidate_id", "wrong-candidate", "run_release_candidate_matches"),
+    ]
+
+    for field, value, expected_error in cases:
+        path = mutated_packet(
+            tmp_path,
+            f"wrong_run_{field}.json",
+            ["run_binding", field],
+            value,
+        )
+
+        assert_failure(run_tool(path), f"check_failed: {expected_error}")
+
+
+def test_non_self_consistent_current_run_key_fails_closed(tmp_path: Path) -> None:
+    path = mutated_packet(
+        tmp_path,
+        "non_self_consistent_run_key.json",
+        ["run_binding", "workflow_name"],
+        "Other workflow",
+    )
+
+    assert_failure(run_tool(path), "check_failed: current_run_key_self_consistent")
+
+
+def test_wrong_artifact_binding_fails_closed(tmp_path: Path) -> None:
+    cases = [
+        ("subject_name", "git+https://example.invalid/wrong@refs/tags/v0", "artifact_subject_name_matches"),
+        ("subject_sha256", "c" * 64, "artifact_subject_sha256_matches"),
+        ("resource_uri", "git+https://example.invalid/wrong@refs/tags/v0", "artifact_resource_uri_matches"),
+        ("release_candidate_id", "wrong-candidate", "artifact_release_candidate_matches"),
+        ("artifact_digest_sha256", "d" * 64, "artifact_digest_sha256_matches"),
+    ]
+
+    for field, value, expected_error in cases:
+        path = mutated_packet(
+            tmp_path,
+            f"wrong_artifact_{field}.json",
+            ["artifact_binding", field],
+            value,
+        )
+
+        assert_failure(run_tool(path), f"check_failed: {expected_error}")
+
+
+def test_artifact_digest_self_mismatch_fails_closed(tmp_path: Path) -> None:
+    path = mutated_packet(
+        tmp_path,
+        "artifact_digest_self_mismatch.json",
+        ["artifact_binding", "artifact_digest_sha256"],
+        "c" * 64,
+    )
+
+    assert_failure(run_tool(path), "check_failed: artifact_digest_self_consistent")
+
+
+def test_run_artifact_release_candidate_mismatch_fails_closed(tmp_path: Path) -> None:
+    path = mutated_packet(
+        tmp_path,
+        "run_artifact_candidate_mismatch.json",
+        ["artifact_binding", "release_candidate_id"],
+        "wrong-candidate",
+    )
+
+    diagnostic = assert_failure(
+        run_tool(path),
+        "check_failed: run_artifact_release_candidate_consistent",
+    )
+    assert "check_failed: artifact_release_candidate_matches" in diagnostic["errors"]
+
+
+def test_wrong_policy_binding_fails_closed(tmp_path: Path) -> None:
+    cases = [
+        ("expected_policy_id", "wrong-policy", "policy_id_matches"),
+        ("expected_policy_uri", "https://example.invalid/policies/wrong.json", "policy_uri_matches"),
+        ("expected_policy_sha256", "e" * 64, "policy_sha256_matches"),
+    ]
+
+    for field, value, expected_error in cases:
+        path = mutated_packet(
+            tmp_path,
+            f"wrong_policy_{field}.json",
+            ["policy_binding", field],
+            value,
+        )
+
+        assert_failure(run_tool(path), f"check_failed: {expected_error}")
+
+
+def test_wrong_verifier_identity_fails_closed(tmp_path: Path) -> None:
+    path = mutated_packet(
+        tmp_path,
+        "wrong_verifier.json",
+        ["verifier_binding", "expected_verifier_id"],
+        "https://example.invalid/verifiers/wrong",
+    )
+
+    assert_failure(run_tool(path), "check_failed: verifier_id_matches")
+
+
+def test_wrong_expected_verified_level_fails_closed(tmp_path: Path) -> None:
+    path = mutated_packet(
+        tmp_path,
+        "wrong_verified_level.json",
+        ["expected_verified_level"],
+        "SLSA_BUILD_LEVEL_4",
+    )
+
+    assert_failure(run_tool(path), "check_failed: expected_verified_level_matches")
+
+
+def test_wrong_expected_time_verified_fails_closed(tmp_path: Path) -> None:
+    path = mutated_packet(
+        tmp_path,
+        "wrong_time_verified.json",
+        ["freshness", "expected_time_verified"],
+        "2026-07-05T00:00:00Z",
+    )
+
+    assert_failure(run_tool(path), "check_failed: expected_time_verified_matches")
+
+
+def test_wrong_candidate_set_fails_closed(tmp_path: Path) -> None:
+    path = mutated_packet(
+        tmp_path,
+        "wrong_candidate_set.json",
+        ["candidate_set"],
+        "slsa_vsa_release_required_candidate",
+    )
+
+    assert_failure(run_tool(path), "schema_error")
+
+
+def test_refuses_to_write_status_json(tmp_path: Path) -> None:
+    status_path = tmp_path / "status.json"
+    result = run_tool(extra=["--output", str(status_path)])
+
+    assert result.returncode == 2
+    assert not status_path.exists()
+
+    diagnostic = parse_diagnostic(result)
+    assert diagnostic["ok"] is False
+    assert "refusing_to_write_status_json" in diagnostic["errors"]
+
+
+def test_tool_does_not_call_gate_checker() -> None:
+    source = TOOL.read_text(encoding="utf-8")
+    forbidden = "check_" + "gates"
+
+    assert forbidden not in source
+
+
+def test_tool_does_not_write_status_gates_or_activate_release_sets() -> None:
+    source = TOOL.read_text(encoding="utf-8")
+    forbidden = [
+        "status_" + "gates",
+        "release_" + "required",
+        "release_" + "blocking",
+        "prod_" + "required",
+        "stage_" + "required",
+        "gate_" + "materialization",
+    ]
+
+    for marker in forbidden:
+        assert marker not in source, marker
+
+
+def check_check_slsa_vsa_trusted_producer_input_packet_v0() -> None:
+    assert TOOL.exists()
+    assert SCHEMA.exists()
+    assert EXAMPLE.exists()
+
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp_path = Path(raw_tmp)
+
+        test_valid_example_passes()
+        test_output_report_matches_stdout(tmp_path)
+        test_schema_invalid_packet_fails_closed(tmp_path)
+        test_missing_packet_file_returns_read_error(tmp_path)
+        test_wrong_producer_identity_fails_closed(tmp_path)
+        test_wrong_current_run_binding_fails_closed(tmp_path)
+        test_non_self_consistent_current_run_key_fails_closed(tmp_path)
+        test_wrong_artifact_binding_fails_closed(tmp_path)
+        test_artifact_digest_self_mismatch_fails_closed(tmp_path)
+        test_run_artifact_release_candidate_mismatch_fails_closed(tmp_path)
+        test_wrong_policy_binding_fails_closed(tmp_path)
+        test_wrong_verifier_identity_fails_closed(tmp_path)
+        test_wrong_expected_verified_level_fails_closed(tmp_path)
+        test_wrong_expected_time_verified_fails_closed(tmp_path)
+        test_wrong_candidate_set_fails_closed(tmp_path)
+        test_refuses_to_write_status_json(tmp_path)
+        test_tool_does_not_call_gate_checker()
+        test_tool_does_not_write_status_gates_or_activate_release_sets()
+
+
+def test_check_slsa_vsa_trusted_producer_input_packet_v0() -> None:
+    check_check_slsa_vsa_trusted_producer_input_packet_v0()
+
+
+if __name__ == "__main__":
+    check_check_slsa_vsa_trusted_producer_input_packet_v0()
+    print("OK: check_slsa_vsa_trusted_producer_input_packet_v0 smoke passed")

--- a/tools/check_slsa_vsa_trusted_producer_input_packet_v0.py
+++ b/tools/check_slsa_vsa_trusted_producer_input_packet_v0.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+
+TOOL_NAME = "check_slsa_vsa_trusted_producer_input_packet_v0"
+SCHEMA_VERSION = "slsa_vsa_trusted_producer_input_packet_v0"
+PACKET_TYPE = "slsa_vsa_trusted_producer_input_packet"
+RECORDED_SIGNAL_MODE = "recorded_signal_only"
+CANDIDATE_SET = "slsa_vsa_recorded_intake_candidate"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate a SLSA VSA trusted producer input packet."
+    )
+
+    parser.add_argument("--schema", required=True, help="Path to input packet schema")
+    parser.add_argument("--packet", required=True, help="Path to input packet JSON")
+
+    parser.add_argument("--expect-producer-id", required=True)
+    parser.add_argument("--expect-producer-name", required=True)
+    parser.add_argument("--expect-producer-version", required=True)
+    parser.add_argument("--expect-producer-source", required=True)
+    parser.add_argument("--expect-ci-workflow-or-job-identity", required=True)
+
+    parser.add_argument("--expect-current-run-id", required=True)
+    parser.add_argument("--expect-current-run-key", required=True)
+    parser.add_argument("--expect-commit-sha", required=True)
+    parser.add_argument("--expect-release-candidate-id", required=True)
+
+    parser.add_argument("--expect-artifact-subject-name", required=True)
+    parser.add_argument("--expect-artifact-sha256", required=True)
+    parser.add_argument("--expect-artifact-resource-uri", required=True)
+
+    parser.add_argument("--expect-policy-id", required=True)
+    parser.add_argument("--expect-policy-uri", required=True)
+    parser.add_argument("--expect-policy-sha256", required=True)
+
+    parser.add_argument("--expect-verifier-id", required=True)
+    parser.add_argument("--expect-verified-level", required=True)
+    parser.add_argument("--expect-time-verified", required=True)
+
+    parser.add_argument("--expect-candidate-set", default=CANDIDATE_SET)
+    parser.add_argument("--output", help="Optional path for deterministic diagnostic report")
+
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def nested_get(data: Any, path: list[str]) -> Any:
+    cursor = data
+    for key in path:
+        if not isinstance(cursor, dict):
+            return None
+        cursor = cursor.get(key)
+    return cursor
+
+
+def expected_current_run_key_from_packet(packet: dict[str, Any]) -> str | None:
+    run_binding = packet.get("run_binding")
+    if not isinstance(run_binding, dict):
+        return None
+
+    current_run_id = run_binding.get("current_run_id")
+    current_run_number = run_binding.get("current_run_number")
+    current_run_attempt = run_binding.get("current_run_attempt")
+    workflow_name = run_binding.get("workflow_name")
+
+    required_values = [
+        current_run_id,
+        current_run_number,
+        current_run_attempt,
+        workflow_name,
+    ]
+
+    if not all(isinstance(value, str) and value for value in required_values):
+        return None
+
+    return (
+        f"GITHUB_RUN_ID={current_run_id}"
+        f"|GITHUB_RUN_NUMBER={current_run_number}"
+        f"|GITHUB_RUN_ATTEMPT={current_run_attempt}"
+        f"|GITHUB_WORKFLOW={workflow_name}"
+    )
+
+
+def validation_errors(schema: dict[str, Any], packet: Any) -> list[str]:
+    validator = jsonschema.Draft202012Validator(
+        schema,
+        format_checker=jsonschema.FormatChecker(),
+    )
+
+    return [
+        f"schema_error[{list(error.path)}]: {error.message}"
+        for error in sorted(validator.iter_errors(packet), key=lambda err: list(err.path))
+    ]
+
+
+def make_diagnostic(
+    *,
+    ok: bool,
+    schema_valid: bool,
+    checks: dict[str, bool],
+    errors: list[str],
+) -> dict[str, Any]:
+    return {
+        "tool": TOOL_NAME,
+        "ok": ok,
+        "schema_version": SCHEMA_VERSION,
+        "packet_type": PACKET_TYPE,
+        "schema_valid": schema_valid,
+        "checks": checks,
+        "errors": errors,
+    }
+
+
+def emit_report(report: dict[str, Any], output: Path | None) -> None:
+    rendered = json.dumps(report, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+    sys.stdout.write(rendered)
+
+    if output is not None:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered, encoding="utf-8")
+
+
+def build_checks(args: argparse.Namespace, packet: dict[str, Any]) -> dict[str, bool]:
+    packet_run_key = nested_get(packet, ["run_binding", "current_run_key"])
+    expected_run_key_from_packet = expected_current_run_key_from_packet(packet)
+
+    run_release_candidate = nested_get(packet, ["run_binding", "release_candidate_id"])
+    artifact_release_candidate = nested_get(packet, ["artifact_binding", "release_candidate_id"])
+    subject_sha256 = nested_get(packet, ["artifact_binding", "subject_sha256"])
+    artifact_digest_sha256 = nested_get(packet, ["artifact_binding", "artifact_digest_sha256"])
+
+    return {
+        "schema_version_ok": packet.get("schema_version") == SCHEMA_VERSION,
+        "packet_type_ok": packet.get("packet_type") == PACKET_TYPE,
+        "recorded_signal_mode_ok": packet.get("recorded_signal_mode") == RECORDED_SIGNAL_MODE,
+        "candidate_set_matches": packet.get("candidate_set") == args.expect_candidate_set,
+
+        "producer_id_matches": (
+            nested_get(packet, ["producer_identity", "producer_id"])
+            == args.expect_producer_id
+        ),
+        "producer_name_matches": (
+            nested_get(packet, ["producer_identity", "producer_name"])
+            == args.expect_producer_name
+        ),
+        "producer_version_matches": (
+            nested_get(packet, ["producer_identity", "producer_version"])
+            == args.expect_producer_version
+        ),
+        "producer_source_matches": (
+            nested_get(packet, ["producer_identity", "producer_source"])
+            == args.expect_producer_source
+        ),
+        "producer_ci_identity_matches": (
+            nested_get(packet, ["producer_identity", "ci_workflow_or_job_identity"])
+            == args.expect_ci_workflow_or_job_identity
+        ),
+
+        "current_run_id_matches": (
+            nested_get(packet, ["run_binding", "current_run_id"])
+            == args.expect_current_run_id
+        ),
+        "current_run_key_matches": packet_run_key == args.expect_current_run_key,
+        "current_run_key_self_consistent": (
+            isinstance(expected_run_key_from_packet, str)
+            and packet_run_key == expected_run_key_from_packet
+        ),
+        "commit_sha_matches": (
+            nested_get(packet, ["run_binding", "commit_sha"])
+            == args.expect_commit_sha
+        ),
+        "run_release_candidate_matches": (
+            run_release_candidate == args.expect_release_candidate_id
+        ),
+
+        "artifact_subject_name_matches": (
+            nested_get(packet, ["artifact_binding", "subject_name"])
+            == args.expect_artifact_subject_name
+        ),
+        "artifact_subject_sha256_matches": subject_sha256 == args.expect_artifact_sha256,
+        "artifact_resource_uri_matches": (
+            nested_get(packet, ["artifact_binding", "resource_uri"])
+            == args.expect_artifact_resource_uri
+        ),
+        "artifact_release_candidate_matches": (
+            artifact_release_candidate == args.expect_release_candidate_id
+        ),
+        "artifact_digest_sha256_matches": artifact_digest_sha256 == args.expect_artifact_sha256,
+        "artifact_digest_self_consistent": (
+            isinstance(subject_sha256, str)
+            and isinstance(artifact_digest_sha256, str)
+            and subject_sha256 == artifact_digest_sha256
+        ),
+        "run_artifact_release_candidate_consistent": (
+            isinstance(run_release_candidate, str)
+            and run_release_candidate == artifact_release_candidate
+        ),
+
+        "policy_id_matches": (
+            nested_get(packet, ["policy_binding", "expected_policy_id"])
+            == args.expect_policy_id
+        ),
+        "policy_uri_matches": (
+            nested_get(packet, ["policy_binding", "expected_policy_uri"])
+            == args.expect_policy_uri
+        ),
+        "policy_sha256_matches": (
+            nested_get(packet, ["policy_binding", "expected_policy_sha256"])
+            == args.expect_policy_sha256
+        ),
+
+        "verifier_id_matches": (
+            nested_get(packet, ["verifier_binding", "expected_verifier_id"])
+            == args.expect_verifier_id
+        ),
+
+        "expected_verified_level_matches": (
+            packet.get("expected_verified_level") == args.expect_verified_level
+        ),
+        "expected_time_verified_matches": (
+            nested_get(packet, ["freshness", "expected_time_verified"])
+            == args.expect_time_verified
+        ),
+    }
+
+
+def build_report(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
+    try:
+        schema = load_json(Path(args.schema))
+        packet = load_json(Path(args.packet))
+    except Exception as exc:
+        diagnostic = make_diagnostic(
+            ok=False,
+            schema_valid=False,
+            checks={},
+            errors=[f"read_error: {exc}"],
+        )
+        return diagnostic, 2
+
+    try:
+        jsonschema.Draft202012Validator.check_schema(schema)
+    except Exception as exc:
+        diagnostic = make_diagnostic(
+            ok=False,
+            schema_valid=False,
+            checks={},
+            errors=[f"schema_invalid: {exc}"],
+        )
+        return diagnostic, 2
+
+    errors = validation_errors(schema, packet)
+    schema_valid = not errors
+
+    if not isinstance(packet, dict):
+        diagnostic = make_diagnostic(
+            ok=False,
+            schema_valid=schema_valid,
+            checks={},
+            errors=errors + ["packet_not_object"],
+        )
+        return diagnostic, 1
+
+    checks = build_checks(args, packet)
+
+    for check_name, passed in checks.items():
+        if not passed:
+            errors.append(f"check_failed: {check_name}")
+
+    ok = schema_valid and not errors
+
+    diagnostic = make_diagnostic(
+        ok=ok,
+        schema_valid=schema_valid,
+        checks=checks,
+        errors=errors,
+    )
+
+    return diagnostic, 0 if ok else 1
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output) if args.output else None
+
+    if output is not None and output.name == "status.json":
+        report = make_diagnostic(
+            ok=False,
+            schema_valid=False,
+            checks={},
+            errors=["refusing_to_write_status_json"],
+        )
+        emit_report(report, None)
+        return 2
+
+    report, exit_code = build_report(args)
+    emit_report(report, output)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds a deterministic validator for the SLSA VSA trusted producer input packet contract.

New files:

```text
tools/check_slsa_vsa_trusted_producer_input_packet_v0.py
tests/test_check_slsa_vsa_trusted_producer_input_packet_v0.py
```

Updated manifest:

```text
ci/tools-tests.list
```

## Why

The trusted producer input packet contract now exists.

Before rebuilding the trusted producer report builder, the input packet itself needs an explicit validator.

This prevents the future builder from accepting an arbitrary schema-shaped packet without checking that its producer, run, artifact, policy, verifier, and freshness bindings match expected trusted values.

## Scope

The validator checks:

```text
input packet schema validity
producer identity
current-run identity
current-run key
current-run key self-consistency
commit SHA
release candidate ID
artifact subject name
artifact subject digest
artifact resource URI
artifact digest
artifact/run release candidate consistency
policy identity
policy URI
policy digest
verifier identity
expected verified level
expected timeVerified
recorded_signal_only mode
slsa_vsa_recorded_intake_candidate identity
```

It emits a deterministic diagnostic report.

It refuses to write any output file named:

```text
status.json
```

## Non-goals

This PR does not add:

```text
tools/build_slsa_vsa_trusted_evidence_producer_report_v0.py
tools/build_slsa_vsa_trusted_evidence_producer_report_from_input_packet_v0.py
```

This PR does not modify:

```text
pulse_gate_policy_v0.yml
pulse_gate_registry_v0.yml
PULSE_safe_pack_v0/tools/check_gates.py
tools/policy_to_require_args.py
tools/ingest_slsa_vsa_evidence_v0.py
tools/fold_slsa_vsa_intake_into_status_v0.py
.github/workflows/
README.md
CITATION.cff
.zenodo.json
zenodo.preprint.json
ORCID_add_work.json
docs/policy/CHANGELOG.md
tests/fixtures/core_baseline_v0/status.normalized.json
```

This PR does not activate SLSA VSA as:

```text
required
core_required
release_required
prod_required
stage_required
blocking
release_blocking
```

This PR does not change release-authority behavior.

## Tests

Added:

```text
tests/test_check_slsa_vsa_trusted_producer_input_packet_v0.py
```

The test covers:

```text
valid input packet passes
diagnostic output matches stdout
schema-invalid packet fails closed
missing packet returns read error
wrong producer identity fails closed
wrong current-run key fails closed
non-self-consistent current-run key fails closed
wrong commit SHA fails closed
wrong release candidate fails closed
wrong artifact subject fails closed
wrong artifact digest fails closed
artifact/run release candidate mismatch fails closed
wrong policy identity fails closed
wrong policy URI fails closed
wrong policy digest fails closed
wrong verifier identity fails closed
wrong expected verified level fails closed
wrong expected timeVerified fails closed
wrong candidate set fails closed
status.json output is refused
tool does not call check_gates.py
tool does not write status gates
tool does not activate release policy sets
```

## Validation

Expected validation:

```text
python -m py_compile tools/check_slsa_vsa_trusted_producer_input_packet_v0.py
python -m py_compile tests/test_check_slsa_vsa_trusted_producer_input_packet_v0.py
python tests/test_check_slsa_vsa_trusted_producer_input_packet_v0.py
python -m pytest tests/test_check_slsa_vsa_trusted_producer_input_packet_v0.py
python tests/test_tools_tests_list_smoke.py
git diff --check
```

## Follow-up

A later PR may rebuild the trusted producer report builder.

That future builder must consume:

```text
schema-valid SLSA VSA evidence
schema-valid trusted producer input packet
existing trusted producer report schema
existing trusted producer report validator
validated trusted producer input packet
```

The future builder must exit `0` only after:

```text
SLSA VSA evidence schema validates
trusted producer input packet schema validates
trusted producer input packet validator passes
generated producer report schema validates
existing producer report validator passes
```

Each step remains separate.