### PR TITLE
fix(ref): preserve pinned LlamaGuard probe diagnostics

### DIFF
--- a/.github/workflows/llamaguard_hosted_access_preflight.yml
+++ b/.github/workflows/llamaguard_hosted_access_preflight.yml
@@ -146,6 +146,13 @@ jobs:
           report = json.loads(report_path.read_text(encoding="utf-8"))
           runtime = report.get("runtime") or {}
           failure = report.get("failure") or {}
+          probe_contract = report.get("probe_contract") or {}
+
+          required = probe_contract.get("required_probe_files") or []
+          missing = probe_contract.get("missing_probe_files") or []
+
+          required_text = ", ".join(str(item) for item in required) or "none"
+          missing_text = ", ".join(str(item) for item in missing) or "none"
 
           lines = [
               "## LlamaGuard hosted access preflight",
@@ -154,8 +161,14 @@ jobs:
               f"- model: `{runtime.get('model_id', 'unknown')}`",
               f"- requested revision: `{runtime.get('model_revision', 'unknown')}`",
               f"- resolved revision: `{runtime.get('resolved_model_revision', 'unknown')}`",
-              f"- probe files: `{len(report.get('probe_files') or [])}`",
+              f"- revision files checked: `{probe_contract.get('revision_files_checked', False)}`",
+              f"- revision file count: `{probe_contract.get('revision_file_count', 'unknown')}`",
+              f"- required probe files: `{required_text}`",
+              f"- missing probe files: `{missing_text}`",
+              f"- failed probe file: `{probe_contract.get('failed_probe_file') or 'none'}`",
+              f"- successful probe files: `{len(report.get('probe_files') or [])}`",
               f"- failure kind: `{failure.get('kind', 'none')}`",
+              f"- failure field: `{failure.get('field', 'none')}`",
               "- model inference: `not run`",
               "- model weights: `not downloaded`",
               "- release authority: `none`",

--- a/tests/test_llamaguard_hosted_access_preflight_v0.py
+++ b/tests/test_llamaguard_hosted_access_preflight_v0.py
@@ -12,14 +12,38 @@ from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
-TOOL_PATH = ROOT / "tools" / "check_llamaguard_hosted_access_v0.py"
-WORKFLOW_PATH = ROOT / ".github" / "workflows" / "llamaguard_hosted_access_preflight.yml"
-TOOLS_TESTS_LIST = ROOT / "ci" / "tools-tests.list"
-THIS_TEST = "tests/test_llamaguard_hosted_access_preflight_v0.py"
+TOOL_PATH = (
+    ROOT
+    / "tools"
+    / "check_llamaguard_hosted_access_v0.py"
+)
+WORKFLOW_PATH = (
+    ROOT
+    / ".github"
+    / "workflows"
+    / "llamaguard_hosted_access_preflight.yml"
+)
+TOOLS_TESTS_LIST = (
+    ROOT
+    / "ci"
+    / "tools-tests.list"
+)
+THIS_TEST = (
+    "tests/"
+    "test_llamaguard_hosted_access_preflight_v0.py"
+)
 
-EXPECTED_MODEL_ID = "meta-llama/Llama-Guard-3-1B"
-EXPECTED_MODEL_REVISION = "acf7aafa60f0410f8f42b1fa35e077d705892029"
+EXPECTED_MODEL_ID = (
+    "meta-llama/Llama-Guard-3-1B"
+)
+EXPECTED_MODEL_REVISION = (
+    "acf7aafa60f0410f8f42b1fa35e077d705892029"
+)
 EXPECTED_HUB_VERSION = "0.36.0"
+EXPECTED_PROBE_FILES = (
+    "config.json",
+    "tokenizer_config.json",
+)
 
 
 def _load_tool() -> ModuleType:
@@ -27,35 +51,64 @@ def _load_tool() -> ModuleType:
         "check_llamaguard_hosted_access_v0",
         TOOL_PATH,
     )
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
+    assert (
+        spec is not None
+        and spec.loader is not None
+    )
+
+    module = importlib.util.module_from_spec(
+        spec
+    )
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
+
     return module
 
 
 TOOL = _load_tool()
 
 
-def _make_repo(base: Path) -> Path:
+def _make_repo(
+    base: Path,
+) -> Path:
     repo = base / "repo"
-    producer = repo / "PULSE_safe_pack_v0" / "tools" / "run_llamaguard_current_evidence_v0.py"
-    requirements = repo / "PULSE_safe_pack_v0" / "requirements-llamaguard-v0.txt"
-    producer.parent.mkdir(parents=True, exist_ok=True)
+    producer = (
+        repo
+        / "PULSE_safe_pack_v0"
+        / "tools"
+        / "run_llamaguard_current_evidence_v0.py"
+    )
+    requirements = (
+        repo
+        / "PULSE_safe_pack_v0"
+        / "requirements-llamaguard-v0.txt"
+    )
+    producer.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
 
     producer.write_text(
-        "MODEL_ID = \"meta-llama/Llama-Guard-3-1B\"\n"
-        "MODEL_REVISION = \"acf7aafa60f0410f8f42b1fa35e077d705892029\"\n",
+        (
+            'MODEL_ID = '
+            '"meta-llama/Llama-Guard-3-1B"\n'
+            'MODEL_REVISION = '
+            '"acf7aafa60f0410f8f42b1fa35e077d705892029"\n'
+        ),
         encoding="utf-8",
     )
     requirements.write_text(
-        "--extra-index-url https://download.pytorch.org/whl/cpu\n\n"
-        "torch==2.9.1+cpu\n"
-        "transformers==4.57.6\n"
-        "huggingface-hub==0.36.0\n"
-        "safetensors==0.7.0\n",
+        (
+            "--extra-index-url "
+            "https://download.pytorch.org/whl/cpu\n\n"
+            "torch==2.9.1+cpu\n"
+            "transformers==4.57.6\n"
+            "huggingface-hub==0.36.0\n"
+            "safetensors==0.7.0\n"
+        ),
         encoding="utf-8",
     )
+
     return repo
 
 
@@ -79,16 +132,77 @@ class FakeHubHttpError(Exception):
     pass
 
 
-def _bindings(*, resolved_revision: str):
+def _bindings(
+    *,
+    resolved_revision: str,
+    available_files: tuple[str, ...] = (
+        *EXPECTED_PROBE_FILES,
+        "README.md",
+        "model.safetensors",
+    ),
+    download_failure_file: str | None = None,
+    download_failure_type: type[Exception] = (
+        FakeEntryNotFoundError
+    ),
+    invalid_json_file: str | None = None,
+):
     class FakeApi:
-        def __init__(self, *, token: str) -> None:
-            assert token == "hf_test_secret_value"
+        def __init__(
+            self,
+            *,
+            token: str,
+        ) -> None:
+            assert (
+                token
+                == "hf_test_secret_value"
+            )
 
-        def model_info(self, *, repo_id: str, revision: str, token: str):
-            assert repo_id == EXPECTED_MODEL_ID
-            assert revision == EXPECTED_MODEL_REVISION
-            assert token == "hf_test_secret_value"
-            return SimpleNamespace(sha=resolved_revision, gated="auto")
+        def model_info(
+            self,
+            *,
+            repo_id: str,
+            revision: str,
+            token: str,
+        ):
+            assert (
+                repo_id
+                == EXPECTED_MODEL_ID
+            )
+            assert (
+                revision
+                == EXPECTED_MODEL_REVISION
+            )
+            assert (
+                token
+                == "hf_test_secret_value"
+            )
+            return SimpleNamespace(
+                sha=resolved_revision,
+                gated="auto",
+            )
+
+        def list_repo_files(
+            self,
+            *,
+            repo_id: str,
+            revision: str,
+            repo_type: str,
+            token: str,
+        ) -> list[str]:
+            assert (
+                repo_id
+                == EXPECTED_MODEL_ID
+            )
+            assert (
+                revision
+                == EXPECTED_MODEL_REVISION
+            )
+            assert repo_type == "model"
+            assert (
+                token
+                == "hf_test_secret_value"
+            )
+            return list(available_files)
 
     def fake_download_file(
         *,
@@ -98,26 +212,75 @@ def _bindings(*, resolved_revision: str):
         token: str,
         cache_dir: str,
     ) -> str:
-        assert repo_id == EXPECTED_MODEL_ID
-        assert revision == EXPECTED_MODEL_REVISION
-        assert token == "hf_test_secret_value"
-        assert filename in {"config.json", "tokenizer_config.json"}
-        path = Path(cache_dir) / "probe" / filename
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(
-            json.dumps({"filename": filename, "revision": revision}),
-            encoding="utf-8",
+        assert (
+            repo_id
+            == EXPECTED_MODEL_ID
         )
+        assert (
+            revision
+            == EXPECTED_MODEL_REVISION
+        )
+        assert (
+            token
+            == "hf_test_secret_value"
+        )
+        assert (
+            filename
+            in EXPECTED_PROBE_FILES
+        )
+
+        if (
+            download_failure_file
+            == filename
+        ):
+            raise download_failure_type(
+                filename
+            )
+
+        path = (
+            Path(cache_dir)
+            / "probe"
+            / filename
+        )
+        path.parent.mkdir(
+            parents=True,
+            exist_ok=True,
+        )
+        if invalid_json_file == filename:
+            path.write_text(
+                "{not-json",
+                encoding="utf-8",
+            )
+        else:
+            path.write_text(
+                json.dumps(
+                    {
+                        "filename": filename,
+                        "revision": revision,
+                    }
+                ),
+                encoding="utf-8",
+            )
         return str(path)
 
     return TOOL.HuggingFaceBindings(
         api_factory=FakeApi,
         download_file=fake_download_file,
-        gated_repo_error=FakeGatedRepoError,
-        repository_not_found_error=FakeRepositoryNotFoundError,
-        revision_not_found_error=FakeRevisionNotFoundError,
-        entry_not_found_error=FakeEntryNotFoundError,
-        hub_http_error=FakeHubHttpError,
+        gated_repo_error=(
+            FakeGatedRepoError
+        ),
+        repository_not_found_error=(
+            FakeRepositoryNotFoundError
+        ),
+        revision_not_found_error=(
+            FakeRevisionNotFoundError
+        ),
+        entry_not_found_error=(
+            FakeEntryNotFoundError
+        ),
+        hub_http_error=(
+            FakeHubHttpError
+        ),
     )
 
 
@@ -127,39 +290,103 @@ def _run_check(
     reported_git_sha: str = "a" * 40,
     checked_out_git_sha: str | None = None,
 ) -> tuple[dict, int]:
-    actual_head = checked_out_git_sha or reported_git_sha
-    with mock.patch.object(TOOL, "_git_head", return_value=actual_head):
+    actual_head = (
+        checked_out_git_sha
+        or reported_git_sha
+    )
+
+    with mock.patch.object(
+        TOOL,
+        "_git_head",
+        return_value=actual_head,
+    ):
         return TOOL.check_access(
             repo_root=repo,
             token_env="HF_TOKEN",
-            repository="HKati/pulse-release-gates-0.1",
+            repository=(
+                "HKati/"
+                "pulse-release-gates-0.1"
+            ),
             git_sha=reported_git_sha,
             workflow_ref=(
-                "HKati/pulse-release-gates-0.1/"
-                ".github/workflows/llamaguard_hosted_access_preflight.yml@refs/heads/main"
+                "HKati/"
+                "pulse-release-gates-0.1/"
+                ".github/workflows/"
+                "llamaguard_hosted_access_preflight.yml"
+                "@refs/heads/main"
             ),
             run_id="12345",
             run_attempt="1",
         )
 
 
+def _run_with_bindings(
+    repo: Path,
+    bindings,
+) -> tuple[dict, int]:
+    with (
+        mock.patch.dict(
+            os.environ,
+            {
+                "HF_TOKEN":
+                "hf_test_secret_value"
+            },
+            clear=False,
+        ),
+        mock.patch.object(
+            TOOL,
+            "_installed_hub_version",
+            return_value=(
+                EXPECTED_HUB_VERSION
+            ),
+        ),
+        mock.patch.object(
+            TOOL,
+            "_load_huggingface_bindings",
+            return_value=bindings,
+        ),
+    ):
+        return _run_check(repo)
+
+
 def test_canonical_runtime_identity_comes_from_repository_files() -> None:
     with tempfile.TemporaryDirectory() as temp:
-        repo = _make_repo(Path(temp))
-        runtime = TOOL._canonical_runtime_identity(repo)
+        repo = _make_repo(
+            Path(temp)
+        )
+        runtime = (
+            TOOL._canonical_runtime_identity(
+                repo
+            )
+        )
 
-    assert runtime["model_id"] == EXPECTED_MODEL_ID
-    assert runtime["model_revision"] == EXPECTED_MODEL_REVISION
-    assert runtime["huggingface_hub_version"] == EXPECTED_HUB_VERSION
-    assert len(runtime["producer_sha256"]) == 64
-    assert len(runtime["runtime_requirements_sha256"]) == 64
-
-
+    assert (
+        runtime["model_id"]
+        == EXPECTED_MODEL_ID
+    )
+    assert (
+        runtime["model_revision"]
+        == EXPECTED_MODEL_REVISION
+    )
+    assert (
+        runtime["huggingface_hub_version"]
+        == EXPECTED_HUB_VERSION
+    )
+    assert len(
+        runtime["producer_sha256"]
+    ) == 64
+    assert len(
+        runtime[
+            "runtime_requirements_sha256"
+        ]
+    ) == 64
 
 
 def test_reported_git_sha_must_match_checked_out_head() -> None:
     with tempfile.TemporaryDirectory() as temp:
-        repo = _make_repo(Path(temp))
+        repo = _make_repo(
+            Path(temp)
+        )
         report, exit_code = _run_check(
             repo,
             reported_git_sha="a" * 40,
@@ -168,13 +395,27 @@ def test_reported_git_sha_must_match_checked_out_head() -> None:
 
     assert exit_code == 1
     assert report["ok"] is False
-    assert report["failure"]["kind"] == "git_sha_checkout_mismatch"
-    assert report["source"]["git_sha"] == "a" * 40
-    assert report["source"]["checked_out_git_sha"] == "b" * 40
+    assert (
+        report["failure"]["kind"]
+        == "git_sha_checkout_mismatch"
+    )
+    assert (
+        report["source"]["git_sha"]
+        == "a" * 40
+    )
+    assert (
+        report["source"][
+            "checked_out_git_sha"
+        ]
+        == "b" * 40
+    )
     check = next(
         item
         for item in report["checks"]
-        if item["check_id"] == "source.git_sha_matches_checkout"
+        if (
+            item["check_id"]
+            == "source.git_sha_matches_checkout"
+        )
     )
     assert check["passed"] is False
 
@@ -182,116 +423,380 @@ def test_reported_git_sha_must_match_checked_out_head() -> None:
 def test_canonical_inputs_reject_symlinked_parent_directory() -> None:
     with tempfile.TemporaryDirectory() as temp:
         base = Path(temp)
-        outside = _make_repo(base / "outside")
+        outside = _make_repo(
+            base / "outside"
+        )
         repo = base / "repo"
-        repo.mkdir(parents=True)
-        (repo / "PULSE_safe_pack_v0").symlink_to(
-            outside / "PULSE_safe_pack_v0",
+        repo.mkdir(
+            parents=True
+        )
+        (
+            repo
+            / "PULSE_safe_pack_v0"
+        ).symlink_to(
+            (
+                outside
+                / "PULSE_safe_pack_v0"
+            ),
             target_is_directory=True,
         )
 
         try:
-            TOOL._canonical_runtime_identity(repo)
+            TOOL._canonical_runtime_identity(
+                repo
+            )
         except TOOL.PreflightError as exc:
-            assert exc.code == "repository_path_symlink_component"
-            assert exc.field == TOOL.PRODUCER_REL
+            assert (
+                exc.code
+                == "repository_path_symlink_component"
+            )
+            assert (
+                exc.field
+                == TOOL.PRODUCER_REL
+            )
         else:
-            raise AssertionError("symlinked canonical input parent was accepted")
+            raise AssertionError(
+                "symlinked canonical input "
+                "parent was accepted"
+            )
 
 
 def test_missing_token_fails_without_loading_network_client() -> None:
     with tempfile.TemporaryDirectory() as temp:
-        repo = _make_repo(Path(temp))
-        with mock.patch.dict(os.environ, {"HF_TOKEN": ""}, clear=False), mock.patch.object(
-            TOOL,
-            "_load_huggingface_bindings",
-            side_effect=AssertionError("network client must not load without a token"),
+        repo = _make_repo(
+            Path(temp)
+        )
+
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"HF_TOKEN": ""},
+                clear=False,
+            ),
+            mock.patch.object(
+                TOOL,
+                "_load_huggingface_bindings",
+                side_effect=AssertionError(
+                    "network client must not "
+                    "load without a token"
+                ),
+            ),
         ):
-            report, exit_code = _run_check(repo)
+            report, exit_code = (
+                _run_check(repo)
+            )
 
     assert exit_code == 1
     assert report["ok"] is False
     assert report["status"] == "blocked"
-    assert report["failure"]["kind"] == "missing_token"
-    assert report["authority_boundary"]["authorizes_release"] is False
+    assert (
+        report["failure"]["kind"]
+        == "missing_token"
+    )
+    assert (
+        report["authority_boundary"][
+            "authorizes_release"
+        ]
+        is False
+    )
 
 
-def test_success_probes_only_small_metadata_files_and_never_records_token() -> None:
+def test_success_lists_exact_revision_and_probes_only_metadata() -> None:
     with tempfile.TemporaryDirectory() as temp:
-        repo = _make_repo(Path(temp))
-        with mock.patch.dict(
-            os.environ,
-            {"HF_TOKEN": "hf_test_secret_value"},
-            clear=False,
-        ), mock.patch.object(
-            TOOL,
-            "_installed_hub_version",
-            return_value=EXPECTED_HUB_VERSION,
-        ), mock.patch.object(
-            TOOL,
-            "_load_huggingface_bindings",
-            return_value=_bindings(resolved_revision=EXPECTED_MODEL_REVISION),
-        ):
-            report, exit_code = _run_check(repo)
+        repo = _make_repo(
+            Path(temp)
+        )
+        report, exit_code = (
+            _run_with_bindings(
+                repo,
+                _bindings(
+                    resolved_revision=(
+                        EXPECTED_MODEL_REVISION
+                    )
+                ),
+            )
+        )
 
-    rendered = json.dumps(report, sort_keys=True)
+    rendered = json.dumps(
+        report,
+        sort_keys=True,
+    )
+
     assert exit_code == 0
     assert report["ok"] is True
-    assert report["status"] == "accessible"
-    assert report["runtime"]["resolved_model_revision"] == EXPECTED_MODEL_REVISION
-    assert [item["path"] for item in report["probe_files"]] == [
-        "config.json",
-        "tokenizer_config.json",
-    ]
-    assert all(item["json_object"] is True for item in report["probe_files"])
-    assert "hf_test_secret_value" not in rendered
-    assert report["authority_boundary"] == TOOL.AUTHORITY_BOUNDARY
+    assert (
+        report["status"]
+        == "accessible"
+    )
+    assert (
+        report["runtime"][
+            "resolved_model_revision"
+        ]
+        == EXPECTED_MODEL_REVISION
+    )
+    assert (
+        report["probe_contract"][
+            "revision_files_checked"
+        ]
+        is True
+    )
+    assert (
+        report["probe_contract"][
+            "revision_file_count"
+        ]
+        == 4
+    )
+    assert len(
+        report["probe_contract"][
+            "revision_file_list_sha256"
+        ]
+    ) == 64
+    assert (
+        report["probe_contract"][
+            "missing_probe_files"
+        ]
+        == []
+    )
+    assert (
+        report["probe_contract"][
+            "failed_probe_file"
+        ]
+        is None
+    )
+    assert [
+        item["path"]
+        for item in report["probe_files"]
+    ] == list(
+        EXPECTED_PROBE_FILES
+    )
+    assert all(
+        item["json_object"] is True
+        for item in report["probe_files"]
+    )
+    assert (
+        "hf_test_secret_value"
+        not in rendered
+    )
+    assert (
+        report["authority_boundary"]
+        == TOOL.AUTHORITY_BOUNDARY
+    )
+
+
+def test_missing_probe_in_pinned_revision_preserves_filename() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        repo = _make_repo(
+            Path(temp)
+        )
+        report, exit_code = (
+            _run_with_bindings(
+                repo,
+                _bindings(
+                    resolved_revision=(
+                        EXPECTED_MODEL_REVISION
+                    ),
+                    available_files=(
+                        "README.md",
+                        "config.json",
+                        "model.safetensors",
+                    ),
+                ),
+            )
+        )
+
+    assert exit_code == 1
+    assert (
+        report["failure"]["kind"]
+        == "pinned_revision_missing_probe_file"
+    )
+    assert (
+        report["failure"]["field"]
+        == "tokenizer_config.json"
+    )
+    assert (
+        report["probe_contract"][
+            "revision_files_checked"
+        ]
+        is True
+    )
+    assert (
+        report["probe_contract"][
+            "missing_probe_files"
+        ]
+        == ["tokenizer_config.json"]
+    )
+    assert (
+        report["probe_contract"][
+            "failed_probe_file"
+        ]
+        is None
+    )
+    assert report["probe_files"] == []
+
+
+def test_listed_probe_download_failure_preserves_filename_and_partial_success() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        repo = _make_repo(
+            Path(temp)
+        )
+        report, exit_code = (
+            _run_with_bindings(
+                repo,
+                _bindings(
+                    resolved_revision=(
+                        EXPECTED_MODEL_REVISION
+                    ),
+                    download_failure_file=(
+                        "tokenizer_config.json"
+                    ),
+                ),
+            )
+        )
+
+    assert exit_code == 1
+    assert (
+        report["failure"]["kind"]
+        == "probe_file_access_denied_or_unavailable"
+    )
+    assert (
+        report["failure"]["field"]
+        == "tokenizer_config.json"
+    )
+    assert (
+        report["probe_contract"][
+            "missing_probe_files"
+        ]
+        == []
+    )
+    assert (
+        report["probe_contract"][
+            "failed_probe_file"
+        ]
+        == "tokenizer_config.json"
+    )
+    assert [
+        item["path"]
+        for item in report["probe_files"]
+    ] == ["config.json"]
+
+
+def test_invalid_probe_json_preserves_local_validation_failure() -> None:
+    with tempfile.TemporaryDirectory() as temp:
+        repo = _make_repo(
+            Path(temp)
+        )
+        report, exit_code = (
+            _run_with_bindings(
+                repo,
+                _bindings(
+                    resolved_revision=(
+                        EXPECTED_MODEL_REVISION
+                    ),
+                    invalid_json_file=(
+                        "tokenizer_config.json"
+                    ),
+                ),
+            )
+        )
+
+    assert exit_code == 1
+    assert (
+        report["failure"]["kind"]
+        == "probe_invalid_json"
+    )
+    assert (
+        report["failure"]["field"]
+        == "tokenizer_config.json"
+    )
+    assert (
+        report["probe_contract"][
+            "failed_probe_file"
+        ]
+        == "tokenizer_config.json"
+    )
+    assert [
+        item["path"]
+        for item in report["probe_files"]
+    ] == ["config.json"]
 
 
 def test_resolved_revision_mismatch_fails_closed() -> None:
     with tempfile.TemporaryDirectory() as temp:
-        repo = _make_repo(Path(temp))
-        with mock.patch.dict(
-            os.environ,
-            {"HF_TOKEN": "hf_test_secret_value"},
-            clear=False,
-        ), mock.patch.object(
-            TOOL,
-            "_installed_hub_version",
-            return_value=EXPECTED_HUB_VERSION,
-        ), mock.patch.object(
-            TOOL,
-            "_load_huggingface_bindings",
-            return_value=_bindings(resolved_revision="b" * 40),
-        ):
-            report, exit_code = _run_check(repo)
+        repo = _make_repo(
+            Path(temp)
+        )
+        report, exit_code = (
+            _run_with_bindings(
+                repo,
+                _bindings(
+                    resolved_revision="b" * 40
+                ),
+            )
+        )
 
     assert exit_code == 1
-    assert report["failure"]["kind"] == "model_revision_mismatch"
+    assert (
+        report["failure"]["kind"]
+        == "model_revision_mismatch"
+    )
+    assert (
+        report["failure"]["field"]
+        == "model_revision"
+    )
+    assert (
+        report["probe_contract"][
+            "revision_files_checked"
+        ]
+        is False
+    )
     assert report["probe_files"] == []
 
 
 def test_output_safety_refuses_repository_and_status_outputs() -> None:
     with tempfile.TemporaryDirectory() as temp:
-        repo = _make_repo(Path(temp))
-        outside = Path(temp) / "outside" / "report.json"
+        repo = _make_repo(
+            Path(temp)
+        )
+        outside = (
+            Path(temp)
+            / "outside"
+            / "report.json"
+        )
 
-        assert TOOL._normalize_output(repo, outside) == outside.resolve()
+        assert (
+            TOOL._normalize_output(
+                repo,
+                outside,
+            )
+            == outside.resolve()
+        )
 
         for bad in (
             repo / "report.json",
-            Path(temp) / "outside" / "status.json",
+            (
+                Path(temp)
+                / "outside"
+                / "status.json"
+            ),
         ):
             try:
-                TOOL._normalize_output(repo, bad)
+                TOOL._normalize_output(
+                    repo,
+                    bad,
+                )
             except TOOL.PreflightError:
                 pass
             else:
-                raise AssertionError(f"unsafe output accepted: {bad}")
+                raise AssertionError(
+                    f"unsafe output accepted: {bad}"
+                )
 
 
 def test_tool_source_has_no_inference_or_weight_download_surface() -> None:
-    text = TOOL_PATH.read_text(encoding="utf-8")
+    text = TOOL_PATH.read_text(
+        encoding="utf-8"
+    )
+
     for forbidden in (
         "snapshot_download",
         "AutoModel",
@@ -305,20 +810,52 @@ def test_tool_source_has_no_inference_or_weight_download_surface() -> None:
     ):
         assert forbidden not in text, forbidden
 
-    assert TOOL.PROBE_FILES == ("config.json", "tokenizer_config.json")
-    assert TOOL.AUTHORITY_BOUNDARY["runs_model_inference"] is False
-    assert TOOL.AUTHORITY_BOUNDARY["downloads_model_weights"] is False
-    assert TOOL.AUTHORITY_BOUNDARY["authorizes_release"] is False
+    assert (
+        TOOL.PROBE_FILES
+        == EXPECTED_PROBE_FILES
+    )
+    assert (
+        "list_repo_files" in text
+    )
+    assert (
+        TOOL.AUTHORITY_BOUNDARY[
+            "runs_model_inference"
+        ]
+        is False
+    )
+    assert (
+        TOOL.AUTHORITY_BOUNDARY[
+            "downloads_model_weights"
+        ]
+        is False
+    )
+    assert (
+        TOOL.AUTHORITY_BOUNDARY[
+            "authorizes_release"
+        ]
+        is False
+    )
 
 
-def test_workflow_is_manual_read_only_and_secret_scoped() -> None:
-    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+def test_workflow_is_manual_read_only_secret_scoped_and_surfaces_probe_diagnostics() -> None:
+    text = WORKFLOW_PATH.read_text(
+        encoding="utf-8"
+    )
 
     assert text.startswith(
-        "name: LlamaGuard hosted access preflight release check\n"
+        (
+            "name: LlamaGuard hosted access "
+            "preflight release check\n"
+        )
     )
     assert "\n  workflow_dispatch:" in text
-    for trigger in ("\n  push:", "\n  pull_request:", "\n  schedule:", "\n  release:"):
+
+    for trigger in (
+        "\n  push:",
+        "\n  pull_request:",
+        "\n  schedule:",
+        "\n  release:",
+    ):
         assert trigger not in text
 
     assert "expected_source_sha:" in text
@@ -326,7 +863,10 @@ def test_workflow_is_manual_read_only_and_secret_scoped() -> None:
     assert "EXPECTED_SOURCE_SHA" in text
     assert "persist-credentials: false" in text
 
-    assert text.count("secrets.HF_TOKEN") == 1
+    assert (
+        text.count("secrets.HF_TOKEN")
+        == 1
+    )
     assert "set -x" not in text
     assert 'echo "${HF_TOKEN}' not in text
     assert "id-token:" not in text
@@ -334,17 +874,60 @@ def test_workflow_is_manual_read_only_and_secret_scoped() -> None:
     assert "artifact-metadata:" not in text
     assert "actions/attest@" not in text
 
-    assert "tools/check_llamaguard_hosted_access_v0.py" in text
-    assert "--token-env \"HF_TOKEN\"" in text
-    assert "--output \"${REPORT_PATH}\"" in text
-    assert "${{ runner.temp }}/llamaguard_hosted_access_preflight_v0.json" in text
+    assert (
+        "tools/"
+        "check_llamaguard_hosted_access_v0.py"
+        in text
+    )
+    assert (
+        '--token-env "HF_TOKEN"'
+        in text
+    )
+    assert (
+        '--output "${REPORT_PATH}"'
+        in text
+    )
+    assert (
+        "${{ runner.temp }}/"
+        "llamaguard_hosted_access_preflight_v0.json"
+        in text
+    )
 
-    upload_index = text.index("Upload sanitized hosted-access preflight report")
-    tool_index = text.index("tools/check_llamaguard_hosted_access_v0.py")
+    for expected in (
+        "revision files checked:",
+        "revision file count:",
+        "required probe files:",
+        "missing probe files:",
+        "failed probe file:",
+        "failure field:",
+    ):
+        assert expected in text
+
+    upload_index = text.index(
+        (
+            "Upload sanitized "
+            "hosted-access preflight report"
+        )
+    )
+    tool_index = text.index(
+        (
+            "tools/"
+            "check_llamaguard_hosted_access_v0.py"
+        )
+    )
     assert tool_index < upload_index
-    assert "if: ${{ always() }}" in text[upload_index:]
-    assert "if-no-files-found: error" in text[upload_index:]
-    assert "retention-days: 30" in text[upload_index:]
+    assert (
+        "if: ${{ always() }}"
+        in text[upload_index:]
+    )
+    assert (
+        "if-no-files-found: error"
+        in text[upload_index:]
+    )
+    assert (
+        "retention-days: 30"
+        in text[upload_index:]
+    )
 
     for forbidden in (
         "check_gates.py",
@@ -361,13 +944,31 @@ def test_workflow_is_manual_read_only_and_secret_scoped() -> None:
 
 def test_tools_manifest_registers_preflight_smoke_once() -> None:
     entries = [
-        raw.split("#", 1)[0].strip()
-        for raw in TOOLS_TESTS_LIST.read_text(encoding="utf-8").splitlines()
-        if raw.split("#", 1)[0].strip()
+        raw.split(
+            "#",
+            1,
+        )[0].strip()
+        for raw in TOOLS_TESTS_LIST.read_text(
+            encoding="utf-8"
+        ).splitlines()
+        if raw.split(
+            "#",
+            1,
+        )[0].strip()
     ]
-    assert entries.count(THIS_TEST) == 1
-    current_run_test = "tests/test_llamaguard_current_run_workflow_wiring_v0.py"
-    assert entries.index(current_run_test) < entries.index(THIS_TEST)
+
+    assert entries.count(
+        THIS_TEST
+    ) == 1
+
+    current_run_test = (
+        "tests/"
+        "test_llamaguard_current_run_workflow_wiring_v0.py"
+    )
+    assert (
+        entries.index(current_run_test)
+        < entries.index(THIS_TEST)
+    )
 
 
 def check_llamaguard_hosted_access_preflight_v0() -> None:
@@ -375,14 +976,20 @@ def check_llamaguard_hosted_access_preflight_v0() -> None:
     test_reported_git_sha_must_match_checked_out_head()
     test_canonical_inputs_reject_symlinked_parent_directory()
     test_missing_token_fails_without_loading_network_client()
-    test_success_probes_only_small_metadata_files_and_never_records_token()
+    test_success_lists_exact_revision_and_probes_only_metadata()
+    test_missing_probe_in_pinned_revision_preserves_filename()
+    test_listed_probe_download_failure_preserves_filename_and_partial_success()
+    test_invalid_probe_json_preserves_local_validation_failure()
     test_resolved_revision_mismatch_fails_closed()
     test_output_safety_refuses_repository_and_status_outputs()
     test_tool_source_has_no_inference_or_weight_download_surface()
-    test_workflow_is_manual_read_only_and_secret_scoped()
+    test_workflow_is_manual_read_only_secret_scoped_and_surfaces_probe_diagnostics()
     test_tools_manifest_registers_preflight_smoke_once()
 
 
 if __name__ == "__main__":
     check_llamaguard_hosted_access_preflight_v0()
-    print("OK: LlamaGuard hosted access preflight contract")
+    print(
+        "OK: LlamaGuard hosted access "
+        "preflight diagnostics contract"
+    )

--- a/tools/check_llamaguard_hosted_access_v0.py
+++ b/tools/check_llamaguard_hosted_access_v0.py
@@ -14,18 +14,20 @@ import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Iterable
 
 
 TOOL_NAME = "check_llamaguard_hosted_access_v0"
-TOOL_VERSION = "0.1.0"
+TOOL_VERSION = "0.1.1"
 SCHEMA_VERSION = "llamaguard_hosted_access_preflight_v0"
 
 PRODUCER_REL = (
     "PULSE_safe_pack_v0/tools/"
     "run_llamaguard_current_evidence_v0.py"
 )
-RUNTIME_REQUIREMENTS_REL = "PULSE_safe_pack_v0/requirements-llamaguard-v0.txt"
+RUNTIME_REQUIREMENTS_REL = (
+    "PULSE_safe_pack_v0/requirements-llamaguard-v0.txt"
+)
 PROBE_FILES: tuple[str, ...] = (
     "config.json",
     "tokenizer_config.json",
@@ -33,7 +35,9 @@ PROBE_FILES: tuple[str, ...] = (
 MAX_PROBE_BYTES = 2 * 1024 * 1024
 
 HEX40_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
-REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+REPOSITORY_RE = re.compile(
+    r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+)
 POSITIVE_INT_RE = re.compile(r"^[1-9][0-9]*$")
 HUB_REQUIREMENT_RE = re.compile(
     r"^huggingface-hub==(?P<version>[A-Za-z0-9_.+!-]+)$",
@@ -55,7 +59,12 @@ AUTHORITY_BOUNDARY = {
 
 
 class PreflightError(ValueError):
-    def __init__(self, code: str, *, field: str | None = None) -> None:
+    def __init__(
+        self,
+        code: str,
+        *,
+        field: str | None = None,
+    ) -> None:
         super().__init__(code)
         self.code = code
         self.field = field
@@ -101,49 +110,101 @@ def _installed_hub_version() -> str:
     try:
         return importlib.metadata.version("huggingface-hub")
     except importlib.metadata.PackageNotFoundError as exc:
-        raise PreflightError("huggingface_hub_not_installed") from exc
+        raise PreflightError(
+            "huggingface_hub_not_installed"
+        ) from exc
 
 
-def _json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+def _json_object(
+    pairs: list[tuple[str, Any]],
+) -> dict[str, Any]:
     result: dict[str, Any] = {}
+
     for key, value in pairs:
         if key in result:
-            raise StrictJsonError("probe_duplicate_json_key", field=key)
+            raise StrictJsonError(
+                "probe_duplicate_json_key",
+                field=key,
+            )
         result[key] = value
+
     return result
 
 
-def _read_strict_json_object(path: Path) -> dict[str, Any]:
+def _read_strict_json_object(
+    path: Path,
+) -> dict[str, Any]:
     try:
         payload = json.loads(
-            path.read_text(encoding="utf-8", errors="strict"),
+            path.read_text(
+                encoding="utf-8",
+                errors="strict",
+            ),
             object_pairs_hook=_json_object,
-            parse_constant=lambda value: (_ for _ in ()).throw(
-                StrictJsonError("probe_non_finite_json", field=value)
+            parse_constant=lambda value: (
+                _ for _ in ()
+            ).throw(
+                StrictJsonError(
+                    "probe_non_finite_json",
+                    field=value,
+                )
             ),
         )
     except PreflightError:
         raise
     except Exception as exc:
-        raise PreflightError("probe_invalid_json") from exc
+        raise PreflightError(
+            "probe_invalid_json"
+        ) from exc
 
     if not isinstance(payload, dict):
-        raise PreflightError("probe_json_not_object")
+        raise PreflightError(
+            "probe_json_not_object"
+        )
+
     return payload
 
 
-def _sha256(path: Path) -> str:
+def _sha256(
+    path: Path,
+) -> str:
     digest = hashlib.sha256()
+
     with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(65536), b""):
+        for chunk in iter(
+            lambda: handle.read(65536),
+            b"",
+        ):
             digest.update(chunk)
+
     return digest.hexdigest()
 
 
-def _normalize_repo_root(path: Path) -> Path:
-    resolved = Path(os.path.abspath(os.path.normpath(str(path))))
-    if resolved.is_symlink() or not resolved.is_dir():
-        raise PreflightError("repo_root_not_regular_directory")
+def _sha256_text(
+    value: str,
+) -> str:
+    return hashlib.sha256(
+        value.encode("utf-8")
+    ).hexdigest()
+
+
+def _normalize_repo_root(
+    path: Path,
+) -> Path:
+    resolved = Path(
+        os.path.abspath(
+            os.path.normpath(str(path))
+        )
+    )
+
+    if (
+        resolved.is_symlink()
+        or not resolved.is_dir()
+    ):
+        raise PreflightError(
+            "repo_root_not_regular_directory"
+        )
+
     return resolved
 
 
@@ -153,11 +214,17 @@ def _reject_symlink_components(
     relative: str,
 ) -> None:
     try:
-        relative_path = path.relative_to(repo_root)
+        relative_path = path.relative_to(
+            repo_root
+        )
     except ValueError as exc:
-        raise PreflightError("repository_path_escape", field=relative) from exc
+        raise PreflightError(
+            "repository_path_escape",
+            field=relative,
+        ) from exc
 
     current = repo_root
+
     for part in relative_path.parts:
         current = current / part
         if current.is_symlink():
@@ -167,21 +234,44 @@ def _reject_symlink_components(
             )
 
 
-def _safe_repo_path(repo_root: Path, relative: str) -> Path:
-    path = Path(os.path.abspath(os.path.normpath(str(repo_root / relative))))
+def _safe_repo_path(
+    repo_root: Path,
+    relative: str,
+) -> Path:
+    path = Path(
+        os.path.abspath(
+            os.path.normpath(
+                str(repo_root / relative)
+            )
+        )
+    )
+
     try:
         path.relative_to(repo_root)
     except ValueError as exc:
-        raise PreflightError("repository_path_escape", field=relative) from exc
+        raise PreflightError(
+            "repository_path_escape",
+            field=relative,
+        ) from exc
 
-    _reject_symlink_components(repo_root, path, relative)
+    _reject_symlink_components(
+        repo_root,
+        path,
+        relative,
+    )
 
     if not path.is_file():
-        raise PreflightError("repository_file_missing_or_symlinked", field=relative)
+        raise PreflightError(
+            "repository_file_missing_or_symlinked",
+            field=relative,
+        )
+
     return path
 
 
-def _git_head(repo_root: Path) -> str:
+def _git_head(
+    repo_root: Path,
+) -> str:
     try:
         result = subprocess.run(
             [
@@ -197,124 +287,284 @@ def _git_head(repo_root: Path) -> str:
             timeout=15,
         )
     except Exception as exc:
-        raise PreflightError("git_head_unavailable") from exc
+        raise PreflightError(
+            "git_head_unavailable"
+        ) from exc
 
     head = result.stdout.strip().lower()
+
     if not HEX40_RE.fullmatch(head):
-        raise PreflightError("git_head_not_concrete_sha")
+        raise PreflightError(
+            "git_head_not_concrete_sha"
+        )
+
     return head
 
 
-def _extract_string_constants(path: Path, names: set[str]) -> dict[str, str]:
+def _extract_string_constants(
+    path: Path,
+    names: set[str],
+) -> dict[str, str]:
     try:
-        tree = ast.parse(path.read_text(encoding="utf-8", errors="strict"))
+        tree = ast.parse(
+            path.read_text(
+                encoding="utf-8",
+                errors="strict",
+            )
+        )
     except Exception as exc:
-        raise PreflightError("producer_source_parse_failed") from exc
+        raise PreflightError(
+            "producer_source_parse_failed"
+        ) from exc
 
     values: dict[str, str] = {}
-    for node in tree.body:
-        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
-            continue
-        target = node.targets[0]
-        if not isinstance(target, ast.Name) or target.id not in names:
-            continue
-        if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
-            values[target.id] = node.value.value
 
-    missing = sorted(names - values.keys())
+    for node in tree.body:
+        if (
+            not isinstance(node, ast.Assign)
+            or len(node.targets) != 1
+        ):
+            continue
+
+        target = node.targets[0]
+
+        if (
+            not isinstance(target, ast.Name)
+            or target.id not in names
+        ):
+            continue
+
+        if (
+            isinstance(node.value, ast.Constant)
+            and isinstance(
+                node.value.value,
+                str,
+            )
+        ):
+            values[target.id] = (
+                node.value.value
+            )
+
+    missing = sorted(
+        names - values.keys()
+    )
+
     if missing:
-        raise PreflightError("producer_identity_constant_missing", field=",".join(missing))
+        raise PreflightError(
+            "producer_identity_constant_missing",
+            field=",".join(missing),
+        )
+
     return values
 
 
-def _canonical_runtime_identity(repo_root: Path) -> dict[str, str]:
-    producer = _safe_repo_path(repo_root, PRODUCER_REL)
-    requirements = _safe_repo_path(repo_root, RUNTIME_REQUIREMENTS_REL)
+def _canonical_runtime_identity(
+    repo_root: Path,
+) -> dict[str, str]:
+    producer = _safe_repo_path(
+        repo_root,
+        PRODUCER_REL,
+    )
+    requirements = _safe_repo_path(
+        repo_root,
+        RUNTIME_REQUIREMENTS_REL,
+    )
 
-    constants = _extract_string_constants(producer, {"MODEL_ID", "MODEL_REVISION"})
-    model_id = constants["MODEL_ID"].strip()
-    model_revision = constants["MODEL_REVISION"].strip().lower()
+    constants = _extract_string_constants(
+        producer,
+        {
+            "MODEL_ID",
+            "MODEL_REVISION",
+        },
+    )
+    model_id = constants[
+        "MODEL_ID"
+    ].strip()
+    model_revision = constants[
+        "MODEL_REVISION"
+    ].strip().lower()
 
-    if not model_id or "/" not in model_id:
-        raise PreflightError("invalid_model_id")
-    if not HEX40_RE.fullmatch(model_revision):
-        raise PreflightError("invalid_model_revision")
+    if (
+        not model_id
+        or "/" not in model_id
+    ):
+        raise PreflightError(
+            "invalid_model_id"
+        )
+
+    if not HEX40_RE.fullmatch(
+        model_revision
+    ):
+        raise PreflightError(
+            "invalid_model_revision"
+        )
 
     matched_versions: list[str] = []
-    for raw in requirements.read_text(encoding="utf-8", errors="strict").splitlines():
-        line = raw.split("#", 1)[0].strip()
-        match = HUB_REQUIREMENT_RE.fullmatch(line)
+
+    for raw in requirements.read_text(
+        encoding="utf-8",
+        errors="strict",
+    ).splitlines():
+        line = raw.split(
+            "#",
+            1,
+        )[0].strip()
+        match = HUB_REQUIREMENT_RE.fullmatch(
+            line
+        )
+
         if match:
-            matched_versions.append(match.group("version"))
+            matched_versions.append(
+                match.group("version")
+            )
 
     if len(matched_versions) != 1:
-        raise PreflightError("huggingface_hub_pin_not_unique")
+        raise PreflightError(
+            "huggingface_hub_pin_not_unique"
+        )
 
     return {
         "model_id": model_id,
         "model_revision": model_revision,
-        "huggingface_hub_version": matched_versions[0],
+        "huggingface_hub_version": (
+            matched_versions[0]
+        ),
         "producer_path": PRODUCER_REL,
-        "producer_sha256": _sha256(producer),
-        "runtime_requirements_path": RUNTIME_REQUIREMENTS_REL,
-        "runtime_requirements_sha256": _sha256(requirements),
+        "producer_sha256": _sha256(
+            producer
+        ),
+        "runtime_requirements_path": (
+            RUNTIME_REQUIREMENTS_REL
+        ),
+        "runtime_requirements_sha256": (
+            _sha256(requirements)
+        ),
     }
 
 
-def _validate_repository(value: str) -> str:
+def _validate_repository(
+    value: str,
+) -> str:
     repository = value.strip()
-    if not REPOSITORY_RE.fullmatch(repository):
-        raise PreflightError("invalid_repository")
+
+    if not REPOSITORY_RE.fullmatch(
+        repository
+    ):
+        raise PreflightError(
+            "invalid_repository"
+        )
+
     return repository
 
 
-def _validate_sha(value: str) -> str:
+def _validate_sha(
+    value: str,
+) -> str:
     sha = value.strip().lower()
+
     if not HEX40_RE.fullmatch(sha):
-        raise PreflightError("invalid_git_sha")
+        raise PreflightError(
+            "invalid_git_sha"
+        )
+
     return sha
 
 
-def _validate_positive_int(value: str, field: str) -> str:
+def _validate_positive_int(
+    value: str,
+    field: str,
+) -> str:
     text = value.strip()
-    if not POSITIVE_INT_RE.fullmatch(text):
-        raise PreflightError("invalid_positive_integer", field=field)
+
+    if not POSITIVE_INT_RE.fullmatch(
+        text
+    ):
+        raise PreflightError(
+            "invalid_positive_integer",
+            field=field,
+        )
+
     return text
 
 
-def _validate_non_empty(value: str, field: str) -> str:
+def _validate_non_empty(
+    value: str,
+    field: str,
+) -> str:
     text = value.strip()
+
     if not text:
-        raise PreflightError("missing_required_text", field=field)
+        raise PreflightError(
+            "missing_required_text",
+            field=field,
+        )
+
     return text
 
 
-def _normalize_output(repo_root: Path, output: Path) -> Path:
-    resolved = Path(os.path.abspath(os.path.normpath(str(output))))
-    if resolved.name == "status.json":
-        raise PreflightError("refusing_to_write_status_json")
-    if resolved.is_symlink():
-        raise PreflightError("refusing_to_write_symlink_output")
-    if resolved.exists() and not resolved.is_file():
-        raise PreflightError("refusing_to_write_non_file_output")
+def _normalize_output(
+    repo_root: Path,
+    output: Path,
+) -> Path:
+    resolved = Path(
+        os.path.abspath(
+            os.path.normpath(str(output))
+        )
+    )
 
-    for parent in (resolved.parent, *resolved.parent.parents):
-        if parent.exists() and parent.is_symlink():
-            raise PreflightError("refusing_to_write_through_symlink_parent")
+    if resolved.name == "status.json":
+        raise PreflightError(
+            "refusing_to_write_status_json"
+        )
+
+    if resolved.is_symlink():
+        raise PreflightError(
+            "refusing_to_write_symlink_output"
+        )
+
+    if (
+        resolved.exists()
+        and not resolved.is_file()
+    ):
+        raise PreflightError(
+            "refusing_to_write_non_file_output"
+        )
+
+    for parent in (
+        resolved.parent,
+        *resolved.parent.parents,
+    ):
+        if (
+            parent.exists()
+            and parent.is_symlink()
+        ):
+            raise PreflightError(
+                "refusing_to_write_through_symlink_parent"
+            )
 
     try:
         resolved.relative_to(repo_root)
     except ValueError:
         return resolved
-    raise PreflightError("refusing_to_write_inside_repository")
+
+    raise PreflightError(
+        "refusing_to_write_inside_repository"
+    )
 
 
 def _utc_now() -> str:
     return (
-        dt.datetime.now(tz=dt.timezone.utc)
+        dt.datetime.now(
+            tz=dt.timezone.utc
+        )
         .replace(microsecond=0)
-        .isoformat(timespec="seconds")
-        .replace("+00:00", "Z")
+        .isoformat(
+            timespec="seconds"
+        )
+        .replace(
+            "+00:00",
+            "Z",
+        )
     )
 
 
@@ -345,9 +595,21 @@ def _base_report(
         },
         "runtime": runtime,
         "checks": [],
+        "probe_contract": {
+            "required_probe_files": list(
+                PROBE_FILES
+            ),
+            "revision_files_checked": False,
+            "revision_file_count": None,
+            "revision_file_list_sha256": None,
+            "missing_probe_files": [],
+            "failed_probe_file": None,
+        },
         "probe_files": [],
         "failure": None,
-        "authority_boundary": dict(AUTHORITY_BOUNDARY),
+        "authority_boundary": dict(
+            AUTHORITY_BOUNDARY
+        ),
     }
 
 
@@ -374,23 +636,177 @@ def _fail(
     http_status: int | None = None,
     exception_type: str | None = None,
 ) -> tuple[dict[str, Any], int]:
-    failure: dict[str, Any] = {"kind": kind}
+    failure: dict[str, Any] = {
+        "kind": kind
+    }
+
     if field:
         failure["field"] = field
+
     if http_status is not None:
-        failure["http_status"] = http_status
+        failure["http_status"] = (
+            http_status
+        )
+
     if exception_type:
-        failure["exception_type"] = exception_type
+        failure["exception_type"] = (
+            exception_type
+        )
+
     report["failure"] = failure
     report["ok"] = False
     report["status"] = "blocked"
+
     return report, 1
 
 
-def _http_status(exc: BaseException) -> int | None:
-    response = getattr(exc, "response", None)
-    status = getattr(response, "status_code", None)
-    return status if isinstance(status, int) else None
+def _http_status(
+    exc: BaseException,
+) -> int | None:
+    response = getattr(
+        exc,
+        "response",
+        None,
+    )
+    status = getattr(
+        response,
+        "status_code",
+        None,
+    )
+
+    return (
+        status
+        if isinstance(status, int)
+        else None
+    )
+
+
+def _normalize_repo_file_list(
+    values: Iterable[Any],
+) -> list[str]:
+    files: list[str] = []
+
+    if isinstance(values, (str, bytes)):
+        raise PreflightError(
+            "pinned_revision_file_list_invalid"
+        )
+
+    try:
+        iterator = iter(values)
+    except TypeError as exc:
+        raise PreflightError(
+            "pinned_revision_file_list_invalid"
+        ) from exc
+
+    for value in iterator:
+        if (
+            not isinstance(value, str)
+            or not value.strip()
+        ):
+            raise PreflightError(
+                "pinned_revision_file_list_invalid"
+            )
+
+        path = value.strip()
+
+        if (
+            path.startswith("/")
+            or "\\" in path
+            or path in {".", ".."}
+            or any(
+                part in {"", ".", ".."}
+                for part in path.split("/")
+            )
+        ):
+            raise PreflightError(
+                "pinned_revision_file_list_invalid",
+                field=path,
+            )
+
+        files.append(path)
+
+    if not files:
+        raise PreflightError(
+            "pinned_revision_file_list_empty"
+        )
+
+    if len(files) != len(set(files)):
+        raise PreflightError(
+            "pinned_revision_file_list_duplicate"
+        )
+
+    return sorted(files)
+
+
+def _fail_hub_exception(
+    report: dict[str, Any],
+    exc: BaseException,
+    bindings: HuggingFaceBindings,
+    *,
+    field: str | None = None,
+    entry_failure_kind: str,
+) -> tuple[dict[str, Any], int]:
+    if isinstance(
+        exc,
+        bindings.gated_repo_error,
+    ):
+        return _fail(
+            report,
+            "gated_model_access_denied",
+            field=field,
+            http_status=_http_status(exc),
+        )
+
+    if isinstance(
+        exc,
+        bindings.revision_not_found_error,
+    ):
+        return _fail(
+            report,
+            "model_revision_not_found",
+            field=field,
+            http_status=_http_status(exc),
+        )
+
+    if isinstance(
+        exc,
+        bindings.entry_not_found_error,
+    ):
+        return _fail(
+            report,
+            entry_failure_kind,
+            field=field,
+            http_status=_http_status(exc),
+        )
+
+    if isinstance(
+        exc,
+        bindings.repository_not_found_error,
+    ):
+        return _fail(
+            report,
+            "model_repository_not_found_or_inaccessible",
+            field=field,
+            http_status=_http_status(exc),
+        )
+
+    if isinstance(
+        exc,
+        bindings.hub_http_error,
+    ):
+        return _fail(
+            report,
+            "huggingface_hub_http_error",
+            field=field,
+            http_status=_http_status(exc),
+        )
+
+    return _fail(
+        report,
+        "unexpected_preflight_error",
+        field=field,
+        exception_type=type(exc).__name__,
+    )
 
 
 def check_access(
@@ -403,13 +819,31 @@ def check_access(
     run_id: str,
     run_attempt: str,
 ) -> tuple[dict[str, Any], int]:
-    repo_root = _normalize_repo_root(repo_root)
-    repository = _validate_repository(repository)
-    git_sha = _validate_sha(git_sha)
-    workflow_ref = _validate_non_empty(workflow_ref, "workflow_ref")
-    run_id = _validate_positive_int(run_id, "run_id")
-    run_attempt = _validate_positive_int(run_attempt, "run_attempt")
-    token_env = _validate_non_empty(token_env, "token_env")
+    repo_root = _normalize_repo_root(
+        repo_root
+    )
+    repository = _validate_repository(
+        repository
+    )
+    git_sha = _validate_sha(
+        git_sha
+    )
+    workflow_ref = _validate_non_empty(
+        workflow_ref,
+        "workflow_ref",
+    )
+    run_id = _validate_positive_int(
+        run_id,
+        "run_id",
+    )
+    run_attempt = _validate_positive_int(
+        run_attempt,
+        "run_attempt",
+    )
+    token_env = _validate_non_empty(
+        token_env,
+        "token_env",
+    )
 
     runtime: dict[str, str] | None = None
     report = _base_report(
@@ -422,15 +856,26 @@ def check_access(
     )
 
     try:
-        checked_out_git_sha = _git_head(repo_root)
-        report["source"]["checked_out_git_sha"] = checked_out_git_sha
-        git_sha_matches = checked_out_git_sha == git_sha
+        checked_out_git_sha = _git_head(
+            repo_root
+        )
+        report["source"][
+            "checked_out_git_sha"
+        ] = checked_out_git_sha
+        git_sha_matches = (
+            checked_out_git_sha
+            == git_sha
+        )
         _add_check(
             report,
             "source.git_sha_matches_checkout",
             git_sha_matches,
-            "reported git SHA matches the checked-out repository HEAD",
+            (
+                "reported git SHA matches "
+                "the checked-out repository HEAD"
+            ),
         )
+
         if not git_sha_matches:
             return _fail(
                 report,
@@ -442,248 +887,619 @@ def check_access(
             report,
             "source.git_sha_matches_checkout",
             False,
-            "checked-out repository HEAD could not be verified",
+            (
+                "checked-out repository HEAD "
+                "could not be verified"
+            ),
         )
-        return _fail(report, exc.code, field=exc.field)
+        return _fail(
+            report,
+            exc.code,
+            field=exc.field,
+        )
 
     try:
-        runtime = _canonical_runtime_identity(repo_root)
+        runtime = _canonical_runtime_identity(
+            repo_root
+        )
         report["runtime"] = runtime
         _add_check(
             report,
             "runtime.canonical_identity_loaded",
             True,
-            "model identity, revision, and Hub client pin were read from canonical repository files",
+            (
+                "model identity, revision, and "
+                "Hub client pin were read from "
+                "canonical repository files"
+            ),
         )
     except PreflightError as exc:
         _add_check(
             report,
             "runtime.canonical_identity_loaded",
             False,
-            "canonical hosted runtime identity could not be loaded",
+            (
+                "canonical hosted runtime identity "
+                "could not be loaded"
+            ),
         )
-        return _fail(report, exc.code, field=exc.field)
+        return _fail(
+            report,
+            exc.code,
+            field=exc.field,
+        )
 
-    token = os.environ.get(token_env, "").strip()
+    token = os.environ.get(
+        token_env,
+        "",
+    ).strip()
     token_present = bool(token)
     _add_check(
         report,
         "token.present",
         token_present,
-        f"environment variable {token_env} is non-empty",
+        (
+            f"environment variable {token_env} "
+            "is non-empty"
+        ),
     )
-    if not token_present:
-        return _fail(report, "missing_token", field=token_env)
 
-    expected_hub_version = runtime["huggingface_hub_version"]
+    if not token_present:
+        return _fail(
+            report,
+            "missing_token",
+            field=token_env,
+        )
+
+    expected_hub_version = runtime[
+        "huggingface_hub_version"
+    ]
+
     try:
-        installed_hub_version = _installed_hub_version()
+        installed_hub_version = (
+            _installed_hub_version()
+        )
     except PreflightError as exc:
         _add_check(
             report,
             "runtime.huggingface_hub_version",
             False,
-            "pinned Hugging Face Hub client is not installed",
+            (
+                "pinned Hugging Face Hub client "
+                "is not installed"
+            ),
         )
-        return _fail(report, exc.code)
+        return _fail(
+            report,
+            exc.code,
+        )
 
-    version_matches = installed_hub_version == expected_hub_version
+    version_matches = (
+        installed_hub_version
+        == expected_hub_version
+    )
     _add_check(
         report,
         "runtime.huggingface_hub_version",
         version_matches,
-        "installed Hugging Face Hub client matches the canonical runtime pin",
+        (
+            "installed Hugging Face Hub client "
+            "matches the canonical runtime pin"
+        ),
     )
-    report["runtime"]["installed_huggingface_hub_version"] = installed_hub_version
+    report["runtime"][
+        "installed_huggingface_hub_version"
+    ] = installed_hub_version
+
     if not version_matches:
-        return _fail(report, "huggingface_hub_version_mismatch")
-
-    try:
-        bindings = _load_huggingface_bindings()
-        api = bindings.api_factory(token=token)
-        info = api.model_info(
-            repo_id=runtime["model_id"],
-            revision=runtime["model_revision"],
-            token=token,
-        )
-
-        resolved_revision = getattr(info, "sha", None)
-        resolved_matches = (
-            isinstance(resolved_revision, str)
-            and resolved_revision.lower() == runtime["model_revision"]
-        )
-        _add_check(
-            report,
-            "model.revision_resolved",
-            resolved_matches,
-            "Hub model metadata resolved to the exact pinned commit revision",
-        )
-        report["runtime"]["resolved_model_revision"] = (
-            resolved_revision.lower()
-            if isinstance(resolved_revision, str)
-            else None
-        )
-        gated = getattr(info, "gated", None)
-        report["runtime"]["gated"] = gated if isinstance(gated, (bool, str)) else None
-
-        if not resolved_matches:
-            return _fail(report, "model_revision_mismatch")
-
-        with tempfile.TemporaryDirectory(
-            prefix="pulse-llamaguard-access-preflight-"
-        ) as temp_dir_text:
-            temp_dir = Path(temp_dir_text).resolve()
-            probes: list[dict[str, Any]] = []
-
-            for filename in PROBE_FILES:
-                downloaded = Path(
-                    bindings.download_file(
-                        repo_id=runtime["model_id"],
-                        filename=filename,
-                        revision=runtime["model_revision"],
-                        token=token,
-                        cache_dir=str(temp_dir),
-                    )
-                )
-                resolved_file = downloaded.resolve(strict=True)
-                try:
-                    resolved_file.relative_to(temp_dir)
-                except ValueError as exc:
-                    raise PreflightError(
-                        "probe_download_escaped_temporary_cache",
-                        field=filename,
-                    ) from exc
-
-                if not resolved_file.is_file():
-                    raise PreflightError("probe_file_missing", field=filename)
-
-                size = resolved_file.stat().st_size
-                if size <= 0:
-                    raise PreflightError("probe_file_empty", field=filename)
-                if size > MAX_PROBE_BYTES:
-                    raise PreflightError("probe_file_too_large", field=filename)
-
-                _read_strict_json_object(resolved_file)
-                probes.append(
-                    {
-                        "path": filename,
-                        "size_bytes": size,
-                        "sha256": _sha256(resolved_file),
-                        "json_object": True,
-                    }
-                )
-
-            report["probe_files"] = probes
-
-        _add_check(
-            report,
-            "model.metadata_files_accessible",
-            len(report["probe_files"]) == len(PROBE_FILES),
-            "small pinned-revision metadata files were downloaded and parsed without model weights or inference",
-        )
-
-    except PreflightError as exc:
-        return _fail(report, exc.code, field=exc.field)
-    except Exception as exc:  # noqa: BLE001
-        bindings_value = locals().get("bindings")
-        if isinstance(bindings_value, HuggingFaceBindings):
-            if isinstance(exc, bindings_value.gated_repo_error):
-                return _fail(
-                    report,
-                    "gated_model_access_denied",
-                    http_status=_http_status(exc),
-                )
-            if isinstance(exc, bindings_value.revision_not_found_error):
-                return _fail(
-                    report,
-                    "model_revision_not_found",
-                    http_status=_http_status(exc),
-                )
-            if isinstance(exc, bindings_value.entry_not_found_error):
-                return _fail(
-                    report,
-                    "probe_file_not_found",
-                    http_status=_http_status(exc),
-                )
-            if isinstance(exc, bindings_value.repository_not_found_error):
-                return _fail(
-                    report,
-                    "model_repository_not_found_or_inaccessible",
-                    http_status=_http_status(exc),
-                )
-            if isinstance(exc, bindings_value.hub_http_error):
-                return _fail(
-                    report,
-                    "huggingface_hub_http_error",
-                    http_status=_http_status(exc),
-                )
-
         return _fail(
             report,
-            "unexpected_preflight_error",
-            exception_type=type(exc).__name__,
+            "huggingface_hub_version_mismatch",
         )
+
+    bindings = _load_huggingface_bindings()
+    api = bindings.api_factory(
+        token=token
+    )
+
+    try:
+        info = api.model_info(
+            repo_id=runtime["model_id"],
+            revision=runtime[
+                "model_revision"
+            ],
+            token=token,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _fail_hub_exception(
+            report,
+            exc,
+            bindings,
+            field="model_info",
+            entry_failure_kind=(
+                "model_metadata_unavailable"
+            ),
+        )
+
+    resolved_revision = getattr(
+        info,
+        "sha",
+        None,
+    )
+    resolved_matches = (
+        isinstance(
+            resolved_revision,
+            str,
+        )
+        and resolved_revision.lower()
+        == runtime["model_revision"]
+    )
+    _add_check(
+        report,
+        "model.revision_resolved",
+        resolved_matches,
+        (
+            "Hub model metadata resolved to "
+            "the exact pinned commit revision"
+        ),
+    )
+    report["runtime"][
+        "resolved_model_revision"
+    ] = (
+        resolved_revision.lower()
+        if isinstance(
+            resolved_revision,
+            str,
+        )
+        else None
+    )
+    gated = getattr(
+        info,
+        "gated",
+        None,
+    )
+    report["runtime"]["gated"] = (
+        gated
+        if isinstance(
+            gated,
+            (bool, str),
+        )
+        else None
+    )
+
+    if not resolved_matches:
+        return _fail(
+            report,
+            "model_revision_mismatch",
+            field="model_revision",
+        )
+
+    try:
+        raw_revision_files = (
+            api.list_repo_files(
+                repo_id=runtime["model_id"],
+                revision=runtime[
+                    "model_revision"
+                ],
+                repo_type="model",
+                token=token,
+            )
+        )
+        revision_files = (
+            _normalize_repo_file_list(
+                raw_revision_files
+            )
+        )
+    except PreflightError as exc:
+        _add_check(
+            report,
+            "model.pinned_revision_file_list",
+            False,
+            (
+                "pinned revision file list "
+                "failed local validation"
+            ),
+        )
+        return _fail(
+            report,
+            exc.code,
+            field=exc.field,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _add_check(
+            report,
+            "model.pinned_revision_file_list",
+            False,
+            (
+                "pinned revision file list "
+                "could not be retrieved"
+            ),
+        )
+        return _fail_hub_exception(
+            report,
+            exc,
+            bindings,
+            field="repository_tree",
+            entry_failure_kind=(
+                "pinned_revision_tree_unavailable"
+            ),
+        )
+
+    revision_file_text = (
+        "\n".join(revision_files)
+        + "\n"
+    )
+    probe_contract = report[
+        "probe_contract"
+    ]
+    probe_contract[
+        "revision_files_checked"
+    ] = True
+    probe_contract[
+        "revision_file_count"
+    ] = len(revision_files)
+    probe_contract[
+        "revision_file_list_sha256"
+    ] = _sha256_text(
+        revision_file_text
+    )
+
+    missing_probe_files = [
+        filename
+        for filename in PROBE_FILES
+        if filename
+        not in set(revision_files)
+    ]
+    probe_contract[
+        "missing_probe_files"
+    ] = missing_probe_files
+    probes_declared = (
+        not missing_probe_files
+    )
+    _add_check(
+        report,
+        "model.pinned_revision_probe_files_declared",
+        probes_declared,
+        (
+            "all required metadata probe files "
+            "are present in the exact pinned revision"
+        ),
+    )
+
+    if missing_probe_files:
+        return _fail(
+            report,
+            "pinned_revision_missing_probe_file",
+            field=missing_probe_files[0],
+        )
+
+    with tempfile.TemporaryDirectory(
+        prefix=(
+            "pulse-llamaguard-"
+            "access-preflight-"
+        )
+    ) as temp_dir_text:
+        temp_dir = Path(
+            temp_dir_text
+        ).resolve()
+
+        for filename in PROBE_FILES:
+            try:
+                downloaded = Path(
+                    bindings.download_file(
+                        repo_id=runtime[
+                            "model_id"
+                        ],
+                        filename=filename,
+                        revision=runtime[
+                            "model_revision"
+                        ],
+                        token=token,
+                        cache_dir=str(
+                            temp_dir
+                        ),
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001
+                probe_contract[
+                    "failed_probe_file"
+                ] = filename
+                _add_check(
+                    report,
+                    (
+                        "model.metadata_file."
+                        f"{filename}"
+                    ),
+                    False,
+                    (
+                        "listed pinned-revision "
+                        "metadata file could not "
+                        "be downloaded"
+                    ),
+                )
+                return _fail_hub_exception(
+                    report,
+                    exc,
+                    bindings,
+                    field=filename,
+                    entry_failure_kind=(
+                        "probe_file_access_denied_or_unavailable"
+                    ),
+                )
+
+            try:
+                resolved_file = (
+                    downloaded.resolve(
+                        strict=True
+                    )
+                )
+                resolved_file.relative_to(
+                    temp_dir
+                )
+
+                if not resolved_file.is_file():
+                    raise PreflightError(
+                        "probe_file_missing",
+                        field=filename,
+                    )
+
+                size = (
+                    resolved_file
+                    .stat()
+                    .st_size
+                )
+
+                if size <= 0:
+                    raise PreflightError(
+                        "probe_file_empty",
+                        field=filename,
+                    )
+
+                if size > MAX_PROBE_BYTES:
+                    raise PreflightError(
+                        "probe_file_too_large",
+                        field=filename,
+                    )
+
+                _read_strict_json_object(
+                    resolved_file
+                )
+            except PreflightError as exc:
+                probe_contract[
+                    "failed_probe_file"
+                ] = filename
+                _add_check(
+                    report,
+                    (
+                        "model.metadata_file."
+                        f"{filename}"
+                    ),
+                    False,
+                    (
+                        "downloaded metadata file "
+                        "failed local validation"
+                    ),
+                )
+                return _fail(
+                    report,
+                    exc.code,
+                    field=(
+                        exc.field
+                        or filename
+                    ),
+                )
+            except ValueError as exc:
+                probe_contract[
+                    "failed_probe_file"
+                ] = filename
+                _add_check(
+                    report,
+                    (
+                        "model.metadata_file."
+                        f"{filename}"
+                    ),
+                    False,
+                    (
+                        "downloaded metadata file "
+                        "escaped the temporary cache"
+                    ),
+                )
+                return _fail(
+                    report,
+                    "probe_download_escaped_temporary_cache",
+                    field=filename,
+                    exception_type=(
+                        type(exc).__name__
+                    ),
+                )
+            except Exception as exc:  # noqa: BLE001
+                probe_contract[
+                    "failed_probe_file"
+                ] = filename
+                _add_check(
+                    report,
+                    (
+                        "model.metadata_file."
+                        f"{filename}"
+                    ),
+                    False,
+                    (
+                        "downloaded metadata file "
+                        "could not be validated"
+                    ),
+                )
+                return _fail(
+                    report,
+                    "unexpected_probe_validation_error",
+                    field=filename,
+                    exception_type=(
+                        type(exc).__name__
+                    ),
+                )
+
+            report["probe_files"].append(
+                {
+                    "path": filename,
+                    "size_bytes": size,
+                    "sha256": _sha256(
+                        resolved_file
+                    ),
+                    "json_object": True,
+                }
+            )
+            _add_check(
+                report,
+                (
+                    "model.metadata_file."
+                    f"{filename}"
+                ),
+                True,
+                (
+                    "metadata file was downloaded "
+                    "from the exact pinned revision "
+                    "and parsed as a strict JSON object"
+                ),
+            )
+
+    _add_check(
+        report,
+        "model.metadata_files_accessible",
+        (
+            len(report["probe_files"])
+            == len(PROBE_FILES)
+        ),
+        (
+            "all small pinned-revision metadata "
+            "files were downloaded and parsed "
+            "without model weights or inference"
+        ),
+    )
 
     report["ok"] = True
     report["status"] = "accessible"
     report["failure"] = None
+
     return report, 0
 
 
-def _render(report: dict[str, Any]) -> str:
-    return json.dumps(
-        report,
-        indent=2,
-        ensure_ascii=False,
-        sort_keys=True,
-        allow_nan=False,
-    ) + "\n"
+def _render(
+    report: dict[str, Any],
+) -> str:
+    return (
+        json.dumps(
+            report,
+            indent=2,
+            ensure_ascii=False,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        + "\n"
+    )
 
 
-def _write_report(path: Path, report: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
+def _write_report(
+    path: Path,
+    report: dict[str, Any],
+) -> None:
+    path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
     if path.is_symlink():
-        raise PreflightError("refusing_to_write_symlink_output")
-    path.write_text(_render(report), encoding="utf-8")
+        raise PreflightError(
+            "refusing_to_write_symlink_output"
+        )
+
+    path.write_text(
+        _render(report),
+        encoding="utf-8",
+    )
 
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Verify that the configured Hugging Face token can read the exact "
-            "pinned LlamaGuard model revision without downloading model weights."
+            "Verify that the configured "
+            "Hugging Face token can list and "
+            "read the required metadata files "
+            "from the exact pinned LlamaGuard "
+            "model revision without downloading "
+            "model weights."
         )
     )
-    parser.add_argument("--repo-root", required=True)
-    parser.add_argument("--token-env", default="HF_TOKEN")
-    parser.add_argument("--repository", required=True)
-    parser.add_argument("--git-sha", required=True)
-    parser.add_argument("--workflow-ref", required=True)
-    parser.add_argument("--run-id", required=True)
-    parser.add_argument("--run-attempt", required=True)
-    parser.add_argument("--output", required=True)
+    parser.add_argument(
+        "--repo-root",
+        required=True,
+    )
+    parser.add_argument(
+        "--token-env",
+        default="HF_TOKEN",
+    )
+    parser.add_argument(
+        "--repository",
+        required=True,
+    )
+    parser.add_argument(
+        "--git-sha",
+        required=True,
+    )
+    parser.add_argument(
+        "--workflow-ref",
+        required=True,
+    )
+    parser.add_argument(
+        "--run-id",
+        required=True,
+    )
+    parser.add_argument(
+        "--run-attempt",
+        required=True,
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+    )
     return parser
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(
+    argv: list[str] | None = None,
+) -> int:
     args = _parser().parse_args(argv)
 
     try:
-        repo_root = _normalize_repo_root(Path(args.repo_root))
-        output = _normalize_output(repo_root, Path(args.output))
+        repo_root = _normalize_repo_root(
+            Path(args.repo_root)
+        )
+        output = _normalize_output(
+            repo_root,
+            Path(args.output),
+        )
     except PreflightError as exc:
         diagnostic = {
             "schema_version": SCHEMA_VERSION,
-            "tool": {"name": TOOL_NAME, "version": TOOL_VERSION},
+            "tool": {
+                "name": TOOL_NAME,
+                "version": TOOL_VERSION,
+            },
             "ok": False,
             "status": "output_refused",
             "failure": {
                 "kind": exc.code,
-                **({"field": exc.field} if exc.field else {}),
+                **(
+                    {"field": exc.field}
+                    if exc.field
+                    else {}
+                ),
             },
-            "authority_boundary": dict(AUTHORITY_BOUNDARY),
+            "authority_boundary": dict(
+                AUTHORITY_BOUNDARY
+            ),
         }
-        sys.stdout.write(_render(diagnostic))
+        sys.stdout.write(
+            _render(diagnostic)
+        )
         return 2
 
     try:
@@ -698,31 +1514,63 @@ def main(argv: list[str] | None = None) -> int:
         )
     except PreflightError as exc:
         report = _base_report(
-            repository=str(args.repository),
-            git_sha=str(args.git_sha),
-            workflow_ref=str(args.workflow_ref),
-            run_id=str(args.run_id),
-            run_attempt=str(args.run_attempt),
+            repository=str(
+                args.repository
+            ),
+            git_sha=str(
+                args.git_sha
+            ),
+            workflow_ref=str(
+                args.workflow_ref
+            ),
+            run_id=str(
+                args.run_id
+            ),
+            run_attempt=str(
+                args.run_attempt
+            ),
             runtime=None,
         )
-        report, exit_code = _fail(report, exc.code, field=exc.field)
+        report, exit_code = _fail(
+            report,
+            exc.code,
+            field=exc.field,
+        )
     except Exception as exc:  # noqa: BLE001
         report = _base_report(
-            repository=str(args.repository),
-            git_sha=str(args.git_sha),
-            workflow_ref=str(args.workflow_ref),
-            run_id=str(args.run_id),
-            run_attempt=str(args.run_attempt),
+            repository=str(
+                args.repository
+            ),
+            git_sha=str(
+                args.git_sha
+            ),
+            workflow_ref=str(
+                args.workflow_ref
+            ),
+            run_id=str(
+                args.run_id
+            ),
+            run_attempt=str(
+                args.run_attempt
+            ),
             runtime=None,
         )
         report, exit_code = _fail(
             report,
             "unexpected_preflight_error",
-            exception_type=type(exc).__name__,
+            exception_type=(
+                type(exc).__name__
+            ),
         )
 
-    _write_report(output, report)
-    sys.stdout.write(_render(report))
+    _write_report(
+        output,
+        report,
+    )
+    sys.stdout.write(
+        _render(report)
+    )
+
     return exit_code
 
 


### PR DESCRIPTION
## Summary

Improve the hosted LlamaGuard access preflight so a blocked metadata probe
preserves the exact relation between:

```text
pinned model revision
→ files declared by that revision
→ required probe files
→ successful downloads
→ failed probe file
→ sanitized failure class
```

The previous preflight correctly blocked, but an `EntryNotFoundError` was
reduced to:

```text
probe_file_not_found
```

without preserving:

- which required file failed;
- whether the file existed in the exact pinned revision;
- whether an earlier probe had already succeeded;
- whether the failure occurred during listing, downloading, or local
  validation.

This PR closes that diagnostic gap without changing the model revision,
credential, runtime producer, or release-authority path.

## Files

Modified:

```text
tools/check_llamaguard_hosted_access_v0.py
.github/workflows/llamaguard_hosted_access_preflight.yml
tests/test_llamaguard_hosted_access_preflight_v0.py
```

No other file is changed.

`ci/tools-tests.list` is unchanged because the existing test path is already
registered exactly once.

## Updated mechanical path

```text
manual workflow_dispatch on main
→ exact source-SHA verification
→ canonical model ID and revision loading
→ pinned huggingface-hub version verification
→ exact model revision resolution
→ exact pinned-revision file listing
→ required probe-file presence comparison
→ metadata-file download attempts
→ local path, size, and strict-JSON validation
→ sanitized diagnostic report
→ GitHub Step Summary
```

## Exact revision-tree diagnostics

The preflight now records:

```text
required_probe_files
revision_files_checked
revision_file_count
revision_file_list_sha256
missing_probe_files
failed_probe_file
probe_files
failure.kind
failure.field
```

The complete revision file list is not copied into the public report.

Instead, the report preserves:

```text
file count
SHA-256 digest of the normalized file list
required-file presence results
```

This keeps the report bounded while preserving the exact revision-tree check.

## Failure separation

### Required file absent from the pinned revision

```text
failure.kind:
pinned_revision_missing_probe_file

failure.field:
<exact filename>
```

Example:

```text
failure.kind:
pinned_revision_missing_probe_file

failure.field:
tokenizer_config.json
```

This means the file is not declared by the exact pinned revision.

### File declared but not downloadable

```text
failure.kind:
probe_file_access_denied_or_unavailable

failure.field:
<exact filename>
```

This means the file appears in the exact pinned revision tree, but the
configured credential cannot retrieve it through the metadata-download path.

### Downloaded file fails local validation

The existing local failure classes remain distinct, including:

```text
probe_download_escaped_temporary_cache
probe_file_missing
probe_file_empty
probe_file_too_large
probe_invalid_json
probe_duplicate_json_key
probe_non_finite_json
probe_json_not_object
```

Each probe-local failure preserves the exact filename in:

```text
failure.field
```

## Partial success preservation

If:

```text
config.json
```

downloads and validates, but:

```text
tokenizer_config.json
```

fails, the report retains:

```text
probe_files:
- config.json

failed_probe_file:
tokenizer_config.json
```

A later failure therefore no longer erases an earlier successful probe.

## Workflow summary

The manual workflow summary now displays:

```text
status
model
requested revision
resolved revision
revision files checked
revision file count
required probe files
missing probe files
failed probe file
successful probe-file count
failure kind
failure field
model inference state
model-weight download state
release-authority state
```

The workflow remains:

```text
workflow_dispatch only
main only
exact expected source SHA
contents: read
HF_TOKEN scoped to one step
artifact upload with if: always()
```

## Secret and report boundary

The report does not include:

```text
HF_TOKEN
token prefix
Authorization header
raw request headers
raw exception message
full credential-bearing request data
```

Unexpected failures record only bounded diagnostic information such as:

```text
failure kind
failure field
HTTP status, when safely available
exception type, when required
```

## Authority boundary

This preflight does not:

- run model inference;
- download model weights;
- produce release evidence;
- write `status.json`;
- write or materialize gates;
- call `check_gates.py`;
- invoke the recorded release-evidence verifier;
- invoke the materializer;
- create an attestation;
- authorize or block release;
- create a release-grade reference run.

```text
hosted access preflight PASS
≠ hosted model execution PASS
≠ external evidence verified
≠ release authorized
```

## Regression coverage

The updated smoke covers:

- canonical model ID and revision extraction;
- canonical `huggingface-hub` pin extraction;
- reported SHA versus checked-out HEAD;
- symlinked canonical-input parent rejection;
- missing-token failure before network-client loading;
- exact pinned revision resolution;
- exact revision file listing;
- revision file-count and file-list digest recording;
- required probe-file presence checking;
- missing pinned-revision probe-file classification;
- exact missing filename preservation;
- listed-but-unavailable probe classification;
- exact failed filename preservation;
- successful first probe retained when the second fails;
- strict JSON validation;
- invalid JSON kept distinct from path-escape failure;
- token non-disclosure;
- output-path safety;
- metadata-only behavior;
- no inference or model-weight surface;
- manual-only workflow triggering;
- main-only source binding;
- least-privilege permissions;
- single-step `HF_TOKEN` scope;
- diagnostic Step Summary fields;
- artifact upload;
- existing tools-test manifest registration.

## Verification

```text
python -m py_compile \
  tools/check_llamaguard_hosted_access_v0.py \
  tests/test_llamaguard_hosted_access_preflight_v0.py

python tests/test_llamaguard_hosted_access_preflight_v0.py

python -m pytest -q \
  tests/test_llamaguard_hosted_access_preflight_v0.py

git diff --check

git diff --name-only origin/main...HEAD
```

Local regression result:

```text
py_compile: PASS
standalone smoke: PASS
pytest: 13 passed
```

Expected changed-file result:

```text
.github/workflows/llamaguard_hosted_access_preflight.yml
tests/test_llamaguard_hosted_access_preflight_v0.py
tools/check_llamaguard_hosted_access_v0.py
```

## Non-effects

No change to:

```text
PULSE_safe_pack_v0/tools/run_llamaguard_current_evidence_v0.py
PULSE_safe_pack_v0/requirements-llamaguard-v0.txt
.github/workflows/pulse_ci.yml
HF_TOKEN repository secret
pinned model ID
pinned model revision
pulse_gate_policy_v0.yml
pulse_gate_registry_v0.yml
recorded verifier
materializer
check_gates.py
package assembly
package verification
schemas
SLSA/VSA activation
DOI and citation identity
Zenodo metadata
release metadata
release-authority behavior
```

## Expected review result

```text
exact pinned-revision file surface checked
missing revision file distinguished from download failure
failure filename preserved
partial probe success preserved
GitHub Summary exposes bounded diagnostics
metadata-only boundary preserved
secret scope preserved
non-authority boundary preserved
three existing files modified
no runtime model or release-authority change
```