### PR TITLE
docs(index): register half-paradox technical formulation

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -207,6 +207,7 @@ It does not create authority beyond the artifact-bound path defined by the linke
 
 ## Theory and measurement protocols
 
+- [PULSEMECH_RELATION_HALF_PARADOX_MATHEMATICAL_PHYSICAL_QUANTUM_FORMULATION_v0.md](PULSEMECH_RELATION_HALF_PARADOX_MATHEMATICAL_PHYSICAL_QUANTUM_FORMULATION_v0.md) — **Reader / audit surface.** Target-relative technical formulation across mathematical systems, classical mechanics, control theory, information theory, finite-dimensional quantum mechanics, and PULSEmech decision mechanics; non-normative and non-authorizing.
 - [theory_overlay_v0.md](theory_overlay_v0.md) — Theory Overlay v0 diagnostic contract.
 - [time_as_consequence_v0_1.md](time_as_consequence_v0_1.md) — Workshop paper on time as consequence.
 - [time_as_consequence_one_pager_v0_1.md](time_as_consequence_one_pager_v0_1.md) — One-page summary.


### PR DESCRIPTION
## Summary

Register the technical half-paradox formulation added by PR #2718 in the full
repository documentation index.

## File

Modified:

```text
docs/INDEX.md
```

No other file is changed.

## Index placement

The document is added under:

```text
Theory and measurement protocols
```

Document:

```text
docs/PULSEMECH_RELATION_HALF_PARADOX_MATHEMATICAL_PHYSICAL_QUANTUM_FORMULATION_v0.md
```

Classification:

```text
Reader / audit surface
technical
non-normative
non-authorizing
```

## Reason

`docs/INDEX.md` requires the index to be updated when a document is added,
renamed, superseded, or changes implementation status.

PR #2718 added the technical formulation but did not add its documentation
entrypoint and status classification.

This follow-up closes that indexing omission.

## DCO verification

The Codex DCO finding on PR #2718 was a false positive.

The reviewed source commit:

```text
7ee9e911ed66dd83e538f90ddb57b1c8330523ad
```

already contains a `Signed-off-by` trailer, and the repository DCO Check
completed successfully.

No history rewrite or retrospective commit amendment is required.

This follow-up commit also includes its own DCO sign-off.

## Boundary

This PR does not:

- modify the technical formulation;
- modify workflows;
- modify policy or registry;
- modify verifiers or materializers;
- modify package assembly or verification;
- modify schemas;
- activate gates;
- activate SLSA/VSA;
- modify DOI, citation, Zenodo, or release metadata;
- change release-authority behavior.

## Verification

```text
git diff --check
git diff --name-only origin/main...HEAD
```

Expected changed-file result:

```text
docs/INDEX.md
```

Expected review result:

```text
documentation index entry present
status classification present
technical formulation unchanged
one documentation file changed
authority behavior unchanged
DCO sign-off present
```