### PR TITLE
feat(slsa): bind vsa evidence policy identity

### DIFF
--- a/examples/slsa/slsa_vsa_evidence_example_v0.json
+++ b/examples/slsa/slsa_vsa_evidence_example_v0.json
@@ -22,6 +22,7 @@
       "timeVerified": "2026-07-04T00:00:00Z",
       "resourceUri": "git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0",
       "policy": {
+        "id": "pulse-gate-policy-v0",
         "uri": "https://example.invalid/policies/pulse-slsa-vsa-policy-v0.json",
         "digest": {
           "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/schemas/slsa_vsa_evidence_v0.schema.json
+++ b/schemas/slsa_vsa_evidence_v0.schema.json
@@ -102,9 +102,15 @@
               "type": "object",
               "additionalProperties": true,
               "required": [
-                "uri"
+                "id",
+                "uri",
+                "digest"
               ],
               "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "uri": {
                   "type": "string",
                   "minLength": 1
@@ -215,9 +221,18 @@
     "digestMap": {
       "type": "object",
       "minProperties": 1,
+      "required": [
+        "sha256"
+      ],
       "propertyNames": {
         "type": "string",
         "pattern": "^[A-Za-z0-9._+:-]+$"
+      },
+      "properties": {
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$"
+        }
       },
       "additionalProperties": {
         "type": "string",


### PR DESCRIPTION
Bind SLSA VSA evidence to an explicit policy identity.

This updates the SLSA VSA evidence contract so predicate.policy requires an id, uri, and digest.

The policy digest remains mandatory and the digest map now requires a sha256 value.

No builder added.
No workflow change.
No policy change.
No gate registry change.
No check_gates.py change.
No release-authority behavior change.
No SLSA VSA release-required activation.

<!-- PULSE PR Template v1.0 — keep sections; fill what applies. -->

## Summary
<!-- Short: what changes and why? -->

## What’s included
- [ ] Code
- [ ] Docs
- [ ] CI / workflow
- Paths / files touched:

## CI usage
```yaml
# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json
```

## Impact
- Additive / backwards-compatible
- Breaking change — details:
- Performance / SLO impact:
- Security considerations:

What’s included
 Code
 Docs
 CI / workflow

Paths / files touched:

CI usage

# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json

Impact
Additive / backwards-compatible

Breaking change — details:

Performance / SLO impact:

Security considerations:

### Security Intake (v0) — dependency / external code (if applicable)
**Intake v0:** PASS | REVIEW | HARD STOP  
**Isolation used (if REVIEW):** yes / no  

**Reasons (1–3 bullets):**
- 
- 
- 

**Checks**
- [ ] No password-protected ZIP / random binary download involved
- [ ] Repo age ≥ 12 months and maintainer history looks real
- [ ] No postinstall/preinstall scripts (or justified + reviewed)
- [ ] No obfuscation / base64 blobs / runtime-downloaded binaries
- [ ] No instructions like “disable Defender/AV”
- [ ] First run done in VM/container (if REVIEW)

> If any HIGH-risk signal appears → mark **HARD STOP** and do not merge.

Notes

Follow-ups:

Risks / mitigations:

PULSE checklist (release authority)
 PULSE CI is green on this PR
 Quality Ledger link (if enabled)
 Badges updated (PASS / RDSI / Q-Ledger)


## Notes
- Follow-ups:
- Risks / mitigations:

## PULSE checklist (release authority)
- [ ] PULSE CI is green on this PR
- [ ] Quality Ledger link (if enabled)
- [ ] Badges updated (PASS / RDSI / Q‑Ledger)
