### PR TITLE
feat(release): add release-grade package completeness checker v1

### DIFF
--- a/tests/test_check_release_grade_package_complete_v1.py
+++ b/tests/test_check_release_grade_package_complete_v1.py
@@ -1,0 +1,617 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "tools" / "check_release_grade_package_complete_v1.py"
+TOOLS_TESTS_LIST = ROOT / "ci" / "tools-tests.list"
+
+THIS_TEST = "tests/test_check_release_grade_package_complete_v1.py"
+
+PACKAGE_INVENTORY = "package_digest_inventory_v0.json"
+
+SUBJECT_NAME = "git+https://github.com/HKati/pulse-release-gates-0.1@refs/tags/v0.1.0"
+SUBJECT_SHA256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+COMMIT_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+POLICY_ID = "pulse-gate-policy-v0"
+POLICY_URI = "https://pulse.invalid/policies/pulse-slsa-vsa-policy-v0.json"
+POLICY_SHA256 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+VERIFIER_ID = "https://pulse.invalid/verifiers/pulsemech-vsa-verifier-v0"
+VERIFIED_LEVEL = "SLSA_BUILD_LEVEL_3"
+TIME_VERIFIED = "2026-07-04T00:00:00Z"
+CURRENT_RUN_KEY = (
+    "GITHUB_RUN_ID=1234567890"
+    "|GITHUB_RUN_NUMBER=2692"
+    "|GITHUB_RUN_ATTEMPT=1"
+    "|GITHUB_WORKFLOW=PULSE CI"
+)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def all_package_files(package_dir: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in package_dir.rglob("*")
+        if path.is_file() and path.relative_to(package_dir).as_posix() != PACKAGE_INVENTORY
+    )
+
+
+def rebuild_digest_inventory(package_dir: Path) -> None:
+    files = []
+    for path in all_package_files(package_dir):
+        relative = path.relative_to(package_dir).as_posix()
+        files.append(
+            {
+                "path": relative,
+                "sha256": sha256_file(path),
+                "size_bytes": path.stat().st_size,
+            }
+        )
+
+    write_json(
+        package_dir / PACKAGE_INVENTORY,
+        {
+            "schema_version": "release_grade_reference_package_digest_inventory_v0",
+            "algorithm": "sha256",
+            "file_count": len(files),
+            "files": files,
+        },
+    )
+
+
+def packet_payload() -> dict[str, Any]:
+    return {
+        "schema_version": "slsa_vsa_trusted_producer_input_packet_v0",
+        "packet_type": "slsa_vsa_trusted_producer_input_packet",
+        "created_utc": "2026-07-07T00:00:00Z",
+        "producer_identity": {
+            "producer_id": "pulse_slsa_vsa_trusted_evidence_producer_v0",
+            "producer_name": "PULSE SLSA VSA trusted evidence producer",
+            "producer_version": "0.1.0",
+            "producer_source": "github-actions",
+            "ci_workflow_or_job_identity": "PULSE CI / SLSA VSA trusted evidence producer",
+        },
+        "run_binding": {
+            "current_run_id": "1234567890",
+            "current_run_number": "2692",
+            "current_run_attempt": "1",
+            "current_run_key": CURRENT_RUN_KEY,
+            "workflow_name": "PULSE CI",
+            "job_name": "slsa-vsa-trusted-evidence-producer",
+            "commit_sha": COMMIT_SHA,
+            "release_candidate_id": "pulse-release-gates-0.1-candidate-v0",
+        },
+        "artifact_binding": {
+            "subject_name": SUBJECT_NAME,
+            "subject_sha256": SUBJECT_SHA256,
+            "resource_uri": SUBJECT_NAME,
+            "release_candidate_id": "pulse-release-gates-0.1-candidate-v0",
+            "artifact_digest_sha256": SUBJECT_SHA256,
+        },
+        "policy_binding": {
+            "expected_policy_id": POLICY_ID,
+            "expected_policy_uri": POLICY_URI,
+            "expected_policy_sha256": POLICY_SHA256,
+        },
+        "verifier_binding": {
+            "expected_verifier_id": VERIFIER_ID,
+        },
+        "expected_verified_level": VERIFIED_LEVEL,
+        "freshness": {
+            "expected_time_verified": TIME_VERIFIED,
+            "freshness_epoch": "current_run",
+        },
+        "recorded_signal_mode": "recorded_signal_only",
+        "candidate_set": "slsa_vsa_recorded_intake_candidate",
+    }
+
+
+def report_payload() -> dict[str, Any]:
+    return {
+        "schema_version": "slsa_vsa_trusted_evidence_producer_report_v0",
+        "report_type": "slsa_vsa_trusted_evidence_producer_report",
+        "created_utc": "2026-07-07T00:00:00Z",
+        "producer": {
+            "producer_id": "pulse_slsa_vsa_trusted_evidence_producer_v0",
+            "producer_name": "PULSE SLSA VSA trusted evidence producer",
+            "producer_version": "0.1.0",
+            "producer_source": "github-actions",
+            "ci_workflow_or_job_identity": "PULSE CI / SLSA VSA trusted evidence producer",
+        },
+        "run_binding": {
+            "current_run_id": "1234567890",
+            "current_run_number": "2692",
+            "current_run_attempt": "1",
+            "current_run_key": CURRENT_RUN_KEY,
+            "workflow_name": "PULSE CI",
+            "job_name": "slsa-vsa-trusted-evidence-producer",
+            "commit_sha": COMMIT_SHA,
+            "release_candidate_id": "pulse-release-gates-0.1-candidate-v0",
+        },
+        "artifact_binding": {
+            "subject_name": SUBJECT_NAME,
+            "subject_sha256": SUBJECT_SHA256,
+            "resource_uri": SUBJECT_NAME,
+            "release_candidate_id": "pulse-release-gates-0.1-candidate-v0",
+            "artifact_digest_sha256": SUBJECT_SHA256,
+            "subject_digest_matches": True,
+            "resource_uri_matches": True,
+            "release_candidate_matches": True,
+            "artifact_digest_matches": True,
+        },
+        "policy_binding": {
+            "expected_policy_id": POLICY_ID,
+            "expected_policy_uri": POLICY_URI,
+            "expected_policy_sha256": POLICY_SHA256,
+            "evidence_policy_id": POLICY_ID,
+            "evidence_policy_uri": POLICY_URI,
+            "evidence_policy_sha256": POLICY_SHA256,
+            "policy_identity_matches": True,
+            "policy_digest_matches": True,
+        },
+        "verifier_binding": {
+            "expected_verifier_id": VERIFIER_ID,
+            "evidence_verifier_id": VERIFIER_ID,
+            "verifier_trusted": True,
+        },
+        "evidence": {
+            "evidence_path": "artifacts/slsa/vsa_evidence.json",
+            "evidence_sha256": "c" * 64,
+            "evidence_schema_version": "slsa_vsa_evidence_v0",
+            "evidence_type": "slsa_vsa",
+            "time_verified": TIME_VERIFIED,
+            "verification_result": "PASSED",
+            "expected_verified_level": VERIFIED_LEVEL,
+            "evidence_verified_levels": [VERIFIED_LEVEL],
+            "verified_level_ok": True,
+        },
+        "freshness": {
+            "freshness_result": "fresh_current_run",
+            "stale_vsa_evidence": False,
+            "previous_run_artifact_reuse": False,
+            "time_verified_current_run_match": True,
+            "current_run_binding_ok": True,
+        },
+        "recorded_signal_mode": "recorded_signal_only",
+        "candidate_set": "slsa_vsa_recorded_intake_candidate",
+        "producer_decision": "TRUSTED_EVIDENCE_ACCEPTED",
+        "ok": True,
+        "failed_checks": [],
+        "warnings": [],
+    }
+
+
+def make_complete_package(tmp_path: Path) -> Path:
+    package_dir = tmp_path / "release_grade_package"
+    package_dir.mkdir()
+
+    write_json(
+        package_dir / "run_metadata_v0.json",
+        {
+            "schema_version": "release_grade_run_metadata_v0",
+            "repository": "HKati/pulse-release-gates-0.1",
+            "git_sha": COMMIT_SHA,
+            "workflow_ref": (
+                "HKati/pulse-release-gates-0.1/.github/workflows/pulse_ci.yml@"
+                + COMMIT_SHA
+            ),
+            "run_id": 1234567890,
+            "run_attempt": 1,
+            "run_key": CURRENT_RUN_KEY,
+            "authority_boundary": {
+                "authorizes_release": False,
+                "package_only": True,
+            },
+        },
+    )
+    write_json(
+        package_dir / "artifacts" / "required_gate_evidence_v0.json",
+        {
+            "schema_version": "required_gate_evidence_v0",
+            "gates": {
+                "core_required_reference_ok": True,
+            },
+        },
+    )
+    write_json(
+        package_dir / "artifacts" / "status_baseline.json",
+        {
+            "schema_version": "status_baseline_v0",
+            "metrics": {
+                "git_sha": COMMIT_SHA,
+                "run_key": CURRENT_RUN_KEY,
+            },
+            "gates": {
+                "core_required_reference_ok": True,
+            },
+        },
+    )
+    write_json(
+        package_dir / "artifacts" / "recorded_release_candidate_index_v0.json",
+        {
+            "schema_version": "recorded_release_candidate_index_v0",
+            "candidates": ["candidate_0.json"],
+        },
+    )
+    write_json(
+        package_dir / "artifacts" / "release_evidence_input_manifest_v0.json",
+        {
+            "schema_version": "release_evidence_input_manifest_v0",
+            "inputs": ["status_baseline.json", "slsa_vsa_trusted_producer_report_v0.json"],
+        },
+    )
+    write_json(
+        package_dir / "artifacts" / "recorded_release_evidence_verifier_v0.json",
+        {
+            "schema_version": "recorded_release_evidence_verifier_v0",
+            "status": "verified",
+            "errors": [],
+        },
+    )
+    write_json(
+        package_dir / "artifacts" / "status.json",
+        {
+            "schema_version": "status_v0",
+            "metrics": {
+                "git_sha": COMMIT_SHA,
+                "run_key": CURRENT_RUN_KEY,
+            },
+            "gates": {
+                "core_required_reference_ok": True,
+            },
+        },
+    )
+    write_json(
+        package_dir / "artifacts" / "release_decision_v0.json",
+        {
+            "schema_version": "release_decision_v0",
+            "decision": "allow",
+            "ok": True,
+            "source": "package-completeness-fixture",
+        },
+    )
+    write_json(
+        package_dir / "artifacts" / "artifact_provenance_binding_v0.json",
+        {
+            "schema_version": "artifact_provenance_binding_v0",
+            "subject_name": SUBJECT_NAME,
+            "subject_sha256": SUBJECT_SHA256,
+            "commit_sha": COMMIT_SHA,
+        },
+    )
+    write_json(
+        package_dir / "artifacts" / "release_authority_v0.json",
+        {
+            "schema_version": "release_authority_v0",
+            "authority_boundary": {
+                "authorizes_release": False,
+                "source": "fixture",
+            },
+            "decision_artifact": "artifacts/release_decision_v0.json",
+        },
+    )
+    write_text(
+        package_dir / "artifacts" / "report_card.html",
+        "<html><body>release grade package complete</body></html>\n",
+    )
+    write_json(
+        package_dir
+        / "artifacts"
+        / "recorded_release_candidates"
+        / "candidate_0.json",
+        {
+            "schema_version": "recorded_release_candidate_v0",
+            "validation": {
+                "status": "passed",
+            },
+            "authority_boundary": {
+                "creates_release_authority": False,
+            },
+        },
+    )
+    write_json(
+        package_dir / "release-authority-audit-bundle" / "manifest.json",
+        {
+            "schema_version": "release_authority_audit_bundle_manifest_v0",
+            "artifacts": ["artifacts/release_decision_v0.json"],
+        },
+    )
+    write_json(
+        package_dir / "artifacts" / "slsa" / "slsa_vsa_trusted_producer_input_packet_v0.json",
+        packet_payload(),
+    )
+    write_json(
+        package_dir / "artifacts" / "slsa" / "slsa_vsa_trusted_evidence_producer_report_v0.json",
+        report_payload(),
+    )
+
+    rebuild_digest_inventory(package_dir)
+    return package_dir
+
+
+def run_tool(
+    package_dir: Path,
+    *,
+    output: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    command = [
+        sys.executable,
+        str(TOOL),
+        "--package-dir",
+        str(package_dir),
+    ]
+
+    if output is not None:
+        command.extend(["--output", str(output)])
+
+    return subprocess.run(
+        command,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def parse_report(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    assert result.stdout, result.stderr
+    loaded = json.loads(result.stdout)
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def assert_failure(
+    result: subprocess.CompletedProcess[str],
+    expected_fragment: str,
+) -> dict[str, Any]:
+    assert result.returncode != 0, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+
+    report = parse_report(result)
+    assert report["ok"] is False
+    assert any(expected_fragment in error for error in report["errors"]), report["errors"]
+    return report
+
+
+def test_manifest_registers_completeness_checker_exactly_once() -> None:
+    entries = [
+        line.split("#", 1)[0].strip()
+        for line in TOOLS_TESTS_LIST.read_text(encoding="utf-8").splitlines()
+    ]
+    entries = [line for line in entries if line]
+
+    assert entries.count(THIS_TEST) == 1
+
+
+def test_manifest_places_checker_in_release_grade_block() -> None:
+    entries = [
+        line.split("#", 1)[0].strip()
+        for line in TOOLS_TESTS_LIST.read_text(encoding="utf-8").splitlines()
+    ]
+    entries = [line for line in entries if line]
+
+    checker_index = entries.index(THIS_TEST)
+    after_index = entries.index("tests/test_release_grade_reference_package_verification_wiring_v0.py")
+    before_index = entries.index("tests/test_release_grade_reference_qualification_advisory_boundary_v0.py")
+
+    assert after_index < checker_index < before_index
+
+
+def test_complete_package_passes_and_output_matches_stdout(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    output = tmp_path / "completeness_report.json"
+
+    result = run_tool(package_dir, output=output)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+    assert output.exists()
+    assert output.read_text(encoding="utf-8") == result.stdout
+
+    report = parse_report(result)
+    assert report["schema_version"] == "release_grade_package_completeness_v1"
+    assert report["ok"] is True
+    assert report["status"] == "complete"
+    assert report["errors"] == []
+    assert report["authority_boundary"]["authorizes_release"] is False
+    assert report["authority_boundary"]["package_completeness_only"] is True
+    assert report["summary"]["checks_failed"] == 0
+
+
+def test_missing_required_file_fails_closed(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    (package_dir / "artifacts" / "status.json").unlink()
+    rebuild_digest_inventory(package_dir)
+
+    report = assert_failure(run_tool(package_dir), "required_file:artifacts/status.json")
+
+    assert report["status"] == "incomplete"
+
+
+def test_empty_required_file_fails_closed(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    write_text(package_dir / "artifacts" / "report_card.html", "")
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(run_tool(package_dir), "non_empty_file:artifacts/report_card.html")
+
+
+def test_duplicate_json_key_fails_closed(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    write_text(
+        package_dir / "artifacts" / "status.json",
+        '{"schema_version": "status_v0", "schema_version": "duplicate"}\n',
+    )
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(run_tool(package_dir), "duplicate JSON key")
+
+
+def test_stub_marker_fails_closed(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    packet = read_json(
+        package_dir / "artifacts" / "slsa" / "slsa_vsa_trusted_producer_input_packet_v0.json"
+    )
+    packet["producer_identity"]["producer_id"] = "replace-me"
+    write_json(
+        package_dir / "artifacts" / "slsa" / "slsa_vsa_trusted_producer_input_packet_v0.json",
+        packet,
+    )
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(
+        run_tool(package_dir),
+        "non_stub_json:artifacts/slsa/slsa_vsa_trusted_producer_input_packet_v0.json",
+    )
+
+
+def test_digest_inventory_mismatch_fails_closed(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+
+    status_path = package_dir / "artifacts" / "status.json"
+    status = read_json(status_path)
+    status["metrics"]["git_sha"] = "b" * 40
+    write_json(status_path, status)
+
+    assert_failure(run_tool(package_dir), "digest_inventory.digest:artifacts/status.json")
+
+
+def test_slsa_packet_report_mismatch_fails_closed(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    report_path = (
+        package_dir
+        / "artifacts"
+        / "slsa"
+        / "slsa_vsa_trusted_evidence_producer_report_v0.json"
+    )
+    report = read_json(report_path)
+    report["run_binding"]["current_run_key"] = (
+        "GITHUB_RUN_ID=9999999999|GITHUB_RUN_NUMBER=2692|GITHUB_RUN_ATTEMPT=1|GITHUB_WORKFLOW=PULSE CI"
+    )
+    write_json(report_path, report)
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(run_tool(package_dir), "slsa_vsa.current_run_key")
+
+
+def test_stale_or_rejected_slsa_report_fails_closed(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    report_path = (
+        package_dir
+        / "artifacts"
+        / "slsa"
+        / "slsa_vsa_trusted_evidence_producer_report_v0.json"
+    )
+    report = read_json(report_path)
+    report["producer_decision"] = "TRUSTED_EVIDENCE_REJECTED"
+    report["ok"] = False
+    report["failed_checks"] = ["freshness_epoch_current"]
+    report["freshness"]["freshness_result"] = "rejected_stale_vsa"
+    report["freshness"]["current_run_binding_ok"] = False
+    write_json(report_path, report)
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(run_tool(package_dir), "slsa_vsa.report.accepted")
+
+
+def test_refuses_status_json_output(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    output = tmp_path / "status.json"
+
+    result = run_tool(package_dir, output=output)
+
+    assert result.returncode == 2
+    assert not output.exists()
+
+    report = parse_report(result)
+    assert report["ok"] is False
+    assert "refusing_to_write_status_json" in report["errors"]
+
+
+def test_refuses_output_inside_package_dir(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    output = package_dir / "completeness_report.json"
+
+    result = run_tool(package_dir, output=output)
+
+    assert result.returncode == 2
+    assert not output.exists()
+
+    report = parse_report(result)
+    assert report["ok"] is False
+    assert "refusing_to_write_inside_package_dir" in report["errors"]
+
+
+def test_tool_does_not_call_release_gate_or_materializer_engines() -> None:
+    source = TOOL.read_text(encoding="utf-8")
+    forbidden = [
+        "check_" + "gates.py",
+        "policy_to_require_args.py",
+        "fold_slsa_vsa_intake_into_status_v0.py",
+        "materialize_release_required_from_verifier_v0.py",
+    ]
+
+    for marker in forbidden:
+        assert marker not in source, marker
+
+
+def check_check_release_grade_package_complete_v1() -> None:
+    assert TOOL.exists()
+    assert TOOLS_TESTS_LIST.exists()
+
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        tmp_path = Path(raw_tmp)
+
+        test_manifest_registers_completeness_checker_exactly_once()
+        test_manifest_places_checker_in_release_grade_block()
+        test_complete_package_passes_and_output_matches_stdout(tmp_path)
+        test_missing_required_file_fails_closed(tmp_path)
+        test_empty_required_file_fails_closed(tmp_path)
+        test_duplicate_json_key_fails_closed(tmp_path)
+        test_stub_marker_fails_closed(tmp_path)
+        test_digest_inventory_mismatch_fails_closed(tmp_path)
+        test_slsa_packet_report_mismatch_fails_closed(tmp_path)
+        test_stale_or_rejected_slsa_report_fails_closed(tmp_path)
+        test_refuses_status_json_output(tmp_path)
+        test_refuses_output_inside_package_dir(tmp_path)
+        test_tool_does_not_call_release_gate_or_materializer_engines()
+
+
+def test_check_release_grade_package_complete_v1() -> None:
+    check_check_release_grade_package_complete_v1()
+
+
+if __name__ == "__main__":
+    check_check_release_grade_package_complete_v1()
+    print("OK: check_release_grade_package_complete_v1 smoke passed")

--- a/tests/test_check_release_grade_package_complete_v1.py
+++ b/tests/test_check_release_grade_package_complete_v1.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -212,8 +213,12 @@ def report_payload() -> dict[str, Any]:
 
 
 def make_complete_package(tmp_path: Path) -> Path:
-    package_dir = tmp_path / "release_grade_package"
-    package_dir.mkdir()
+    package_dir = Path(
+        tempfile.mkdtemp(
+            prefix="release_grade_package_",
+            dir=tmp_path,
+        )
+    )
 
     write_json(
         package_dir / "run_metadata_v0.json",
@@ -267,7 +272,11 @@ def make_complete_package(tmp_path: Path) -> Path:
         package_dir / "artifacts" / "release_evidence_input_manifest_v0.json",
         {
             "schema_version": "release_evidence_input_manifest_v0",
-            "inputs": ["status_baseline.json", "slsa_vsa_trusted_producer_report_v0.json"],
+            "inputs": [
+                "status_baseline.json",
+                "slsa_vsa_trusted_producer_report_v0.json",
+                "external/llamaguard_raw.jsonl",
+            ],
         },
     )
     write_json(
@@ -278,6 +287,75 @@ def make_complete_package(tmp_path: Path) -> Path:
             "errors": [],
         },
     )
+
+    write_text(
+        package_dir / "artifacts" / "external" / "llamaguard_raw.jsonl",
+        json.dumps(
+            {
+                "schema_version": "llamaguard_raw_evidence_record_v0",
+                "run": {
+                    "repository": "HKati/pulse-release-gates-0.1",
+                    "git_sha": COMMIT_SHA,
+                    "run_key": CURRENT_RUN_KEY,
+                    "workflow_ref": (
+                        "HKati/pulse-release-gates-0.1/.github/workflows/pulse_ci.yml@"
+                        + COMMIT_SHA
+                    ),
+                },
+                "result": "pass",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+    )
+    write_json(
+        package_dir / "artifacts" / "external" / "llamaguard_evaluator_manifest_v0.json",
+        {
+            "schema_version": "llamaguard_evaluator_manifest_v0",
+            "run": {
+                "repository": "HKati/pulse-release-gates-0.1",
+                "git_sha": COMMIT_SHA,
+                "run_key": CURRENT_RUN_KEY,
+            },
+            "evaluator": "llamaguard",
+        },
+    )
+    write_json(
+        package_dir / "artifacts" / "external" / "llamaguard_summary.json",
+        {
+            "schema_version": "llamaguard_summary_v0",
+            "summary": {
+                "status": "pass",
+            },
+        },
+    )
+    write_json(
+        package_dir / "artifacts" / "external" / "llamaguard_summary.bundle.json",
+        {
+            "schema_version": "llamaguard_summary_bundle_v0",
+            "bundle": {
+                "status": "present",
+            },
+        },
+    )
+    write_json(
+        package_dir / "artifacts" / "external" / "llamaguard_summary.envelope.json",
+        {
+            "schema_version": "llamaguard_summary_envelope_v0",
+            "envelope": {
+                "status": "present",
+            },
+        },
+    )
+    write_json(
+        package_dir / "artifacts" / "external" / "llamaguard_attestation_verifier_v1.json",
+        {
+            "schema_version": "llamaguard_attestation_verifier_v1",
+            "status": "verified",
+            "errors": [],
+        },
+    )
+
     write_json(
         package_dir / "artifacts" / "status.json",
         {
@@ -459,6 +537,14 @@ def test_missing_required_file_fails_closed(tmp_path: Path) -> None:
     assert report["status"] == "incomplete"
 
 
+def test_missing_external_evidence_file_fails_closed(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    (package_dir / "artifacts" / "external" / "llamaguard_summary.json").unlink()
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(run_tool(package_dir), "required_file:artifacts/external/llamaguard_summary.json")
+
+
 def test_empty_required_file_fails_closed(tmp_path: Path) -> None:
     package_dir = make_complete_package(tmp_path)
     write_text(package_dir / "artifacts" / "report_card.html", "")
@@ -525,6 +611,125 @@ def test_slsa_packet_report_mismatch_fails_closed(tmp_path: Path) -> None:
     assert_failure(run_tool(package_dir), "slsa_vsa.current_run_key")
 
 
+def test_slsa_report_producer_mismatch_fails_closed(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    report_path = (
+        package_dir
+        / "artifacts"
+        / "slsa"
+        / "slsa_vsa_trusted_evidence_producer_report_v0.json"
+    )
+    report = read_json(report_path)
+    report["producer"]["producer_id"] = "wrong-producer"
+    write_json(report_path, report)
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(run_tool(package_dir), "slsa_vsa.producer_identity")
+
+
+def test_slsa_run_key_self_inconsistency_fails_closed(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    packet_path = (
+        package_dir / "artifacts" / "slsa" / "slsa_vsa_trusted_producer_input_packet_v0.json"
+    )
+    report_path = (
+        package_dir
+        / "artifacts"
+        / "slsa"
+        / "slsa_vsa_trusted_evidence_producer_report_v0.json"
+    )
+
+    packet = read_json(packet_path)
+    report = read_json(report_path)
+    packet["run_binding"]["current_run_number"] = "9999"
+    report["run_binding"]["current_run_number"] = "9999"
+    write_json(packet_path, packet)
+    write_json(report_path, report)
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(run_tool(package_dir), "slsa_vsa.packet_run_key_self_consistent")
+
+
+def test_slsa_artifact_flag_failure_fails_closed(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    report_path = (
+        package_dir
+        / "artifacts"
+        / "slsa"
+        / "slsa_vsa_trusted_evidence_producer_report_v0.json"
+    )
+    report = read_json(report_path)
+    report["artifact_binding"]["subject_digest_matches"] = False
+    write_json(report_path, report)
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(run_tool(package_dir), "slsa_vsa.artifact_flags")
+
+
+def test_slsa_report_evidence_time_mismatch_fails_closed(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    report_path = (
+        package_dir
+        / "artifacts"
+        / "slsa"
+        / "slsa_vsa_trusted_evidence_producer_report_v0.json"
+    )
+    report = read_json(report_path)
+    report["evidence"]["time_verified"] = "2026-07-05T00:00:00Z"
+    write_json(report_path, report)
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(run_tool(package_dir), "slsa_vsa.freshness")
+
+
+def test_slsa_report_evidence_policy_mismatch_fails_closed(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    report_path = (
+        package_dir
+        / "artifacts"
+        / "slsa"
+        / "slsa_vsa_trusted_evidence_producer_report_v0.json"
+    )
+    report = read_json(report_path)
+    report["policy_binding"]["evidence_policy_sha256"] = "d" * 64
+    write_json(report_path, report)
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(run_tool(package_dir), "slsa_vsa.policy_binding")
+
+
+def test_slsa_report_evidence_verifier_mismatch_fails_closed(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    report_path = (
+        package_dir
+        / "artifacts"
+        / "slsa"
+        / "slsa_vsa_trusted_evidence_producer_report_v0.json"
+    )
+    report = read_json(report_path)
+    report["verifier_binding"]["evidence_verifier_id"] = "https://pulse.invalid/verifiers/wrong"
+    write_json(report_path, report)
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(run_tool(package_dir), "slsa_vsa.verifier_binding")
+
+
+def test_slsa_failed_verification_result_fails_closed(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    report_path = (
+        package_dir
+        / "artifacts"
+        / "slsa"
+        / "slsa_vsa_trusted_evidence_producer_report_v0.json"
+    )
+    report = read_json(report_path)
+    report["evidence"]["verification_result"] = "FAILED"
+    write_json(report_path, report)
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(run_tool(package_dir), "slsa_vsa.verification_result")
+
+
 def test_stale_or_rejected_slsa_report_fails_closed(tmp_path: Path) -> None:
     package_dir = make_complete_package(tmp_path)
     report_path = (
@@ -573,6 +778,27 @@ def test_refuses_output_inside_package_dir(tmp_path: Path) -> None:
     assert "refusing_to_write_inside_package_dir" in report["errors"]
 
 
+def test_refuses_symlink_output_targeting_package_file(tmp_path: Path) -> None:
+    package_dir = make_complete_package(tmp_path)
+    status_path = package_dir / "artifacts" / "status.json"
+    status_before = status_path.read_text(encoding="utf-8")
+    output = tmp_path / "outside_report_link.json"
+
+    try:
+        os.symlink(status_path, output)
+    except (OSError, NotImplementedError):
+        return
+
+    result = run_tool(package_dir, output=output)
+
+    assert result.returncode == 2
+    assert status_path.read_text(encoding="utf-8") == status_before
+
+    report = parse_report(result)
+    assert report["ok"] is False
+    assert "refusing_to_write_symlink_output" in report["errors"]
+
+
 def test_tool_does_not_call_release_gate_or_materializer_engines() -> None:
     source = TOOL.read_text(encoding="utf-8")
     forbidden = [
@@ -597,14 +823,23 @@ def check_check_release_grade_package_complete_v1() -> None:
         test_manifest_places_checker_in_release_grade_block()
         test_complete_package_passes_and_output_matches_stdout(tmp_path)
         test_missing_required_file_fails_closed(tmp_path)
+        test_missing_external_evidence_file_fails_closed(tmp_path)
         test_empty_required_file_fails_closed(tmp_path)
         test_duplicate_json_key_fails_closed(tmp_path)
         test_stub_marker_fails_closed(tmp_path)
         test_digest_inventory_mismatch_fails_closed(tmp_path)
         test_slsa_packet_report_mismatch_fails_closed(tmp_path)
+        test_slsa_report_producer_mismatch_fails_closed(tmp_path)
+        test_slsa_run_key_self_inconsistency_fails_closed(tmp_path)
+        test_slsa_artifact_flag_failure_fails_closed(tmp_path)
+        test_slsa_report_evidence_time_mismatch_fails_closed(tmp_path)
+        test_slsa_report_evidence_policy_mismatch_fails_closed(tmp_path)
+        test_slsa_report_evidence_verifier_mismatch_fails_closed(tmp_path)
+        test_slsa_failed_verification_result_fails_closed(tmp_path)
         test_stale_or_rejected_slsa_report_fails_closed(tmp_path)
         test_refuses_status_json_output(tmp_path)
         test_refuses_output_inside_package_dir(tmp_path)
+        test_refuses_symlink_output_targeting_package_file(tmp_path)
         test_tool_does_not_call_release_gate_or_materializer_engines()
 
 

--- a/tools/check_release_grade_package_complete_v1.py
+++ b/tools/check_release_grade_package_complete_v1.py
@@ -1,0 +1,967 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+TOOL_NAME = "check_release_grade_package_complete_v1"
+SCHEMA_VERSION = "release_grade_package_completeness_v1"
+TOOL_VERSION = "0.1.0"
+
+REQUIRED_FILES: tuple[str, ...] = (
+    "package_digest_inventory_v0.json",
+    "run_metadata_v0.json",
+    "artifacts/required_gate_evidence_v0.json",
+    "artifacts/status_baseline.json",
+    "artifacts/recorded_release_candidate_index_v0.json",
+    "artifacts/release_evidence_input_manifest_v0.json",
+    "artifacts/recorded_release_evidence_verifier_v0.json",
+    "artifacts/status.json",
+    "artifacts/release_decision_v0.json",
+    "artifacts/artifact_provenance_binding_v0.json",
+    "artifacts/release_authority_v0.json",
+    "artifacts/report_card.html",
+    "artifacts/slsa/slsa_vsa_trusted_producer_input_packet_v0.json",
+    "artifacts/slsa/slsa_vsa_trusted_evidence_producer_report_v0.json",
+)
+
+REQUIRED_DIRS: tuple[str, ...] = (
+    "artifacts/recorded_release_candidates",
+    "release-authority-audit-bundle",
+)
+
+JSON_OBJECT_FILES: tuple[str, ...] = (
+    "package_digest_inventory_v0.json",
+    "run_metadata_v0.json",
+    "artifacts/required_gate_evidence_v0.json",
+    "artifacts/status_baseline.json",
+    "artifacts/recorded_release_candidate_index_v0.json",
+    "artifacts/release_evidence_input_manifest_v0.json",
+    "artifacts/recorded_release_evidence_verifier_v0.json",
+    "artifacts/status.json",
+    "artifacts/release_decision_v0.json",
+    "artifacts/artifact_provenance_binding_v0.json",
+    "artifacts/release_authority_v0.json",
+    "artifacts/slsa/slsa_vsa_trusted_producer_input_packet_v0.json",
+    "artifacts/slsa/slsa_vsa_trusted_evidence_producer_report_v0.json",
+)
+
+SLSA_PACKET_PATH = "artifacts/slsa/slsa_vsa_trusted_producer_input_packet_v0.json"
+SLSA_REPORT_PATH = "artifacts/slsa/slsa_vsa_trusted_evidence_producer_report_v0.json"
+
+STUB_MARKERS = (
+    "todo",
+    "tbd",
+    "stub",
+    "placeholder",
+    "not implemented",
+    "replace-me",
+    "fill me",
+    "example.invalid",
+)
+
+AUTHORITY_BOUNDARY = {
+    "read_only": True,
+    "authorizes_release": False,
+    "blocks_release": False,
+    "creates_release_authority": False,
+    "materializes_status": False,
+    "materializes_required_gates": False,
+    "calls_check_gates": False,
+    "package_completeness_only": True,
+}
+
+
+class CompletenessError(ValueError):
+    """Release-grade completeness check error."""
+
+
+class StrictJsonError(CompletenessError):
+    """Strict JSON parse error."""
+
+
+def _json_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+
+    for key, value in pairs:
+        if key in result:
+            raise StrictJsonError(f"duplicate JSON key {key!r}")
+
+        result[key] = value
+
+    return result
+
+
+def _bad_constant(value: str) -> None:
+    raise StrictJsonError(f"non-finite JSON constant {value!r}")
+
+
+def _finite_tree(value: Any, label: str) -> None:
+    if value is None or isinstance(value, (str, bool, int)):
+        return
+
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise CompletenessError(f"{label} contains non-finite number")
+        return
+
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _finite_tree(item, f"{label}[{index}]")
+        return
+
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _finite_tree(item, f"{label}.{key}")
+        return
+
+    raise CompletenessError(f"{label} contains unsupported JSON value")
+
+
+def _resolve(path: Path) -> Path:
+    return Path(os.path.abspath(os.path.normpath(str(path))))
+
+
+def _require_package_dir(path: Path) -> Path:
+    resolved = _resolve(path)
+
+    if resolved.is_symlink() or not resolved.is_dir():
+        raise CompletenessError(f"package_dir must be a non-symlink directory: {resolved}")
+
+    return resolved
+
+
+def _package_path(package_dir: Path, relative: str) -> Path:
+    path = _resolve(package_dir / relative)
+
+    try:
+        path.relative_to(package_dir)
+    except ValueError as exc:
+        raise CompletenessError(f"package path escapes root: {relative}") from exc
+
+    return path
+
+
+def _load_json(path: Path, label: str) -> Any:
+    if path.is_symlink() or not path.is_file():
+        raise CompletenessError(f"{label} must be a regular non-symlink file")
+
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_json_pairs,
+            parse_constant=_bad_constant,
+        )
+    except CompletenessError:
+        raise
+    except Exception as exc:
+        raise CompletenessError(f"{label} is not valid JSON: {exc}") from exc
+
+    _finite_tree(payload, label)
+    return payload
+
+
+def _load_json_object(path: Path, label: str) -> dict[str, Any]:
+    payload = _load_json(path, label)
+
+    if not isinstance(payload, dict):
+        raise CompletenessError(f"{label} must be a JSON object")
+
+    return payload
+
+
+def _sha256(path: Path) -> str:
+    if path.is_symlink() or not path.is_file():
+        raise CompletenessError(f"SHA-256 input must be a regular file: {path}")
+
+    digest = hashlib.sha256()
+
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+
+    return digest.hexdigest()
+
+
+def _iter_package_files(package_dir: Path) -> list[Path]:
+    files: list[Path] = []
+
+    for path in package_dir.rglob("*"):
+        if path.is_symlink():
+            raise CompletenessError(f"package must not contain symlinks: {path}")
+
+        if path.is_file():
+            files.append(path)
+
+    return sorted(files, key=lambda item: item.relative_to(package_dir).as_posix())
+
+
+def _check(
+    checks: list[dict[str, Any]],
+    errors: list[str],
+    check_id: str,
+    condition: bool,
+    details: str,
+) -> None:
+    passed = bool(condition)
+    checks.append(
+        {
+            "check_id": check_id,
+            "passed": passed,
+            "details": details,
+        }
+    )
+
+    if not passed:
+        errors.append(f"{check_id}: {details}")
+
+
+def _nested_get(value: Any, path: tuple[str, ...]) -> Any:
+    cursor = value
+
+    for key in path:
+        if not isinstance(cursor, dict):
+            return None
+
+        cursor = cursor.get(key)
+
+    return cursor
+
+
+def _iter_string_values(value: Any, path: str = "$") -> list[tuple[str, str]]:
+    values: list[tuple[str, str]] = []
+
+    if isinstance(value, str):
+        values.append((path, value))
+        return values
+
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            values.extend(_iter_string_values(item, f"{path}[{index}]"))
+        return values
+
+    if isinstance(value, dict):
+        for key, item in value.items():
+            values.extend(_iter_string_values(item, f"{path}.{key}"))
+        return values
+
+    return values
+
+
+def _stub_marker_hits(value: str) -> list[str]:
+    lowered = value.lower()
+    return [marker for marker in STUB_MARKERS if marker in lowered]
+
+
+def _verify_required_surface(
+    *,
+    package_dir: Path,
+    checks: list[dict[str, Any]],
+    errors: list[str],
+) -> None:
+    for relative in REQUIRED_FILES:
+        path = _package_path(package_dir, relative)
+        exists = path.is_file() and not path.is_symlink()
+        _check(
+            checks,
+            errors,
+            f"required_file:{relative}",
+            exists,
+            f"{relative} is present as a regular file",
+        )
+
+        if exists:
+            _check(
+                checks,
+                errors,
+                f"non_empty_file:{relative}",
+                path.stat().st_size > 0,
+                f"{relative} is non-empty",
+            )
+
+    for relative in REQUIRED_DIRS:
+        path = _package_path(package_dir, relative)
+        exists = path.is_dir() and not path.is_symlink()
+        has_files = exists and any(item.is_file() for item in path.rglob("*"))
+        _check(
+            checks,
+            errors,
+            f"required_dir:{relative}",
+            exists and has_files,
+            f"{relative} is present as a non-empty non-symlink directory",
+        )
+
+
+def _verify_json_objects(
+    *,
+    package_dir: Path,
+    checks: list[dict[str, Any]],
+    errors: list[str],
+) -> dict[str, dict[str, Any]]:
+    loaded: dict[str, dict[str, Any]] = {}
+
+    for relative in JSON_OBJECT_FILES:
+        path = _package_path(package_dir, relative)
+
+        try:
+            payload = _load_json_object(path, relative)
+            loaded[relative] = payload
+            _check(
+                checks,
+                errors,
+                f"json_object:{relative}",
+                True,
+                f"{relative} is a strict JSON object",
+            )
+
+            stub_hits: list[str] = []
+            for json_path, text in _iter_string_values(payload):
+                for marker in _stub_marker_hits(text):
+                    stub_hits.append(f"{json_path} contains {marker!r}")
+
+            _check(
+                checks,
+                errors,
+                f"non_stub_json:{relative}",
+                not stub_hits,
+                f"{relative} contains no stub/placeholder markers",
+            )
+
+            if stub_hits:
+                for hit in stub_hits[:20]:
+                    errors.append(f"non_stub_json:{relative}: {hit}")
+
+        except CompletenessError as exc:
+            _check(
+                checks,
+                errors,
+                f"json_object:{relative}",
+                False,
+                str(exc),
+            )
+
+    return loaded
+
+
+def _verify_report_card(
+    *,
+    package_dir: Path,
+    checks: list[dict[str, Any]],
+    errors: list[str],
+) -> None:
+    relative = "artifacts/report_card.html"
+    path = _package_path(package_dir, relative)
+
+    if not path.is_file() or path.is_symlink():
+        return
+
+    text = path.read_text(encoding="utf-8")
+    hits = _stub_marker_hits(text)
+
+    _check(
+        checks,
+        errors,
+        "report_card.non_stub",
+        not hits,
+        "report_card.html contains no stub/placeholder markers",
+    )
+
+
+def _verify_digest_inventory(
+    *,
+    package_dir: Path,
+    inventory: dict[str, Any] | None,
+    checks: list[dict[str, Any]],
+    errors: list[str],
+) -> None:
+    if inventory is None:
+        _check(
+            checks,
+            errors,
+            "digest_inventory.present",
+            False,
+            "package digest inventory is present",
+        )
+        return
+
+    _check(
+        checks,
+        errors,
+        "digest_inventory.schema_version",
+        inventory.get("schema_version") == "release_grade_reference_package_digest_inventory_v0",
+        "digest inventory schema_version is release_grade_reference_package_digest_inventory_v0",
+    )
+    _check(
+        checks,
+        errors,
+        "digest_inventory.algorithm",
+        inventory.get("algorithm") == "sha256",
+        "digest inventory algorithm is sha256",
+    )
+
+    files = inventory.get("files")
+    if not isinstance(files, list) or not files:
+        _check(
+            checks,
+            errors,
+            "digest_inventory.files",
+            False,
+            "digest inventory files must be a non-empty array",
+        )
+        return
+
+    seen: dict[str, dict[str, Any]] = {}
+    duplicate_seen = False
+
+    for index, item in enumerate(files):
+        if not isinstance(item, dict):
+            _check(
+                checks,
+                errors,
+                f"digest_inventory.entry:{index}",
+                False,
+                "digest inventory entry must be an object",
+            )
+            continue
+
+        relative = item.get("path")
+        digest = item.get("sha256")
+        size = item.get("size_bytes")
+
+        if not isinstance(relative, str) or not relative or relative.startswith("/"):
+            _check(
+                checks,
+                errors,
+                f"digest_inventory.path:{index}",
+                False,
+                "digest inventory path must be a relative string",
+            )
+            continue
+
+        if relative in seen:
+            duplicate_seen = True
+
+        seen[relative] = item
+
+        if not isinstance(digest, str) or len(digest) != 64:
+            _check(
+                checks,
+                errors,
+                f"digest_inventory.sha256:{relative}",
+                False,
+                f"{relative} has invalid sha256 field",
+            )
+            continue
+
+        if not all(char in "0123456789abcdefABCDEF" for char in digest):
+            _check(
+                checks,
+                errors,
+                f"digest_inventory.sha256:{relative}",
+                False,
+                f"{relative} sha256 field is not hex",
+            )
+            continue
+
+        if not isinstance(size, int) or size < 0:
+            _check(
+                checks,
+                errors,
+                f"digest_inventory.size:{relative}",
+                False,
+                f"{relative} has invalid size_bytes",
+            )
+            continue
+
+        try:
+            path = _package_path(package_dir, relative)
+        except CompletenessError as exc:
+            _check(
+                checks,
+                errors,
+                f"digest_inventory.path_safe:{relative}",
+                False,
+                str(exc),
+            )
+            continue
+
+        if not path.is_file() or path.is_symlink():
+            _check(
+                checks,
+                errors,
+                f"digest_inventory.file_present:{relative}",
+                False,
+                f"{relative} is listed but missing or symlinked",
+            )
+            continue
+
+        actual_digest = _sha256(path)
+        actual_size = path.stat().st_size
+
+        _check(
+            checks,
+            errors,
+            f"digest_inventory.digest:{relative}",
+            actual_digest == digest.lower(),
+            f"{relative} digest matches inventory",
+        )
+        _check(
+            checks,
+            errors,
+            f"digest_inventory.size_bytes:{relative}",
+            actual_size == size,
+            f"{relative} size matches inventory",
+        )
+
+    _check(
+        checks,
+        errors,
+        "digest_inventory.unique_paths",
+        not duplicate_seen,
+        "digest inventory has unique paths",
+    )
+
+    actual_files = {
+        path.relative_to(package_dir).as_posix()
+        for path in _iter_package_files(package_dir)
+        if path.relative_to(package_dir).as_posix() != "package_digest_inventory_v0.json"
+    }
+    listed_files = set(seen)
+
+    _check(
+        checks,
+        errors,
+        "digest_inventory.file_count",
+        inventory.get("file_count") == len(files),
+        "digest inventory file_count equals listed file count",
+    )
+    _check(
+        checks,
+        errors,
+        "digest_inventory.exact_coverage",
+        actual_files == listed_files,
+        "digest inventory exactly covers package files except itself",
+    )
+
+
+def _verify_recorded_candidates(
+    *,
+    package_dir: Path,
+    checks: list[dict[str, Any]],
+    errors: list[str],
+) -> None:
+    candidate_dir = _package_path(package_dir, "artifacts/recorded_release_candidates")
+    if not candidate_dir.is_dir() or candidate_dir.is_symlink():
+        return
+
+    candidates = sorted(
+        path
+        for path in candidate_dir.rglob("*.json")
+        if path.is_file() and not path.is_symlink()
+    )
+
+    _check(
+        checks,
+        errors,
+        "recorded_candidates.non_empty",
+        bool(candidates),
+        "recorded_release_candidates contains at least one JSON candidate",
+    )
+
+    for candidate in candidates:
+        relative = candidate.relative_to(package_dir).as_posix()
+
+        try:
+            payload = _load_json_object(candidate, relative)
+            _check(
+                checks,
+                errors,
+                f"recorded_candidate.json:{relative}",
+                True,
+                f"{relative} is strict JSON object",
+            )
+        except CompletenessError as exc:
+            _check(
+                checks,
+                errors,
+                f"recorded_candidate.json:{relative}",
+                False,
+                str(exc),
+            )
+            continue
+
+        validation = payload.get("validation")
+        _check(
+            checks,
+            errors,
+            f"recorded_candidate.validation:{relative}",
+            isinstance(validation, dict)
+            and validation.get("status") in {"passed", "verified", "accepted"},
+            f"{relative} has passed/verified validation status",
+        )
+
+
+def _verify_slsa_trusted_producer_chain(
+    *,
+    loaded: dict[str, dict[str, Any]],
+    checks: list[dict[str, Any]],
+    errors: list[str],
+) -> None:
+    packet = loaded.get(SLSA_PACKET_PATH)
+    report = loaded.get(SLSA_REPORT_PATH)
+
+    if packet is None or report is None:
+        _check(
+            checks,
+            errors,
+            "slsa_vsa.packet_report.present",
+            False,
+            "trusted producer input packet and report are both present",
+        )
+        return
+
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.packet.schema_version",
+        packet.get("schema_version") == "slsa_vsa_trusted_producer_input_packet_v0",
+        "trusted producer input packet schema_version is v0",
+    )
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.packet.packet_type",
+        packet.get("packet_type") == "slsa_vsa_trusted_producer_input_packet",
+        "trusted producer input packet packet_type is correct",
+    )
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.packet.recorded_signal_mode",
+        packet.get("recorded_signal_mode") == "recorded_signal_only",
+        "trusted producer input packet uses recorded_signal_only",
+    )
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.packet.candidate_set",
+        packet.get("candidate_set") == "slsa_vsa_recorded_intake_candidate",
+        "trusted producer input packet candidate_set is recorded-intake candidate",
+    )
+
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.report.schema_version",
+        report.get("schema_version") == "slsa_vsa_trusted_evidence_producer_report_v0",
+        "trusted producer report schema_version is v0",
+    )
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.report.report_type",
+        report.get("report_type") == "slsa_vsa_trusted_evidence_producer_report",
+        "trusted producer report report_type is correct",
+    )
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.report.accepted",
+        report.get("ok") is True
+        and report.get("producer_decision") == "TRUSTED_EVIDENCE_ACCEPTED"
+        and report.get("failed_checks") == [],
+        "trusted producer report is accepted with no failed checks",
+    )
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.report.recorded_signal_mode",
+        report.get("recorded_signal_mode") == "recorded_signal_only",
+        "trusted producer report uses recorded_signal_only",
+    )
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.report.candidate_set",
+        report.get("candidate_set") == "slsa_vsa_recorded_intake_candidate",
+        "trusted producer report candidate_set is recorded-intake candidate",
+    )
+
+    packet_run_key = _nested_get(packet, ("run_binding", "current_run_key"))
+    report_run_key = _nested_get(report, ("run_binding", "current_run_key"))
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.current_run_key",
+        isinstance(packet_run_key, str) and packet_run_key == report_run_key,
+        "trusted producer packet/report current_run_key matches",
+    )
+
+    packet_commit = _nested_get(packet, ("run_binding", "commit_sha"))
+    report_commit = _nested_get(report, ("run_binding", "commit_sha"))
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.commit_sha",
+        isinstance(packet_commit, str) and packet_commit == report_commit,
+        "trusted producer packet/report commit_sha matches",
+    )
+
+    packet_candidate = _nested_get(packet, ("run_binding", "release_candidate_id"))
+    report_candidate = _nested_get(report, ("run_binding", "release_candidate_id"))
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.release_candidate_id",
+        isinstance(packet_candidate, str) and packet_candidate == report_candidate,
+        "trusted producer packet/report release_candidate_id matches",
+    )
+
+    packet_subject_sha = _nested_get(packet, ("artifact_binding", "subject_sha256"))
+    report_subject_sha = _nested_get(report, ("artifact_binding", "subject_sha256"))
+    packet_artifact_sha = _nested_get(packet, ("artifact_binding", "artifact_digest_sha256"))
+    report_artifact_sha = _nested_get(report, ("artifact_binding", "artifact_digest_sha256"))
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.artifact_digest",
+        isinstance(packet_subject_sha, str)
+        and packet_subject_sha == packet_artifact_sha
+        and packet_subject_sha == report_subject_sha
+        and packet_subject_sha == report_artifact_sha,
+        "trusted producer packet/report artifact digest binding matches",
+    )
+
+    packet_policy_id = _nested_get(packet, ("policy_binding", "expected_policy_id"))
+    report_policy_id = _nested_get(report, ("policy_binding", "expected_policy_id"))
+    packet_policy_sha = _nested_get(packet, ("policy_binding", "expected_policy_sha256"))
+    report_policy_sha = _nested_get(report, ("policy_binding", "expected_policy_sha256"))
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.policy_binding",
+        isinstance(packet_policy_id, str)
+        and packet_policy_id == report_policy_id
+        and isinstance(packet_policy_sha, str)
+        and packet_policy_sha == report_policy_sha
+        and report.get("policy_binding", {}).get("policy_digest_matches") is True,
+        "trusted producer packet/report policy binding matches and report confirms digest",
+    )
+
+    packet_verifier = _nested_get(packet, ("verifier_binding", "expected_verifier_id"))
+    report_verifier = _nested_get(report, ("verifier_binding", "expected_verifier_id"))
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.verifier_binding",
+        isinstance(packet_verifier, str)
+        and packet_verifier == report_verifier
+        and report.get("verifier_binding", {}).get("verifier_trusted") is True,
+        "trusted producer packet/report verifier binding matches and report trusts verifier",
+    )
+
+    packet_level = packet.get("expected_verified_level")
+    report_level = _nested_get(report, ("evidence", "expected_verified_level"))
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.verified_level",
+        isinstance(packet_level, str)
+        and packet_level == report_level
+        and report.get("evidence", {}).get("verified_level_ok") is True,
+        "trusted producer packet/report expected verified level matches and is accepted",
+    )
+
+    packet_time = _nested_get(packet, ("freshness", "expected_time_verified"))
+    report_time_ok = _nested_get(report, ("freshness", "time_verified_current_run_match"))
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.freshness",
+        isinstance(packet_time, str)
+        and report.get("freshness", {}).get("freshness_result") == "fresh_current_run"
+        and report.get("freshness", {}).get("current_run_binding_ok") is True
+        and report_time_ok is True,
+        "trusted producer report confirms fresh current-run evidence",
+    )
+
+
+def _make_report(
+    *,
+    package_dir: Path,
+    checks: list[dict[str, Any]],
+    errors: list[str],
+) -> dict[str, Any]:
+    failed = [check for check in checks if not check.get("passed", False)]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "tool": {
+            "name": TOOL_NAME,
+            "version": TOOL_VERSION,
+        },
+        "ok": not errors,
+        "status": "complete" if not errors else "incomplete",
+        "package": {
+            "path": str(package_dir),
+        },
+        "summary": {
+            "required_files": len(REQUIRED_FILES),
+            "required_dirs": len(REQUIRED_DIRS),
+            "checks_total": len(checks),
+            "checks_failed": len(failed),
+        },
+        "checks": checks,
+        "errors": errors,
+        "authority_boundary": dict(AUTHORITY_BOUNDARY),
+    }
+
+
+def check_package(package_dir: Path) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+    errors: list[str] = []
+    resolved_package_dir = _resolve(package_dir)
+
+    try:
+        resolved_package_dir = _require_package_dir(package_dir)
+        _verify_required_surface(
+            package_dir=resolved_package_dir,
+            checks=checks,
+            errors=errors,
+        )
+        loaded = _verify_json_objects(
+            package_dir=resolved_package_dir,
+            checks=checks,
+            errors=errors,
+        )
+        _verify_report_card(
+            package_dir=resolved_package_dir,
+            checks=checks,
+            errors=errors,
+        )
+        _verify_digest_inventory(
+            package_dir=resolved_package_dir,
+            inventory=loaded.get("package_digest_inventory_v0.json"),
+            checks=checks,
+            errors=errors,
+        )
+        _verify_recorded_candidates(
+            package_dir=resolved_package_dir,
+            checks=checks,
+            errors=errors,
+        )
+        _verify_slsa_trusted_producer_chain(
+            loaded=loaded,
+            checks=checks,
+            errors=errors,
+        )
+
+    except CompletenessError as exc:
+        errors.append(str(exc))
+
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"unexpected completeness failure: {exc}")
+
+    return _make_report(
+        package_dir=resolved_package_dir,
+        checks=checks,
+        errors=errors,
+    )
+
+
+def _render(data: dict[str, Any]) -> str:
+    return json.dumps(
+        data,
+        indent=2,
+        ensure_ascii=False,
+        sort_keys=True,
+        allow_nan=False,
+    ) + "\n"
+
+
+def _write_report(path: Path, report: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_render(report), encoding="utf-8")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Check release-grade package structural completeness."
+    )
+    parser.add_argument("--package-dir", required=True)
+    parser.add_argument("--output")
+    return parser
+
+
+def _output_refused_report(package_dir: Path, output: Path, reason: str) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "tool": {
+            "name": TOOL_NAME,
+            "version": TOOL_VERSION,
+        },
+        "ok": False,
+        "status": "output_refused",
+        "package": {
+            "path": str(package_dir),
+        },
+        "summary": {
+            "required_files": len(REQUIRED_FILES),
+            "required_dirs": len(REQUIRED_DIRS),
+            "checks_total": 0,
+            "checks_failed": 1,
+        },
+        "checks": [],
+        "errors": [reason],
+        "output": {
+            "path": str(output),
+        },
+        "authority_boundary": dict(AUTHORITY_BOUNDARY),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    package_dir = _resolve(Path(args.package_dir))
+    output = _resolve(Path(args.output)) if args.output else None
+
+    if output is not None and output.name == "status.json":
+        report = _output_refused_report(
+            package_dir,
+            output,
+            "refusing_to_write_status_json",
+        )
+        sys.stdout.write(_render(report))
+        return 2
+
+    if output is not None:
+        try:
+            output.relative_to(package_dir)
+            report = _output_refused_report(
+                package_dir,
+                output,
+                "refusing_to_write_inside_package_dir",
+            )
+            sys.stdout.write(_render(report))
+            return 2
+        except ValueError:
+            pass
+
+    report = check_package(package_dir)
+    sys.stdout.write(_render(report))
+
+    if output is not None:
+        _write_report(output, report)
+
+    return 0 if report["ok"] is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_release_grade_package_complete_v1.py
+++ b/tools/check_release_grade_package_complete_v1.py
@@ -13,7 +13,7 @@ from typing import Any
 
 TOOL_NAME = "check_release_grade_package_complete_v1"
 SCHEMA_VERSION = "release_grade_package_completeness_v1"
-TOOL_VERSION = "0.1.0"
+TOOL_VERSION = "0.1.1"
 
 REQUIRED_FILES: tuple[str, ...] = (
     "package_digest_inventory_v0.json",
@@ -23,6 +23,12 @@ REQUIRED_FILES: tuple[str, ...] = (
     "artifacts/recorded_release_candidate_index_v0.json",
     "artifacts/release_evidence_input_manifest_v0.json",
     "artifacts/recorded_release_evidence_verifier_v0.json",
+    "artifacts/external/llamaguard_raw.jsonl",
+    "artifacts/external/llamaguard_evaluator_manifest_v0.json",
+    "artifacts/external/llamaguard_summary.json",
+    "artifacts/external/llamaguard_summary.bundle.json",
+    "artifacts/external/llamaguard_summary.envelope.json",
+    "artifacts/external/llamaguard_attestation_verifier_v1.json",
     "artifacts/status.json",
     "artifacts/release_decision_v0.json",
     "artifacts/artifact_provenance_binding_v0.json",
@@ -45,12 +51,21 @@ JSON_OBJECT_FILES: tuple[str, ...] = (
     "artifacts/recorded_release_candidate_index_v0.json",
     "artifacts/release_evidence_input_manifest_v0.json",
     "artifacts/recorded_release_evidence_verifier_v0.json",
+    "artifacts/external/llamaguard_evaluator_manifest_v0.json",
+    "artifacts/external/llamaguard_summary.json",
+    "artifacts/external/llamaguard_summary.bundle.json",
+    "artifacts/external/llamaguard_summary.envelope.json",
+    "artifacts/external/llamaguard_attestation_verifier_v1.json",
     "artifacts/status.json",
     "artifacts/release_decision_v0.json",
     "artifacts/artifact_provenance_binding_v0.json",
     "artifacts/release_authority_v0.json",
     "artifacts/slsa/slsa_vsa_trusted_producer_input_packet_v0.json",
     "artifacts/slsa/slsa_vsa_trusted_evidence_producer_report_v0.json",
+)
+
+JSONL_FILES: tuple[str, ...] = (
+    "artifacts/external/llamaguard_raw.jsonl",
 )
 
 SLSA_PACKET_PATH = "artifacts/slsa/slsa_vsa_trusted_producer_input_packet_v0.json"
@@ -67,6 +82,24 @@ STUB_MARKERS = (
     "example.invalid",
 )
 
+PRODUCER_FIELDS = (
+    "producer_id",
+    "producer_name",
+    "producer_version",
+    "producer_source",
+    "ci_workflow_or_job_identity",
+)
+
+RUN_BINDING_FIELDS = (
+    "current_run_id",
+    "current_run_number",
+    "current_run_attempt",
+    "workflow_name",
+    "job_name",
+    "commit_sha",
+    "release_candidate_id",
+)
+
 AUTHORITY_BOUNDARY = {
     "read_only": True,
     "authorizes_release": False,
@@ -74,7 +107,7 @@ AUTHORITY_BOUNDARY = {
     "creates_release_authority": False,
     "materializes_status": False,
     "materializes_required_gates": False,
-    "calls_check_gates": False,
+    "calls_gate_checker": False,
     "package_completeness_only": True,
 }
 
@@ -177,6 +210,42 @@ def _load_json_object(path: Path, label: str) -> dict[str, Any]:
     return payload
 
 
+def _load_jsonl_objects(path: Path, label: str) -> list[dict[str, Any]]:
+    if path.is_symlink() or not path.is_file():
+        raise CompletenessError(f"{label} must be a regular non-symlink file")
+
+    records: list[dict[str, Any]] = []
+
+    with path.open("r", encoding="utf-8", errors="strict") as handle:
+        for line_number, raw in enumerate(handle, start=1):
+            if not raw.strip():
+                continue
+
+            try:
+                record = json.loads(
+                    raw,
+                    object_pairs_hook=_json_pairs,
+                    parse_constant=_bad_constant,
+                )
+            except CompletenessError:
+                raise
+            except Exception as exc:
+                raise CompletenessError(
+                    f"{label} line {line_number} is not valid JSON: {exc}"
+                ) from exc
+
+            if not isinstance(record, dict):
+                raise CompletenessError(f"{label} line {line_number} must be a JSON object")
+
+            _finite_tree(record, f"{label} line {line_number}")
+            records.append(record)
+
+    if not records:
+        raise CompletenessError(f"{label} must contain at least one JSONL record")
+
+    return records
+
+
 def _sha256(path: Path) -> str:
     if path.is_symlink() or not path.is_file():
         raise CompletenessError(f"SHA-256 input must be a regular file: {path}")
@@ -235,6 +304,16 @@ def _nested_get(value: Any, path: tuple[str, ...]) -> Any:
     return cursor
 
 
+def _as_text(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+
+    if isinstance(value, int):
+        return str(value)
+
+    return None
+
+
 def _iter_string_values(value: Any, path: str = "$") -> list[tuple[str, str]]:
     values: list[tuple[str, str]] = []
 
@@ -258,6 +337,33 @@ def _iter_string_values(value: Any, path: str = "$") -> list[tuple[str, str]]:
 def _stub_marker_hits(value: str) -> list[str]:
     lowered = value.lower()
     return [marker for marker in STUB_MARKERS if marker in lowered]
+
+
+def _canonical_current_run_key(binding: Any) -> str | None:
+    if not isinstance(binding, dict):
+        return None
+
+    current_run_id = _as_text(binding.get("current_run_id"))
+    current_run_number = _as_text(binding.get("current_run_number"))
+    current_run_attempt = _as_text(binding.get("current_run_attempt"))
+    workflow_name = _as_text(binding.get("workflow_name"))
+
+    required = (
+        current_run_id,
+        current_run_number,
+        current_run_attempt,
+        workflow_name,
+    )
+
+    if not all(isinstance(value, str) and value for value in required):
+        return None
+
+    return (
+        f"GITHUB_RUN_ID={current_run_id}"
+        f"|GITHUB_RUN_NUMBER={current_run_number}"
+        f"|GITHUB_RUN_ATTEMPT={current_run_attempt}"
+        f"|GITHUB_WORKFLOW={workflow_name}"
+    )
 
 
 def _verify_required_surface(
@@ -348,6 +454,34 @@ def _verify_json_objects(
             )
 
     return loaded
+
+
+def _verify_jsonl_files(
+    *,
+    package_dir: Path,
+    checks: list[dict[str, Any]],
+    errors: list[str],
+) -> None:
+    for relative in JSONL_FILES:
+        path = _package_path(package_dir, relative)
+
+        try:
+            records = _load_jsonl_objects(path, relative)
+            _check(
+                checks,
+                errors,
+                f"jsonl:{relative}",
+                bool(records),
+                f"{relative} contains at least one strict JSONL object",
+            )
+        except CompletenessError as exc:
+            _check(
+                checks,
+                errors,
+                f"jsonl:{relative}",
+                False,
+                str(exc),
+            )
 
 
 def _verify_report_card(
@@ -694,102 +828,228 @@ def _verify_slsa_trusted_producer_chain(
         "trusted producer report candidate_set is recorded-intake candidate",
     )
 
+    packet_producer = packet.get("producer_identity")
+    report_producer = report.get("producer")
+    producer_matches = (
+        isinstance(packet_producer, dict)
+        and isinstance(report_producer, dict)
+        and all(
+            isinstance(packet_producer.get(field), str)
+            and packet_producer.get(field) == report_producer.get(field)
+            for field in PRODUCER_FIELDS
+        )
+    )
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.producer_identity",
+        producer_matches,
+        "trusted producer packet/report producer identity matches exactly",
+    )
+
+    packet_run = packet.get("run_binding")
+    report_run = report.get("run_binding")
     packet_run_key = _nested_get(packet, ("run_binding", "current_run_key"))
     report_run_key = _nested_get(report, ("run_binding", "current_run_key"))
+    packet_derived_run_key = _canonical_current_run_key(packet_run)
+    report_derived_run_key = _canonical_current_run_key(report_run)
+
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.packet_run_key_self_consistent",
+        isinstance(packet_run_key, str) and packet_run_key == packet_derived_run_key,
+        "trusted producer packet current_run_key is self-consistent with run fields",
+    )
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.report_run_key_self_consistent",
+        isinstance(report_run_key, str) and report_run_key == report_derived_run_key,
+        "trusted producer report current_run_key is self-consistent with run fields",
+    )
     _check(
         checks,
         errors,
         "slsa_vsa.current_run_key",
-        isinstance(packet_run_key, str) and packet_run_key == report_run_key,
-        "trusted producer packet/report current_run_key matches",
+        isinstance(packet_run_key, str)
+        and packet_run_key == report_run_key
+        and packet_run_key == packet_derived_run_key
+        and packet_run_key == report_derived_run_key,
+        "trusted producer packet/report current_run_key matches and is derived from run fields",
     )
 
-    packet_commit = _nested_get(packet, ("run_binding", "commit_sha"))
-    report_commit = _nested_get(report, ("run_binding", "commit_sha"))
+    run_fields_match = (
+        isinstance(packet_run, dict)
+        and isinstance(report_run, dict)
+        and all(
+            _as_text(packet_run.get(field)) is not None
+            and _as_text(packet_run.get(field)) == _as_text(report_run.get(field))
+            for field in RUN_BINDING_FIELDS
+        )
+    )
     _check(
         checks,
         errors,
-        "slsa_vsa.commit_sha",
-        isinstance(packet_commit, str) and packet_commit == report_commit,
-        "trusted producer packet/report commit_sha matches",
+        "slsa_vsa.run_fields",
+        run_fields_match,
+        "trusted producer packet/report run fields match",
     )
 
-    packet_candidate = _nested_get(packet, ("run_binding", "release_candidate_id"))
-    report_candidate = _nested_get(report, ("run_binding", "release_candidate_id"))
-    _check(
-        checks,
-        errors,
-        "slsa_vsa.release_candidate_id",
-        isinstance(packet_candidate, str) and packet_candidate == report_candidate,
-        "trusted producer packet/report release_candidate_id matches",
-    )
+    packet_artifact = packet.get("artifact_binding")
+    report_artifact = report.get("artifact_binding")
+
+    packet_subject_name = _nested_get(packet, ("artifact_binding", "subject_name"))
+    report_subject_name = _nested_get(report, ("artifact_binding", "subject_name"))
+    packet_resource_uri = _nested_get(packet, ("artifact_binding", "resource_uri"))
+    report_resource_uri = _nested_get(report, ("artifact_binding", "resource_uri"))
+    packet_artifact_candidate = _nested_get(packet, ("artifact_binding", "release_candidate_id"))
+    report_artifact_candidate = _nested_get(report, ("artifact_binding", "release_candidate_id"))
 
     packet_subject_sha = _nested_get(packet, ("artifact_binding", "subject_sha256"))
     report_subject_sha = _nested_get(report, ("artifact_binding", "subject_sha256"))
     packet_artifact_sha = _nested_get(packet, ("artifact_binding", "artifact_digest_sha256"))
     report_artifact_sha = _nested_get(report, ("artifact_binding", "artifact_digest_sha256"))
+
+    artifact_fields_match = (
+        isinstance(packet_artifact, dict)
+        and isinstance(report_artifact, dict)
+        and isinstance(packet_subject_name, str)
+        and packet_subject_name == report_subject_name
+        and isinstance(packet_resource_uri, str)
+        and packet_resource_uri == report_resource_uri
+        and isinstance(packet_artifact_candidate, str)
+        and packet_artifact_candidate == report_artifact_candidate
+        and isinstance(packet_subject_sha, str)
+        and packet_subject_sha == packet_artifact_sha
+        and packet_subject_sha == report_subject_sha
+        and packet_subject_sha == report_artifact_sha
+    )
+    artifact_flags_match = (
+        isinstance(report_artifact, dict)
+        and report_artifact.get("subject_digest_matches") is True
+        and report_artifact.get("resource_uri_matches") is True
+        and report_artifact.get("release_candidate_matches") is True
+        and report_artifact.get("artifact_digest_matches") is True
+    )
     _check(
         checks,
         errors,
         "slsa_vsa.artifact_digest",
-        isinstance(packet_subject_sha, str)
-        and packet_subject_sha == packet_artifact_sha
-        and packet_subject_sha == report_subject_sha
-        and packet_subject_sha == report_artifact_sha,
-        "trusted producer packet/report artifact digest binding matches",
+        artifact_fields_match,
+        "trusted producer packet/report artifact identity and digest binding matches",
+    )
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.artifact_flags",
+        artifact_flags_match,
+        "trusted producer report artifact/resource/candidate flags are all true",
     )
 
+    packet_policy = packet.get("policy_binding")
+    report_policy = report.get("policy_binding")
     packet_policy_id = _nested_get(packet, ("policy_binding", "expected_policy_id"))
-    report_policy_id = _nested_get(report, ("policy_binding", "expected_policy_id"))
+    packet_policy_uri = _nested_get(packet, ("policy_binding", "expected_policy_uri"))
     packet_policy_sha = _nested_get(packet, ("policy_binding", "expected_policy_sha256"))
+    report_policy_id = _nested_get(report, ("policy_binding", "expected_policy_id"))
+    report_policy_uri = _nested_get(report, ("policy_binding", "expected_policy_uri"))
     report_policy_sha = _nested_get(report, ("policy_binding", "expected_policy_sha256"))
+    report_evidence_policy_id = _nested_get(report, ("policy_binding", "evidence_policy_id"))
+    report_evidence_policy_uri = _nested_get(report, ("policy_binding", "evidence_policy_uri"))
+    report_evidence_policy_sha = _nested_get(report, ("policy_binding", "evidence_policy_sha256"))
+
+    policy_matches = (
+        isinstance(packet_policy, dict)
+        and isinstance(report_policy, dict)
+        and isinstance(packet_policy_id, str)
+        and packet_policy_id == report_policy_id
+        and packet_policy_id == report_evidence_policy_id
+        and isinstance(packet_policy_uri, str)
+        and packet_policy_uri == report_policy_uri
+        and packet_policy_uri == report_evidence_policy_uri
+        and isinstance(packet_policy_sha, str)
+        and packet_policy_sha == report_policy_sha
+        and packet_policy_sha == report_evidence_policy_sha
+        and report_policy.get("policy_identity_matches") is True
+        and report_policy.get("policy_digest_matches") is True
+    )
     _check(
         checks,
         errors,
         "slsa_vsa.policy_binding",
-        isinstance(packet_policy_id, str)
-        and packet_policy_id == report_policy_id
-        and isinstance(packet_policy_sha, str)
-        and packet_policy_sha == report_policy_sha
-        and report.get("policy_binding", {}).get("policy_digest_matches") is True,
-        "trusted producer packet/report policy binding matches and report confirms digest",
+        policy_matches,
+        "trusted producer packet/report expected and evidence policy binding matches",
     )
 
     packet_verifier = _nested_get(packet, ("verifier_binding", "expected_verifier_id"))
     report_verifier = _nested_get(report, ("verifier_binding", "expected_verifier_id"))
+    report_evidence_verifier = _nested_get(report, ("verifier_binding", "evidence_verifier_id"))
+    report_verifier_binding = report.get("verifier_binding")
+    verifier_matches = (
+        isinstance(report_verifier_binding, dict)
+        and isinstance(packet_verifier, str)
+        and packet_verifier == report_verifier
+        and packet_verifier == report_evidence_verifier
+        and report_verifier_binding.get("verifier_trusted") is True
+    )
     _check(
         checks,
         errors,
         "slsa_vsa.verifier_binding",
-        isinstance(packet_verifier, str)
-        and packet_verifier == report_verifier
-        and report.get("verifier_binding", {}).get("verifier_trusted") is True,
-        "trusted producer packet/report verifier binding matches and report trusts verifier",
+        verifier_matches,
+        "trusted producer packet/report expected and evidence verifier binding matches",
     )
 
+    report_evidence = report.get("evidence")
     packet_level = packet.get("expected_verified_level")
     report_level = _nested_get(report, ("evidence", "expected_verified_level"))
+    evidence_levels = _nested_get(report, ("evidence", "evidence_verified_levels"))
+    verification_result = _nested_get(report, ("evidence", "verification_result"))
+
+    _check(
+        checks,
+        errors,
+        "slsa_vsa.verification_result",
+        verification_result == "PASSED",
+        "trusted producer report evidence verification_result is PASSED",
+    )
+
+    verified_level_matches = (
+        isinstance(report_evidence, dict)
+        and isinstance(packet_level, str)
+        and packet_level == report_level
+        and isinstance(evidence_levels, list)
+        and packet_level in evidence_levels
+        and report_evidence.get("verified_level_ok") is True
+    )
     _check(
         checks,
         errors,
         "slsa_vsa.verified_level",
-        isinstance(packet_level, str)
-        and packet_level == report_level
-        and report.get("evidence", {}).get("verified_level_ok") is True,
+        verified_level_matches,
         "trusted producer packet/report expected verified level matches and is accepted",
     )
 
     packet_time = _nested_get(packet, ("freshness", "expected_time_verified"))
+    report_time = _nested_get(report, ("evidence", "time_verified"))
+    report_freshness = report.get("freshness")
     report_time_ok = _nested_get(report, ("freshness", "time_verified_current_run_match"))
+
+    freshness_matches = (
+        isinstance(report_freshness, dict)
+        and isinstance(packet_time, str)
+        and packet_time == report_time
+        and report_freshness.get("freshness_result") == "fresh_current_run"
+        and report_freshness.get("current_run_binding_ok") is True
+        and report_time_ok is True
+    )
     _check(
         checks,
         errors,
         "slsa_vsa.freshness",
-        isinstance(packet_time, str)
-        and report.get("freshness", {}).get("freshness_result") == "fresh_current_run"
-        and report.get("freshness", {}).get("current_run_binding_ok") is True
-        and report_time_ok is True,
-        "trusted producer report confirms fresh current-run evidence",
+        freshness_matches,
+        "trusted producer report confirms fresh current-run evidence matching packet time",
     )
 
 
@@ -841,6 +1101,11 @@ def check_package(package_dir: Path) -> dict[str, Any]:
             checks=checks,
             errors=errors,
         )
+        _verify_jsonl_files(
+            package_dir=resolved_package_dir,
+            checks=checks,
+            errors=errors,
+        )
         _verify_report_card(
             package_dir=resolved_package_dir,
             checks=checks,
@@ -888,6 +1153,8 @@ def _render(data: dict[str, Any]) -> str:
 
 def _write_report(path: Path, report: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise CompletenessError("refusing_to_write_symlink_output")
     path.write_text(_render(report), encoding="utf-8")
 
 
@@ -927,38 +1194,51 @@ def _output_refused_report(package_dir: Path, output: Path, reason: str) -> dict
     }
 
 
+def _output_safety_error(package_dir: Path, output: Path) -> str | None:
+    if output.name == "status.json":
+        return "refusing_to_write_status_json"
+
+    if output.is_symlink():
+        return "refusing_to_write_symlink_output"
+
+    if output.exists() and not output.is_file():
+        return "refusing_to_write_non_file_output"
+
+    for parent in (output.parent, *output.parent.parents):
+        if parent.exists() and parent.is_symlink():
+            return "refusing_to_write_through_symlink_parent"
+
+    real_output = output.resolve(strict=False)
+
+    try:
+        real_output.relative_to(package_dir)
+        return "refusing_to_write_inside_package_dir"
+    except ValueError:
+        return None
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     package_dir = _resolve(Path(args.package_dir))
     output = _resolve(Path(args.output)) if args.output else None
 
-    if output is not None and output.name == "status.json":
-        report = _output_refused_report(
-            package_dir,
-            output,
-            "refusing_to_write_status_json",
-        )
-        sys.stdout.write(_render(report))
-        return 2
-
     if output is not None:
-        try:
-            output.relative_to(package_dir)
-            report = _output_refused_report(
-                package_dir,
-                output,
-                "refusing_to_write_inside_package_dir",
-            )
+        output_error = _output_safety_error(package_dir, output)
+        if output_error is not None:
+            report = _output_refused_report(package_dir, output, output_error)
             sys.stdout.write(_render(report))
             return 2
-        except ValueError:
-            pass
 
     report = check_package(package_dir)
     sys.stdout.write(_render(report))
 
     if output is not None:
-        _write_report(output, report)
+        try:
+            _write_report(output, report)
+        except CompletenessError as exc:
+            refused = _output_refused_report(package_dir, output, str(exc))
+            sys.stdout.write(_render(refused))
+            return 2
 
     return 0 if report["ok"] is True else 1
 


### PR DESCRIPTION
## Summary

Adds a non-authorizing release-grade package completeness checker v1.

The new tool checks whether a release-grade package has the required
structural surface before deeper release-grade package verification.

It validates:

- required files;
- required directories;
- strict JSON object parsing;
- non-empty required files;
- non-stub JSON content;
- digest inventory replay;
- recorded release candidate presence;
- SLSA/VSA trusted producer input packet and report consistency.

## Scope

Tool + test + tools-tests registration only.

No workflow changes.
No policy changes.
No registry changes.
No release-authority behavior changes.
No DOI changes.
No release-required activation.
No blocking activation.

## Files

Added:

- `tools/check_release_grade_package_complete_v1.py`
- `tests/test_check_release_grade_package_complete_v1.py`

Modified:

- `ci/tools-tests.list`

## Product-closure relevance

The existing release-grade package verifier remains the deeper package
verification layer.

This PR adds a structural completeness preflight so missing, empty,
stubbed, malformed, digest-mismatched, or SLSA/VSA-inconsistent packages
fail closed before they can be treated as release-grade complete.

## Authority boundary

The checker is read-only and non-authorizing.

It does not:

- read or write `status.json`;
- call `check_gates.py`;
- materialize gates;
- invoke policy materialization;
- authorize release;
- modify workflows;
- modify policy or registry files;
- modify release-authority tools;
- modify DOI metadata;
- modify README or changelog.

The report explicitly states that package completeness is not release
authorization.

## Checks

The checker requires:

- `package_digest_inventory_v0.json`;
- `run_metadata_v0.json`;
- `artifacts/required_gate_evidence_v0.json`;
- `artifacts/status_baseline.json`;
- `artifacts/recorded_release_candidate_index_v0.json`;
- `artifacts/release_evidence_input_manifest_v0.json`;
- `artifacts/recorded_release_evidence_verifier_v0.json`;
- `artifacts/status.json`;
- `artifacts/release_decision_v0.json`;
- `artifacts/artifact_provenance_binding_v0.json`;
- `artifacts/release_authority_v0.json`;
- `artifacts/report_card.html`;
- `artifacts/slsa/slsa_vsa_trusted_producer_input_packet_v0.json`;
- `artifacts/slsa/slsa_vsa_trusted_evidence_producer_report_v0.json`;
- non-empty `artifacts/recorded_release_candidates/`;
- non-empty `release-authority-audit-bundle/`.

The SLSA/VSA trusted producer check confirms:

- packet schema identity;
- report schema identity;
- accepted producer decision;
- recorded-signal mode;
- recorded-intake candidate set;
- current-run key binding;
- commit binding;
- release-candidate binding;
- artifact digest binding;
- policy binding;
- verifier binding;
- expected verified level;
- fresh current-run acceptance.

## Tests

Tests cover:

- complete package acceptance;
- deterministic stdout/output report behavior;
- missing required file failure;
- empty required file failure;
- duplicate JSON key failure;
- stub marker failure;
- digest inventory mismatch failure;
- SLSA/VSA packet-report mismatch failure;
- rejected/stale trusted producer report failure;
- `status.json` output refusal;
- package-internal output refusal;
- source-level guardrails against release gate/materializer engines;
- tools-tests manifest registration.

## Verification

Expected:

- `python -m py_compile tools/check_release_grade_package_complete_v1.py`
- `python tests/test_check_release_grade_package_complete_v1.py`
- `python -m pytest tests/test_check_release_grade_package_complete_v1.py`
- `python tests/test_tools_tests_list_smoke.py`
- `git diff --check`