### PR TITLE
ci(ref): add hosted LlamaGuard access preflight

### DIFF
--- a/.github/workflows/llamaguard_hosted_access_preflight.yml
+++ b/.github/workflows/llamaguard_hosted_access_preflight.yml
@@ -1,0 +1,165 @@
+name: LlamaGuard hosted access preflight
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_source_sha:
+        description: "Exact 40-hex main commit to preflight; must match the selected workflow ref"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: llamaguard-hosted-access-preflight-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Verify access to pinned LlamaGuard revision
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout fixed source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pinned
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # pinned
+        with:
+          python-version: "3.11"
+
+      - name: Verify fixed source identity
+        shell: bash
+        env:
+          EXPECTED_SOURCE_SHA: ${{ inputs.expected_source_sha }}
+        run: |
+          set -euo pipefail
+
+          EXPECTED="${EXPECTED_SOURCE_SHA,,}"
+          ACTUAL="${GITHUB_SHA,,}"
+          CHECKED_OUT="$(git rev-parse HEAD | tr '[:upper:]' '[:lower:]')"
+
+          if [[ ! "${EXPECTED}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::expected_source_sha must be an exact 40-hex commit SHA"
+            exit 1
+          fi
+
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error::hosted access preflight must run from refs/heads/main; got ${GITHUB_REF}"
+            exit 1
+          fi
+
+          if [[ "${EXPECTED}" != "${ACTUAL}" || "${EXPECTED}" != "${CHECKED_OUT}" ]]; then
+            echo "::error::fixed source mismatch"
+            echo "expected=${EXPECTED}"
+            echo "github_sha=${ACTUAL}"
+            echo "checked_out=${CHECKED_OUT}"
+            exit 1
+          fi
+
+          echo "OK: fixed source identity matches ${EXPECTED}"
+
+      - name: Install pinned Hugging Face Hub client only
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          REQUIREMENTS="PULSE_safe_pack_v0/requirements-llamaguard-v0.txt"
+          mapfile -t HUB_REQUIREMENTS < <(
+            grep -E '^huggingface-hub==[A-Za-z0-9_.+!-]+$' "${REQUIREMENTS}"
+          )
+
+          if [[ "${#HUB_REQUIREMENTS[@]}" -ne 1 ]]; then
+            echo "::error::expected exactly one huggingface-hub pin in ${REQUIREMENTS}"
+            exit 1
+          fi
+
+          python -m pip install \
+            --disable-pip-version-check \
+            --no-cache-dir \
+            "${HUB_REQUIREMENTS[0]}"
+
+      - name: Check token and pinned model metadata access
+        shell: bash
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_HOME: ${{ runner.temp }}/huggingface
+          HF_HUB_DISABLE_TELEMETRY: "1"
+          TOKENIZERS_PARALLELISM: "false"
+          REPORT_PATH: ${{ runner.temp }}/llamaguard_hosted_access_preflight_v0.json
+        run: |
+          set -euo pipefail
+
+          python tools/check_llamaguard_hosted_access_v0.py \
+            --repo-root "${GITHUB_WORKSPACE}" \
+            --token-env "HF_TOKEN" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --git-sha "${GITHUB_SHA}" \
+            --workflow-ref "${GITHUB_WORKFLOW_REF}" \
+            --run-id "${GITHUB_RUN_ID}" \
+            --run-attempt "${GITHUB_RUN_ATTEMPT}" \
+            --output "${REPORT_PATH}"
+
+      - name: Upload sanitized hosted-access preflight report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        with:
+          name: llamaguard-hosted-access-preflight-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/llamaguard_hosted_access_preflight_v0.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Summarize hosted-access preflight
+        if: ${{ always() }}
+        shell: bash
+        env:
+          REPORT_PATH: ${{ runner.temp }}/llamaguard_hosted_access_preflight_v0.json
+        run: |
+          set -euo pipefail
+
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          from pathlib import Path
+
+          report_path = Path(os.environ["REPORT_PATH"])
+          summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
+
+          if not report_path.is_file() or report_path.is_symlink():
+              text = (
+                  "## LlamaGuard hosted access preflight\n\n"
+                  "- status: `report missing`\n"
+                  "- authority: `non-authorizing access preflight`\n"
+              )
+              summary_path.write_text(text, encoding="utf-8")
+              raise SystemExit(0)
+
+          report = json.loads(report_path.read_text(encoding="utf-8"))
+          runtime = report.get("runtime") or {}
+          failure = report.get("failure") or {}
+
+          lines = [
+              "## LlamaGuard hosted access preflight",
+              "",
+              f"- status: `{report.get('status', 'unknown')}`",
+              f"- model: `{runtime.get('model_id', 'unknown')}`",
+              f"- requested revision: `{runtime.get('model_revision', 'unknown')}`",
+              f"- resolved revision: `{runtime.get('resolved_model_revision', 'unknown')}`",
+              f"- probe files: `{len(report.get('probe_files') or [])}`",
+              f"- failure kind: `{failure.get('kind', 'none')}`",
+              "- model inference: `not run`",
+              "- model weights: `not downloaded`",
+              "- release authority: `none`",
+              "",
+          ]
+          summary_path.write_text("\n".join(lines), encoding="utf-8")
+          PY

--- a/.github/workflows/llamaguard_hosted_access_preflight.yml
+++ b/.github/workflows/llamaguard_hosted_access_preflight.yml
@@ -1,4 +1,4 @@
-name: LlamaGuard hosted access preflight
+name: LlamaGuard hosted access preflight release check
 
 on:
   workflow_dispatch:

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -20,6 +20,7 @@ tests/test_llamaguard_ingest_v1.py
 tests/test_run_llamaguard_current_evidence_v0.py
 tests/test_llamaguard_attested_release_path_wiring_v0.py
 tests/test_llamaguard_current_run_workflow_wiring_v0.py
+tests/test_llamaguard_hosted_access_preflight_v0.py
 tests/test_run_all_mode_contract.py
 tests/test_validate_status_schema_tool.py
 tests/test_validate_space_relation_map_tool.py

--- a/tests/test_llamaguard_hosted_access_preflight_v0.py
+++ b/tests/test_llamaguard_hosted_access_preflight_v0.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL_PATH = ROOT / "tools" / "check_llamaguard_hosted_access_v0.py"
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "llamaguard_hosted_access_preflight.yml"
+TOOLS_TESTS_LIST = ROOT / "ci" / "tools-tests.list"
+THIS_TEST = "tests/test_llamaguard_hosted_access_preflight_v0.py"
+
+EXPECTED_MODEL_ID = "meta-llama/Llama-Guard-3-1B"
+EXPECTED_MODEL_REVISION = "acf7aafa60f0410f8f42b1fa35e077d705892029"
+EXPECTED_HUB_VERSION = "0.36.0"
+
+
+def _load_tool() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "check_llamaguard_hosted_access_v0",
+        TOOL_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+TOOL = _load_tool()
+
+
+def _make_repo(base: Path) -> Path:
+    repo = base / "repo"
+    producer = repo / "PULSE_safe_pack_v0" / "tools" / "run_llamaguard_current_evidence_v0.py"
+    requirements = repo / "PULSE_safe_pack_v0" / "requirements-llamaguard-v0.txt"
+    producer.parent.mkdir(parents=True, exist_ok=True)
+
+    producer.write_text(
+        "MODEL_ID = \"meta-llama/Llama-Guard-3-1B\"\n"
+        "MODEL_REVISION = \"acf7aafa60f0410f8f42b1fa35e077d705892029\"\n",
+        encoding="utf-8",
+    )
+    requirements.write_text(
+        "--extra-index-url https://download.pytorch.org/whl/cpu\n\n"
+        "torch==2.9.1+cpu\n"
+        "transformers==4.57.6\n"
+        "huggingface-hub==0.36.0\n"
+        "safetensors==0.7.0\n",
+        encoding="utf-8",
+    )
+    return repo
+
+
+class FakeGatedRepoError(Exception):
+    pass
+
+
+class FakeRepositoryNotFoundError(Exception):
+    pass
+
+
+class FakeRevisionNotFoundError(Exception):
+    pass
+
+
+class FakeEntryNotFoundError(Exception):
+    pass
+
+
+class FakeHubHttpError(Exception):
+    pass
+
+
+def _bindings(*, resolved_revision: str):
+    class FakeApi:
+        def __init__(self, *, token: str) -> None:
+            assert token == "hf_test_secret_value"
+
+        def model_info(self, *, repo_id: str, revision: str, token: str):
+            assert repo_id == EXPECTED_MODEL_ID
+            assert revision == EXPECTED_MODEL_REVISION
+            assert token == "hf_test_secret_value"
+            return SimpleNamespace(sha=resolved_revision, gated="auto")
+
+    def fake_download_file(
+        *,
+        repo_id: str,
+        filename: str,
+        revision: str,
+        token: str,
+        cache_dir: str,
+    ) -> str:
+        assert repo_id == EXPECTED_MODEL_ID
+        assert revision == EXPECTED_MODEL_REVISION
+        assert token == "hf_test_secret_value"
+        assert filename in {"config.json", "tokenizer_config.json"}
+        path = Path(cache_dir) / "probe" / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"filename": filename, "revision": revision}),
+            encoding="utf-8",
+        )
+        return str(path)
+
+    return TOOL.HuggingFaceBindings(
+        api_factory=FakeApi,
+        download_file=fake_download_file,
+        gated_repo_error=FakeGatedRepoError,
+        repository_not_found_error=FakeRepositoryNotFoundError,
+        revision_not_found_error=FakeRevisionNotFoundError,
+        entry_not_found_error=FakeEntryNotFoundError,
+        hub_http_error=FakeHubHttpError,
+    )
+
+
+def _run_check(
+    repo: Path,
+    *,
+    reported_git_sha: str = "a" * 40,
+    checked_out_git_sha: str | None = None,
+) -> tuple[dict, int]:
+    actual_head = checked_out_git_sha or reported_git_sha
+    with mock.patch.object(TOOL, "_git_head", return_value=actual_head):
+        return TOOL.check_access(
+            repo_root=repo,
+            token_env="HF_TOKEN",
+            repository="HKati/pulse-release-gates-0.1",
+            git_sha=reported_git_sha,
+            workflow_ref=(
+                "HKati/pulse-release-gates-0.1/"
+                ".github/workflows/llamaguard_hosted_access_preflight.yml@refs/heads/main"
+            ),
+            run_id="12345",
+            run_attempt="1",
+        )
+
+
+def test_canonical_runtime_identity_comes_from_repository_files() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        repo = _make_repo(Path(temp))
+        runtime = TOOL._canonical_runtime_identity(repo)
+
+    assert runtime["model_id"] == EXPECTED_MODEL_ID
+    assert runtime["model_revision"] == EXPECTED_MODEL_REVISION
+    assert runtime["huggingface_hub_version"] == EXPECTED_HUB_VERSION
+    assert len(runtime["producer_sha256"]) == 64
+    assert len(runtime["runtime_requirements_sha256"]) == 64
+
+
+
+
+def test_reported_git_sha_must_match_checked_out_head() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        repo = _make_repo(Path(temp))
+        report, exit_code = _run_check(
+            repo,
+            reported_git_sha="a" * 40,
+            checked_out_git_sha="b" * 40,
+        )
+
+    assert exit_code == 1
+    assert report["ok"] is False
+    assert report["failure"]["kind"] == "git_sha_checkout_mismatch"
+    assert report["source"]["git_sha"] == "a" * 40
+    assert report["source"]["checked_out_git_sha"] == "b" * 40
+    check = next(
+        item
+        for item in report["checks"]
+        if item["check_id"] == "source.git_sha_matches_checkout"
+    )
+    assert check["passed"] is False
+
+
+def test_canonical_inputs_reject_symlinked_parent_directory() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        base = Path(temp)
+        outside = _make_repo(base / "outside")
+        repo = base / "repo"
+        repo.mkdir(parents=True)
+        (repo / "PULSE_safe_pack_v0").symlink_to(
+            outside / "PULSE_safe_pack_v0",
+            target_is_directory=True,
+        )
+
+        try:
+            TOOL._canonical_runtime_identity(repo)
+        except TOOL.PreflightError as exc:
+            assert exc.code == "repository_path_symlink_component"
+            assert exc.field == TOOL.PRODUCER_REL
+        else:
+            raise AssertionError("symlinked canonical input parent was accepted")
+
+
+def test_missing_token_fails_without_loading_network_client() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        repo = _make_repo(Path(temp))
+        with mock.patch.dict(os.environ, {"HF_TOKEN": ""}, clear=False), mock.patch.object(
+            TOOL,
+            "_load_huggingface_bindings",
+            side_effect=AssertionError("network client must not load without a token"),
+        ):
+            report, exit_code = _run_check(repo)
+
+    assert exit_code == 1
+    assert report["ok"] is False
+    assert report["status"] == "blocked"
+    assert report["failure"]["kind"] == "missing_token"
+    assert report["authority_boundary"]["authorizes_release"] is False
+
+
+def test_success_probes_only_small_metadata_files_and_never_records_token() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        repo = _make_repo(Path(temp))
+        with mock.patch.dict(
+            os.environ,
+            {"HF_TOKEN": "hf_test_secret_value"},
+            clear=False,
+        ), mock.patch.object(
+            TOOL,
+            "_installed_hub_version",
+            return_value=EXPECTED_HUB_VERSION,
+        ), mock.patch.object(
+            TOOL,
+            "_load_huggingface_bindings",
+            return_value=_bindings(resolved_revision=EXPECTED_MODEL_REVISION),
+        ):
+            report, exit_code = _run_check(repo)
+
+    rendered = json.dumps(report, sort_keys=True)
+    assert exit_code == 0
+    assert report["ok"] is True
+    assert report["status"] == "accessible"
+    assert report["runtime"]["resolved_model_revision"] == EXPECTED_MODEL_REVISION
+    assert [item["path"] for item in report["probe_files"]] == [
+        "config.json",
+        "tokenizer_config.json",
+    ]
+    assert all(item["json_object"] is True for item in report["probe_files"])
+    assert "hf_test_secret_value" not in rendered
+    assert report["authority_boundary"] == TOOL.AUTHORITY_BOUNDARY
+
+
+def test_resolved_revision_mismatch_fails_closed() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        repo = _make_repo(Path(temp))
+        with mock.patch.dict(
+            os.environ,
+            {"HF_TOKEN": "hf_test_secret_value"},
+            clear=False,
+        ), mock.patch.object(
+            TOOL,
+            "_installed_hub_version",
+            return_value=EXPECTED_HUB_VERSION,
+        ), mock.patch.object(
+            TOOL,
+            "_load_huggingface_bindings",
+            return_value=_bindings(resolved_revision="b" * 40),
+        ):
+            report, exit_code = _run_check(repo)
+
+    assert exit_code == 1
+    assert report["failure"]["kind"] == "model_revision_mismatch"
+    assert report["probe_files"] == []
+
+
+def test_output_safety_refuses_repository_and_status_outputs() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        repo = _make_repo(Path(temp))
+        outside = Path(temp) / "outside" / "report.json"
+
+        assert TOOL._normalize_output(repo, outside) == outside.resolve()
+
+        for bad in (
+            repo / "report.json",
+            Path(temp) / "outside" / "status.json",
+        ):
+            try:
+                TOOL._normalize_output(repo, bad)
+            except TOOL.PreflightError:
+                pass
+            else:
+                raise AssertionError(f"unsafe output accepted: {bad}")
+
+
+def test_tool_source_has_no_inference_or_weight_download_surface() -> None:
+    text = TOOL_PATH.read_text(encoding="utf-8")
+    for forbidden in (
+        "snapshot_download",
+        "AutoModel",
+        "AutoTokenizer",
+        "from_pretrained",
+        "pytorch_model.bin",
+        "model.safetensors",
+        "check_gates.py",
+        "materialize_release_required_from_verifier_v0.py",
+        "actions/attest",
+    ):
+        assert forbidden not in text, forbidden
+
+    assert TOOL.PROBE_FILES == ("config.json", "tokenizer_config.json")
+    assert TOOL.AUTHORITY_BOUNDARY["runs_model_inference"] is False
+    assert TOOL.AUTHORITY_BOUNDARY["downloads_model_weights"] is False
+    assert TOOL.AUTHORITY_BOUNDARY["authorizes_release"] is False
+
+
+def test_workflow_is_manual_read_only_and_secret_scoped() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert text.startswith(
+        "name: LlamaGuard hosted access preflight release check\n"
+    )
+    assert "\n  workflow_dispatch:" in text
+    for trigger in ("\n  push:", "\n  pull_request:", "\n  schedule:", "\n  release:"):
+        assert trigger not in text
+
+    assert "expected_source_sha:" in text
+    assert "refs/heads/main" in text
+    assert "EXPECTED_SOURCE_SHA" in text
+    assert "persist-credentials: false" in text
+
+    assert text.count("secrets.HF_TOKEN") == 1
+    assert "set -x" not in text
+    assert 'echo "${HF_TOKEN}' not in text
+    assert "id-token:" not in text
+    assert "attestations:" not in text
+    assert "artifact-metadata:" not in text
+    assert "actions/attest@" not in text
+
+    assert "tools/check_llamaguard_hosted_access_v0.py" in text
+    assert "--token-env \"HF_TOKEN\"" in text
+    assert "--output \"${REPORT_PATH}\"" in text
+    assert "${{ runner.temp }}/llamaguard_hosted_access_preflight_v0.json" in text
+
+    upload_index = text.index("Upload sanitized hosted-access preflight report")
+    tool_index = text.index("tools/check_llamaguard_hosted_access_v0.py")
+    assert tool_index < upload_index
+    assert "if: ${{ always() }}" in text[upload_index:]
+    assert "if-no-files-found: error" in text[upload_index:]
+    assert "retention-days: 30" in text[upload_index:]
+
+    for forbidden in (
+        "check_gates.py",
+        "policy_to_require_args.py",
+        "materialize_release_required_from_verifier_v0.py",
+        "status.json",
+        "release_required",
+        "release_blocking",
+        "prod_required",
+        "stage_required",
+    ):
+        assert forbidden not in text, forbidden
+
+
+def test_tools_manifest_registers_preflight_smoke_once() -> None:
+    entries = [
+        raw.split("#", 1)[0].strip()
+        for raw in TOOLS_TESTS_LIST.read_text(encoding="utf-8").splitlines()
+        if raw.split("#", 1)[0].strip()
+    ]
+    assert entries.count(THIS_TEST) == 1
+    current_run_test = "tests/test_llamaguard_current_run_workflow_wiring_v0.py"
+    assert entries.index(current_run_test) < entries.index(THIS_TEST)
+
+
+def check_llamaguard_hosted_access_preflight_v0() -> None:
+    test_canonical_runtime_identity_comes_from_repository_files()
+    test_reported_git_sha_must_match_checked_out_head()
+    test_canonical_inputs_reject_symlinked_parent_directory()
+    test_missing_token_fails_without_loading_network_client()
+    test_success_probes_only_small_metadata_files_and_never_records_token()
+    test_resolved_revision_mismatch_fails_closed()
+    test_output_safety_refuses_repository_and_status_outputs()
+    test_tool_source_has_no_inference_or_weight_download_surface()
+    test_workflow_is_manual_read_only_and_secret_scoped()
+    test_tools_manifest_registers_preflight_smoke_once()
+
+
+if __name__ == "__main__":
+    check_llamaguard_hosted_access_preflight_v0()
+    print("OK: LlamaGuard hosted access preflight contract")

--- a/tools/check_llamaguard_hosted_access_v0.py
+++ b/tools/check_llamaguard_hosted_access_v0.py
@@ -1,0 +1,657 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ast
+import datetime as dt
+import hashlib
+import importlib.metadata
+import json
+import os
+import re
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+
+TOOL_NAME = "check_llamaguard_hosted_access_v0"
+TOOL_VERSION = "0.1.0"
+SCHEMA_VERSION = "llamaguard_hosted_access_preflight_v0"
+
+PRODUCER_REL = (
+    "PULSE_safe_pack_v0/tools/"
+    "run_llamaguard_current_evidence_v0.py"
+)
+RUNTIME_REQUIREMENTS_REL = "PULSE_safe_pack_v0/requirements-llamaguard-v0.txt"
+PROBE_FILES: tuple[str, ...] = (
+    "config.json",
+    "tokenizer_config.json",
+)
+MAX_PROBE_BYTES = 2 * 1024 * 1024
+
+HEX40_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+POSITIVE_INT_RE = re.compile(r"^[1-9][0-9]*$")
+HUB_REQUIREMENT_RE = re.compile(
+    r"^huggingface-hub==(?P<version>[A-Za-z0-9_.+!-]+)$",
+    re.IGNORECASE,
+)
+
+AUTHORITY_BOUNDARY = {
+    "access_preflight_only": True,
+    "runs_model_inference": False,
+    "downloads_model_weights": False,
+    "produces_release_evidence": False,
+    "writes_status": False,
+    "materializes_gates": False,
+    "calls_gate_checker": False,
+    "creates_attestation": False,
+    "authorizes_release": False,
+    "blocks_release": False,
+}
+
+
+class PreflightError(ValueError):
+    def __init__(self, code: str, *, field: str | None = None) -> None:
+        super().__init__(code)
+        self.code = code
+        self.field = field
+
+
+class StrictJsonError(PreflightError):
+    pass
+
+
+@dataclass(frozen=True)
+class HuggingFaceBindings:
+    api_factory: Callable[..., Any]
+    download_file: Callable[..., str]
+    gated_repo_error: type[BaseException]
+    repository_not_found_error: type[BaseException]
+    revision_not_found_error: type[BaseException]
+    entry_not_found_error: type[BaseException]
+    hub_http_error: type[BaseException]
+
+
+def _load_huggingface_bindings() -> HuggingFaceBindings:
+    from huggingface_hub import HfApi, hf_hub_download
+    from huggingface_hub.utils import (
+        EntryNotFoundError,
+        GatedRepoError,
+        HfHubHTTPError,
+        RepositoryNotFoundError,
+        RevisionNotFoundError,
+    )
+
+    return HuggingFaceBindings(
+        api_factory=HfApi,
+        download_file=hf_hub_download,
+        gated_repo_error=GatedRepoError,
+        repository_not_found_error=RepositoryNotFoundError,
+        revision_not_found_error=RevisionNotFoundError,
+        entry_not_found_error=EntryNotFoundError,
+        hub_http_error=HfHubHTTPError,
+    )
+
+
+def _installed_hub_version() -> str:
+    try:
+        return importlib.metadata.version("huggingface-hub")
+    except importlib.metadata.PackageNotFoundError as exc:
+        raise PreflightError("huggingface_hub_not_installed") from exc
+
+
+def _json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise StrictJsonError("probe_duplicate_json_key", field=key)
+        result[key] = value
+    return result
+
+
+def _read_strict_json_object(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8", errors="strict"),
+            object_pairs_hook=_json_object,
+            parse_constant=lambda value: (_ for _ in ()).throw(
+                StrictJsonError("probe_non_finite_json", field=value)
+            ),
+        )
+    except PreflightError:
+        raise
+    except Exception as exc:
+        raise PreflightError("probe_invalid_json") from exc
+
+    if not isinstance(payload, dict):
+        raise PreflightError("probe_json_not_object")
+    return payload
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _normalize_repo_root(path: Path) -> Path:
+    resolved = Path(os.path.abspath(os.path.normpath(str(path))))
+    if resolved.is_symlink() or not resolved.is_dir():
+        raise PreflightError("repo_root_not_regular_directory")
+    return resolved
+
+
+def _safe_repo_path(repo_root: Path, relative: str) -> Path:
+    path = Path(os.path.abspath(os.path.normpath(str(repo_root / relative))))
+    try:
+        path.relative_to(repo_root)
+    except ValueError as exc:
+        raise PreflightError("repository_path_escape", field=relative) from exc
+
+    if path.is_symlink() or not path.is_file():
+        raise PreflightError("repository_file_missing_or_symlinked", field=relative)
+    return path
+
+
+def _extract_string_constants(path: Path, names: set[str]) -> dict[str, str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="strict"))
+    except Exception as exc:
+        raise PreflightError("producer_source_parse_failed") from exc
+
+    values: dict[str, str] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name) or target.id not in names:
+            continue
+        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            values[target.id] = node.value.value
+
+    missing = sorted(names - values.keys())
+    if missing:
+        raise PreflightError("producer_identity_constant_missing", field=",".join(missing))
+    return values
+
+
+def _canonical_runtime_identity(repo_root: Path) -> dict[str, str]:
+    producer = _safe_repo_path(repo_root, PRODUCER_REL)
+    requirements = _safe_repo_path(repo_root, RUNTIME_REQUIREMENTS_REL)
+
+    constants = _extract_string_constants(producer, {"MODEL_ID", "MODEL_REVISION"})
+    model_id = constants["MODEL_ID"].strip()
+    model_revision = constants["MODEL_REVISION"].strip().lower()
+
+    if not model_id or "/" not in model_id:
+        raise PreflightError("invalid_model_id")
+    if not HEX40_RE.fullmatch(model_revision):
+        raise PreflightError("invalid_model_revision")
+
+    matched_versions: list[str] = []
+    for raw in requirements.read_text(encoding="utf-8", errors="strict").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        match = HUB_REQUIREMENT_RE.fullmatch(line)
+        if match:
+            matched_versions.append(match.group("version"))
+
+    if len(matched_versions) != 1:
+        raise PreflightError("huggingface_hub_pin_not_unique")
+
+    return {
+        "model_id": model_id,
+        "model_revision": model_revision,
+        "huggingface_hub_version": matched_versions[0],
+        "producer_path": PRODUCER_REL,
+        "producer_sha256": _sha256(producer),
+        "runtime_requirements_path": RUNTIME_REQUIREMENTS_REL,
+        "runtime_requirements_sha256": _sha256(requirements),
+    }
+
+
+def _validate_repository(value: str) -> str:
+    repository = value.strip()
+    if not REPOSITORY_RE.fullmatch(repository):
+        raise PreflightError("invalid_repository")
+    return repository
+
+
+def _validate_sha(value: str) -> str:
+    sha = value.strip().lower()
+    if not HEX40_RE.fullmatch(sha):
+        raise PreflightError("invalid_git_sha")
+    return sha
+
+
+def _validate_positive_int(value: str, field: str) -> str:
+    text = value.strip()
+    if not POSITIVE_INT_RE.fullmatch(text):
+        raise PreflightError("invalid_positive_integer", field=field)
+    return text
+
+
+def _validate_non_empty(value: str, field: str) -> str:
+    text = value.strip()
+    if not text:
+        raise PreflightError("missing_required_text", field=field)
+    return text
+
+
+def _normalize_output(repo_root: Path, output: Path) -> Path:
+    resolved = Path(os.path.abspath(os.path.normpath(str(output))))
+    if resolved.name == "status.json":
+        raise PreflightError("refusing_to_write_status_json")
+    if resolved.is_symlink():
+        raise PreflightError("refusing_to_write_symlink_output")
+    if resolved.exists() and not resolved.is_file():
+        raise PreflightError("refusing_to_write_non_file_output")
+
+    for parent in (resolved.parent, *resolved.parent.parents):
+        if parent.exists() and parent.is_symlink():
+            raise PreflightError("refusing_to_write_through_symlink_parent")
+
+    try:
+        resolved.relative_to(repo_root)
+    except ValueError:
+        return resolved
+    raise PreflightError("refusing_to_write_inside_repository")
+
+
+def _utc_now() -> str:
+    return (
+        dt.datetime.now(tz=dt.timezone.utc)
+        .replace(microsecond=0)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _base_report(
+    *,
+    repository: str,
+    git_sha: str,
+    workflow_ref: str,
+    run_id: str,
+    run_attempt: str,
+    runtime: dict[str, str] | None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "tool": {
+            "name": TOOL_NAME,
+            "version": TOOL_VERSION,
+        },
+        "created_utc": _utc_now(),
+        "ok": False,
+        "status": "blocked",
+        "source": {
+            "repository": repository,
+            "git_sha": git_sha,
+            "workflow_ref": workflow_ref,
+            "run_id": run_id,
+            "run_attempt": run_attempt,
+        },
+        "runtime": runtime,
+        "checks": [],
+        "probe_files": [],
+        "failure": None,
+        "authority_boundary": dict(AUTHORITY_BOUNDARY),
+    }
+
+
+def _add_check(
+    report: dict[str, Any],
+    check_id: str,
+    passed: bool,
+    details: str,
+) -> None:
+    report["checks"].append(
+        {
+            "check_id": check_id,
+            "passed": bool(passed),
+            "details": details,
+        }
+    )
+
+
+def _fail(
+    report: dict[str, Any],
+    kind: str,
+    *,
+    field: str | None = None,
+    http_status: int | None = None,
+    exception_type: str | None = None,
+) -> tuple[dict[str, Any], int]:
+    failure: dict[str, Any] = {"kind": kind}
+    if field:
+        failure["field"] = field
+    if http_status is not None:
+        failure["http_status"] = http_status
+    if exception_type:
+        failure["exception_type"] = exception_type
+    report["failure"] = failure
+    report["ok"] = False
+    report["status"] = "blocked"
+    return report, 1
+
+
+def _http_status(exc: BaseException) -> int | None:
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    return status if isinstance(status, int) else None
+
+
+def check_access(
+    *,
+    repo_root: Path,
+    token_env: str,
+    repository: str,
+    git_sha: str,
+    workflow_ref: str,
+    run_id: str,
+    run_attempt: str,
+) -> tuple[dict[str, Any], int]:
+    repository = _validate_repository(repository)
+    git_sha = _validate_sha(git_sha)
+    workflow_ref = _validate_non_empty(workflow_ref, "workflow_ref")
+    run_id = _validate_positive_int(run_id, "run_id")
+    run_attempt = _validate_positive_int(run_attempt, "run_attempt")
+    token_env = _validate_non_empty(token_env, "token_env")
+
+    runtime: dict[str, str] | None = None
+    report = _base_report(
+        repository=repository,
+        git_sha=git_sha,
+        workflow_ref=workflow_ref,
+        run_id=run_id,
+        run_attempt=run_attempt,
+        runtime=runtime,
+    )
+
+    try:
+        runtime = _canonical_runtime_identity(repo_root)
+        report["runtime"] = runtime
+        _add_check(
+            report,
+            "runtime.canonical_identity_loaded",
+            True,
+            "model identity, revision, and Hub client pin were read from canonical repository files",
+        )
+    except PreflightError as exc:
+        _add_check(
+            report,
+            "runtime.canonical_identity_loaded",
+            False,
+            "canonical hosted runtime identity could not be loaded",
+        )
+        return _fail(report, exc.code, field=exc.field)
+
+    token = os.environ.get(token_env, "").strip()
+    token_present = bool(token)
+    _add_check(
+        report,
+        "token.present",
+        token_present,
+        f"environment variable {token_env} is non-empty",
+    )
+    if not token_present:
+        return _fail(report, "missing_token", field=token_env)
+
+    expected_hub_version = runtime["huggingface_hub_version"]
+    try:
+        installed_hub_version = _installed_hub_version()
+    except PreflightError as exc:
+        _add_check(
+            report,
+            "runtime.huggingface_hub_version",
+            False,
+            "pinned Hugging Face Hub client is not installed",
+        )
+        return _fail(report, exc.code)
+
+    version_matches = installed_hub_version == expected_hub_version
+    _add_check(
+        report,
+        "runtime.huggingface_hub_version",
+        version_matches,
+        "installed Hugging Face Hub client matches the canonical runtime pin",
+    )
+    report["runtime"]["installed_huggingface_hub_version"] = installed_hub_version
+    if not version_matches:
+        return _fail(report, "huggingface_hub_version_mismatch")
+
+    try:
+        bindings = _load_huggingface_bindings()
+        api = bindings.api_factory(token=token)
+        info = api.model_info(
+            repo_id=runtime["model_id"],
+            revision=runtime["model_revision"],
+            token=token,
+        )
+
+        resolved_revision = getattr(info, "sha", None)
+        resolved_matches = (
+            isinstance(resolved_revision, str)
+            and resolved_revision.lower() == runtime["model_revision"]
+        )
+        _add_check(
+            report,
+            "model.revision_resolved",
+            resolved_matches,
+            "Hub model metadata resolved to the exact pinned commit revision",
+        )
+        report["runtime"]["resolved_model_revision"] = (
+            resolved_revision.lower()
+            if isinstance(resolved_revision, str)
+            else None
+        )
+        gated = getattr(info, "gated", None)
+        report["runtime"]["gated"] = gated if isinstance(gated, (bool, str)) else None
+
+        if not resolved_matches:
+            return _fail(report, "model_revision_mismatch")
+
+        with tempfile.TemporaryDirectory(
+            prefix="pulse-llamaguard-access-preflight-"
+        ) as temp_dir_text:
+            temp_dir = Path(temp_dir_text).resolve()
+            probes: list[dict[str, Any]] = []
+
+            for filename in PROBE_FILES:
+                downloaded = Path(
+                    bindings.download_file(
+                        repo_id=runtime["model_id"],
+                        filename=filename,
+                        revision=runtime["model_revision"],
+                        token=token,
+                        cache_dir=str(temp_dir),
+                    )
+                )
+                resolved_file = downloaded.resolve(strict=True)
+                try:
+                    resolved_file.relative_to(temp_dir)
+                except ValueError as exc:
+                    raise PreflightError(
+                        "probe_download_escaped_temporary_cache",
+                        field=filename,
+                    ) from exc
+
+                if not resolved_file.is_file():
+                    raise PreflightError("probe_file_missing", field=filename)
+
+                size = resolved_file.stat().st_size
+                if size <= 0:
+                    raise PreflightError("probe_file_empty", field=filename)
+                if size > MAX_PROBE_BYTES:
+                    raise PreflightError("probe_file_too_large", field=filename)
+
+                _read_strict_json_object(resolved_file)
+                probes.append(
+                    {
+                        "path": filename,
+                        "size_bytes": size,
+                        "sha256": _sha256(resolved_file),
+                        "json_object": True,
+                    }
+                )
+
+            report["probe_files"] = probes
+
+        _add_check(
+            report,
+            "model.metadata_files_accessible",
+            len(report["probe_files"]) == len(PROBE_FILES),
+            "small pinned-revision metadata files were downloaded and parsed without model weights or inference",
+        )
+
+    except PreflightError as exc:
+        return _fail(report, exc.code, field=exc.field)
+    except Exception as exc:  # noqa: BLE001
+        bindings_value = locals().get("bindings")
+        if isinstance(bindings_value, HuggingFaceBindings):
+            if isinstance(exc, bindings_value.gated_repo_error):
+                return _fail(
+                    report,
+                    "gated_model_access_denied",
+                    http_status=_http_status(exc),
+                )
+            if isinstance(exc, bindings_value.revision_not_found_error):
+                return _fail(
+                    report,
+                    "model_revision_not_found",
+                    http_status=_http_status(exc),
+                )
+            if isinstance(exc, bindings_value.entry_not_found_error):
+                return _fail(
+                    report,
+                    "probe_file_not_found",
+                    http_status=_http_status(exc),
+                )
+            if isinstance(exc, bindings_value.repository_not_found_error):
+                return _fail(
+                    report,
+                    "model_repository_not_found_or_inaccessible",
+                    http_status=_http_status(exc),
+                )
+            if isinstance(exc, bindings_value.hub_http_error):
+                return _fail(
+                    report,
+                    "huggingface_hub_http_error",
+                    http_status=_http_status(exc),
+                )
+
+        return _fail(
+            report,
+            "unexpected_preflight_error",
+            exception_type=type(exc).__name__,
+        )
+
+    report["ok"] = True
+    report["status"] = "accessible"
+    report["failure"] = None
+    return report, 0
+
+
+def _render(report: dict[str, Any]) -> str:
+    return json.dumps(
+        report,
+        indent=2,
+        ensure_ascii=False,
+        sort_keys=True,
+        allow_nan=False,
+    ) + "\n"
+
+
+def _write_report(path: Path, report: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise PreflightError("refusing_to_write_symlink_output")
+    path.write_text(_render(report), encoding="utf-8")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify that the configured Hugging Face token can read the exact "
+            "pinned LlamaGuard model revision without downloading model weights."
+        )
+    )
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--token-env", default="HF_TOKEN")
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--git-sha", required=True)
+    parser.add_argument("--workflow-ref", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--run-attempt", required=True)
+    parser.add_argument("--output", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+
+    try:
+        repo_root = _normalize_repo_root(Path(args.repo_root))
+        output = _normalize_output(repo_root, Path(args.output))
+    except PreflightError as exc:
+        diagnostic = {
+            "schema_version": SCHEMA_VERSION,
+            "tool": {"name": TOOL_NAME, "version": TOOL_VERSION},
+            "ok": False,
+            "status": "output_refused",
+            "failure": {
+                "kind": exc.code,
+                **({"field": exc.field} if exc.field else {}),
+            },
+            "authority_boundary": dict(AUTHORITY_BOUNDARY),
+        }
+        sys.stdout.write(_render(diagnostic))
+        return 2
+
+    try:
+        report, exit_code = check_access(
+            repo_root=repo_root,
+            token_env=args.token_env,
+            repository=args.repository,
+            git_sha=args.git_sha,
+            workflow_ref=args.workflow_ref,
+            run_id=args.run_id,
+            run_attempt=args.run_attempt,
+        )
+    except PreflightError as exc:
+        report = _base_report(
+            repository=str(args.repository),
+            git_sha=str(args.git_sha),
+            workflow_ref=str(args.workflow_ref),
+            run_id=str(args.run_id),
+            run_attempt=str(args.run_attempt),
+            runtime=None,
+        )
+        report, exit_code = _fail(report, exc.code, field=exc.field)
+    except Exception as exc:  # noqa: BLE001
+        report = _base_report(
+            repository=str(args.repository),
+            git_sha=str(args.git_sha),
+            workflow_ref=str(args.workflow_ref),
+            run_id=str(args.run_id),
+            run_attempt=str(args.run_attempt),
+            runtime=None,
+        )
+        report, exit_code = _fail(
+            report,
+            "unexpected_preflight_error",
+            exception_type=type(exc).__name__,
+        )
+
+    _write_report(output, report)
+    sys.stdout.write(_render(report))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_llamaguard_hosted_access_v0.py
+++ b/tools/check_llamaguard_hosted_access_v0.py
@@ -9,6 +9,7 @@ import importlib.metadata
 import json
 import os
 import re
+import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
@@ -146,6 +147,26 @@ def _normalize_repo_root(path: Path) -> Path:
     return resolved
 
 
+def _reject_symlink_components(
+    repo_root: Path,
+    path: Path,
+    relative: str,
+) -> None:
+    try:
+        relative_path = path.relative_to(repo_root)
+    except ValueError as exc:
+        raise PreflightError("repository_path_escape", field=relative) from exc
+
+    current = repo_root
+    for part in relative_path.parts:
+        current = current / part
+        if current.is_symlink():
+            raise PreflightError(
+                "repository_path_symlink_component",
+                field=relative,
+            )
+
+
 def _safe_repo_path(repo_root: Path, relative: str) -> Path:
     path = Path(os.path.abspath(os.path.normpath(str(repo_root / relative))))
     try:
@@ -153,9 +174,35 @@ def _safe_repo_path(repo_root: Path, relative: str) -> Path:
     except ValueError as exc:
         raise PreflightError("repository_path_escape", field=relative) from exc
 
-    if path.is_symlink() or not path.is_file():
+    _reject_symlink_components(repo_root, path, relative)
+
+    if not path.is_file():
         raise PreflightError("repository_file_missing_or_symlinked", field=relative)
     return path
+
+
+def _git_head(repo_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "rev-parse",
+                "HEAD",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except Exception as exc:
+        raise PreflightError("git_head_unavailable") from exc
+
+    head = result.stdout.strip().lower()
+    if not HEX40_RE.fullmatch(head):
+        raise PreflightError("git_head_not_concrete_sha")
+    return head
 
 
 def _extract_string_constants(path: Path, names: set[str]) -> dict[str, str]:
@@ -356,6 +403,7 @@ def check_access(
     run_id: str,
     run_attempt: str,
 ) -> tuple[dict[str, Any], int]:
+    repo_root = _normalize_repo_root(repo_root)
     repository = _validate_repository(repository)
     git_sha = _validate_sha(git_sha)
     workflow_ref = _validate_non_empty(workflow_ref, "workflow_ref")
@@ -372,6 +420,31 @@ def check_access(
         run_attempt=run_attempt,
         runtime=runtime,
     )
+
+    try:
+        checked_out_git_sha = _git_head(repo_root)
+        report["source"]["checked_out_git_sha"] = checked_out_git_sha
+        git_sha_matches = checked_out_git_sha == git_sha
+        _add_check(
+            report,
+            "source.git_sha_matches_checkout",
+            git_sha_matches,
+            "reported git SHA matches the checked-out repository HEAD",
+        )
+        if not git_sha_matches:
+            return _fail(
+                report,
+                "git_sha_checkout_mismatch",
+                field="git_sha",
+            )
+    except PreflightError as exc:
+        _add_check(
+            report,
+            "source.git_sha_matches_checkout",
+            False,
+            "checked-out repository HEAD could not be verified",
+        )
+        return _fail(report, exc.code, field=exc.field)
 
     try:
         runtime = _canonical_runtime_identity(repo_root)


### PR DESCRIPTION
## Summary

Add a manual, read-only hosted-access preflight for the exact LlamaGuard model
revision used by the standing release-grade workflow.

The preflight verifies the provider-access prerequisite before any controlled
`hosted_full_runtime` execution is attempted.

## Files

Added:

- `.github/workflows/llamaguard_hosted_access_preflight.yml`
- `tools/check_llamaguard_hosted_access_v0.py`
- `tests/test_llamaguard_hosted_access_preflight_v0.py`

Modified:

- `ci/tools-tests.list`

## Mechanical path

```text
manual workflow_dispatch on main
→ exact expected source SHA check
→ canonical model ID and revision loaded from the standing producer
→ pinned huggingface-hub version loaded from the standing runtime requirements
→ HF_TOKEN presence check
→ exact revision metadata resolution
→ config.json access
→ tokenizer_config.json access
→ sanitized non-authorizing JSON report
```

The preflight reads the canonical model identity from:

```text
PULSE_safe_pack_v0/tools/run_llamaguard_current_evidence_v0.py
```

and the canonical Hub client pin from:

```text
PULSE_safe_pack_v0/requirements-llamaguard-v0.txt
```

It therefore does not introduce a second model or revision source of truth.

## Access scope

The preflight downloads only two small JSON metadata files from the exact
pinned revision:

```text
config.json
tokenizer_config.json
```

It does not download model weights and does not run inference.

## Fixed-source boundary

The manual workflow requires an exact 40-hex `expected_source_sha` input.

It fails unless all three values match:

```text
expected_source_sha
= GITHUB_SHA
= checked-out git HEAD
```

The workflow is restricted to:

```text
refs/heads/main
```

## Secret boundary

`HF_TOKEN` is exposed only to the access-check step.

The report never records:

- the token;
- token prefixes;
- authorization headers;
- raw exception messages that may contain request details.

Failures are reduced to sanitized failure classes such as:

```text
missing_token
gated_model_access_denied
model_revision_not_found
model_repository_not_found_or_inaccessible
probe_file_not_found
huggingface_hub_http_error
```

## Report

The workflow uploads:

```text
llamaguard-hosted-access-preflight-<run_id>-<run_attempt>
```

containing:

```text
llamaguard_hosted_access_preflight_v0.json
```

The report records source identity, canonical runtime identity, resolved model
revision, metadata-file digests and sizes, sanitized checks, and the explicit
non-authority boundary.

## Authority boundary

This preflight does not:

- run model inference;
- download model weights;
- produce release evidence;
- write `status.json`;
- write or materialize gates;
- call `check_gates.py`;
- invoke the recorded verifier or materializer;
- create a GitHub attestation;
- authorize or block release;
- create a release-grade reference run.

```text
hosted access preflight PASS
≠ hosted model execution PASS
≠ external evidence verified
≠ release authorized
```

## Tests

The registered smoke covers:

- canonical model identity and revision extraction;
- canonical Hub client pin extraction;
- missing-token failure without network-client initialization;
- exact resolved-revision binding;
- metadata-only probe behavior;
- token absence from report output;
- revision mismatch fail-closed behavior;
- output-path safety;
- no inference or weight-download surface;
- manual-only workflow triggering;
- main-only and exact-source enforcement;
- least-privilege permissions;
- single-step secret scope;
- report upload with `if: always()`;
- tools-tests manifest registration.

## Verification

```text
python -m py_compile tools/check_llamaguard_hosted_access_v0.py
python tests/test_llamaguard_hosted_access_preflight_v0.py
python -m pytest -q tests/test_llamaguard_hosted_access_preflight_v0.py
python tests/test_tools_tests_list_smoke.py
git diff --check
```

## Non-effects

No workflow behavior in `pulse_ci.yml` changes.
No policy or registry changes.
No verifier or materializer changes.
No package-contract changes.
No SLSA/VSA activation.
No DOI, citation, Zenodo, tag, GitHub Release, or release-metadata changes.
No release-authority behavior changes.