### PR TITLE
fix(ci): accept canonical external summary metrics

### DIFF
--- a/scripts/check_external_summaries_present.py
+++ b/scripts/check_external_summaries_present.py
@@ -5,7 +5,9 @@ Strict release semantics:
 - decoy files such as foo_summary.json must not count as external detector evidence;
 - canonical detector summary filenames count;
 - --required can override the canonical list with explicit expected filenames;
-- --require_metric_key checks that each accepted file contains at least one metric key.
+- --require_metric_key accepts either:
+  - a legacy flat metric key at the summary-object level; or
+  - a canonical external_summary_v1 metrics[] entry carrying key + value.
 """
 
 from __future__ import annotations
@@ -45,39 +47,133 @@ DEFAULT_METRIC_KEYS = (
 
 
 def read_json(path: Path) -> object:
-    return json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    return json.loads(
+        path.read_text(
+            encoding="utf-8",
+            errors="strict",
+        )
+    )
 
 
 def read_jsonl(path: Path) -> list[object]:
     out: list[object] = []
-    with path.open("r", encoding="utf-8", errors="strict") as handle:
+
+    with path.open(
+        "r",
+        encoding="utf-8",
+        errors="strict",
+    ) as handle:
         for line_no, line in enumerate(handle, start=1):
             line = line.strip()
+
             if not line:
                 continue
+
             try:
                 out.append(json.loads(line))
             except json.JSONDecodeError as exc:
-                raise ValueError(f"{path}: invalid JSON on line {line_no}: {exc}") from exc
+                raise ValueError(
+                    f"{path}: invalid JSON on line {line_no}: {exc}"
+                ) from exc
+
     return out
 
 
-def has_any_metric_key(obj: object, metric_keys: tuple[str, ...]) -> bool:
+def _has_legacy_metric_key(
+    obj: dict[str, object],
+    metric_keys: tuple[str, ...],
+) -> bool:
+    """Return whether a legacy flat summary carries a known metric key."""
+
+    return any(
+        key in obj
+        for key in metric_keys
+    )
+
+
+def _has_canonical_metric_entry(
+    obj: dict[str, object],
+) -> bool:
+    """Recognize an external_summary_v1-style metrics[] carrier.
+
+    This precheck intentionally does not replace schema validation.
+
+    It establishes only that at least one declared metric object carries:
+
+    - a non-empty metric key; and
+    - a value field.
+
+    Full shape and type validation remains the responsibility of the
+    canonical external summary schema.
+    """
+
+    metrics = obj.get("metrics")
+
+    if not isinstance(metrics, list) or not metrics:
+        return False
+
+    for metric in metrics:
+        if not isinstance(metric, dict):
+            continue
+
+        metric_key = metric.get("key")
+
+        if (
+            isinstance(metric_key, str)
+            and metric_key.strip()
+            and "value" in metric
+        ):
+            return True
+
+    return False
+
+
+def _dict_has_metric_carrier(
+    obj: dict[str, object],
+    metric_keys: tuple[str, ...],
+) -> bool:
+    """Recognize either an accepted legacy or canonical metric carrier."""
+
+    return (
+        _has_legacy_metric_key(
+            obj,
+            metric_keys,
+        )
+        or _has_canonical_metric_entry(obj)
+    )
+
+
+def has_any_metric_key(
+    obj: object,
+    metric_keys: tuple[str, ...],
+) -> bool:
+    """Accept legacy flat summaries and canonical metrics[] summaries."""
+
     if isinstance(obj, dict):
-        return any(key in obj for key in metric_keys)
+        return _dict_has_metric_carrier(
+            obj,
+            metric_keys,
+        )
 
     if isinstance(obj, list):
         return any(
-            isinstance(item, dict) and any(key in item for key in metric_keys)
+            isinstance(item, dict)
+            and _dict_has_metric_carrier(
+                item,
+                metric_keys,
+            )
             for item in obj
         )
 
     return False
 
 
-def iter_candidate_files(external_dir: Path) -> Iterable[Path]:
+def iter_candidate_files(
+    external_dir: Path,
+) -> Iterable[Path]:
     for filename in CANONICAL_SUMMARY_FILENAMES:
         path = external_dir / filename
+
         if path.exists():
             yield path
 
@@ -85,80 +181,141 @@ def iter_candidate_files(external_dir: Path) -> Iterable[Path]:
 def parse_summary(path: Path) -> object:
     if path.suffix.lower() == ".jsonl":
         return read_jsonl(path)
+
     return read_json(path)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Fail-closed external detector summary precheck."
+        description=(
+            "Fail-closed external detector summary precheck."
+        )
     )
+
     parser.add_argument(
         "--external_dir",
         required=True,
-        help="Directory containing external detector summary artifacts.",
+        help=(
+            "Directory containing external detector "
+            "summary artifacts."
+        ),
     )
+
     parser.add_argument(
         "--required",
         action="append",
         default=[],
-        help="Required summary filename. Repeat for multiple files.",
+        help=(
+            "Required summary filename. "
+            "Repeat for multiple files."
+        ),
     )
+
     parser.add_argument(
         "--require_metric_key",
         action="store_true",
-        help="Require at least one expected metric key in each accepted summary.",
+        help=(
+            "Require a legacy flat metric key or a canonical "
+            "metrics[] entry carrying key + value in each "
+            "accepted summary."
+        ),
     )
+
     parser.add_argument(
         "--metric_keys",
         nargs="*",
         default=list(DEFAULT_METRIC_KEYS),
-        help="Override metric keys checked by --require_metric_key.",
+        help=(
+            "Override legacy flat metric keys checked by "
+            "--require_metric_key."
+        ),
     )
+
     args = parser.parse_args()
 
     external_dir = Path(args.external_dir)
     metric_keys = tuple(args.metric_keys)
+
     errors: list[str] = []
 
-    if not external_dir.exists() or not external_dir.is_dir():
-        errors.append(f"external_dir missing or not a directory: {external_dir}")
+    if (
+        not external_dir.exists()
+        or not external_dir.is_dir()
+    ):
+        errors.append(
+            "external_dir missing or not a directory: "
+            f"{external_dir}"
+        )
 
     files: list[Path] = []
+
     if not errors:
         if args.required:
-            files = [external_dir / filename for filename in args.required]
+            files = [
+                external_dir / filename
+                for filename in args.required
+            ]
         else:
-            files = list(iter_candidate_files(external_dir))
+            files = list(
+                iter_candidate_files(external_dir)
+            )
 
         if not files:
             errors.append(
-                f"No canonical external detector summaries found in: {external_dir} "
-                f"(expected one of: {', '.join(CANONICAL_SUMMARY_FILENAMES)})"
+                "No canonical external detector summaries "
+                f"found in: {external_dir} "
+                "(expected one of: "
+                f"{', '.join(CANONICAL_SUMMARY_FILENAMES)})"
             )
 
     for path in files:
         if not path.exists():
-            errors.append(f"Missing required summary: {path}")
+            errors.append(
+                f"Missing required summary: {path}"
+            )
             continue
 
         try:
             obj = parse_summary(path)
         except Exception as exc:
-            errors.append(f"Unparseable summary: {path} ({exc})")
+            errors.append(
+                f"Unparseable summary: {path} ({exc})"
+            )
             continue
 
-        if args.require_metric_key and not has_any_metric_key(obj, metric_keys):
+        if (
+            args.require_metric_key
+            and not has_any_metric_key(
+                obj,
+                metric_keys,
+            )
+        ):
             errors.append(
-                f"Summary has no expected metric key {metric_keys}: {path}"
+                "Summary has no accepted metric carrier "
+                f"(legacy keys {metric_keys} or canonical "
+                "metrics[] entry with non-empty 'key' and "
+                f"present 'value'): {path}"
             )
 
     if errors:
-        print("ERRORS (fail-closed):", file=sys.stderr)
+        print(
+            "ERRORS (fail-closed):",
+            file=sys.stderr,
+        )
+
         for error in errors:
-            print(f" - {error}", file=sys.stderr)
+            print(
+                f" - {error}",
+                file=sys.stderr,
+            )
+
         return 1
 
-    print(f"OK: canonical external summaries present and parseable ({len(files)} file(s)).")
+    print(
+        "OK: canonical external summaries present and "
+        f"parseable ({len(files)} file(s))."
+    )
+
     return 0
 
 

--- a/tests/test_check_external_summaries_present.py
+++ b/tests/test_check_external_summaries_present.py
@@ -7,7 +7,9 @@ The checker is intentionally exercised as a subprocess, matching CI behavior.
 Security invariant:
 - default strict/release discovery is canonical-only;
 - decoy or non-canonical *_summary.json/jsonl files must fail by default;
-- explicit --required may override discovery for an explicitly named operator check.
+- explicit --required may override discovery for an explicitly named operator check;
+- metric presence accepts legacy flat summaries and canonical metrics[] carriers;
+- empty or incomplete canonical metrics[] carriers fail closed.
 """
 
 from __future__ import annotations
@@ -24,11 +26,24 @@ def run_checker(
     external_dir: Path,
     extra_args: list[str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    script = repo / "scripts" / "check_external_summaries_present.py"
-    if not script.exists():
-        raise FileNotFoundError(f"Missing checker script at: {script}")
+    script = (
+        repo
+        / "scripts"
+        / "check_external_summaries_present.py"
+    )
 
-    cmd = [sys.executable, str(script), "--external_dir", str(external_dir)]
+    if not script.exists():
+        raise FileNotFoundError(
+            f"Missing checker script at: {script}"
+        )
+
+    cmd = [
+        sys.executable,
+        str(script),
+        "--external_dir",
+        str(external_dir),
+    ]
+
     if extra_args:
         cmd.extend(extra_args)
 
@@ -40,15 +55,59 @@ def run_checker(
     )
 
 
-def assert_rc(res: subprocess.CompletedProcess[str], expected: int) -> None:
+def assert_rc(
+    res: subprocess.CompletedProcess[str],
+    expected: int,
+) -> None:
     if res.returncode != expected:
-        print("=== Unexpected return code ===", file=sys.stderr)
-        print(f"expected={expected} got={res.returncode}", file=sys.stderr)
-        print("=== STDOUT ===", file=sys.stderr)
-        print(res.stdout, file=sys.stderr)
-        print("=== STDERR ===", file=sys.stderr)
-        print(res.stderr, file=sys.stderr)
-        raise AssertionError("checker returned unexpected exit code")
+        print(
+            "=== Unexpected return code ===",
+            file=sys.stderr,
+        )
+
+        print(
+            f"expected={expected} "
+            f"got={res.returncode}",
+            file=sys.stderr,
+        )
+
+        print(
+            "=== STDOUT ===",
+            file=sys.stderr,
+        )
+
+        print(
+            res.stdout,
+            file=sys.stderr,
+        )
+
+        print(
+            "=== STDERR ===",
+            file=sys.stderr,
+        )
+
+        print(
+            res.stderr,
+            file=sys.stderr,
+        )
+
+        raise AssertionError(
+            "checker returned unexpected exit code"
+        )
+
+
+def write_json(
+    path: Path,
+    payload: object,
+) -> None:
+    path.write_text(
+        json.dumps(
+            payload,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 def main() -> int:
@@ -56,116 +115,377 @@ def main() -> int:
 
     # Case 1: empty directory -> FAIL
     with tempfile.TemporaryDirectory() as td:
-        d = Path(td)
-        res = run_checker(repo, d)
-        assert_rc(res, 1)
+        external_dir = Path(td)
+
+        result = run_checker(
+            repo,
+            external_dir,
+        )
+
+        assert_rc(result, 1)
 
     # Case 2: unrelated JSON present -> FAIL
     with tempfile.TemporaryDirectory() as td:
-        d = Path(td)
-        (d / "metadata.json").write_text(
-            json.dumps({"hello": "world"}) + "\n",
-            encoding="utf-8",
+        external_dir = Path(td)
+
+        write_json(
+            external_dir / "metadata.json",
+            {
+                "hello": "world",
+            },
         )
-        res = run_checker(repo, d)
-        assert_rc(res, 1)
+
+        result = run_checker(
+            repo,
+            external_dir,
+        )
+
+        assert_rc(result, 1)
 
     # Case 3: decoy JSON summary -> FAIL by default
     with tempfile.TemporaryDirectory() as td:
-        d = Path(td)
-        (d / "foo_summary.json").write_text(
-            json.dumps({"value": 0.0}) + "\n",
-            encoding="utf-8",
+        external_dir = Path(td)
+
+        write_json(
+            external_dir / "foo_summary.json",
+            {
+                "value": 0.0,
+            },
         )
-        res = run_checker(repo, d)
-        assert_rc(res, 1)
+
+        result = run_checker(
+            repo,
+            external_dir,
+        )
+
+        assert_rc(result, 1)
 
     # Case 4: decoy JSONL summary -> FAIL by default
     with tempfile.TemporaryDirectory() as td:
-        d = Path(td)
-        (d / "foo_summary.jsonl").write_text(
+        external_dir = Path(td)
+
+        (
+            external_dir
+            / "foo_summary.jsonl"
+        ).write_text(
             '{"rate": 0.0}\n',
             encoding="utf-8",
         )
-        res = run_checker(repo, d)
-        assert_rc(res, 1)
 
-    # Case 5: canonical JSON summary -> PASS
-    with tempfile.TemporaryDirectory() as td:
-        d = Path(td)
-        (d / "llamaguard_summary.json").write_text(
-            json.dumps({"rate": 0.1}) + "\n",
-            encoding="utf-8",
+        result = run_checker(
+            repo,
+            external_dir,
         )
-        res = run_checker(repo, d)
-        assert_rc(res, 0)
 
-    # Case 6: canonical JSONL summary -> PASS
+        assert_rc(result, 1)
+
+    # Case 5: canonical legacy-flat JSON summary -> PASS
     with tempfile.TemporaryDirectory() as td:
-        d = Path(td)
-        (d / "llamaguard_summary.jsonl").write_text(
+        external_dir = Path(td)
+
+        write_json(
+            external_dir
+            / "llamaguard_summary.json",
+            {
+                "rate": 0.1,
+            },
+        )
+
+        result = run_checker(
+            repo,
+            external_dir,
+        )
+
+        assert_rc(result, 0)
+
+    # Case 6: canonical legacy-flat JSONL summary -> PASS
+    with tempfile.TemporaryDirectory() as td:
+        external_dir = Path(td)
+
+        (
+            external_dir
+            / "llamaguard_summary.jsonl"
+        ).write_text(
             '{"rate": 0.0}\n',
             encoding="utf-8",
         )
-        res = run_checker(repo, d)
-        assert_rc(res, 0)
 
-    # Case 7: canonical adapter-style key -> PASS under --require_metric_key
-    with tempfile.TemporaryDirectory() as td:
-        d = Path(td)
-        (d / "promptfoo_summary.json").write_text(
-            json.dumps({"fail_rate": 0.02}) + "\n",
-            encoding="utf-8",
+        result = run_checker(
+            repo,
+            external_dir,
         )
-        res = run_checker(repo, d, ["--require_metric_key"])
-        assert_rc(res, 0)
 
-    # Case 8: canonical summary without metric key -> FAIL under --require_metric_key
+        assert_rc(result, 0)
+
+    # Case 7: canonical adapter-style flat key
+    # -> PASS with metric check
     with tempfile.TemporaryDirectory() as td:
-        d = Path(td)
-        (d / "promptfoo_summary.json").write_text(
-            json.dumps({"note": "no metric here"}) + "\n",
-            encoding="utf-8",
+        external_dir = Path(td)
+
+        write_json(
+            external_dir
+            / "promptfoo_summary.json",
+            {
+                "fail_rate": 0.02,
+            },
         )
-        res = run_checker(repo, d, ["--require_metric_key"])
-        assert_rc(res, 1)
+
+        result = run_checker(
+            repo,
+            external_dir,
+            [
+                "--require_metric_key",
+            ],
+        )
+
+        assert_rc(result, 0)
+
+    # Case 8: flat canonical summary without metric
+    # -> FAIL with metric check
+    with tempfile.TemporaryDirectory() as td:
+        external_dir = Path(td)
+
+        write_json(
+            external_dir
+            / "promptfoo_summary.json",
+            {
+                "note": "no metric here",
+            },
+        )
+
+        result = run_checker(
+            repo,
+            external_dir,
+            [
+                "--require_metric_key",
+            ],
+        )
+
+        assert_rc(result, 1)
 
     # Case 9: malformed canonical summary -> FAIL
     with tempfile.TemporaryDirectory() as td:
-        d = Path(td)
-        (d / "llamaguard_summary.json").write_text(
+        external_dir = Path(td)
+
+        (
+            external_dir
+            / "llamaguard_summary.json"
+        ).write_text(
             '{"rate":',
             encoding="utf-8",
         )
-        res = run_checker(repo, d)
-        assert_rc(res, 1)
+
+        result = run_checker(
+            repo,
+            external_dir,
+        )
+
+        assert_rc(result, 1)
 
     # Case 10: --required missing file -> FAIL
     with tempfile.TemporaryDirectory() as td:
-        d = Path(td)
-        res = run_checker(repo, d, ["--required", "missing_summary.json"])
-        assert_rc(res, 1)
+        external_dir = Path(td)
 
-    # Case 11: non-canonical metric summary -> FAIL by default,
-    # but PASS when explicitly named by --required.
+        result = run_checker(
+            repo,
+            external_dir,
+            [
+                "--required",
+                "missing_summary.json",
+            ],
+        )
+
+        assert_rc(result, 1)
+
+    # Case 11: a non-canonical metric summary fails
+    # default discovery but may be explicitly named by
+    # an operator through --required.
     with tempfile.TemporaryDirectory() as td:
-        d = Path(td)
-        (d / "empty_summary.json").write_text(
-            json.dumps({"value": 0.0}) + "\n",
+        external_dir = Path(td)
+
+        write_json(
+            external_dir
+            / "empty_summary.json",
+            {
+                "value": 0.0,
+            },
+        )
+
+        result = run_checker(
+            repo,
+            external_dir,
+            [
+                "--require_metric_key",
+            ],
+        )
+
+        assert_rc(result, 1)
+
+        result = run_checker(
+            repo,
+            external_dir,
+            [
+                "--required",
+                "empty_summary.json",
+                "--require_metric_key",
+            ],
+        )
+
+        assert_rc(result, 0)
+
+    # Case 12: external_summary_v1-style metrics[]
+    # carrier with key + value -> PASS.
+    with tempfile.TemporaryDirectory() as td:
+        external_dir = Path(td)
+
+        write_json(
+            external_dir
+            / "llamaguard_summary.json",
+            {
+                "metrics": [
+                    {
+                        "key": (
+                            "llamaguard_violation_rate"
+                        ),
+                        "value": 0.0,
+                        "passed": True,
+                    }
+                ],
+            },
+        )
+
+        result = run_checker(
+            repo,
+            external_dir,
+            [
+                "--require_metric_key",
+            ],
+        )
+
+        assert_rc(result, 0)
+
+    # Case 13: canonical metrics[] must not be empty.
+    with tempfile.TemporaryDirectory() as td:
+        external_dir = Path(td)
+
+        write_json(
+            external_dir
+            / "llamaguard_summary.json",
+            {
+                "metrics": [],
+            },
+        )
+
+        result = run_checker(
+            repo,
+            external_dir,
+            [
+                "--require_metric_key",
+            ],
+        )
+
+        assert_rc(result, 1)
+
+    # Case 14: canonical metric object without
+    # value -> FAIL.
+    with tempfile.TemporaryDirectory() as td:
+        external_dir = Path(td)
+
+        write_json(
+            external_dir
+            / "llamaguard_summary.json",
+            {
+                "metrics": [
+                    {
+                        "key": (
+                            "llamaguard_violation_rate"
+                        ),
+                        "passed": True,
+                    }
+                ],
+            },
+        )
+
+        result = run_checker(
+            repo,
+            external_dir,
+            [
+                "--require_metric_key",
+            ],
+        )
+
+        assert_rc(result, 1)
+
+    # Case 15: canonical metric object requires
+    # a non-empty key.
+    with tempfile.TemporaryDirectory() as td:
+        external_dir = Path(td)
+
+        write_json(
+            external_dir
+            / "llamaguard_summary.json",
+            {
+                "metrics": [
+                    {
+                        "key": "   ",
+                        "value": 0.0,
+                        "passed": True,
+                    }
+                ],
+            },
+        )
+
+        result = run_checker(
+            repo,
+            external_dir,
+            [
+                "--require_metric_key",
+            ],
+        )
+
+        assert_rc(result, 1)
+
+    # Case 16: external_summary_v1-style JSONL
+    # metrics[] carrier -> PASS.
+    with tempfile.TemporaryDirectory() as td:
+        external_dir = Path(td)
+
+        (
+            external_dir
+            / "llamaguard_summary.jsonl"
+        ).write_text(
+            json.dumps(
+                {
+                    "metrics": [
+                        {
+                            "key": (
+                                "llamaguard_violation_rate"
+                            ),
+                            "value": 0.0,
+                            "passed": True,
+                        }
+                    ],
+                }
+            )
+            + "\n",
             encoding="utf-8",
         )
 
-        res = run_checker(repo, d, ["--require_metric_key"])
-        assert_rc(res, 1)
-
-        res = run_checker(
+        result = run_checker(
             repo,
-            d,
-            ["--required", "empty_summary.json", "--require_metric_key"],
+            external_dir,
+            [
+                "--require_metric_key",
+            ],
         )
-        assert_rc(res, 0)
 
-    print("OK: check_external_summaries_present smoke tests passed")
+        assert_rc(result, 0)
+
+    print(
+        "OK: check_external_summaries_present "
+        "smoke tests passed"
+    )
+
     return 0
 
 


### PR DESCRIPTION
## Summary

Align the strict external-summary presence precheck with the canonical
`external_summary_v1` metric structure.

The current-run hosted LlamaGuard producer successfully created:

```text
llamaguard_raw.jsonl
llamaguard_evaluator_manifest_v0.json
llamaguard_summary.json
```

The canonical summary carried its metric in the schema-defined form:

```json
{
  "metrics": [
    {
      "key": "llamaguard_violation_rate",
      "value": 0.0,
      "passed": true
    }
  ]
}
```

The existing presence checker only searched for recognized metric keys at the
document root. It therefore rejected the valid canonical summary even though
the required `metrics[]` carrier and its `value` field were present.

## Files

Modified:

```text
scripts/check_external_summaries_present.py
tests/test_check_external_summaries_present.py
```

No other file is changed.

The existing test is already registered in:

```text
ci/tools-tests.list
```

No manifest update is required.

## Failure mechanism

The old metric check was effectively:

```text
summary root
→ search for value / rate / violation_rate / fail_rate / ...
```

The canonical schema carries metrics as:

```text
summary
→ metrics[]
→ metric object
→ key
→ value
→ passed
```

The result was a false-negative relation:

```text
schema-conformant canonical summary
+ nested metrics[] value
+ root-only presence checker
→ fail-closed rejection
```

## Correction

The checker now accepts either of the established carriers.

### Legacy flat carrier

```json
{
  "fail_rate": 0.02
}
```

### Canonical external_summary_v1-style carrier

```json
{
  "metrics": [
    {
      "key": "llamaguard_violation_rate",
      "value": 0.0,
      "passed": true
    }
  ]
}
```

For the canonical carrier, the precheck requires at least one metric object
with:

```text
non-empty key
+ present value field
```

The presence check deliberately does not duplicate complete schema validation.

```text
presence checker
→ metric carrier exists

canonical schema validator
→ complete structure and type validity
```

## Fail-closed preservation

The following continue to fail:

```text
empty external directory
unrelated JSON file
non-canonical decoy summary filename
malformed canonical JSON or JSONL
missing explicitly required summary
canonical summary without an accepted metric carrier
metrics: []
metric object without value
metric object with blank key
```

The following continue to pass:

```text
legacy canonical flat JSON
legacy canonical flat JSONL
recognized legacy adapter metric key
explicitly named non-canonical summary through --required
```

The following now also pass:

```text
canonical JSON metrics[] carrier
canonical JSONL metrics[] carrier
```

## Discovery boundary

Default discovery remains limited to the declared canonical filenames:

```text
llamaguard_summary.json
llamaguard_summary.jsonl
promptguard_summary.json
promptguard_summary.jsonl
garak_summary.json
garak_summary.jsonl
azure_eval_summary.json
azure_eval_summary.jsonl
promptfoo_summary.json
promptfoo_summary.jsonl
deepeval_summary.json
deepeval_summary.jsonl
```

A file such as:

```text
foo_summary.json
```

does not become accepted evidence merely because it contains a metric.

The existing `--required` operator override remains explicit and unchanged.

## Regression coverage

The updated subprocess-level smoke test covers:

```text
1. empty directory → FAIL
2. unrelated JSON → FAIL
3. decoy JSON summary → FAIL
4. decoy JSONL summary → FAIL
5. canonical legacy-flat JSON → PASS
6. canonical legacy-flat JSONL → PASS
7. legacy adapter metric with --require_metric_key → PASS
8. canonical flat summary without metric → FAIL
9. malformed canonical summary → FAIL
10. missing --required file → FAIL
11. explicit --required override → PASS
12. canonical metrics[] with key + value → PASS
13. empty canonical metrics[] → FAIL
14. canonical metric without value → FAIL
15. canonical metric with blank key → FAIL
16. canonical JSONL metrics[] carrier → PASS
```

## Authority boundary

This change affects only the presence precheck used before the recorded
release-grade path.

It does not:

- determine the aggregate external result;
- validate the complete external-summary schema;
- attest the summary;
- verify signer identity;
- fold evidence into `status.json`;
- materialize gates;
- replace `check_gates.py`;
- create release authority;
- force an allow result.

The canonical authority path remains:

```text
current-run evidence
→ canonical summary
→ attestation and verification
→ recorded evidence verification
→ atomic status materialization
→ declared policy
→ required + release_required gate enforcement
→ primary CI allow/block result
```

## Non-effects

No changes to:

```text
.github/workflows/pulse_ci.yml
PULSE_safe_pack_v0/tools/adapters/llamaguard_ingest.py
schemas/external_summary_v1.schema.json
PULSE_safe_pack_v0/schemas/external_summary_v1.schema.json
pulse_gate_policy_v0.yml
pulse_gate_registry_v0.yml
PULSE_safe_pack_v0/tools/check_gates.py
recorded evidence verifier
release-required materializer
package assembly or verification
LlamaGuard model identity
LlamaGuard pinned revision
HF_TOKEN
SLSA/VSA activation
DOI and citation identity
Zenodo metadata
release metadata
```

## Verification

Run:

```text
python -m py_compile \
  scripts/check_external_summaries_present.py \
  tests/test_check_external_summaries_present.py

python tests/test_check_external_summaries_present.py

python -m pytest -q \
  tests/test_check_external_summaries_present.py

git diff --check

git diff --name-only origin/main...HEAD
```

Expected changed-file result:

```text
scripts/check_external_summaries_present.py
tests/test_check_external_summaries_present.py
```

Expected standalone smoke result:

```text
OK: check_external_summaries_present smoke tests passed
```

## Post-merge validation

Because the source commit changes, first run the hosted-access preflight
against the new exact `main` SHA.

After the preflight passes, rerun:

```text
strict_external_evidence:
true

llamaguard_evidence_mode:
hosted_full_runtime
```

The previous hosted run already demonstrated that the pinned runtime,
inference, raw evidence, evaluator manifest, and canonical summary producer
could execute. This PR removes the false-negative presence check immediately
after canonical summary production.

A later verifier, materializer, gate, attestation, or package failure remains a
valid fail-closed result and must not be converted into PASS.