### PR TITLE
feat(slsa): bind vsa evidence policy identity

### DIFF
--- a/examples/slsa/slsa_vsa_evidence_example_v0.json
+++ b/examples/slsa/slsa_vsa_evidence_example_v0.json
@@ -22,6 +22,7 @@
       "timeVerified": "2026-07-04T00:00:00Z",
       "resourceUri": "git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0",
       "policy": {
+        "id": "pulse-gate-policy-v0",
         "uri": "https://example.invalid/policies/pulse-slsa-vsa-policy-v0.json",
         "digest": {
           "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/schemas/slsa_vsa_evidence_v0.schema.json
+++ b/schemas/slsa_vsa_evidence_v0.schema.json
@@ -102,15 +102,21 @@
               "type": "object",
               "additionalProperties": true,
               "required": [
-                "uri"
+                "id",
+                "uri",
+                "digest"
               ],
               "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "uri": {
                   "type": "string",
                   "minLength": 1
                 },
                 "digest": {
-                  "$ref": "#/$defs/digestMap"
+                  "$ref": "#/$defs/policyDigestMap"
                 }
               }
             },
@@ -218,6 +224,27 @@
       "propertyNames": {
         "type": "string",
         "pattern": "^[A-Za-z0-9._+:-]+$"
+      },
+      "additionalProperties": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "policyDigestMap": {
+      "type": "object",
+      "minProperties": 1,
+      "required": [
+        "sha256"
+      ],
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9._+:-]+$"
+      },
+      "properties": {
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$"
+        }
       },
       "additionalProperties": {
         "type": "string",

--- a/tests/test_slsa_vsa_evidence_schema_v0.py
+++ b/tests/test_slsa_vsa_evidence_schema_v0.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import json
 from pathlib import Path
+from typing import Any
 
 from jsonschema import Draft202012Validator
 
@@ -16,20 +19,53 @@ REQUIRED_PULSE_SIGNALS = [
     "slsa_vsa_resource_uri_matches",
     "slsa_vsa_policy_digest_matches",
     "slsa_vsa_result_passed",
-    "slsa_vsa_verified_level_ok"
+    "slsa_vsa_verified_level_ok",
 ]
 
+EXPECTED_POLICY = {
+    "id": "pulse-gate-policy-v0",
+    "uri": "https://example.invalid/policies/pulse-slsa-vsa-policy-v0.json",
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+}
 
-def load_json(path: Path) -> dict:
+
+def load_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def check_slsa_vsa_evidence_schema_v0() -> None:
-    schema = load_json(SCHEMA_PATH)
-    example = load_json(EXAMPLE_PATH)
+def load_example() -> dict[str, Any]:
+    return load_json(EXAMPLE_PATH)
 
+
+def validator() -> Draft202012Validator:
+    schema = load_json(SCHEMA_PATH)
     Draft202012Validator.check_schema(schema)
-    Draft202012Validator(schema).validate(example)
+    return Draft202012Validator(schema)
+
+
+def validation_errors(instance: dict[str, Any]) -> list[str]:
+    return [
+        error.message
+        for error in validator().iter_errors(instance)
+    ]
+
+
+def policy_object(example: dict[str, Any]) -> dict[str, Any]:
+    return example["vsa"]["predicate"]["policy"]
+
+
+def subject_digest(example: dict[str, Any]) -> dict[str, Any]:
+    return example["vsa"]["subject"][0]["digest"]
+
+
+def input_attestation_digest(example: dict[str, Any]) -> dict[str, Any]:
+    return example["vsa"]["predicate"]["inputAttestations"][0]["digest"]
+
+
+def check_slsa_vsa_evidence_schema_v0() -> None:
+    example = load_example()
+
+    validator().validate(example)
 
     assert example["schema_version"] == "slsa_vsa_evidence_v0"
     assert example["evidence_type"] == "slsa_vsa"
@@ -47,6 +83,11 @@ def check_slsa_vsa_evidence_schema_v0() -> None:
     assert verifier["id"] != "https://github.com/slsa-framework/slsa-verifier"
     assert isinstance(verifier["version"], dict)
     assert verifier["version"]["slsa-verifier"] == "v2.7.0"
+
+    policy = predicate["policy"]
+    assert policy["id"] == EXPECTED_POLICY["id"]
+    assert policy["uri"] == EXPECTED_POLICY["uri"]
+    assert policy["digest"]["sha256"] == EXPECTED_POLICY["sha256"]
 
     input_attestations = predicate["inputAttestations"]
     assert input_attestations
@@ -68,10 +109,137 @@ def check_slsa_vsa_evidence_schema_v0() -> None:
         assert pulse_signals[signal] is True
 
 
+def test_example_validates() -> None:
+    validator().validate(load_example())
+
+
+def test_policy_identity_is_required() -> None:
+    example = load_example()
+    del policy_object(example)["id"]
+
+    assert validation_errors(example)
+
+
+def test_policy_identity_must_be_non_empty() -> None:
+    example = load_example()
+    policy_object(example)["id"] = ""
+
+    assert validation_errors(example)
+
+
+def test_policy_uri_is_still_required() -> None:
+    example = load_example()
+    del policy_object(example)["uri"]
+
+    assert validation_errors(example)
+
+
+def test_policy_digest_is_still_required() -> None:
+    example = load_example()
+    del policy_object(example)["digest"]
+
+    assert validation_errors(example)
+
+
+def test_policy_digest_sha256_is_required() -> None:
+    example = load_example()
+    del policy_object(example)["digest"]["sha256"]
+
+    assert validation_errors(example)
+
+
+def test_policy_digest_sha256_must_be_64_character_hex() -> None:
+    bad_values = [
+        "b" * 63,
+        "b" * 65,
+        "g" * 64,
+        "",
+    ]
+
+    for value in bad_values:
+        example = load_example()
+        policy_object(example)["digest"]["sha256"] = value
+
+        assert validation_errors(example), value
+
+
+def test_policy_uri_only_evidence_is_rejected() -> None:
+    example = load_example()
+    policy = policy_object(example)
+    policy.clear()
+    policy["uri"] = EXPECTED_POLICY["uri"]
+
+    assert validation_errors(example)
+
+
+def test_policy_identity_without_digest_is_rejected() -> None:
+    example = load_example()
+    policy = policy_object(example)
+    policy.clear()
+    policy["id"] = EXPECTED_POLICY["id"]
+    policy["uri"] = EXPECTED_POLICY["uri"]
+
+    assert validation_errors(example)
+
+
+def test_policy_digest_without_identity_is_rejected() -> None:
+    example = load_example()
+    policy = policy_object(example)
+    policy.clear()
+    policy["uri"] = EXPECTED_POLICY["uri"]
+    policy["digest"] = {
+        "sha256": EXPECTED_POLICY["sha256"],
+    }
+
+    assert validation_errors(example)
+
+
+def test_subject_digest_map_remains_algorithm_generic() -> None:
+    example = load_example()
+    subject_digest(example).clear()
+    subject_digest(example)["sha512"] = "nonempty-sha512-placeholder"
+
+    validator().validate(example)
+
+
+def test_input_attestation_digest_map_remains_algorithm_generic() -> None:
+    example = load_example()
+    input_attestation_digest(example).clear()
+    input_attestation_digest(example)["sha512"] = "nonempty-sha512-placeholder"
+
+    validator().validate(example)
+
+
+def test_policy_digest_map_requires_sha256_even_if_other_digest_exists() -> None:
+    example = load_example()
+    policy_digest = policy_object(example)["digest"]
+    policy_digest.clear()
+    policy_digest["sha512"] = "nonempty-sha512-placeholder"
+
+    assert validation_errors(example)
+
+
 def test_slsa_vsa_evidence_schema_v0() -> None:
     check_slsa_vsa_evidence_schema_v0()
 
 
+def check_policy_identity_binding_tests() -> None:
+    test_example_validates()
+    test_policy_identity_is_required()
+    test_policy_identity_must_be_non_empty()
+    test_policy_uri_is_still_required()
+    test_policy_digest_is_still_required()
+    test_policy_digest_sha256_is_required()
+    test_policy_digest_sha256_must_be_64_character_hex()
+    test_policy_uri_only_evidence_is_rejected()
+    test_policy_identity_without_digest_is_rejected()
+    test_policy_digest_without_identity_is_rejected()
+    test_subject_digest_map_remains_algorithm_generic()
+    test_input_attestation_digest_map_remains_algorithm_generic()
+    test_policy_digest_map_requires_sha256_even_if_other_digest_exists()
+
+
 if __name__ == "__main__":
     check_slsa_vsa_evidence_schema_v0()
+    check_policy_identity_binding_tests()
     print("OK: slsa_vsa_evidence_v0 schema and example are valid")


### PR DESCRIPTION
## Summary

Stage 1 of a manual, staged SLSA VSA evidence policy identity binding change.

This PR currently updates only the SLSA VSA evidence schema contract.

Current stage:

```text
1/3 — schema contract only
```

Current changed file:

```text
schemas/slsa_vsa_evidence_v0.schema.json
```

## Why

A future trusted producer report builder must not synthesize `evidence_policy_id` from expected policy inputs.

The evidence side must carry the policy identity that the future builder will compare against the trusted producer input packet.

This stage updates the SLSA VSA evidence schema so:

```text
vsa.predicate.policy.id
vsa.predicate.policy.uri
vsa.predicate.policy.digest.sha256
```

are required.

## Scope

This stage changes the schema only.

The policy digest binding is policy-specific.

The generic digest map remains unchanged, so this stage does not broaden SHA256 requirements to:

```text
subject.digest
inputAttestations[].digest
```

## Current expected status

This stage is intentionally not merge-ready.

The example and tests will be added in later staged commits:

```text
Stage 2 — update examples/slsa/slsa_vsa_evidence_example_v0.json
Stage 3 — update tests/test_slsa_vsa_evidence_schema_v0.py
```

If CI fails because the example has not yet been aligned with the new schema, that is expected at this intermediate stage.

Do not merge until all stages are complete and reviewed.

## Non-goals

This PR does not add or modify:

```text
tools/build_slsa_vsa_trusted_evidence_producer_report_v0.py
tools/build_slsa_vsa_trusted_evidence_producer_report_from_input_packet_v0.py
tools/check_slsa_vsa_trusted_producer_input_packet_v0.py
schemas/slsa_vsa_trusted_producer_input_packet_v0.schema.json
examples/slsa/slsa_vsa_trusted_producer_input_packet_example_v0.json
tests/test_check_slsa_vsa_trusted_producer_input_packet_v0.py
pulse_gate_policy_v0.yml
pulse_gate_registry_v0.yml
PULSE_safe_pack_v0/tools/check_gates.py
tools/policy_to_require_args.py
tools/fold_slsa_vsa_intake_into_status_v0.py
.github/workflows/
README.md
CITATION.cff
.zenodo.json
zenodo.preprint.json
ORCID_add_work.json
docs/policy/CHANGELOG.md
tests/fixtures/core_baseline_v0/status.normalized.json
```

This PR does not activate SLSA VSA as:

```text
required
core_required
release_required
prod_required
stage_required
blocking
release_blocking
```

This PR does not change release-authority behavior.

## Manual staged plan

```text
Stage 1:
schemas/slsa_vsa_evidence_v0.schema.json

Stage 2:
examples/slsa/slsa_vsa_evidence_example_v0.json

Stage 3:
tests/test_slsa_vsa_evidence_schema_v0.py

Stage 4:
final review, CI, merge

Stage 5:
post-merge external review
```