### PR TITLE
fix(ci): enforce release gates after attested materialization

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -52,11 +52,11 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
-    
+
     env:
       PACK_DIR: ${{ github.workspace }}/PULSE_safe_pack_v0
       REFERENCE_BUNDLE_DIR: ""
- 
+
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pinned
@@ -388,10 +388,10 @@ jobs:
           echo "PULSE_POLICY_SET=${PULSE_POLICY_SET}" >> "$GITHUB_ENV"
           echo "PULSE_LLAMAGUARD_EVIDENCE_MODE=${PULSE_LLAMAGUARD_EVIDENCE_MODE}" >> "$GITHUB_ENV"
           echo "PULSE_RUN_KEY=${PULSE_RUN_KEY}" >> "$GITHUB_ENV"
-        
+
           echo "is_release=${PULSE_IS_RELEASE}" >> "$GITHUB_OUTPUT"
           echo "llamaguard_evidence_mode=${PULSE_LLAMAGUARD_EVIDENCE_MODE}" >> "$GITHUB_OUTPUT"
-         
+
           echo "Computed flags: IS_RELEASE=$PULSE_IS_RELEASE MODE=$PULSE_MODE POLICY_SET=$PULSE_POLICY_SET LLAMAGUARD_EVIDENCE_MODE=$PULSE_LLAMAGUARD_EVIDENCE_MODE"
 
           EXTRA=()
@@ -408,7 +408,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-       
+
           MODE="${PULSE_MODE:-core}"
           echo "Running pack in mode: $MODE"
 
@@ -570,7 +570,7 @@ jobs:
           print("OK: run_mode=prod")
           PY
 
-      - name: release-grade initialize current-run evidence identity 
+      - name: release-grade initialize current-run evidence identity
         if: ${{ steps.release_mode.outputs.is_release == '1' }}
         shell: bash
         run: |
@@ -718,7 +718,7 @@ jobs:
           fi
 
       - name: release-grade upload current-run LlamaGuard evidence
-        if: ${{ steps.release_mode.outputs.is_release == '1' && steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime' }}       
+        if: ${{ steps.release_mode.outputs.is_release == '1' && steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: llamaguard-current-run-${{ github.run_id }}-${{ github.run_attempt }}
@@ -737,7 +737,7 @@ jobs:
           echo "----- status.json (head) -----"
           head -n 200 "${{ env.PACK_DIR }}/artifacts/status.json" || true
           echo "-------------------------------"
-      
+
       - name: Compute external evidence list (for snapshot)
         shell: bash
         run: |
@@ -945,6 +945,55 @@ jobs:
           EXT_DIR="${{ env.PACK_DIR }}/artifacts/external"
           python scripts/check_external_summaries_present.py --external_dir "$EXT_DIR" --require_metric_key
 
+      - name: release-grade pre-attestation artifact postconditions
+        if: ${{ steps.release_mode.outputs.is_release == '1' && steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          REQUIRED_FILES=(
+            "${PACK_DIR}/artifacts/status.json"
+            "${PACK_DIR}/artifacts/status_baseline.json"
+            "${PACK_DIR}/artifacts/status_summary_baseline.md"
+            "${PACK_DIR}/artifacts/status_summary_baseline.json"
+            "${PACK_DIR}/artifacts/required_gate_evidence_v0.json"
+            "${PACK_DIR}/artifacts/self_contained_pulse_evidence_floor_v0.json"
+            "${PACK_DIR}/artifacts/refusal_delta_summary.json"
+            "${PACK_DIR}/artifacts/external/llamaguard_raw.jsonl"
+            "${PACK_DIR}/artifacts/external/llamaguard_evaluator_manifest_v0.json"
+            "${PACK_DIR}/artifacts/external/llamaguard_summary.json"
+          )
+
+          for artifact in "${REQUIRED_FILES[@]}"; do
+            if [[ ! -f "${artifact}" || -L "${artifact}" || ! -s "${artifact}" ]]; then
+              echo "::error::release-grade pre-attestation artifact is missing, empty, or symlinked: ${artifact}"
+              exit 1
+            fi
+
+            sha256sum "${artifact}"
+          done
+
+          echo "OK: release-grade pre-attestation artifact postconditions satisfied"
+
+      - name: Upload release-grade pre-attestation pulse artifacts
+        if: ${{ steps.release_mode.outputs.is_release == '1' && steps.release_mode.outputs.llamaguard_evidence_mode == 'hosted_full_runtime' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        with:
+          name: pulse-pre-attestation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            PULSE_safe_pack_v0/artifacts/status.json
+            PULSE_safe_pack_v0/artifacts/status_baseline.json
+            PULSE_safe_pack_v0/artifacts/status_summary_baseline.md
+            PULSE_safe_pack_v0/artifacts/status_summary_baseline.json
+            PULSE_safe_pack_v0/artifacts/required_gate_evidence_v0.json
+            PULSE_safe_pack_v0/artifacts/self_contained_pulse_evidence_floor_v0.json
+            PULSE_safe_pack_v0/artifacts/refusal_delta_summary.json
+            PULSE_safe_pack_v0/artifacts/external/llamaguard_raw.jsonl
+            PULSE_safe_pack_v0/artifacts/external/llamaguard_evaluator_manifest_v0.json
+            PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.json
+          if-no-files-found: error
+          retention-days: 30
+
       - name: Augment status (external + top-level flags)
         if: ${{ steps.release_mode.outputs.is_release != '1' }}
         shell: bash
@@ -1009,7 +1058,7 @@ jobs:
 
           "${AUGMENT_CMD[@]}"
 
-      
+
       - name: "ci: schema validate status.json (status_v1)"
         shell: bash
         run: |
@@ -1021,10 +1070,10 @@ jobs:
           python tools/validate_status_schema.py \
             --schema "$SCHEMA" \
             --status "$STATUS"
-      
+
       - name: Re-render Quality Ledger from final status
         id: quality_ledger_final_render
-        if: ${{ always() }}
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1041,9 +1090,9 @@ jobs:
             --out "$REPORT"
 
           echo "OK: re-rendered Quality Ledger from final status.json"
-      
+
       - name: Export final summary (post-augment)
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1054,21 +1103,21 @@ jobs:
 
           if [ ! -f "$SCRIPT" ]; then
             if [[ "${PULSE_IS_RELEASE:-0}" == "1" ]]; then
-          
+
               echo "::error::status_to_summary.py not found at $SCRIPT on release-grade run"
               exit 1
             fi
-       
+
             echo "::notice::SKIP: status_to_summary.py not found at $SCRIPT (optional)"
             exit 0
           fi
-      
+
           if [ ! -f "$STATUS" ]; then
             if [[ "${PULSE_IS_RELEASE:-0}" == "1" ]]; then
               echo "::error::status.json not found at $STATUS; cannot export release-grade final summary"
               exit 1
-            fi    
-          
+            fi
+
             echo "::notice::SKIP: status.json not found at $STATUS; skipping final summary (optional)"
             exit 0
           fi
@@ -1118,9 +1167,10 @@ jobs:
 
           print(f"OK: non-demo status.version on tag: {v}")
           PY
-      
+
 
       - name: Build release authority manifest (audit-only)
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1184,9 +1234,9 @@ jobs:
           fi
 
           echo "OK: release authority manifest audit sidecar ready at $OUT"
-    
+
       - name: Upload release authority manifest (audit-only)
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -1196,7 +1246,7 @@ jobs:
           retention-days: 30
 
       - name: Summarize release authority manifest (audit-only)
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1225,7 +1275,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Insert release authority manifest section into Quality Ledger (audit-only)
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1261,7 +1311,7 @@ jobs:
           echo "OK: release authority manifest section inserted into Quality Ledger"
 
       - name: Stage release authority audit bundle (audit-only)
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1304,7 +1354,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload release authority audit bundle (audit-only)
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -1314,6 +1364,7 @@ jobs:
           retention-days: 30
 
       - name: "ci: enforce gates via check_gates (policy-derived)"
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1399,6 +1450,7 @@ jobs:
           PY
 
       - name: Compute stability map
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1411,6 +1463,7 @@ jobs:
           python "$SCRIPT" --status "$STATUS"
 
       - name: Render stability map
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1423,6 +1476,7 @@ jobs:
           python "$SCRIPT" --status "$STATUS"
 
       - name: Compute field-level stability
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1435,6 +1489,7 @@ jobs:
           python "$SCRIPT" --status "$STATUS"
 
       - name: Compute field-level gating scores
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1447,6 +1502,7 @@ jobs:
           python "$SCRIPT" --status "$STATUS"
 
       - name: Compute EPF overlay
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1459,6 +1515,7 @@ jobs:
           python "$SCRIPT" --status "$STATUS"
 
       - name: Generate PULSE snapshot report (HTML)
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1471,6 +1528,7 @@ jobs:
           python "$SCRIPT" --status "$STATUS"
 
       - name: Generate PULSE snapshot report (Markdown)
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1483,6 +1541,7 @@ jobs:
           python "$SCRIPT" --status "$STATUS"
 
       - name: Write PULSE summary
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1495,6 +1554,7 @@ jobs:
           python "$SCRIPT" --status "$STATUS"
 
       - name: Prepare overlay outputs
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1526,6 +1586,7 @@ jobs:
           copy_if_exists "${{ env.PACK_DIR }}/artifacts/g_epf_overlay_v0.md" "$OVERLAY_DIR/g_epf_overlay_v0.md"
 
       - name: Export overlay HTML summary
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1538,7 +1599,7 @@ jobs:
           python "$SCRIPT" --overlay_dir "$OVERLAY_DIR"
 
       - name: Copy overlay HTML to report root
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1553,7 +1614,7 @@ jobs:
           cp "$SRC" "$DST"
 
       - name: Write status.json key-order diagnosis (for debugging)
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1568,6 +1629,7 @@ jobs:
           python "$SCRIPT" --status "$STATUS"
 
       - name: Write separation-phase report (HTML)
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1580,6 +1642,7 @@ jobs:
           python "$SCRIPT" --status "$STATUS"
 
       - name: Write separation-phase report (Markdown)
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1592,6 +1655,7 @@ jobs:
           python "$SCRIPT" --status "$STATUS"
 
       - name: Write separation-phase per-gate matrix
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1604,6 +1668,7 @@ jobs:
           python "$SCRIPT" --status "$STATUS"
 
       - name: Write separation-phase per-gate matrix (MD)
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1616,6 +1681,7 @@ jobs:
           python "$SCRIPT" --status "$STATUS"
 
       - name: Generate separation-phase overlay for snapshot
+        if: ${{ steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1634,7 +1700,7 @@ jobs:
           python "$SCRIPT" --status "$STATUS"
 
       - name: Release-grade artifact postconditions
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1682,7 +1748,7 @@ jobs:
           echo "OK: artifact postconditions satisfied (IS_RELEASE=$IS_RELEASE)"
 
       - name: "Release decision v0: materialize artifact"
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1727,7 +1793,7 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: "Release decision v0: render ledger section"
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1768,9 +1834,9 @@ jobs:
             printf -- '- output: `%s`\n' "${OUT_PATH}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-  
+
       - name: "Release decision v0: compose report card"
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1823,9 +1889,9 @@ jobs:
             printf -- '- section: `%s`\n' "${SECTION_PATH}"
             printf -- '- output: `%s`\n' "${OUT_PATH}"
           } >> "${GITHUB_STEP_SUMMARY}"
-      
+
       - name: "Release authority artifact binding v0: materialize and verify"
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1875,16 +1941,16 @@ jobs:
           } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: "Upload release authority artifact binding v0"
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
         with:
           name: release-authority-artifact-binding-v0
           if-no-files-found: warn
           path: ${{ env.PACK_DIR }}/artifacts/artifact_provenance_binding_v0.json
           retention-days: 30
-      
+
       - name: "Upload release decision v0 artifact bundle"
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
         with:
           name: release-decision-v0
@@ -1894,9 +1960,9 @@ jobs:
             ${{ env.PACK_DIR }}/artifacts/release_decision_v0.json
             ${{ env.PACK_DIR }}/artifacts/release_decision_v0_ledger_section.html
             ${{ env.PACK_DIR }}/artifacts/report_card.with_release_decision.html
-      
+
       - name: "Release decision v0: summarize artifact"
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         shell: bash
         env:
           RELEASE_DECISION_PATH: ${{ env.PACK_DIR }}/artifacts/release_decision_v0.json
@@ -2031,9 +2097,9 @@ jobs:
 
           _write_summary("\n".join(lines))
           PY
-      
+
       - name: Export JUnit and SARIF from final status
-        if: always()
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         shell: bash
         env:
           PULSE_EVENT_NAME: ${{ github.event_name }}
@@ -2114,7 +2180,7 @@ jobs:
 
       - name: Check release-grade reference run qualification (advisory)
         id: release_grade_reference_qualify
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true') }}
+        if: ${{ (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true')) }}
         shell: bash
         run: |
           set -euo pipefail
@@ -2171,7 +2237,7 @@ jobs:
 
       - name: Quality Ledger / status parity
         id: quality_ledger_status_parity
-        if: ${{ always() && steps.quality_ledger_final_render.outcome == 'success' }}
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') && steps.quality_ledger_final_render.outcome == 'success' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -2183,7 +2249,7 @@ jobs:
             --ledger "$LEDGER"
 
       - name: mark release-grade reference parity state
-        if: ${{ always() }}
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
         shell: bash
         run: |
          if [[ "${{ steps.quality_ledger_status_parity.outcome }}" == "success" ]]; then
@@ -2191,9 +2257,9 @@ jobs:
           else
             echo "REFERENCE_LEDGER_PARITY_OK=false" >> "$GITHUB_ENV"
           fi
-      
+
       - name: assemble release-grade reference bundle
-        if: ${{ (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true')) && env.REFERENCE_RUN_QUALIFIED == 'true' && env.REFERENCE_LEDGER_PARITY_OK == 'true' }}
+        if: ${{ (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true')) && env.REFERENCE_RUN_QUALIFIED == 'true' && env.REFERENCE_LEDGER_PARITY_OK == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -2233,21 +2299,22 @@ jobs:
             cp "${PACK_DIR}/artifacts/reports/sarif.json" "$BUNDLE_DIR/reports/sarif.json"
           elif [ -f "reports/sarif.json" ]; then
             cp "reports/sarif.json" "$BUNDLE_DIR/reports/sarif.json"
-          fi 
+          fi
 
           echo "REFERENCE_BUNDLE_DIR=${BUNDLE_DIR}" >> "$GITHUB_ENV"
 
       - name: upload release-grade reference bundle
-        if: ${{ env.REFERENCE_BUNDLE_DIR != '' && env.REFERENCE_RUN_QUALIFIED == 'true' && env.REFERENCE_LEDGER_PARITY_OK == 'true' }}
+        if: ${{ (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') && env.REFERENCE_BUNDLE_DIR != '' && env.REFERENCE_RUN_QUALIFIED == 'true' && env.REFERENCE_LEDGER_PARITY_OK == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: release-grade-reference-run-v0
           path: ${{ env.REFERENCE_BUNDLE_DIR }}
           if-no-files-found: error
           retention-days: 30
-      
+
       - name: Upload artifacts
-        if: ${{ always() && steps.quality_ledger_final_render.outcome == 'success' && steps.quality_ledger_status_parity.outcome == 'success' }}
+        if: ${{ always() && (steps.release_mode.outputs.is_release != '1' || steps.release_mode.outputs.llamaguard_evidence_mode != 'hosted_full_runtime') && steps.quality_ledger_final_render.outcome == 'success' && steps.quality_ledger_status_parity.outcome == 'success' }}
+
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
         with:
           name: pulse-report
@@ -2261,7 +2328,7 @@ jobs:
   attest_release_authority_artifact_binding:
     name: "Release authority artifact binding v0: attest"
     needs: pulse
-    if: ${{ github.event_name != 'pull_request' && needs.pulse.result == 'success' }}
+    if: ${{ github.event_name != 'pull_request' && needs.pulse.result == 'success' && !startsWith(github.ref, 'refs/tags/v') && !startsWith(github.ref, 'refs/tags/V') && (github.event_name != 'workflow_dispatch' || github.event.inputs.strict_external_evidence != 'true' || github.event.inputs.llamaguard_evidence_mode != 'hosted_full_runtime') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -2270,6 +2337,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
+
     steps:
       - name: Download verified release authority artifact binding
         shell: bash
@@ -2437,19 +2505,20 @@ jobs:
             PULSE_safe_pack_v0/artifacts/external/llamaguard_attestation_verifier_v1.json
           if-no-files-found: error
           retention-days: 30
-  
+
   release_grade_recorded_path:
-    name: "Release-grade recorded path: attested evidence to gates"
+    name: "Release-grade recorded path: attested evidence to final authority artifacts"
     needs: attest_llamaguard_current_run_summary
     if: ${{ github.event_name != 'pull_request' && needs.attest_llamaguard_current_run_summary.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true' && github.event.inputs.llamaguard_evidence_mode == 'hosted_full_runtime')) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: read
       actions: read
 
     env:
       PACK_DIR: ${{ github.workspace }}/PULSE_safe_pack_v0
+      REFERENCE_BUNDLE_DIR: ""
 
     steps:
       - name: Checkout
@@ -2471,14 +2540,14 @@ jobs:
           python -m pip install -r requirements.txt
           python -m pip install jsonschema
 
-      - name: Download baseline pulse artifacts
+      - name: Download pre-attestation pulse artifacts
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          DOWNLOAD_DIR="${RUNNER_TEMP}/pulse-report"
+          DOWNLOAD_DIR="${RUNNER_TEMP}/pulse-pre-attestation"
           CANONICAL_ARTIFACTS="${GITHUB_WORKSPACE}/PULSE_safe_pack_v0/artifacts"
 
           rm -rf "${DOWNLOAD_DIR}"
@@ -2486,7 +2555,7 @@ jobs:
 
           gh run download "${GITHUB_RUN_ID}" \
             --repo "${GITHUB_REPOSITORY}" \
-            --name "pulse-report" \
+            --name "pulse-pre-attestation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
             --dir "${DOWNLOAD_DIR}"
 
           copy_required_artifact () {
@@ -2496,12 +2565,12 @@ jobs:
             src="$(find "${DOWNLOAD_DIR}" -type f -name "${name}" | head -n 1 || true)"
 
             if [[ -z "${src}" ]]; then
-              echo "::error::pulse-report artifact is missing ${name}"
+              echo "::error::pre-attestation artifact is missing ${name}"
               exit 1
             fi
 
             if [[ -L "${src}" ]]; then
-              echo "::error::pulse-report artifact must not be a symlink: ${src}"
+              echo "::error::pre-attestation artifact must not be a symlink: ${src}"
               exit 1
             fi
 
@@ -2510,17 +2579,23 @@ jobs:
 
           copy_required_artifact "status.json"
           copy_required_artifact "status_baseline.json"
+          copy_required_artifact "status_summary_baseline.md"
+          copy_required_artifact "status_summary_baseline.json"
           copy_required_artifact "required_gate_evidence_v0.json"
+          copy_required_artifact "self_contained_pulse_evidence_floor_v0.json"
           copy_required_artifact "refusal_delta_summary.json"
 
           for artifact in \
             "${CANONICAL_ARTIFACTS}/status.json" \
             "${CANONICAL_ARTIFACTS}/status_baseline.json" \
+            "${CANONICAL_ARTIFACTS}/status_summary_baseline.md" \
+            "${CANONICAL_ARTIFACTS}/status_summary_baseline.json" \
             "${CANONICAL_ARTIFACTS}/required_gate_evidence_v0.json" \
+            "${CANONICAL_ARTIFACTS}/self_contained_pulse_evidence_floor_v0.json" \
             "${CANONICAL_ARTIFACTS}/refusal_delta_summary.json"
           do
-            if [[ ! -f "${artifact}" || -L "${artifact}" ]]; then
-              echo "::error::Restored baseline artifact is not a regular non-symlink file: ${artifact}"
+            if [[ ! -f "${artifact}" || -L "${artifact}" || ! -s "${artifact}" ]]; then
+              echo "::error::restored pre-attestation artifact is missing, empty, or symlinked: ${artifact}"
               exit 1
             fi
 
@@ -2542,7 +2617,7 @@ jobs:
 
           gh run download "${GITHUB_RUN_ID}" \
             --repo "${GITHUB_REPOSITORY}" \
-            --name "llamaguard-attested-current-run-${{ github.run_id }}-${{ github.run_attempt }}" \
+            --name "llamaguard-attested-current-run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
             --dir "${DOWNLOAD_DIR}"
 
           restore_external_artifact () {
@@ -2567,38 +2642,38 @@ jobs:
 
           restore_external_artifact \
             "llamaguard_raw.jsonl" \
-            "PULSE_safe_pack_v0/artifacts/external/llamaguard_raw.jsonl"
+            "${CANONICAL_EXTERNAL}/llamaguard_raw.jsonl"
 
           restore_external_artifact \
             "llamaguard_evaluator_manifest_v0.json" \
-            "PULSE_safe_pack_v0/artifacts/external/llamaguard_evaluator_manifest_v0.json"
+            "${CANONICAL_EXTERNAL}/llamaguard_evaluator_manifest_v0.json"
 
           restore_external_artifact \
             "llamaguard_summary.json" \
-            "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.json"
+            "${CANONICAL_EXTERNAL}/llamaguard_summary.json"
 
           restore_external_artifact \
             "llamaguard_summary.bundle.json" \
-            "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.bundle.json"
+            "${CANONICAL_EXTERNAL}/llamaguard_summary.bundle.json"
 
           restore_external_artifact \
             "llamaguard_summary.envelope.json" \
-            "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.envelope.json"
+            "${CANONICAL_EXTERNAL}/llamaguard_summary.envelope.json"
 
           restore_external_artifact \
             "llamaguard_attestation_verifier_v1.json" \
-            "PULSE_safe_pack_v0/artifacts/external/llamaguard_attestation_verifier_v1.json"
+            "${CANONICAL_EXTERNAL}/llamaguard_attestation_verifier_v1.json"
 
           for artifact in \
-            "PULSE_safe_pack_v0/artifacts/external/llamaguard_raw.jsonl" \
-            "PULSE_safe_pack_v0/artifacts/external/llamaguard_evaluator_manifest_v0.json" \
-            "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.json" \
-            "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.bundle.json" \
-            "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.envelope.json" \
-            "PULSE_safe_pack_v0/artifacts/external/llamaguard_attestation_verifier_v1.json"
+            "${CANONICAL_EXTERNAL}/llamaguard_raw.jsonl" \
+            "${CANONICAL_EXTERNAL}/llamaguard_evaluator_manifest_v0.json" \
+            "${CANONICAL_EXTERNAL}/llamaguard_summary.json" \
+            "${CANONICAL_EXTERNAL}/llamaguard_summary.bundle.json" \
+            "${CANONICAL_EXTERNAL}/llamaguard_summary.envelope.json" \
+            "${CANONICAL_EXTERNAL}/llamaguard_attestation_verifier_v1.json"
           do
-            if [[ ! -f "${artifact}" || -L "${artifact}" ]]; then
-              echo "::error::Restored attested LlamaGuard artifact is not a regular non-symlink file: ${artifact}"
+            if [[ ! -f "${artifact}" || -L "${artifact}" || ! -s "${artifact}" ]]; then
+              echo "::error::restored attested LlamaGuard artifact is missing, empty, or symlinked: ${artifact}"
               exit 1
             fi
 
@@ -2652,52 +2727,480 @@ jobs:
         run: |
           set -euo pipefail
 
-          STATUS="${PACK_DIR}/artifacts/status.json"
-          SCHEMA="$GITHUB_WORKSPACE/schemas/status/release_grade_status_v1.schema.json"
-
           python tools/validate_status_schema.py \
-            --schema "$SCHEMA" \
-            --status "$STATUS" \
+            --schema "${GITHUB_WORKSPACE}/schemas/status/release_grade_status_v1.schema.json" \
+            --status "${PACK_DIR}/artifacts/status.json" \
             --max-errors 20
-      
+
       - name: "ci: forbid stubbed status on release-grade runs (post-materialization)"
         shell: bash
         run: |
           set -euo pipefail
 
-          STATUS="${PACK_DIR}/artifacts/status.json"
-          python ci/check_release_no_stub_status.py --status "$STATUS"
-      
-      - name: release-grade enforce release-required gates via check_gates
+          python ci/check_release_no_stub_status.py \
+            --status "${PACK_DIR}/artifacts/status.json"
+
+      - name: release-grade enforce required and release-required gates via check_gates
         shell: bash
         run: |
           set -euo pipefail
 
-          STATUS="PULSE_safe_pack_v0/artifacts/status.json"
+          STATUS="${PACK_DIR}/artifacts/status.json"
 
           if [[ ! -f "${STATUS}" || -L "${STATUS}" ]]; then
             echo "::error::release-grade status is missing or symlinked: ${STATUS}"
             exit 1
           fi
 
-          RELEASE_REQ_STR="$(python tools/policy_to_require_args.py \
-            --policy pulse_gate_policy_v0.yml \
-            --set release_required \
-            --format space)"
+          mapfile -t REQUIRED_GATES < <(
+            python tools/policy_to_require_args.py \
+              --policy pulse_gate_policy_v0.yml \
+              --set required \
+              --format newline
+          )
 
-          read -r -a RELEASE_REQ <<< "$RELEASE_REQ_STR"
+          mapfile -t RELEASE_REQUIRED_GATES < <(
+            python tools/policy_to_require_args.py \
+              --policy pulse_gate_policy_v0.yml \
+              --set release_required \
+              --format newline
+          )
 
-          if (( ${#RELEASE_REQ[@]} == 0 )); then
+          if (( ${#REQUIRED_GATES[@]} == 0 )); then
+            echo "::error::derived gate set is empty: required"
+            exit 1
+          fi
+
+          if (( ${#RELEASE_REQUIRED_GATES[@]} == 0 )); then
             echo "::error::derived gate set is empty: release_required"
             exit 1
           fi
 
-          echo "Enforcing release_required gate set (${#RELEASE_REQ[@]} gates)"
-          printf '%s\n' "${RELEASE_REQ[@]}" | sed 's/^/ - /'
+          declare -A SEEN=()
+          EFFECTIVE_GATES=()
+
+          for gate in "${REQUIRED_GATES[@]}" "${RELEASE_REQUIRED_GATES[@]}"; do
+            if [[ -z "${gate}" ]]; then
+              continue
+            fi
+
+            if [[ -z "${SEEN[${gate}]+x}" ]]; then
+              SEEN["${gate}"]=1
+              EFFECTIVE_GATES+=("${gate}")
+            fi
+          done
+
+          if (( ${#EFFECTIVE_GATES[@]} == 0 )); then
+            echo "::error::workflow-effective release-grade gate set is empty"
+            exit 1
+          fi
+
+          echo "Enforcing workflow-effective required + release_required gate set (${#EFFECTIVE_GATES[@]} gates)"
+          printf '%s\n' "${EFFECTIVE_GATES[@]}" | sed 's/^/ - /'
 
           python "${PACK_DIR}/tools/check_gates.py" \
             --status "${STATUS}" \
-            --require "${RELEASE_REQ[@]}"
+            --require "${EFFECTIVE_GATES[@]}"
+
+      - name: Render final release-grade Quality Ledger
+        id: release_grade_quality_ledger_render
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python "${PACK_DIR}/tools/render_quality_ledger.py" \
+            --status "${PACK_DIR}/artifacts/status.json" \
+            --out "${PACK_DIR}/artifacts/report_card.html"
+
+      - name: Export final release-grade status summary
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python "${PACK_DIR}/tools/status_to_summary.py" \
+            --status "${PACK_DIR}/artifacts/status.json" \
+            --out_md "${PACK_DIR}/artifacts/status_summary.md" \
+            --out_json "${PACK_DIR}/artifacts/status_summary.json"
+
+      - name: Materialize final release decision v0
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python "${PACK_DIR}/tools/materialize_release_decision.py" \
+            --status "${PACK_DIR}/artifacts/status.json" \
+            --policy pulse_gate_policy_v0.yml \
+            --target prod \
+            --out "${PACK_DIR}/artifacts/release_decision_v0.json" \
+            --status-schema schemas/status/status_v1.schema.json
+
+      - name: Render final release decision ledger section
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python "${PACK_DIR}/tools/render_release_decision_ledger_section.py" \
+            --input "${PACK_DIR}/artifacts/release_decision_v0.json" \
+            --schema schemas/release_decision_v0.schema.json \
+            --out "${PACK_DIR}/artifacts/release_decision_v0_ledger_section.html"
+
+      - name: Build and verify final release authority manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python "${PACK_DIR}/tools/build_release_authority_manifest_v0.py" \
+            --status "${PACK_DIR}/artifacts/status.json" \
+            --policy "${GITHUB_WORKSPACE}/pulse_gate_policy_v0.yml" \
+            --registry "${GITHUB_WORKSPACE}/pulse_gate_registry_v0.yml" \
+            --evaluator "${PACK_DIR}/tools/check_gates.py" \
+            --policy-set "required+release_required" \
+            --out "${PACK_DIR}/artifacts/release_authority_v0.json" \
+            --workflow-name "${GITHUB_WORKFLOW:-PULSE CI}" \
+            --event-name "${GITHUB_EVENT_NAME:-unknown}" \
+            --ref "${GITHUB_REF:-unknown}" \
+            --git-sha "${GITHUB_SHA}"
+
+          python "${PACK_DIR}/tools/check_release_authority_manifest_v0.py" \
+            --manifest "${PACK_DIR}/artifacts/release_authority_v0.json" \
+            --schema "${GITHUB_WORKSPACE}/schemas/release_authority_v0.schema.json"
+
+      - name: Insert final release authority manifest into Quality Ledger
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python "${PACK_DIR}/tools/insert_release_authority_manifest_ledger_section.py" \
+            --report "${PACK_DIR}/artifacts/report_card.html" \
+            --manifest "${PACK_DIR}/artifacts/release_authority_v0.json" \
+            --href "release_authority_v0.json"
+
+      - name: Compose final release decision report
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python "${PACK_DIR}/tools/insert_release_decision_ledger_section.py" \
+            --report "${PACK_DIR}/artifacts/report_card.html" \
+            --section "${PACK_DIR}/artifacts/release_decision_v0_ledger_section.html" \
+            --out "${PACK_DIR}/artifacts/report_card.with_release_decision.html"
+
+      - name: Verify final Quality Ledger and status parity
+        id: release_grade_quality_ledger_status_parity
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python "${PACK_DIR}/tools/check_quality_ledger_status_parity.py" \
+            --status "${PACK_DIR}/artifacts/status.json" \
+            --ledger "${PACK_DIR}/artifacts/report_card.html"
+
+          echo "REFERENCE_LEDGER_PARITY_OK=true" >> "$GITHUB_ENV"
+
+      - name: Materialize and verify final release authority artifact binding
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          POLICY_ARGS=(
+            --policy-set required
+            --policy-set release_required
+          )
+
+          python "${PACK_DIR}/tools/build_artifact_provenance_binding_v0.py" \
+            --status "${PACK_DIR}/artifacts/status.json" \
+            --policy "${GITHUB_WORKSPACE}/pulse_gate_policy_v0.yml" \
+            --ledger "${PACK_DIR}/artifacts/report_card.html" \
+            --release-decision "${PACK_DIR}/artifacts/release_decision_v0.json" \
+            --release-authority-manifest "${PACK_DIR}/artifacts/release_authority_v0.json" \
+            --out "${PACK_DIR}/artifacts/artifact_provenance_binding_v0.json" \
+            "${POLICY_ARGS[@]}"
+
+          python "${PACK_DIR}/tools/verify_artifact_provenance_binding_v0.py" \
+            --binding "${PACK_DIR}/artifacts/artifact_provenance_binding_v0.json"
+
+      - name: Stage final release authority audit bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BUNDLE="${PACK_DIR}/artifacts/release_authority_audit_bundle"
+
+          rm -rf "${BUNDLE}"
+          mkdir -p "${BUNDLE}"
+
+          cp "${PACK_DIR}/artifacts/report_card.html" \
+            "${BUNDLE}/report_card.html"
+
+          cp "${PACK_DIR}/artifacts/release_authority_v0.json" \
+            "${BUNDLE}/release_authority_v0.json"
+
+          cp "${PACK_DIR}/artifacts/status.json" \
+            "${BUNDLE}/status.json"
+
+      - name: Export final release-grade JUnit and SARIF
+        shell: bash
+        env:
+          PULSE_EVENT_NAME: ${{ github.event_name }}
+          PULSE_REF: ${{ github.ref }}
+          PULSE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          export PULSE_STATUS="${PACK_DIR}/artifacts/status.json"
+          export PULSE_JUNIT="${PACK_DIR}/artifacts/reports/junit.xml"
+          export PULSE_SARIF="${PACK_DIR}/artifacts/reports/sarif.json"
+
+          mkdir -p "${PACK_DIR}/artifacts/reports" "${PACK_DIR}/artifacts/meta"
+
+          python "${PACK_DIR}/tools/status_to_junit.py"
+
+          mapfile -t REQUIRED_GATES < <(
+            python tools/policy_to_require_args.py \
+              --policy pulse_gate_policy_v0.yml \
+              --set required \
+              --format newline
+          )
+
+          mapfile -t RELEASE_REQUIRED_GATES < <(
+            python tools/policy_to_require_args.py \
+              --policy pulse_gate_policy_v0.yml \
+              --set release_required \
+              --format newline
+          )
+
+          declare -A SEEN=()
+          EFFECTIVE_GATES=()
+
+          for gate in "${REQUIRED_GATES[@]}" "${RELEASE_REQUIRED_GATES[@]}"; do
+            if [[ -n "${gate}" && -z "${SEEN[${gate}]+x}" ]]; then
+              SEEN["${gate}"]=1
+              EFFECTIVE_GATES+=("${gate}")
+            fi
+          done
+
+          if (( ${#EFFECTIVE_GATES[@]} == 0 )); then
+            echo "::error::release-grade SARIF gate set is empty"
+            exit 1
+          fi
+
+          python "${PACK_DIR}/tools/status_to_sarif.py" \
+            --require "${EFFECTIVE_GATES[@]}"
+
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          meta = {
+              "event_name": os.environ["PULSE_EVENT_NAME"],
+              "ref": os.environ["PULSE_REF"],
+              "sha": os.environ["PULSE_SHA"],
+              "pr_number": None,
+              "is_fork": False,
+          }
+
+          out = Path(os.environ["PACK_DIR"]) / "artifacts" / "meta" / "sarif_upload.json"
+          out.write_text(json.dumps(meta, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          print(f"Wrote {out}")
+          PY
+
+      - name: Check release-grade reference run qualification (advisory)
+        id: release_grade_reference_qualify
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TOOL="${PACK_DIR}/tools/check_release_grade_reference_run_v0.py"
+          STATUS="${PACK_DIR}/artifacts/status.json"
+          MANIFEST="${PACK_DIR}/artifacts/release_authority_v0.json"
+          REPORT="${PACK_DIR}/artifacts/report_card.html"
+          AUDIT_BUNDLE="${PACK_DIR}/artifacts/release_authority_audit_bundle"
+
+          set +e
+          python "$TOOL" \
+            --status "$STATUS" \
+            --manifest "$MANIFEST" \
+            --report "$REPORT" \
+            --audit-bundle-dir "$AUDIT_BUNDLE"
+          CHECK_RC=$?
+          set -e
+
+          if [[ "$CHECK_RC" -ne 0 ]]; then
+            RESULT="Not qualified (advisory)"
+            echo "::warning::release-grade reference qualification failed; release outcome unchanged"
+            echo "REFERENCE_RUN_QUALIFIED=false" >> "$GITHUB_ENV"
+            echo "qualified=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Release-grade reference run"
+              echo
+              echo "| Field | Value |"
+              echo "|---|---|"
+              echo "| Workflow path | \`${GITHUB_REF}\` / \`${GITHUB_EVENT_NAME}\` |"
+              echo "| Active enforce set | \`required+release_required\` |"
+              echo "| Qualification | \`${RESULT}\` |"
+              echo "| Authority | Advisory / non-normative / non-blocking; release outcome unchanged |"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          RESULT="Qualified"
+          echo "REFERENCE_RUN_QUALIFIED=true" >> "$GITHUB_ENV"
+          echo "qualified=true" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Release-grade reference run"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Workflow path | \`${GITHUB_REF}\` / \`${GITHUB_EVENT_NAME}\` |"
+            echo "| Active enforce set | \`required+release_required\` |"
+            echo "| Qualification | \`${RESULT}\` |"
+            echo "| Authority | Advisory / non-normative / non-blocking; release outcome unchanged |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit 0
+
+      - name: Assemble advisory release-grade reference bundle
+        if: ${{ env.REFERENCE_RUN_QUALIFIED == 'true' && env.REFERENCE_LEDGER_PARITY_OK == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BUNDLE_DIR="${RUNNER_TEMP}/release-grade-reference-run-v0"
+          rm -rf "${BUNDLE_DIR}"
+          mkdir -p "${BUNDLE_DIR}/artifacts" "${BUNDLE_DIR}/reports"
+
+          cp "${PACK_DIR}/artifacts/status.json" \
+            "${BUNDLE_DIR}/artifacts/status.json"
+          cp "${PACK_DIR}/artifacts/report_card.html" \
+            "${BUNDLE_DIR}/artifacts/report_card.html"
+          cp "${PACK_DIR}/artifacts/release_authority_v0.json" \
+            "${BUNDLE_DIR}/artifacts/release_authority_v0.json"
+          cp -a "${PACK_DIR}/artifacts/release_authority_audit_bundle" \
+            "${BUNDLE_DIR}/release-authority-audit-bundle"
+
+          mkdir -p "${BUNDLE_DIR}/artifacts/external"
+          cp "${PACK_DIR}"/artifacts/external/*_summary.json \
+            "${BUNDLE_DIR}/artifacts/external/"
+
+          cp "${PACK_DIR}/artifacts/reports/junit.xml" \
+            "${BUNDLE_DIR}/reports/junit.xml"
+          cp "${PACK_DIR}/artifacts/reports/sarif.json" \
+            "${BUNDLE_DIR}/reports/sarif.json"
+
+          echo "REFERENCE_BUNDLE_DIR=${BUNDLE_DIR}" >> "$GITHUB_ENV"
+
+      - name: Release-grade final artifact postconditions
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          REQUIRED_FILES=(
+            "${PACK_DIR}/artifacts/status.json"
+            "${PACK_DIR}/artifacts/status_baseline.json"
+            "${PACK_DIR}/artifacts/status_summary.md"
+            "${PACK_DIR}/artifacts/status_summary.json"
+            "${PACK_DIR}/artifacts/status_summary_baseline.md"
+            "${PACK_DIR}/artifacts/status_summary_baseline.json"
+            "${PACK_DIR}/artifacts/required_gate_evidence_v0.json"
+            "${PACK_DIR}/artifacts/refusal_delta_summary.json"
+            "${PACK_DIR}/artifacts/recorded_release_candidate_index_v0.json"
+            "${PACK_DIR}/artifacts/release_evidence_input_manifest_v0.json"
+            "${PACK_DIR}/artifacts/recorded_release_evidence_verifier_v0.json"
+            "${PACK_DIR}/artifacts/release_decision_v0.json"
+            "${PACK_DIR}/artifacts/release_decision_v0_ledger_section.html"
+            "${PACK_DIR}/artifacts/report_card.html"
+            "${PACK_DIR}/artifacts/report_card.with_release_decision.html"
+            "${PACK_DIR}/artifacts/release_authority_v0.json"
+            "${PACK_DIR}/artifacts/artifact_provenance_binding_v0.json"
+            "${PACK_DIR}/artifacts/reports/junit.xml"
+            "${PACK_DIR}/artifacts/reports/sarif.json"
+            "${PACK_DIR}/artifacts/external/llamaguard_raw.jsonl"
+            "${PACK_DIR}/artifacts/external/llamaguard_evaluator_manifest_v0.json"
+            "${PACK_DIR}/artifacts/external/llamaguard_summary.json"
+            "${PACK_DIR}/artifacts/external/llamaguard_summary.bundle.json"
+            "${PACK_DIR}/artifacts/external/llamaguard_summary.envelope.json"
+            "${PACK_DIR}/artifacts/external/llamaguard_attestation_verifier_v1.json"
+          )
+
+          for artifact in "${REQUIRED_FILES[@]}"; do
+            if [[ ! -f "${artifact}" || -L "${artifact}" || ! -s "${artifact}" ]]; then
+              echo "::error::final release-grade artifact is missing, empty, or symlinked: ${artifact}"
+              exit 1
+            fi
+
+            sha256sum "${artifact}"
+          done
+
+          if [[ ! -d "${PACK_DIR}/artifacts/recorded_release_candidates" || -L "${PACK_DIR}/artifacts/recorded_release_candidates" ]]; then
+            echo "::error::recorded release candidate directory is missing or symlinked"
+            exit 1
+          fi
+
+          if [[ ! -d "${PACK_DIR}/artifacts/release_authority_audit_bundle" || -L "${PACK_DIR}/artifacts/release_authority_audit_bundle" ]]; then
+            echo "::error::release authority audit bundle is missing or symlinked"
+            exit 1
+          fi
+
+          echo "OK: final release-grade artifact postconditions satisfied"
+
+      - name: Upload final release authority manifest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        with:
+          name: release-authority-v0
+          path: PULSE_safe_pack_v0/artifacts/release_authority_v0.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload final release authority audit bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        with:
+          name: release-authority-audit-bundle
+          path: PULSE_safe_pack_v0/artifacts/release_authority_audit_bundle/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload final release authority artifact binding
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        with:
+          name: release-authority-artifact-binding-v0
+          path: PULSE_safe_pack_v0/artifacts/artifact_provenance_binding_v0.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload final release decision v0 artifact bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        with:
+          name: release-decision-v0
+          path: |
+            PULSE_safe_pack_v0/artifacts/status.json
+            PULSE_safe_pack_v0/artifacts/release_decision_v0.json
+            PULSE_safe_pack_v0/artifacts/release_decision_v0_ledger_section.html
+            PULSE_safe_pack_v0/artifacts/report_card.with_release_decision.html
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload final pulse report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        with:
+          name: pulse-report
+          path: |
+            PULSE_safe_pack_v0/artifacts/**
+            badges/*.svg
+            reports/junit.xml
+            reports/sarif.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload advisory release-grade reference bundle
+        if: ${{ env.REFERENCE_BUNDLE_DIR != '' && env.REFERENCE_RUN_QUALIFIED == 'true' && env.REFERENCE_LEDGER_PARITY_OK == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
+        with:
+          name: release-grade-reference-run-v0
+          path: ${{ env.REFERENCE_BUNDLE_DIR }}
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Upload release-grade recorded path artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pinned
@@ -2706,12 +3209,26 @@ jobs:
           path: |
             PULSE_safe_pack_v0/artifacts/status.json
             PULSE_safe_pack_v0/artifacts/status_baseline.json
+            PULSE_safe_pack_v0/artifacts/status_summary.md
+            PULSE_safe_pack_v0/artifacts/status_summary.json
+            PULSE_safe_pack_v0/artifacts/status_summary_baseline.md
+            PULSE_safe_pack_v0/artifacts/status_summary_baseline.json
             PULSE_safe_pack_v0/artifacts/required_gate_evidence_v0.json
+            PULSE_safe_pack_v0/artifacts/self_contained_pulse_evidence_floor_v0.json
             PULSE_safe_pack_v0/artifacts/refusal_delta_summary.json
             PULSE_safe_pack_v0/artifacts/recorded_release_candidates/**
             PULSE_safe_pack_v0/artifacts/recorded_release_candidate_index_v0.json
             PULSE_safe_pack_v0/artifacts/release_evidence_input_manifest_v0.json
             PULSE_safe_pack_v0/artifacts/recorded_release_evidence_verifier_v0.json
+            PULSE_safe_pack_v0/artifacts/release_decision_v0.json
+            PULSE_safe_pack_v0/artifacts/release_decision_v0_ledger_section.html
+            PULSE_safe_pack_v0/artifacts/report_card.html
+            PULSE_safe_pack_v0/artifacts/report_card.with_release_decision.html
+            PULSE_safe_pack_v0/artifacts/release_authority_v0.json
+            PULSE_safe_pack_v0/artifacts/artifact_provenance_binding_v0.json
+            PULSE_safe_pack_v0/artifacts/release_authority_audit_bundle/**
+            PULSE_safe_pack_v0/artifacts/reports/junit.xml
+            PULSE_safe_pack_v0/artifacts/reports/sarif.json
             PULSE_safe_pack_v0/artifacts/external/llamaguard_raw.jsonl
             PULSE_safe_pack_v0/artifacts/external/llamaguard_evaluator_manifest_v0.json
             PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.json
@@ -2720,11 +3237,49 @@ jobs:
             PULSE_safe_pack_v0/artifacts/external/llamaguard_attestation_verifier_v1.json
           if-no-files-found: error
           retention-days: 30
-  
+
+  attest_release_grade_artifact_binding:
+    name: "Release-grade artifact binding v0: attest"
+    needs: release_grade_recorded_path
+    if: ${{ github.event_name != 'pull_request' && needs.release_grade_recorded_path.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true' && github.event.inputs.llamaguard_evidence_mode == 'hosted_full_runtime')) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+
+    steps:
+      - name: Download final release-grade artifact binding
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p attestation-subject
+
+          gh run download "${GITHUB_RUN_ID}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --name "release-authority-artifact-binding-v0" \
+            --dir "attestation-subject"
+
+          test -f "attestation-subject/artifact_provenance_binding_v0.json"
+
+          sha256sum "attestation-subject/artifact_provenance_binding_v0.json"
+
+      - name: Attest final release-grade artifact binding v0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+        with:
+          subject-path: attestation-subject/artifact_provenance_binding_v0.json
+          show-summary: true
+
   assemble_release_grade_reference_package:
     name: "Release-grade reference package: assemble complete package"
-    needs: release_grade_recorded_path
-    if: ${{ github.event_name != 'pull_request' && needs.release_grade_recorded_path.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true' && github.event.inputs.llamaguard_evidence_mode == 'hosted_full_runtime')) }}   
+    needs: [release_grade_recorded_path, attest_release_grade_artifact_binding]
+    if: ${{ github.event_name != 'pull_request' && needs.release_grade_recorded_path.result == 'success' && needs.attest_release_grade_artifact_binding.result == 'success' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/V') || (github.event_name == 'workflow_dispatch' && github.event.inputs.strict_external_evidence == 'true' && github.event.inputs.llamaguard_evidence_mode == 'hosted_full_runtime')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -2866,7 +3421,7 @@ jobs:
           path: ${{ runner.temp }}/complete-release-grade-reference-package/
           if-no-files-found: error
           retention-days: 30
-  
+
   verify_release_grade_reference_package:
     name: "Release-grade reference package: verify complete package"
     needs: assemble_release_grade_reference_package

--- a/tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
+++ b/tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
 from pathlib import Path
 
 
@@ -6,17 +9,24 @@ WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pulse_ci.yml"
 TOOLS_TESTS_LIST = REPO_ROOT / "ci" / "tools-tests.list"
 
 ATTEST_SHA = "59d89421af93a897026c735860bf21b6eb4f7b26"
-EXPECTED_ATTEST_IF = (
-    "${{ github.event_name != 'pull_request' && needs.pulse.result == 'success' }}"
-)
+
+CORE_ATTEST_JOB = "attest_release_authority_artifact_binding"
+RELEASE_ATTEST_JOB = "attest_release_grade_artifact_binding"
+RELEASE_PATH_JOB = "release_grade_recorded_path"
 
 
 def read_workflow() -> str:
-    return WORKFLOW.read_text(encoding="utf-8")
+    return WORKFLOW.read_text(
+        encoding="utf-8",
+        errors="strict",
+    )
 
 
 def read_tools_tests_list() -> str:
-    return TOOLS_TESTS_LIST.read_text(encoding="utf-8")
+    return TOOLS_TESTS_LIST.read_text(
+        encoding="utf-8",
+        errors="strict",
+    )
 
 
 def top_level_job_blocks(text: str) -> dict[str, str]:
@@ -24,104 +34,138 @@ def top_level_job_blocks(text: str) -> dict[str, str]:
     offset = 0
 
     for line in text.splitlines(keepends=True):
-        if line.startswith("  ") and not line.startswith("    ") and line.strip().endswith(":"):
+        if (
+            line.startswith("  ")
+            and not line.startswith("    ")
+            and line.strip().endswith(":")
+        ):
             starts.append((line.strip()[:-1], offset))
+
         offset += len(line)
 
     blocks: dict[str, str] = {}
-    for idx, (name, start) in enumerate(starts):
-        end = starts[idx + 1][1] if idx + 1 < len(starts) else len(text)
+
+    for index, (name, start) in enumerate(starts):
+        end = (
+            starts[index + 1][1]
+            if index + 1 < len(starts)
+            else len(text)
+        )
         blocks[name] = text[start:end]
 
     return blocks
 
 
-def workflow_blocks() -> tuple[str, str, dict[str, str]]:
-    text = read_workflow()
-    blocks = top_level_job_blocks(text)
-
-    assert "pulse" in blocks
-    assert "attest_release_authority_artifact_binding" in blocks
-    assert "tools-tests" in blocks
-
-    return blocks["pulse"], blocks["attest_release_authority_artifact_binding"], blocks
-
-
 def job_field(job_block: str, field_name: str) -> str:
     prefix = f"    {field_name}:"
+
     for line in job_block.splitlines():
         if line.startswith(prefix):
             return line.split(":", 1)[1].strip()
+
     raise AssertionError(f"missing job field: {field_name}")
 
 
-def test_pulse_job_remains_read_only_for_attestation_credentials() -> None:
-    pulse_block, _attest_block, _blocks = workflow_blocks()
-
-    assert "permissions:" in pulse_block
-    assert "contents: read" in pulse_block
-
-    assert "id-token: write" not in pulse_block
-    assert "attestations: write" not in pulse_block
-    assert "artifact-metadata: write" not in pulse_block
-
-
-def test_attestation_job_declares_isolated_write_permissions() -> None:
-    _pulse_block, attest_block, _blocks = workflow_blocks()
-
-    assert "permissions:" in attest_block
-    assert "contents: read" in attest_block
-    assert "actions: read" in attest_block
-    assert "id-token: write" in attest_block
-    assert "attestations: write" in attest_block
-    assert "artifact-metadata: write" in attest_block
-
-
-def test_attestation_job_has_exact_combined_guard() -> None:
-    _pulse_block, attest_block, _blocks = workflow_blocks()
-
-    assert job_field(attest_block, "needs") == "pulse"
-    assert job_field(attest_block, "if") == EXPECTED_ATTEST_IF
-
-
-def test_attestation_job_downloads_uploaded_binding_artifact() -> None:
-    _pulse_block, attest_block, _blocks = workflow_blocks()
-
-    assert 'gh run download "${GITHUB_RUN_ID}"' in attest_block
-    assert '--repo "${GITHUB_REPOSITORY}"' in attest_block
-    assert '--name "release-authority-artifact-binding-v0"' in attest_block
-    assert '--dir "attestation-subject"' in attest_block
-    assert 'test -f "attestation-subject/artifact_provenance_binding_v0.json"' in attest_block
-    assert 'sha256sum "attestation-subject/artifact_provenance_binding_v0.json"' in attest_block
-
-
-def test_download_step_runs_before_attestation_action() -> None:
-    _pulse_block, attest_block, _blocks = workflow_blocks()
-
-    download_step_idx = attest_block.index(
-        "- name: Download verified release authority artifact binding"
-    )
-    download_cmd_idx = attest_block.index('gh run download "${GITHUB_RUN_ID}"')
-    repo_arg_idx = attest_block.index('--repo "${GITHUB_REPOSITORY}"')
-    file_check_idx = attest_block.index(
-        'test -f "attestation-subject/artifact_provenance_binding_v0.json"'
-    )
-    attest_step_idx = attest_block.index("- name: Attest release authority artifact binding v0")
-    attest_action_idx = attest_block.index(f"uses: actions/attest@{ATTEST_SHA}")
-
-    assert (
-        download_step_idx
-        < download_cmd_idx
-        < repo_arg_idx
-        < file_check_idx
-        < attest_step_idx
-        < attest_action_idx
-    )
-
-
-def test_attestation_action_is_pinned_to_immutable_sha() -> None:
+def workflow_blocks() -> tuple[str, dict[str, str]]:
     text = read_workflow()
-    _pulse_block, attest_block, blocks = workflow_blocks()
+    blocks = top_level_job_blocks(text)
+
+    for name in (
+        "pulse",
+        CORE_ATTEST_JOB,
+        "attest_llamaguard_current_run_summary",
+        RELEASE_PATH_JOB,
+        RELEASE_ATTEST_JOB,
+        "assemble_release_grade_reference_package",
+        "tools-tests",
+    ):
+        assert name in blocks, name
+
+    return text, blocks
+
+
+def assert_attestation_permissions(job: str) -> None:
+    assert "permissions:" in job
+    assert "contents: read" in job
+    assert "actions: read" in job
+    assert "id-token: write" in job
+    assert "attestations: write" in job
+    assert "artifact-metadata: write" in job
+
+
+def assert_binding_download_and_attestation(job: str) -> None:
+    assert 'gh run download "${GITHUB_RUN_ID}"' in job
+    assert '--repo "${GITHUB_REPOSITORY}"' in job
+    assert '--name "release-authority-artifact-binding-v0"' in job
+    assert "artifact_provenance_binding_v0.json" in job
+    assert f"uses: actions/attest@{ATTEST_SHA}" in job
+    assert (
+        "subject-path: "
+        "attestation-subject/artifact_provenance_binding_v0.json"
+        in job
+    )
+    assert "show-summary: true" in job
+
+
+def test_pulse_job_remains_read_only_for_attestation_credentials() -> None:
+    _text, blocks = workflow_blocks()
+    pulse = blocks["pulse"]
+
+    assert "permissions:" in pulse
+    assert "contents: read" in pulse
+    assert "id-token: write" not in pulse
+    assert "attestations: write" not in pulse
+    assert "artifact-metadata: write" not in pulse
+
+
+def test_core_binding_attestation_remains_non_release_only() -> None:
+    _text, blocks = workflow_blocks()
+    job = blocks[CORE_ATTEST_JOB]
+
+    assert job_field(job, "needs") == "pulse"
+
+    guard = job_field(job, "if")
+
+    for token in (
+        "github.event_name != 'pull_request'",
+        "needs.pulse.result == 'success'",
+        "!startsWith(github.ref, 'refs/tags/v')",
+        "!startsWith(github.ref, 'refs/tags/V')",
+        (
+            "github.event_name != 'workflow_dispatch' || "
+            "github.event.inputs.strict_external_evidence != 'true'"
+        ),
+    ):
+        assert token in guard, token
+
+    assert_attestation_permissions(job)
+    assert_binding_download_and_attestation(job)
+
+
+def test_release_binding_attestation_waits_for_recorded_path() -> None:
+    _text, blocks = workflow_blocks()
+    job = blocks[RELEASE_ATTEST_JOB]
+
+    assert job_field(job, "needs") == RELEASE_PATH_JOB
+
+    guard = job_field(job, "if")
+
+    for token in (
+        "github.event_name != 'pull_request'",
+        "needs.release_grade_recorded_path.result == 'success'",
+        "strict_external_evidence == 'true'",
+        "hosted_full_runtime",
+        "startsWith(github.ref, 'refs/tags/v')",
+        "startsWith(github.ref, 'refs/tags/V')",
+    ):
+        assert token in guard, token
+
+    assert_attestation_permissions(job)
+    assert_binding_download_and_attestation(job)
+
+
+def test_all_attestation_actions_use_immutable_pin() -> None:
+    text = read_workflow()
 
     uses_lines = [
         line.strip()
@@ -129,77 +173,123 @@ def test_attestation_action_is_pinned_to_immutable_sha() -> None:
         if line.strip().startswith("uses: actions/attest@")
     ]
 
-    assert uses_lines, "workflow must contain at least one actions/attest use"
+    assert uses_lines
     assert all(
         line == f"uses: actions/attest@{ATTEST_SHA}"
         for line in uses_lines
     ), uses_lines
 
-    assert f"uses: actions/attest@{ATTEST_SHA}" in attest_block
 
-    for job_name, block in blocks.items():
-        if "uses: actions/attest@" in block:
-            assert f"uses: actions/attest@{ATTEST_SHA}" in block, job_name
+def test_release_binding_is_materialized_before_release_attestation() -> None:
+    text, blocks = workflow_blocks()
+    recorded = blocks[RELEASE_PATH_JOB]
 
-    assert "uses: actions/attest@v4.1.0" not in text
-    assert "uses: actions/attest@v4" not in text
-
-
-def test_attestation_subject_is_release_authority_binding_carrier() -> None:
-    _pulse_block, attest_block, _blocks = workflow_blocks()
-
-    assert "subject-path: attestation-subject/artifact_provenance_binding_v0.json" in attest_block
-    assert "show-summary: true" in attest_block
-
-
-def test_attestation_job_is_separate_job_between_pulse_and_tools_tests() -> None:
-    text = read_workflow()
-
-    pulse_idx = text.index("  pulse:")
-    attest_idx = text.index("  attest_release_authority_artifact_binding:")
-    tools_idx = text.index("  tools-tests:")
-
-    assert pulse_idx < attest_idx < tools_idx
-
-
-def test_binding_materialization_upload_precede_attestation_job() -> None:
-    text = read_workflow()
-
-    materialize_idx = text.index(
-        'Release authority artifact binding v0: materialize and verify'
+    materialize = recorded.index(
+        "Materialize and verify final release authority artifact binding"
     )
-    upload_idx = text.index("Upload release authority artifact binding v0")
-    attest_job_idx = text.index("  attest_release_authority_artifact_binding:")
+    upload = recorded.index(
+        "Upload final release authority artifact binding"
+    )
 
-    assert materialize_idx < upload_idx < attest_job_idx
+    assert materialize < upload
+
+    recorded_index = text.index(f"  {RELEASE_PATH_JOB}:")
+    attest_index = text.index(f"  {RELEASE_ATTEST_JOB}:")
+
+    assert recorded_index < attest_index
 
 
-def test_inline_attestation_step_is_not_present_in_pulse_job() -> None:
-    pulse_block, _attest_block, _blocks = workflow_blocks()
+def test_core_binding_is_materialized_before_core_attestation() -> None:
+    text, blocks = workflow_blocks()
+    pulse = blocks["pulse"]
 
-    assert 'Release authority artifact binding v0: attest' not in pulse_block
-    assert "uses: actions/attest@" not in pulse_block
+    materialize = pulse.index(
+        "Release authority artifact binding v0: materialize and verify"
+    )
+    upload = pulse.index(
+        "Upload release authority artifact binding v0"
+    )
+
+    assert materialize < upload
+
+    pulse_index = text.index("  pulse:")
+    attest_index = text.index(f"  {CORE_ATTEST_JOB}:")
+
+    assert pulse_index < attest_index
+
+
+def test_attestation_jobs_are_isolated_from_producer_jobs() -> None:
+    _text, blocks = workflow_blocks()
+
+    pulse = blocks["pulse"]
+    recorded = blocks[RELEASE_PATH_JOB]
+
+    assert "uses: actions/attest@" not in pulse
+    assert "uses: actions/attest@" not in recorded
+
+    assert (
+        "Release authority artifact binding v0: attest"
+        not in pulse
+    )
+    assert (
+        "Attest final release-grade artifact binding v0"
+        not in recorded
+    )
+
+
+def test_job_order_preserves_phase_boundary() -> None:
+    text, _blocks = workflow_blocks()
+
+    pulse_index = text.index("  pulse:")
+    core_attest_index = text.index(f"  {CORE_ATTEST_JOB}:")
+    llama_attest_index = text.index(
+        "  attest_llamaguard_current_run_summary:"
+    )
+    recorded_index = text.index(f"  {RELEASE_PATH_JOB}:")
+    release_attest_index = text.index(
+        f"  {RELEASE_ATTEST_JOB}:"
+    )
+    package_index = text.index(
+        "  assemble_release_grade_reference_package:"
+    )
+    tools_index = text.index("  tools-tests:")
+
+    assert pulse_index < core_attest_index < tools_index
+    assert (
+        pulse_index
+        < llama_attest_index
+        < recorded_index
+        < release_attest_index
+        < package_index
+        < tools_index
+    )
 
 
 def test_attestation_smoke_is_registered_in_tools_manifest() -> None:
     manifest = read_tools_tests_list()
 
-    assert "tests/test_artifact_provenance_binding_attestation_wiring_smoke.py" in manifest
+    assert (
+        "tests/"
+        "test_artifact_provenance_binding_attestation_wiring_smoke.py"
+        in manifest
+    )
 
 
 def main() -> int:
     test_pulse_job_remains_read_only_for_attestation_credentials()
-    test_attestation_job_declares_isolated_write_permissions()
-    test_attestation_job_has_exact_combined_guard()
-    test_attestation_job_downloads_uploaded_binding_artifact()
-    test_download_step_runs_before_attestation_action()
-    test_attestation_action_is_pinned_to_immutable_sha()
-    test_attestation_subject_is_release_authority_binding_carrier()
-    test_attestation_job_is_separate_job_between_pulse_and_tools_tests()
-    test_binding_materialization_upload_precede_attestation_job()
-    test_inline_attestation_step_is_not_present_in_pulse_job()
+    test_core_binding_attestation_remains_non_release_only()
+    test_release_binding_attestation_waits_for_recorded_path()
+    test_all_attestation_actions_use_immutable_pin()
+    test_release_binding_is_materialized_before_release_attestation()
+    test_core_binding_is_materialized_before_core_attestation()
+    test_attestation_jobs_are_isolated_from_producer_jobs()
+    test_job_order_preserves_phase_boundary()
     test_attestation_smoke_is_registered_in_tools_manifest()
-    print("artifact provenance binding attestation wiring smoke passed")
+
+    print(
+        "OK: core and release-grade artifact-binding "
+        "attestation phase boundaries locked"
+    )
     return 0
 
 

--- a/tests/test_llamaguard_attested_release_path_wiring_v0.py
+++ b/tests/test_llamaguard_attested_release_path_wiring_v0.py
@@ -10,17 +10,23 @@ TOOLS_TESTS_LIST = REPO_ROOT / "ci" / "tools-tests.list"
 
 ATTEST_JOB = "attest_llamaguard_current_run_summary"
 RELEASE_PATH_JOB = "release_grade_recorded_path"
+RELEASE_BINDING_ATTEST_JOB = "attest_release_grade_artifact_binding"
 PACKAGE_JOB = "assemble_release_grade_reference_package"
 VERIFY_JOB = "verify_release_grade_reference_package"
 
-PRE_ATTESTATION_ARTIFACT = (
+PRE_ATTESTATION_UPLOAD_ARTIFACT = (
     "pulse-pre-attestation-"
     "${{ github.run_id }}-${{ github.run_attempt }}"
 )
 
-ATTESTED_ARTIFACT = (
+PRE_ATTESTATION_DOWNLOAD_ARTIFACT = (
+    "pulse-pre-attestation-"
+    "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+)
+
+ATTESTED_DOWNLOAD_ARTIFACT = (
     "llamaguard-attested-current-run-"
-    "${{ github.run_id }}-${{ github.run_attempt }}"
+    "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 )
 
 HOSTED_MODE_GUARD_TOKEN = (
@@ -36,13 +42,6 @@ PRE_ATTESTATION_RELEASE_TOOLS = (
     "tools/build_release_evidence_input_manifest_v0.py",
     "tools/check_recorded_release_evidence_v0.py",
     "tools/materialize_release_required_from_verifier_v0.py",
-)
-
-FINAL_AUTHORITY_TOOLS = (
-    "tools/check_gates.py",
-    "tools/materialize_release_decision.py",
-    "tools/build_release_authority_manifest_v0.py",
-    "tools/build_artifact_provenance_binding_v0.py",
 )
 
 ATTESTED_EXTERNAL_ARTIFACT_PATHS = (
@@ -146,7 +145,7 @@ def _workflow_and_jobs() -> tuple[str, dict[str, str]]:
         "pulse",
         ATTEST_JOB,
         RELEASE_PATH_JOB,
-        "attest_release_grade_artifact_binding",
+        RELEASE_BINDING_ATTEST_JOB,
         PACKAGE_JOB,
         VERIFY_JOB,
         "tools-tests",
@@ -166,7 +165,7 @@ def test_release_grade_job_order() -> None:
     attest_index = text.index(f"  {ATTEST_JOB}:")
     release_path_index = text.index(f"  {RELEASE_PATH_JOB}:")
     binding_attest_index = text.index(
-        "  attest_release_grade_artifact_binding:"
+        f"  {RELEASE_BINDING_ATTEST_JOB}:"
     )
     package_index = text.index(f"  {PACKAGE_JOB}:")
     verify_index = text.index(f"  {VERIFY_JOB}:")
@@ -215,7 +214,7 @@ def test_pre_attestation_artifact_is_uploaded_fail_closed() -> None:
         "Upload release-grade pre-attestation pulse artifacts",
     )
 
-    assert PRE_ATTESTATION_ARTIFACT in upload
+    assert PRE_ATTESTATION_UPLOAD_ARTIFACT in upload
     assert "if-no-files-found: error" in upload
     assert "retention-days: 30" in upload
 
@@ -244,7 +243,7 @@ def test_recorded_path_downloads_pre_attestation_artifact() -> None:
         "Download pre-attestation pulse artifacts",
     )
 
-    assert PRE_ATTESTATION_ARTIFACT in download
+    assert PRE_ATTESTATION_DOWNLOAD_ARTIFACT in download
     assert '--repo "${GITHUB_REPOSITORY}"' in download
 
     for required in (
@@ -294,7 +293,7 @@ def test_recorded_path_restores_attested_evidence_before_verification() -> None:
     _text, blocks = _workflow_and_jobs()
     job = blocks[RELEASE_PATH_JOB]
 
-    artifact_index = job.index(ATTESTED_ARTIFACT)
+    artifact_index = job.index(ATTESTED_DOWNLOAD_ARTIFACT)
 
     for artifact_path in ATTESTED_EXTERNAL_ARTIFACT_PATHS:
         assert artifact_index < job.index(artifact_path)
@@ -414,10 +413,29 @@ def test_release_path_does_not_introduce_parallel_decision_engines() -> None:
 def test_downstream_package_dependency_chain_is_preserved() -> None:
     _text, blocks = _workflow_and_jobs()
 
+    package = blocks[PACKAGE_JOB]
+
     assert _job_field(
-        blocks[PACKAGE_JOB],
+        package,
         "needs",
-    ) == RELEASE_PATH_JOB
+    ) == (
+        "[release_grade_recorded_path, "
+        "attest_release_grade_artifact_binding]"
+    )
+
+    package_guard = _job_field(
+        package,
+        "if",
+    )
+
+    for token in (
+        "needs.release_grade_recorded_path.result == 'success'",
+        (
+            "needs.attest_release_grade_artifact_binding.result "
+            "== 'success'"
+        ),
+    ):
+        assert token in package_guard, token
 
     assert _job_field(
         blocks[VERIFY_JOB],

--- a/tests/test_llamaguard_attested_release_path_wiring_v0.py
+++ b/tests/test_llamaguard_attested_release_path_wiring_v0.py
@@ -12,21 +12,23 @@ ATTEST_JOB = "attest_llamaguard_current_run_summary"
 RELEASE_PATH_JOB = "release_grade_recorded_path"
 PACKAGE_JOB = "assemble_release_grade_reference_package"
 VERIFY_JOB = "verify_release_grade_reference_package"
+
+PRE_ATTESTATION_ARTIFACT = (
+    "pulse-pre-attestation-"
+    "${{ github.run_id }}-${{ github.run_attempt }}"
+)
+
 ATTESTED_ARTIFACT = (
     "llamaguard-attested-current-run-"
     "${{ github.run_id }}-${{ github.run_attempt }}"
 )
+
 HOSTED_MODE_GUARD_TOKEN = (
     "github.event.inputs.llamaguard_evidence_mode == 'hosted_full_runtime'"
 )
 
-STRICT_RELEASE_GUARD_TOKENS = (
-    "github.event_name != 'pull_request'",
-    "needs.attest_llamaguard_current_run_summary.result == 'success'",
-    "strict_external_evidence == 'true'",
-    "startsWith(github.ref, 'refs/tags/v')",
-    "startsWith(github.ref, 'refs/tags/V')",
-    HOSTED_MODE_GUARD_TOKEN,
+NON_RELEASE_STEP_GUARD = (
+    "steps.release_mode.outputs.is_release != '1'"
 )
 
 PRE_ATTESTATION_RELEASE_TOOLS = (
@@ -36,9 +38,11 @@ PRE_ATTESTATION_RELEASE_TOOLS = (
     "tools/materialize_release_required_from_verifier_v0.py",
 )
 
-RELEASE_PATH_TOOLS = (
-    *PRE_ATTESTATION_RELEASE_TOOLS,
+FINAL_AUTHORITY_TOOLS = (
     "tools/check_gates.py",
+    "tools/materialize_release_decision.py",
+    "tools/build_release_authority_manifest_v0.py",
+    "tools/build_artifact_provenance_binding_v0.py",
 )
 
 ATTESTED_EXTERNAL_ARTIFACT_PATHS = (
@@ -116,31 +120,53 @@ def _job_field(job_block: str, field_name: str) -> str:
     raise AssertionError(f"missing job field: {field_name}")
 
 
+def _step_block(job_block: str, step_name: str) -> str:
+    marker = f"      - name: {step_name}"
+    start = job_block.find(marker)
+
+    if start < 0:
+        raise AssertionError(f"missing workflow step: {step_name}")
+
+    next_start = job_block.find(
+        "\n      - name:",
+        start + len(marker),
+    )
+
+    if next_start < 0:
+        return job_block[start:]
+
+    return job_block[start:next_start]
+
+
 def _workflow_and_jobs() -> tuple[str, dict[str, str]]:
     text = _read_workflow()
     blocks = _top_level_job_blocks(text)
 
-    for name in (
+    required_jobs = (
         "pulse",
         ATTEST_JOB,
         RELEASE_PATH_JOB,
+        "attest_release_grade_artifact_binding",
         PACKAGE_JOB,
         VERIFY_JOB,
         "tools-tests",
-    ):
+    )
+
+    for name in required_jobs:
         if name not in blocks:
             raise AssertionError(f"missing workflow job: {name}")
 
     return text, blocks
 
 
-def test_attested_release_path_job_order() -> None:
+def test_release_grade_job_order() -> None:
     text, _blocks = _workflow_and_jobs()
 
     pulse_index = text.index("  pulse:")
     attest_index = text.index(f"  {ATTEST_JOB}:")
-    release_path_index = text.index(
-        f"  {RELEASE_PATH_JOB}:"
+    release_path_index = text.index(f"  {RELEASE_PATH_JOB}:")
+    binding_attest_index = text.index(
+        "  attest_release_grade_artifact_binding:"
     )
     package_index = text.index(f"  {PACKAGE_JOB}:")
     verify_index = text.index(f"  {VERIFY_JOB}:")
@@ -150,6 +176,7 @@ def test_attested_release_path_job_order() -> None:
         pulse_index
         < attest_index
         < release_path_index
+        < binding_attest_index
         < package_index
         < verify_index
         < tools_index
@@ -159,6 +186,9 @@ def test_attested_release_path_job_order() -> None:
 def test_attestation_job_is_hosted_external_model_only() -> None:
     _text, blocks = _workflow_and_jobs()
     job = blocks[ATTEST_JOB]
+
+    assert _job_field(job, "needs") == "pulse"
+
     guard = _job_field(job, "if")
 
     for token in (
@@ -172,157 +202,235 @@ def test_attestation_job_is_hosted_external_model_only() -> None:
         assert token in guard, token
 
 
-def test_release_path_depends_on_attested_llamaguard_job() -> None:
+def test_pre_attestation_artifact_is_uploaded_fail_closed() -> None:
+    _text, blocks = _workflow_and_jobs()
+    pulse = blocks["pulse"]
+
+    postconditions = _step_block(
+        pulse,
+        "release-grade pre-attestation artifact postconditions",
+    )
+    upload = _step_block(
+        pulse,
+        "Upload release-grade pre-attestation pulse artifacts",
+    )
+
+    assert PRE_ATTESTATION_ARTIFACT in upload
+    assert "if-no-files-found: error" in upload
+    assert "retention-days: 30" in upload
+
+    for required in (
+        "status.json",
+        "status_baseline.json",
+        "status_summary_baseline.md",
+        "status_summary_baseline.json",
+        "required_gate_evidence_v0.json",
+        "self_contained_pulse_evidence_floor_v0.json",
+        "refusal_delta_summary.json",
+        "llamaguard_raw.jsonl",
+        "llamaguard_evaluator_manifest_v0.json",
+        "llamaguard_summary.json",
+    ):
+        assert required in postconditions, required
+        assert required in upload, required
+
+
+def test_recorded_path_downloads_pre_attestation_artifact() -> None:
     _text, blocks = _workflow_and_jobs()
     job = blocks[RELEASE_PATH_JOB]
 
-    assert _job_field(job, "needs") == ATTEST_JOB
-
-    guard = _job_field(job, "if")
-
-    for token in STRICT_RELEASE_GUARD_TOKENS:
-        assert token in guard, token
-
-
-def test_tools_tests_is_downstream_of_release_path_via_package_verifier() -> None:
-    _text, blocks = _workflow_and_jobs()
-
-    assert _job_field(blocks[PACKAGE_JOB], "needs") == (
-        RELEASE_PATH_JOB
-    )
-    assert _job_field(blocks[VERIFY_JOB], "needs") == (
-        PACKAGE_JOB
-    )
-    assert _job_field(blocks["tools-tests"], "needs") == (
-        VERIFY_JOB
+    download = _step_block(
+        job,
+        "Download pre-attestation pulse artifacts",
     )
 
+    assert PRE_ATTESTATION_ARTIFACT in download
+    assert '--repo "${GITHUB_REPOSITORY}"' in download
 
-def test_release_grade_candidate_path_runs_only_after_attestation() -> None:
+    for required in (
+        "status.json",
+        "status_baseline.json",
+        "status_summary_baseline.md",
+        "status_summary_baseline.json",
+        "required_gate_evidence_v0.json",
+        "self_contained_pulse_evidence_floor_v0.json",
+        "refusal_delta_summary.json",
+    ):
+        assert required in download, required
+
+
+def test_release_grade_candidate_tools_remain_after_attestation() -> None:
     _text, blocks = _workflow_and_jobs()
     pulse = blocks["pulse"]
+    recorded = blocks[RELEASE_PATH_JOB]
 
     for tool in PRE_ATTESTATION_RELEASE_TOOLS:
-        if tool in pulse:
-            raise AssertionError(
-                "release-grade candidate/verifier/materializer "
-                "path must not run in the pre-attestation pulse "
-                f"job: {tool}"
-            )
+        assert tool not in pulse, tool
+        assert tool in recorded, tool
 
 
-def test_core_check_gates_remains_allowed_in_pulse_job() -> None:
+def test_pre_attestation_final_authority_steps_are_core_only() -> None:
     _text, blocks = _workflow_and_jobs()
     pulse = blocks["pulse"]
 
-    assert "tools/check_gates.py" in pulse
-    assert "ci: enforce gates via check_gates (policy-derived)" in pulse
+    step_names = (
+        "Build release authority manifest (audit-only)",
+        '"ci: enforce gates via check_gates (policy-derived)"',
+        '"Release decision v0: materialize artifact"',
+        (
+            '"Release authority artifact binding v0: '
+            'materialize and verify"'
+        ),
+        "Export JUnit and SARIF from final status",
+        "Upload artifacts",
+    )
+
+    for step_name in step_names:
+        block = _step_block(pulse, step_name)
+        assert NON_RELEASE_STEP_GUARD in block, step_name
 
 
-def test_release_path_downloads_attested_external_evidence_first() -> None:
+def test_recorded_path_restores_attested_evidence_before_verification() -> None:
     _text, blocks = _workflow_and_jobs()
     job = blocks[RELEASE_PATH_JOB]
 
-    download_index = job.index(
-        "Download attested LlamaGuard external evidence"
-    )
     artifact_index = job.index(ATTESTED_ARTIFACT)
 
-    assert download_index < artifact_index
-
     for artifact_path in ATTESTED_EXTERNAL_ARTIFACT_PATHS:
-        restored_index = job.index(artifact_path)
-        assert artifact_index < restored_index
+        assert artifact_index < job.index(artifact_path)
 
-    first_release_tool_index = min(
+    first_tool_index = min(
         job.index(tool)
-        for tool in RELEASE_PATH_TOOLS
+        for tool in PRE_ATTESTATION_RELEASE_TOOLS
     )
 
     for artifact_path in ATTESTED_EXTERNAL_ARTIFACT_PATHS:
-        assert job.index(artifact_path) < first_release_tool_index
+        assert job.index(artifact_path) < first_tool_index
 
 
-def test_release_path_uses_existing_standing_tools_in_order() -> None:
+def test_recorded_path_materializes_before_combined_enforcement() -> None:
     _text, blocks = _workflow_and_jobs()
     job = blocks[RELEASE_PATH_JOB]
+
+    materializer = job.index(
+        "tools/materialize_release_required_from_verifier_v0.py"
+    )
+    schema = job.index("release_grade_status_v1.schema.json")
+    no_stub = job.index("ci/check_release_no_stub_status.py")
+    enforcement = job.index(
+        "release-grade enforce required and release-required gates"
+    )
+
+    assert materializer < schema < no_stub < enforcement
+
+    enforcement_block = _step_block(
+        job,
+        "release-grade enforce required and release-required gates via check_gates",
+    )
+
+    for token in (
+        "--set required",
+        "--set release_required",
+        "EFFECTIVE_GATES",
+        "tools/check_gates.py",
+        '--status "${STATUS}"',
+        '--require "${EFFECTIVE_GATES[@]}"',
+    ):
+        assert token in enforcement_block, token
+
+
+def test_final_authority_artifacts_follow_gate_enforcement() -> None:
+    _text, blocks = _workflow_and_jobs()
+    job = blocks[RELEASE_PATH_JOB]
+
+    enforcement = job.index(
+        "release-grade enforce required and release-required gates"
+    )
+
+    ordered_steps = (
+        "Render final release-grade Quality Ledger",
+        "Export final release-grade status summary",
+        "Materialize final release decision v0",
+        "Build and verify final release authority manifest",
+        "Verify final Quality Ledger and status parity",
+        (
+            "Materialize and verify final release authority "
+            "artifact binding"
+        ),
+        "Stage final release authority audit bundle",
+        "Release-grade final artifact postconditions",
+    )
 
     positions = [
-        job.index(tool)
-        for tool in RELEASE_PATH_TOOLS
+        job.index(f"      - name: {name}")
+        for name in ordered_steps
     ]
 
-    assert positions == sorted(positions), positions
+    assert enforcement < positions[0]
+    assert positions == sorted(positions)
 
 
-def test_release_path_does_not_introduce_parallel_engines() -> None:
+def test_recorded_path_uploads_final_package_inputs() -> None:
     _text, blocks = _workflow_and_jobs()
     job = blocks[RELEASE_PATH_JOB]
 
-    forbidden = (
+    for artifact_name in (
+        "release-authority-v0",
+        "release-authority-audit-bundle",
+        "release-authority-artifact-binding-v0",
+        "release-decision-v0",
+        "pulse-report",
+        (
+            "release-grade-recorded-path-"
+            "${{ github.run_id }}-${{ github.run_attempt }}"
+        ),
+    ):
+        assert artifact_name in job, artifact_name
+
+    for required_path in (
+        "release_decision_v0.json",
+        "artifact_provenance_binding_v0.json",
+        "release_authority_v0.json",
+        "report_card.html",
+        "recorded_release_evidence_verifier_v0.json",
+    ):
+        assert required_path in job, required_path
+
+
+def test_release_path_does_not_introduce_parallel_decision_engines() -> None:
+    _text, blocks = _workflow_and_jobs()
+    job = blocks[RELEASE_PATH_JOB]
+
+    for forbidden in (
         "new_release_decision",
         "parallel_decision",
         "alternate_check_gates",
         "llamaguard_materializer",
         "llamaguard_verifier",
-    )
-
-    for token in forbidden:
-        assert token not in job, token
+    ):
+        assert forbidden not in job, forbidden
 
 
-def test_release_path_keeps_policy_derived_check_gates_enforcement() -> None:
+def test_downstream_package_dependency_chain_is_preserved() -> None:
     _text, blocks = _workflow_and_jobs()
-    job = blocks[RELEASE_PATH_JOB]
 
-    materializer_index = job.index(
-        "tools/materialize_release_required_from_verifier_v0.py"
-    )
-    helper_index = job.index("tools/policy_to_require_args.py")
-    set_index = job.index("--set release_required")
-    check_gates_index = job.index("tools/check_gates.py")
+    assert _job_field(
+        blocks[PACKAGE_JOB],
+        "needs",
+    ) == RELEASE_PATH_JOB
 
-    assert materializer_index < helper_index < set_index < check_gates_index
-    assert "RELEASE_REQ_STR" in job
-    assert '"${RELEASE_REQ[@]}"' in job
-    assert "--status" in job
-    assert "PULSE_safe_pack_v0/artifacts/status.json" in job
+    assert _job_field(
+        blocks[VERIFY_JOB],
+        "needs",
+    ) == PACKAGE_JOB
 
-
-def test_release_grade_status_contract_validates_after_materialization() -> None:
-    _text, blocks = _workflow_and_jobs()
-    pulse = blocks["pulse"]
-    job = blocks[RELEASE_PATH_JOB]
-
-    assert "release_grade_status_v1.schema.json" not in pulse
-
-    materializer_index = job.index(
-        "tools/materialize_release_required_from_verifier_v0.py"
-    )
-    schema_index = job.index("release_grade_status_v1.schema.json")
-    check_gates_index = job.index("tools/check_gates.py")
-
-    assert materializer_index < schema_index < check_gates_index
+    assert _job_field(
+        blocks["tools-tests"],
+        "needs",
+    ) == VERIFY_JOB
 
 
-def test_no_stub_guard_runs_after_materialization() -> None:
-    _text, blocks = _workflow_and_jobs()
-    pulse = blocks["pulse"]
-    job = blocks[RELEASE_PATH_JOB]
-
-    assert "check_release_no_stub_status.py" not in pulse
-
-    materializer_index = job.index(
-        "tools/materialize_release_required_from_verifier_v0.py"
-    )
-    schema_index = job.index("release_grade_status_v1.schema.json")
-    no_stub_index = job.index("ci/check_release_no_stub_status.py")
-    check_gates_index = job.index("tools/check_gates.py")
-
-    assert materializer_index < schema_index < no_stub_index < check_gates_index
-
-
-def test_pr3_workflow_wiring_smoke_registered() -> None:
+def test_workflow_wiring_smoke_registered() -> None:
     manifest = _read_tools_manifest()
 
     assert (
@@ -332,22 +440,23 @@ def test_pr3_workflow_wiring_smoke_registered() -> None:
 
 
 def main() -> int:
-    test_attested_release_path_job_order()
-    test_release_path_depends_on_attested_llamaguard_job()
-    test_attestation_job_is_hosted_external_model_only() 
-    test_tools_tests_is_downstream_of_release_path_via_package_verifier()
-    test_release_grade_candidate_path_runs_only_after_attestation()
-    test_core_check_gates_remains_allowed_in_pulse_job()
-    test_release_path_downloads_attested_external_evidence_first()
-    test_release_path_uses_existing_standing_tools_in_order()
-    test_release_path_does_not_introduce_parallel_engines()
-    test_release_path_keeps_policy_derived_check_gates_enforcement()
-    test_release_grade_status_contract_validates_after_materialization()
-    test_no_stub_guard_runs_after_materialization()
-    test_pr3_workflow_wiring_smoke_registered()
+    test_release_grade_job_order()
+    test_attestation_job_is_hosted_external_model_only()
+    test_pre_attestation_artifact_is_uploaded_fail_closed()
+    test_recorded_path_downloads_pre_attestation_artifact()
+    test_release_grade_candidate_tools_remain_after_attestation()
+    test_pre_attestation_final_authority_steps_are_core_only()
+    test_recorded_path_restores_attested_evidence_before_verification()
+    test_recorded_path_materializes_before_combined_enforcement()
+    test_final_authority_artifacts_follow_gate_enforcement()
+    test_recorded_path_uploads_final_package_inputs()
+    test_release_path_does_not_introduce_parallel_decision_engines()
+    test_downstream_package_dependency_chain_is_preserved()
+    test_workflow_wiring_smoke_registered()
+
     print(
-        "LlamaGuard attested release-path workflow wiring "
-        "smoke passed"
+        "OK: attested release-grade phase boundary and "
+        "final authority wiring locked"
     )
     return 0
 

--- a/tests/test_llamaguard_attested_release_path_wiring_v0.py
+++ b/tests/test_llamaguard_attested_release_path_wiring_v0.py
@@ -44,19 +44,13 @@ PRE_ATTESTATION_RELEASE_TOOLS = (
     "tools/materialize_release_required_from_verifier_v0.py",
 )
 
-ATTESTED_EXTERNAL_ARTIFACT_PATHS = (
-    "PULSE_safe_pack_v0/artifacts/external/llamaguard_raw.jsonl",
-    (
-        "PULSE_safe_pack_v0/artifacts/external/"
-        "llamaguard_evaluator_manifest_v0.json"
-    ),
-    "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.json",
-    "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.bundle.json",
-    "PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.envelope.json",
-    (
-        "PULSE_safe_pack_v0/artifacts/external/"
-        "llamaguard_attestation_verifier_v1.json"
-    ),
+ATTESTED_EXTERNAL_FILENAMES = (
+    "llamaguard_raw.jsonl",
+    "llamaguard_evaluator_manifest_v0.json",
+    "llamaguard_summary.json",
+    "llamaguard_summary.bundle.json",
+    "llamaguard_summary.envelope.json",
+    "llamaguard_attestation_verifier_v1.json",
 )
 
 
@@ -293,18 +287,36 @@ def test_recorded_path_restores_attested_evidence_before_verification() -> None:
     _text, blocks = _workflow_and_jobs()
     job = blocks[RELEASE_PATH_JOB]
 
-    artifact_index = job.index(ATTESTED_DOWNLOAD_ARTIFACT)
-
-    for artifact_path in ATTESTED_EXTERNAL_ARTIFACT_PATHS:
-        assert artifact_index < job.index(artifact_path)
+    step_name = "Download attested LlamaGuard external evidence"
+    download = _step_block(job, step_name)
+    download_step_index = job.index(f"      - name: {step_name}")
 
     first_tool_index = min(
         job.index(tool)
         for tool in PRE_ATTESTATION_RELEASE_TOOLS
     )
 
-    for artifact_path in ATTESTED_EXTERNAL_ARTIFACT_PATHS:
-        assert job.index(artifact_path) < first_tool_index
+    assert download_step_index < first_tool_index
+    assert ATTESTED_DOWNLOAD_ARTIFACT in download
+    assert (
+        'CANONICAL_EXTERNAL="${GITHUB_WORKSPACE}/'
+        'PULSE_safe_pack_v0/artifacts/external"'
+        in download
+    )
+    assert "restore_external_artifact" in download
+
+    for filename in ATTESTED_EXTERNAL_FILENAMES:
+        assert f'"{filename}"' in download, filename
+        destination = f'"${{CANONICAL_EXTERNAL}}/{filename}"'
+        assert destination in download, destination
+
+    for token in (
+        'if [[ -z "${src}" ]]',
+        'if [[ -L "${src}" ]]',
+        'if [[ ! -f "${artifact}" || -L "${artifact}" || ! -s "${artifact}" ]]',
+        'sha256sum "${artifact}"',
+    ):
+        assert token in download, token
 
 
 def test_recorded_path_materializes_before_combined_enforcement() -> None:


### PR DESCRIPTION
## Summary

Restore the release-grade CI phase boundary so final gate enforcement occurs
only after current-run hosted evidence has been attested, recorded evidence has
been verified, and the final release-grade status has been atomically
materialized.

The controlled hosted run exposed a phase-order deadlock:

```text
pre-attestation candidate status
→ final required-gate enforcement
→ pulse job fails on not-yet-materialized gates
→ LlamaGuard attestation is skipped
→ recorded verifier and materializer are skipped
→ final status.json cannot be produced
```

This PR replaces that circular dependency with the declared release-grade path:

```text
current-run evidence production
→ LlamaGuard summary attestation
→ recorded evidence verification
→ atomic gate materialization
→ final status.json
→ required + release_required enforcement
→ final release decision
→ final authority and provenance artifacts
→ package assembly and verification
```

## Failure being corrected

Controlled PULSE CI run `#6043` reached the hosted runtime but the main `pulse`
job attempted release enforcement against the pre-attestation candidate
status.

The following release-grade gates were therefore absent at the time of the
early decision:

```text
detectors_materialized_ok
external_summaries_present
external_all_pass
refusal_delta_evidence_present
```

The failure was correctly fail-closed, but the workflow ordering prevented the
jobs capable of producing those gates from running.

The issue was not:

```text
HF_TOKEN access
model repository access
model revision resolution
required metadata presence
LlamaGuard model identity
```

The issue was:

```text
final enforcement executed before attestation,
recorded verification, and materialization
```

## Files

Modified:

```text
.github/workflows/pulse_ci.yml
tests/test_llamaguard_attested_release_path_wiring_v0.py
tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
```

No other file is changed.

`ci/tools-tests.list` is unchanged because both updated tests are already
registered.

## Release-grade phase 1: pre-attestation producer

In release-grade mode, the `pulse` job now produces and validates the
current-run pre-attestation carrier.

The carrier includes:

```text
status.json
status_baseline.json
status_summary_baseline.md
status_summary_baseline.json
required_gate_evidence_v0.json
self_contained_pulse_evidence_floor_v0.json
refusal_delta_summary.json
llamaguard_raw.jsonl
llamaguard_evaluator_manifest_v0.json
llamaguard_summary.json
```

It is uploaded under the exact current-run artifact name:

```text
pulse-pre-attestation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
```

The upload is fail-closed:

```text
missing file
empty file
symlinked file
artifact upload failure
→ pulse job failure
```

The hosted LlamaGuard evidence remains separately uploaded for the attestation
job:

```text
llamaguard-current-run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
```

## Pre-attestation authority boundary

In release-grade mode, the `pulse` job no longer performs final authority
operations.

Final release-grade execution is excluded from the pre-attestation phase for:

```text
required + release_required check_gates enforcement
prod release decision materialization
final release-authority manifest construction
final artifact provenance binding
final authority audit bundle
final JUnit/SARIF authority export
final pulse-report authority carrier
```

The existing Core/non-release path remains in the `pulse` job.

The release-grade producer phase therefore means:

```text
current-run evidence producer
≠ final release authority
```

## LlamaGuard attestation phase

After the producer job succeeds:

```text
llamaguard_raw.jsonl
+ llamaguard_evaluator_manifest_v0.json
+ llamaguard_summary.json
```

are restored into the isolated attestation job.

The canonical summary is then:

```text
attested
→ canonical envelope built
→ signer and source identity bound
→ cryptographically verified
→ uploaded as attested current-run evidence
```

The immutable attestation action pin remains:

```text
actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
```

The `pulse` producer job retains read-only permissions and does not receive
attestation credentials.

## Release-grade phase 2: recorded path and final authority

The `release_grade_recorded_path` job now owns the post-attestation release
phase.

It restores:

```text
pulse-pre-attestation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
```

and:

```text
llamaguard-attested-current-run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
```

The restored files must be regular, non-symlinked current-run artifacts.

The job then executes the existing canonical mechanisms in this order:

```text
build_recorded_release_candidates_v0.py
→ build_release_evidence_input_manifest_v0.py
→ check_recorded_release_evidence_v0.py
→ materialize_release_required_from_verifier_v0.py
→ release-grade status schema validation
→ no-stub release guard
```

No verifier or materializer implementation is changed.

## Final gate enforcement

After atomic materialization, the workflow derives both active release-grade
gate sets from the declared policy:

```text
required
release_required
```

The lists are obtained through:

```text
tools/policy_to_require_args.py
```

The workflow:

```text
rejects an empty required set
rejects an empty release_required set
deduplicates while preserving order
constructs the workflow-effective gate list
passes the complete list to check_gates.py
```

Final enforcement is:

```text
python PULSE_safe_pack_v0/tools/check_gates.py \
  --status PULSE_safe_pack_v0/artifacts/status.json \
  --require <workflow-effective required + release_required gates>
```

No gate IDs are embedded in the workflow.

The decision remains fail-closed for:

```text
missing gate
false gate
null gate
non-boolean gate
malformed gate
failed verifier
failed materialization
invalid status
```

## Final release artifacts

Only after strict gate enforcement succeeds does the recorded path produce:

```text
status_summary.md
status_summary.json
report_card.html
release_decision_v0.json
release_decision_v0_ledger_section.html
report_card.with_release_decision.html
release_authority_v0.json
artifact_provenance_binding_v0.json
release_authority_audit_bundle/
```

The final release-authority manifest is built with:

```text
policy set:
required+release_required
```

The final provenance binding is built from:

```text
final status.json
declared policy
final Quality Ledger
final release decision
final release-authority manifest
required + release_required gate sets
```

The binding is verified before upload.

## Artifact source preservation

The existing downstream artifact names remain available:

```text
pulse-report
release-decision-v0
release-authority-v0
release-authority-audit-bundle
release-authority-artifact-binding-v0
release-grade-recorded-path-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
```

For a release-grade run, these artifacts now originate from the
post-materialization recorded path.

This preserves the existing package assembly interface without changing the
package assembler.

```text
artifact name preserved
+ source phase corrected
= package contract retained
```

## Artifact-binding attestation lanes

The existing non-release binding attestation remains isolated:

```text
pulse
→ core/non-release binding
→ attest_release_authority_artifact_binding
```

It is explicitly excluded from:

```text
version tags
strict release-grade workflow_dispatch runs
pull requests
```

A separate release-grade attestation job now runs only after the recorded path
succeeds:

```text
release_grade_recorded_path
→ final artifact_provenance_binding_v0.json
→ attest_release_grade_artifact_binding
```

This avoids:

```text
attesting a pre-materialization binding
attesting a missing final carrier
giving the pulse producer job write-capable attestation permissions
```

Both lanes use the same immutable `actions/attest` implementation.

No second release-decision engine is introduced.

## Package path

The downstream package chain remains:

```text
release_grade_recorded_path
→ assemble_release_grade_reference_package
→ verify_release_grade_reference_package
→ tools-tests
```

The package assembler continues to consume the existing artifact interfaces.

No change is made to:

```text
PULSE_safe_pack_v0/tools/assemble_release_grade_reference_package_v0.py
PULSE_safe_pack_v0/tools/verify_release_grade_reference_package_v0.py
tools/check_release_grade_package_complete_v1.py
```

## Regression coverage

### Attested release path wiring

`tests/test_llamaguard_attested_release_path_wiring_v0.py` now locks:

```text
pre-attestation artifact upload
exact current-run artifact naming
attestation before recorded verification
recorded verification before materialization
materialization before final gate enforcement
required + release_required policy derivation
final authority artifacts after gate enforcement
final package inputs uploaded from recorded path
package dependency chain preserved
no parallel decision engine
```

### Artifact-binding attestation wiring

`tests/test_artifact_provenance_binding_attestation_wiring_smoke.py` now locks:

```text
pulse producer remains least-privilege
core binding attestation remains non-release only
release-grade binding attestation waits for recorded-path success
all attest actions use the immutable SHA pin
binding is built before it is attested
attestation jobs remain isolated from producer jobs
release-grade and Core phase order remains explicit
```

## Authority boundary

The canonical authority path remains:

```text
recorded release evidence
→ final status.json
→ declared policy
→ workflow-effective materialized required gates
→ PULSE_safe_pack_v0/tools/check_gates.py
→ primary CI allow/block result
```

The following remain non-authoritative by themselves:

```text
pre-attestation artifact
LlamaGuard raw output
attestation envelope
release-authority audit sidecar
Quality Ledger
package report
GitHub job summary
uploaded artifact presence
```

## Non-effects

No change to:

```text
pulse_gate_policy_v0.yml
pulse_gate_registry_v0.yml
PULSE_safe_pack_v0/tools/check_gates.py
PULSE_safe_pack_v0/tools/check_recorded_release_evidence_v0.py
PULSE_safe_pack_v0/tools/materialize_release_required_from_verifier_v0.py
PULSE_safe_pack_v0/tools/assemble_release_grade_reference_package_v0.py
PULSE_safe_pack_v0/tools/verify_release_grade_reference_package_v0.py
schemas/status/
HF_TOKEN
meta-llama/Llama-Guard-3-1B
acf7aafa60f0410f8f42b1fa35e077d705892029
SLSA/VSA activation state
DOI and citation identity
Zenodo metadata
release metadata
```

## Verification

Run:

```text
python tests/test_llamaguard_attested_release_path_wiring_v0.py

python tests/test_artifact_provenance_binding_attestation_wiring_smoke.py

python tests/test_artifact_provenance_binding_ci_wiring_smoke.py

python tests/test_release_grade_reference_package_assembly_wiring_v0.py

python tests/test_release_grade_reference_package_verification_wiring_v0.py

python tests/test_self_contained_pulse_evidence_floor_workflow_wiring_v0.py

python -m py_compile \
  tests/test_llamaguard_attested_release_path_wiring_v0.py \
  tests/test_artifact_provenance_binding_attestation_wiring_smoke.py

python tools/check_yaml_unique_keys.py \
  .github/workflows/pulse_ci.yml

git diff --check

git diff --name-only origin/main...HEAD
```

Expected changed-file result:

```text
.github/workflows/pulse_ci.yml
tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
tests/test_llamaguard_attested_release_path_wiring_v0.py
```

Expected PR behavior:

```text
workflow lint: PASS
Tools smoke tests: PASS
targeted pytest: PASS
Core pull-request lane: unchanged
hosted release-only jobs on PR: skipped
policy and registry checks: unchanged
package assembly contract: unchanged
```

## Post-merge validation

After merge, run the hosted-access preflight against the new exact `main` SHA.

Only after that preflight passes, run:

```text
strict_external_evidence:
true

llamaguard_evidence_mode:
hosted_full_runtime
```

Expected controlled job order:

```text
pulse
→ LlamaGuard current-run summary: attest and verify
→ Release-grade recorded path: attested evidence to final authority artifacts
→ Release-grade artifact binding v0: attest
→ Release-grade reference package: assemble complete package
→ Release-grade reference package: verify complete package
→ Tools smoke tests
```

A failure after materialization remains a valid fail-closed release block.

The purpose of this PR is not to force a PASS. It is to ensure that the final
decision is made at the correct mechanical phase.