### PR TITLE
fix(ci): separate audit bundle from recorded-path artifact

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -3226,7 +3226,6 @@ jobs:
             PULSE_safe_pack_v0/artifacts/report_card.with_release_decision.html
             PULSE_safe_pack_v0/artifacts/release_authority_v0.json
             PULSE_safe_pack_v0/artifacts/artifact_provenance_binding_v0.json
-            PULSE_safe_pack_v0/artifacts/release_authority_audit_bundle/**
             PULSE_safe_pack_v0/artifacts/reports/junit.xml
             PULSE_safe_pack_v0/artifacts/reports/sarif.json
             PULSE_safe_pack_v0/artifacts/external/llamaguard_raw.jsonl

--- a/tests/test_release_grade_reference_package_assembly_wiring_v0.py
+++ b/tests/test_release_grade_reference_package_assembly_wiring_v0.py
@@ -117,6 +117,17 @@ def _top_level_job_blocks(text: str) -> dict[str, str]:
     return blocks
 
 
+def _step_block(text: str, step_name: str) -> str:
+    marker = f"      - name: {step_name}"
+    start = text.index(marker)
+    next_step = text.find("\n      - name:", start + len(marker))
+
+    if next_step == -1:
+        return text[start:]
+
+    return text[start:next_step]
+
+
 def _workflow_and_jobs() -> tuple[str, dict[str, str]]:
     text = _read_workflow()
     blocks = _top_level_job_blocks(text)
@@ -195,6 +206,28 @@ def test_complete_package_job_downloads_required_inputs() -> None:
         assert path in package_job, path
 
 
+def test_recorded_path_upload_excludes_audit_bundle_artifacts() -> None:
+    text = _read_workflow()
+    recorded_step = _step_block(
+        text,
+        "Upload release-grade recorded path artifacts",
+    )
+    audit_bundle_step = _step_block(
+        text,
+        "Upload final release authority audit bundle",
+    )
+
+    assert (
+        "PULSE_safe_pack_v0/artifacts/release_authority_audit_bundle/**"
+        not in recorded_step
+    )
+    assert "name: release-authority-audit-bundle" in audit_bundle_step
+    assert (
+        "path: PULSE_safe_pack_v0/artifacts/release_authority_audit_bundle/"
+        in audit_bundle_step
+    )
+
+
 def test_complete_package_job_uses_existing_canonical_assembler_tool() -> None:
     _text, blocks = _workflow_and_jobs()
     package_job = blocks[PACKAGE_JOB]
@@ -263,6 +296,7 @@ def main() -> int:
     test_complete_package_job_order_and_dependencies()
     test_complete_package_job_is_release_grade_only()
     test_complete_package_job_downloads_required_inputs()
+    test_recorded_path_upload_excludes_audit_bundle_artifacts()
     test_complete_package_job_uses_existing_canonical_assembler_tool()
     test_complete_package_job_builds_fresh_directory()
     test_complete_package_job_uploads_complete_package_artifact()


### PR DESCRIPTION
## Summary

Separate the release-authority audit bundle from the
`release-grade-recorded-path` artifact.

The controlled hosted release-grade run reached and passed:

```text
current-run LlamaGuard production
→ canonical summary
→ summary attestation and verification
→ recorded evidence verification
→ atomic status materialization
→ required + release_required enforcement
→ release-grade qualification
→ final artifact-binding attestation
```

Complete package assembly then failed because the recorded-path input contained
two files named `status.json`.

## Failure mechanism

The recorded-path artifact contained:

```text
status.json
```

and also recursively included:

```text
release_authority_audit_bundle/status.json
```

The package assembler therefore observed:

```text
release-grade-recorded-path/status.json

release-grade-recorded-path/
└── release_authority_audit_bundle/
    └── status.json
```

The canonical assembler intentionally rejects ambiguous basename matches and
failed closed with:

```text
recorded_path input has ambiguous file matches for 'status.json'
```

This behavior is correct. The assembler must not choose one evidence carrier
arbitrarily.

## Files

Modified:

```text
.github/workflows/pulse_ci.yml
tests/test_release_grade_reference_package_assembly_wiring_v0.py
```

No other file is changed.

The existing package-assembly smoke test is already registered in:

```text
ci/tools-tests.list
```

No test-manifest update is required.

## Workflow correction

The following nested path is removed from the
`Upload release-grade recorded path artifacts` step:

```text
PULSE_safe_pack_v0/artifacts/release_authority_audit_bundle/**
```

The recorded-path artifact continues to carry its canonical root:

```text
PULSE_safe_pack_v0/artifacts/status.json
```

and the recorded evidence, final decision, authority, binding, report, external
evidence, JUnit, and SARIF artifacts required by its declared role.

## Audit bundle preservation

The separate upload remains unchanged:

```text
artifact name:
release-authority-audit-bundle

source:
PULSE_safe_pack_v0/artifacts/release_authority_audit_bundle/
```

Package assembly continues to download that artifact into its own input
directory:

```text
AUDIT_BUNDLE_DIR
=
${INPUT_ROOT}/release-authority-audit-bundle
```

The canonical assembler continues to receive:

```text
--audit-bundle-dir "${AUDIT_BUNDLE_DIR}"
```

Therefore no audit material is removed from the complete reference package.

The correction is:

```text
same required evidence
+ separate source carriers
- duplicate basename inside recorded-path input
```

## Artifact-role boundary

After this change:

```text
release-grade-recorded-path
→ canonical recorded evidence and final authority-path artifacts

release-authority-audit-bundle
→ separate review and traceability directory

release-authority-artifact-binding-v0
→ separately attested provenance-binding carrier

pulse-report
→ final report and authority artifact surface
```

The package assembler receives each source through its declared input
directory.

## Fail-closed preservation

This PR does not weaken ambiguous-file rejection.

The assembler continues to fail when:

```text
a required file is missing
a required directory is missing
multiple unresolved file matches exist
a source or destination traverses a symlink
an input is not a regular file
the audit bundle is empty
a package destination already exists
```

The fix removes the unintended duplicate from the source artifact rather than
loosening the consumer.

## Regression coverage

The updated package-assembly wiring smoke verifies:

```text
recorded-path artifact contains root status.json
recorded-path artifact excludes release_authority_audit_bundle/**
recorded-path artifact contains no nested audit-bundle path
audit bundle remains a separate fail-closed artifact upload
package job downloads release-authority-audit-bundle separately
package job writes that download to AUDIT_BUNDLE_DIR
assembler invocation retains --audit-bundle-dir
canonical package assembler remains unchanged
package job remains non-authorizing
package upload remains fail-closed
```

## Authority boundary

This correction affects only artifact layout for preservation and package
assembly.

It does not alter the authoritative decision path:

```text
recorded release evidence
→ final status.json
→ declared policy
→ materialized required + release_required gate set
→ check_gates.py
→ primary CI allow/block result
```

The complete package remains:

```text
preservation and review surface
≠ release authority
```

## Non-effects

No changes to:

```text
PULSE_safe_pack_v0/tools/assemble_release_grade_reference_package_v0.py
PULSE_safe_pack_v0/tools/verify_release_grade_reference_package_v0.py
tools/check_release_grade_package_complete_v1.py
pulse_gate_policy_v0.yml
pulse_gate_registry_v0.yml
PULSE_safe_pack_v0/tools/check_gates.py
recorded evidence verifier
release-required materializer
status schemas
LlamaGuard producer
LlamaGuard model identity
LlamaGuard pinned revision
HF_TOKEN
attestation signer identity
SLSA/VSA activation
DOI and citation identity
Zenodo metadata
release metadata
```

## Verification

Run:

```text
python -m py_compile \
  tests/test_release_grade_reference_package_assembly_wiring_v0.py

python \
  tests/test_release_grade_reference_package_assembly_wiring_v0.py

python tests/test_llamaguard_attested_release_path_wiring_v0.py

python tests/test_artifact_provenance_binding_attestation_wiring_smoke.py

python tests/test_release_grade_reference_package_verification_wiring_v0.py

python tools/check_yaml_unique_keys.py \
  .github/workflows/pulse_ci.yml

git diff --check

git diff --name-only origin/main...HEAD
```

Expected changed-file result:

```text
.github/workflows/pulse_ci.yml
tests/test_release_grade_reference_package_assembly_wiring_v0.py
```

Expected standalone result:

```text
release-grade reference package assembly workflow wiring smoke passed
```

## Post-merge validation

After merge, run the hosted-access preflight against the new exact `main` SHA.

After the preflight passes, start a new `PULSE CI` workflow-dispatch run with:

```text
strict_external_evidence:
true

llamaguard_evidence_mode:
hosted_full_runtime
```

Do not use `Re-run all jobs` from the previous source commit.

The expected complete path is:

```text
pulse
→ LlamaGuard current-run summary: attest and verify
→ Release-grade recorded path: attested evidence to final authority artifacts
→ Release-grade artifact binding v0: attest
→ Release-grade reference package: assemble complete package
→ Release-grade reference package: verify complete package
→ Tools smoke tests
```

The purpose of this PR is not to weaken package validation. It restores a
single unambiguous source for each package input.