### PR TITLE
fix(package): scope non-stub checks to semantic fields

### DIFF
--- a/tests/test_check_release_grade_package_complete_v1.py
+++ b/tests/test_check_release_grade_package_complete_v1.py
@@ -366,6 +366,11 @@ def make_complete_package(tmp_path: Path) -> Path:
             },
             "gates": {
                 "core_required_reference_ok": True,
+                "detectors_materialized_ok": True,
+            },
+            "diagnostics": {
+                "gates_stubbed": False,
+                "scaffold": False,
             },
         },
     )
@@ -400,7 +405,17 @@ def make_complete_package(tmp_path: Path) -> Path:
     )
     write_text(
         package_dir / "artifacts" / "report_card.html",
-        "<html><body>release grade package complete</body></html>\n",
+        (
+            "<html><body>"
+            "<div class='meta-item'>"
+            "<span class='meta-key'>"
+            "Stub/scaffold marker state"
+            "</span>"
+            "<span class='meta-val'>clear</span>"
+            "</div>"
+            "<div>release grade package complete</div>"
+            "</body></html>\n"
+        ),
     )
     write_json(
         package_dir
@@ -541,6 +556,7 @@ def test_complete_package_passes_and_output_matches_stdout(tmp_path: Path) -> No
     assert report["schema_version"] == "release_grade_package_completeness_v1"
     assert report["ok"] is True
     assert report["status"] == "complete"
+    assert report["tool"]["version"] == "0.1.2"
     assert report["errors"] == []
     assert report["authority_boundary"]["authorizes_release"] is False
     assert report["authority_boundary"]["package_completeness_only"] is True
@@ -595,6 +611,188 @@ def test_release_decision_stubbed_scaffold_diagnostic_vocabulary_is_allowed(
     assert result.returncode == 0, result.stdout + result.stderr
     report = parse_report(result)
     assert report["ok"] is True
+
+
+def test_sigstore_canonicalized_body_is_opaque_to_stub_scan(
+    tmp_path: Path,
+) -> None:
+    package_dir = make_complete_package(tmp_path)
+    bundle_path = (
+        package_dir
+        / "artifacts"
+        / "external"
+        / "llamaguard_summary.bundle.json"
+    )
+
+    bundle = read_json(bundle_path)
+    bundle["verificationMaterial"] = {
+        "tlogEntries": [
+            {
+                "canonicalizedBody": (
+                    "opaque-tbd-transparency-log-body"
+                ),
+                "logIndex": "17",
+            }
+        ],
+    }
+
+    write_json(bundle_path, bundle)
+    rebuild_digest_inventory(package_dir)
+
+    result = run_tool(package_dir)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    report = parse_report(result)
+    assert report["ok"] is True
+
+    checks = {
+        check["check_id"]: check["passed"]
+        for check in report["checks"]
+    }
+
+    assert (
+        checks[
+            "non_stub_json:"
+            "artifacts/external/"
+            "llamaguard_summary.bundle.json"
+        ]
+        is True
+    )
+
+
+def test_bundle_semantic_stub_marker_still_fails_closed(
+    tmp_path: Path,
+) -> None:
+    package_dir = make_complete_package(tmp_path)
+    bundle_path = (
+        package_dir
+        / "artifacts"
+        / "external"
+        / "llamaguard_summary.bundle.json"
+    )
+
+    bundle = read_json(bundle_path)
+    bundle["bundle"]["status"] = "replace-me"
+
+    write_json(bundle_path, bundle)
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(
+        run_tool(package_dir),
+        (
+            "non_stub_json:"
+            "artifacts/external/"
+            "llamaguard_summary.bundle.json"
+        ),
+    )
+
+
+def test_report_card_clear_marker_state_is_semantic_pass(
+    tmp_path: Path,
+) -> None:
+    package_dir = make_complete_package(tmp_path)
+
+    result = run_tool(package_dir)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    report = parse_report(result)
+
+    checks = {
+        check["check_id"]: check["passed"]
+        for check in report["checks"]
+    }
+
+    assert checks["report_card.marker_state_clear"] is True
+    assert checks["report_card.non_stub"] is True
+
+
+def test_report_card_active_stub_state_fails_closed(
+    tmp_path: Path,
+) -> None:
+    package_dir = make_complete_package(tmp_path)
+    report_path = package_dir / "artifacts" / "report_card.html"
+
+    write_text(
+        report_path,
+        (
+            "<html><body>"
+            "<h2>"
+            "PROD READER SURFACE — "
+            "STUBBED/SCAFFOLD EVIDENCE STATE — "
+            "NOT RELEASE-GRADE AUTHORITY"
+            "</h2>"
+            "<div class='meta-item'>"
+            "<span class='meta-key'>"
+            "Stub/scaffold marker state"
+            "</span>"
+            "<span class='meta-val'>"
+            "diagnostics.gates_stubbed"
+            "</span>"
+            "</div>"
+            "</body></html>\n"
+        ),
+    )
+
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(
+        run_tool(package_dir),
+        "report_card.non_stub",
+    )
+
+
+def test_final_status_requires_materialized_detector_gate(
+    tmp_path: Path,
+) -> None:
+    package_dir = make_complete_package(tmp_path)
+    status_path = package_dir / "artifacts" / "status.json"
+
+    status = read_json(status_path)
+    status["gates"]["detectors_materialized_ok"] = False
+
+    write_json(status_path, status)
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(
+        run_tool(package_dir),
+        "status.release_grade.detectors_materialized_ok",
+    )
+
+
+def test_final_status_rejects_gates_stubbed_true(
+    tmp_path: Path,
+) -> None:
+    package_dir = make_complete_package(tmp_path)
+    status_path = package_dir / "artifacts" / "status.json"
+
+    status = read_json(status_path)
+    status["diagnostics"]["gates_stubbed"] = True
+
+    write_json(status_path, status)
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(
+        run_tool(package_dir),
+        "status.release_grade.gates_stubbed_false",
+    )
+
+
+def test_final_status_rejects_scaffold_true(
+    tmp_path: Path,
+) -> None:
+    package_dir = make_complete_package(tmp_path)
+    status_path = package_dir / "artifacts" / "status.json"
+
+    status = read_json(status_path)
+    status["diagnostics"]["scaffold"] = True
+
+    write_json(status_path, status)
+    rebuild_digest_inventory(package_dir)
+
+    assert_failure(
+        run_tool(package_dir),
+        "status.release_grade.scaffold_false",
+    )
 
 
 def test_missing_required_file_fails_closed(tmp_path: Path) -> None:
@@ -895,6 +1093,13 @@ def check_check_release_grade_package_complete_v1() -> None:
         test_current_package_contract_without_slsa_artifacts_passes(tmp_path)
         test_slsa_artifacts_required_when_strict_flag_is_set(tmp_path)
         test_release_decision_stubbed_scaffold_diagnostic_vocabulary_is_allowed(tmp_path)
+        test_sigstore_canonicalized_body_is_opaque_to_stub_scan(tmp_path)
+        test_bundle_semantic_stub_marker_still_fails_closed(tmp_path)
+        test_report_card_clear_marker_state_is_semantic_pass(tmp_path)
+        test_report_card_active_stub_state_fails_closed(tmp_path)
+        test_final_status_requires_materialized_detector_gate(tmp_path)
+        test_final_status_rejects_gates_stubbed_true(tmp_path)
+        test_final_status_rejects_scaffold_true(tmp_path)
         test_missing_required_file_fails_closed(tmp_path)
         test_missing_external_evidence_file_fails_closed(tmp_path)
         test_empty_required_file_fails_closed(tmp_path)

--- a/tools/check_release_grade_package_complete_v1.py
+++ b/tools/check_release_grade_package_complete_v1.py
@@ -13,7 +13,7 @@ from typing import Any
 
 TOOL_NAME = "check_release_grade_package_complete_v1"
 SCHEMA_VERSION = "release_grade_package_completeness_v1"
-TOOL_VERSION = "0.1.1"
+TOOL_VERSION = "0.1.2"
 
 REQUIRED_FILES: tuple[str, ...] = (
     "package_digest_inventory_v0.json",
@@ -87,6 +87,32 @@ STUB_SCAN_EXEMPT_PATH_PREFIXES: tuple[tuple[str, str], ...] = (
     ("artifacts/release_decision_v0.json", "$.decision_basis"),
 )
 
+
+STUB_SCAN_EXEMPT_NORMALIZED_PATHS: tuple[tuple[str, str], ...] = (
+    (
+        "artifacts/external/llamaguard_summary.bundle.json",
+        "$.verificationMaterial.tlogEntries[*].canonicalizedBody",
+    ),
+)
+
+JSON_ARRAY_INDEX_RE = re.compile(r"\[\d+\]")
+
+REPORT_CARD_NON_STUB_MARKERS = tuple(
+    marker
+    for marker in STUB_MARKERS
+    if marker != "stub"
+)
+
+REPORT_CARD_ACTIVE_STUB_PHRASES = (
+    "stubbed/scaffold evidence state",
+    "stub/scaffold markers recorded",
+)
+
+REPORT_CARD_CLEAR_MARKER_SEQUENCE = (
+    "stub/scaffold marker state clear"
+)
+
+
 PRODUCER_FIELDS = (
     "producer_id",
     "producer_name",
@@ -123,6 +149,36 @@ class CompletenessError(ValueError):
 
 class StrictJsonError(CompletenessError):
     """Strict JSON parse error."""
+
+
+class _VisibleTextExtractor(HTMLParser):
+    """Extract visible HTML text while ignoring script and style content."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+        self._suppressed_depth = 0
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        del attrs
+
+        if tag.lower() in {"script", "style"}:
+            self._suppressed_depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if (
+            tag.lower() in {"script", "style"}
+            and self._suppressed_depth > 0
+        ):
+            self._suppressed_depth -= 1
+
+    def handle_data(self, data: str) -> None:
+        if self._suppressed_depth == 0 and data.strip():
+            self.parts.append(data)
 
 
 def _json_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -344,11 +400,39 @@ def _stub_marker_hits(value: str) -> list[str]:
     return [marker for marker in STUB_MARKERS if marker in lowered]
 
 
+def _normalize_json_path(json_path: str) -> str:
+    """Replace concrete JSON-array indexes with a stable wildcard."""
+
+    return JSON_ARRAY_INDEX_RE.sub("[*]", json_path)
+
+
 def _stub_scan_exempt(relative: str, json_path: str) -> bool:
-    return any(
+    if any(
         relative == exempt_relative and json_path.startswith(exempt_prefix)
         for exempt_relative, exempt_prefix in STUB_SCAN_EXEMPT_PATH_PREFIXES
+       ):
+        return True
+
+    normalized_path = _normalize_json_path(json_path)
+
+    return any(
+        relative == exempt_relative
+        and normalized_path == exempt_path
+        for exempt_relative, exempt_path
+        in STUB_SCAN_EXEMPT_NORMALIZED_PATHS
     )
+
+
+def _visible_html_text(value: str) -> str:
+    """Return normalized visible text from a report-card HTML document."""
+
+    parser = _VisibleTextExtractor()
+    parser.feed(value)
+    parser.close()
+
+    return " ".join(
+        " ".join(parser.parts).split()
+    ).lower()
 
 
 def _canonical_current_run_key(binding: Any) -> str | None:
@@ -500,7 +584,66 @@ def _verify_jsonl_files(
             )
 
 
-def _verify_report_card(
+def _verify_final_status_non_stub(
+    *,
+    loaded: dict[str, dict[str, Any]],
+    checks: list[dict[str, Any]],
+    errors: list[str],
+) -> None:
+    """Verify literal release-grade non-stub state in final status.json."""
+
+    relative = "artifacts/status.json"
+    status = loaded.get(relative)
+
+    if status is None:
+        return
+
+    gates = status.get("gates")
+    diagnostics = status.get("diagnostics")
+
+    detectors_materialized = (
+        isinstance(gates, dict)
+        and gates.get("detectors_materialized_ok") is True
+    )
+
+    gates_stubbed_false = (
+        isinstance(diagnostics, dict)
+        and diagnostics.get("gates_stubbed") is False
+    )
+
+    scaffold_false = (
+        isinstance(diagnostics, dict)
+        and diagnostics.get("scaffold") is False
+    )
+
+    _check(
+        checks,
+        errors,
+        "status.release_grade.detectors_materialized_ok",
+        detectors_materialized,
+        (
+            "final status gates.detectors_materialized_ok "
+            "is literal true"
+        ),
+    )
+
+    _check(
+        checks,
+        errors,
+        "status.release_grade.gates_stubbed_false",
+        gates_stubbed_false,
+        "final status diagnostics.gates_stubbed is literal false",
+    )
+
+    _check(
+        checks,
+        errors,
+        "status.release_grade.scaffold_false",
+        scaffold_false,
+        "final status diagnostics.scaffold is literal false",
+    )
+    
+    def _verify_report_card(
     *,
     package_dir: Path,
     checks: list[dict[str, Any]],
@@ -513,15 +656,58 @@ def _verify_report_card(
         return
 
     text = path.read_text(encoding="utf-8")
-    hits = _stub_marker_hits(text)
+        visible_text = _visible_html_text(text)
+
+    marker_hits = [
+        marker
+        for marker in REPORT_CARD_NON_STUB_MARKERS
+        if marker in visible_text
+    ]
+
+    active_stub_hits = [
+        phrase
+        for phrase in REPORT_CARD_ACTIVE_STUB_PHRASES
+        if phrase in visible_text
+    ]
+
+    marker_state_clear = (
+        REPORT_CARD_CLEAR_MARKER_SEQUENCE
+        in visible_text
+    )
+
+    _check(
+        checks,
+        errors,
+        "report_card.marker_state_clear",
+        marker_state_clear,
+        (
+            "report_card.html records "
+            "Stub/scaffold marker state as clear"
+        ),
+    )
 
     _check(
         checks,
         errors,
         "report_card.non_stub",
-        not hits,
-        "report_card.html contains no stub/placeholder markers",
+         not marker_hits and not active_stub_hits,
+        (
+            "report_card.html contains no active semantic "
+            "stub/scaffold or placeholder state"
+        ),
     )
+
+    for marker in marker_hits:
+        errors.append(
+            "report_card.non_stub: "
+            f"visible text contains {marker!r}"
+        )
+
+    for phrase in active_stub_hits:
+        errors.append(
+            "report_card.non_stub: "
+            f"visible text contains active state {phrase!r}"
+        )
 
 
 def _verify_digest_inventory(
@@ -1180,12 +1366,17 @@ def check_package(
             checks=checks,
             errors=errors,
         )
+        _verify_final_status_non_stub(
+            loaded=loaded,
+            checks=checks,
+            errors=errors,
+        )
         _verify_report_card(
             package_dir=resolved_package_dir,
             checks=checks,
             errors=errors,
         )
-        _verify_digest_inventory(
+       _verify_digest_inventory(
             package_dir=resolved_package_dir,
             inventory=loaded.get("package_digest_inventory_v0.json"),
             checks=checks,

--- a/tools/check_release_grade_package_complete_v1.py
+++ b/tools/check_release_grade_package_complete_v1.py
@@ -6,7 +6,9 @@ import hashlib
 import json
 import math
 import os
+import re
 import sys
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any
 
@@ -408,9 +410,11 @@ def _normalize_json_path(json_path: str) -> str:
 
 def _stub_scan_exempt(relative: str, json_path: str) -> bool:
     if any(
-        relative == exempt_relative and json_path.startswith(exempt_prefix)
-        for exempt_relative, exempt_prefix in STUB_SCAN_EXEMPT_PATH_PREFIXES
-       ):
+        relative == exempt_relative
+        and json_path.startswith(exempt_prefix)
+        for exempt_relative, exempt_prefix
+        in STUB_SCAN_EXEMPT_PATH_PREFIXES
+    ):
         return True
 
     normalized_path = _normalize_json_path(json_path)
@@ -642,8 +646,9 @@ def _verify_final_status_non_stub(
         scaffold_false,
         "final status diagnostics.scaffold is literal false",
     )
-    
-    def _verify_report_card(
+
+
+def _verify_report_card(
     *,
     package_dir: Path,
     checks: list[dict[str, Any]],
@@ -655,8 +660,11 @@ def _verify_final_status_non_stub(
     if not path.is_file() or path.is_symlink():
         return
 
-    text = path.read_text(encoding="utf-8")
-        visible_text = _visible_html_text(text)
+    text = path.read_text(
+        encoding="utf-8",
+        errors="strict",
+    )
+    visible_text = _visible_html_text(text)
 
     marker_hits = [
         marker
@@ -690,7 +698,7 @@ def _verify_final_status_non_stub(
         checks,
         errors,
         "report_card.non_stub",
-         not marker_hits and not active_stub_hits,
+        not marker_hits and not active_stub_hits,
         (
             "report_card.html contains no active semantic "
             "stub/scaffold or placeholder state"
@@ -1376,9 +1384,11 @@ def check_package(
             checks=checks,
             errors=errors,
         )
-       _verify_digest_inventory(
+        _verify_digest_inventory(
             package_dir=resolved_package_dir,
-            inventory=loaded.get("package_digest_inventory_v0.json"),
+            inventory=loaded.get(
+                "package_digest_inventory_v0.json"
+            ),
             checks=checks,
             errors=errors,
         )


### PR DESCRIPTION
## Summary

Scope release-grade package non-stub validation to semantic fields instead of
performing unrestricted substring searches over opaque cryptographic carriers
and raw rendered HTML.

The previous controlled hosted run successfully reached:

```text
current-run LlamaGuard production
→ canonical summary
→ summary attestation and cryptographic verification
→ recorded evidence verification
→ atomic status materialization
→ required + release_required enforcement
→ release-grade qualification
→ final artifact-binding attestation
→ complete package assembly
```

The package completeness checker then reported two failures while all required
files, directories, digest entries, sizes, recorded candidates, and exact
inventory coverage passed.

## Files

Modified:

```text
tools/check_release_grade_package_complete_v1.py
tests/test_check_release_grade_package_complete_v1.py
```

No other file is changed.

The test is already registered in:

```text
ci/tools-tests.list
```

No manifest update is required.

## Failure 1: opaque transparency-log carrier

The attestation bundle contained an opaque Sigstore transparency-log value at:

```text
$.verificationMaterial.tlogEntries[0].canonicalizedBody
```

The encoded carrier happened to contain the character sequence:

```text
tbd
```

The previous checker recursively scanned every JSON string and interpreted that
incidental substring as the semantic phrase “to be determined.”

This was a false positive. The field is a canonicalized cryptographic carrier,
not an operator-authored semantic field.

## Failure 2: valid Quality Ledger label

The final Quality Ledger contained the declared label:

```text
Stub/scaffold marker state
```

with the value:

```text
clear
```

The previous checker scanned the complete raw HTML document and rejected any
occurrence of the substring:

```text
stub
```

This incorrectly classified the name of a valid diagnostic field as an active
stub condition.

## JSON correction

The checker now supports an exact, narrowly scoped exemption for:

```text
artifacts/external/llamaguard_summary.bundle.json

$.verificationMaterial.tlogEntries[*].canonicalizedBody
```

Concrete array indexes are normalized before matching:

```text
tlogEntries[0]
tlogEntries[1]
...
→
tlogEntries[*]
```

Only the exact opaque field is exempt.

The following remain subject to normal fail-closed marker scanning:

```text
bundle status
bundle metadata
verification metadata
subject identity
signer identity
repository identity
workflow identity
all other semantic JSON fields
```

Therefore:

```text
canonicalizedBody contains incidental tbd
→ PASS

bundle.bundle.status = replace-me
→ FAIL
```

The entire attestation bundle does not receive a blanket exemption.

## Quality Ledger correction

The checker now parses visible HTML text and ignores script and style content.

The expected valid state is:

```text
Stub/scaffold marker state
→ clear
```

The checker separately rejects active semantic conditions such as:

```text
STUBBED/SCAFFOLD EVIDENCE STATE

stub/scaffold markers recorded

placeholder

replace-me

not implemented

example.invalid
```

This preserves the distinction between:

```text
field name describing stub state
≠
active stub state
```

## Final status checks

The package completeness checker now directly inspects the final:

```text
artifacts/status.json
```

and requires these literal values:

```text
gates.detectors_materialized_ok is true

diagnostics.gates_stubbed is false

diagnostics.scaffold is false
```

These checks are stronger than raw word searches because they inspect the
actual machine state carried by the final status artifact.

The following fail closed:

```text
detectors_materialized_ok missing
detectors_materialized_ok false
detectors_materialized_ok null
detectors_materialized_ok non-boolean

gates_stubbed missing
gates_stubbed true
gates_stubbed null
gates_stubbed non-boolean

scaffold missing
scaffold true
scaffold null
scaffold non-boolean
```

## Tool version

```text
0.1.1
→
0.1.2
```

The report schema remains:

```text
release_grade_package_completeness_v1
```

No schema transition is introduced.

## Regression coverage

The updated test suite proves:

```text
1. complete package fixture → PASS

2. exact tool version 0.1.2 → PASS

3. canonicalizedBody containing incidental tbd → PASS

4. semantic bundle field containing replace-me → FAIL

5. Quality Ledger marker state clear → PASS

6. active STUBBED/SCAFFOLD evidence state → FAIL

7. detectors_materialized_ok=false → FAIL

8. diagnostics.gates_stubbed=true → FAIL

9. diagnostics.scaffold=true → FAIL

10. existing general JSON placeholder rejection → preserved

11. existing strict JSON parsing → preserved

12. existing digest inventory verification → preserved

13. existing recorded-candidate validation → preserved

14. existing SLSA/VSA optional-current-contract behavior → preserved

15. existing output-safety restrictions → preserved
```

## Fail-closed preservation

This PR does not remove non-stub validation.

It changes the validation boundary from:

```text
arbitrary substring anywhere in serialized bytes
```

to:

```text
semantic field inspection
+ exact opaque-carrier exclusion
+ direct final-status assertions
```

The checker continues to reject:

```text
real placeholders
unfinished semantic fields
stubbed final state
scaffold final state
missing detector materialization
malformed JSON
duplicate JSON keys
non-finite values
missing required files
empty required files
missing required directories
symlinks
digest mismatches
size mismatches
inventory coverage mismatches
invalid recorded candidates
invalid SLSA/VSA packet/report binding
unsafe output paths
```

## Authority boundary

The completeness checker remains read-only and non-authoritative.

It does not:

```text
write status.json
materialize gates
call check_gates.py
change policy
create release authority
authorize a release
block the primary release decision
modify evidence
modify attestations
```

Its authority declaration remains:

```text
read_only: true
authorizes_release: false
blocks_release: false
creates_release_authority: false
materializes_status: false
materializes_required_gates: false
calls_gate_checker: false
package_completeness_only: true
```

The authoritative path remains:

```text
recorded release evidence
→ final status.json
→ declared policy
→ materialized required + release_required gate set
→ check_gates.py
→ primary CI allow/block result
```

## Non-effects

No changes to:

```text
.github/workflows/pulse_ci.yml
PULSE_safe_pack_v0/tools/assemble_release_grade_reference_package_v0.py
PULSE_safe_pack_v0/tools/verify_release_grade_reference_package_v0.py
PULSE_safe_pack_v0/tools/render_quality_ledger.py
pulse_gate_policy_v0.yml
pulse_gate_registry_v0.yml
PULSE_safe_pack_v0/tools/check_gates.py
recorded evidence verifier
release-required materializer
status schemas
external summary schemas
LlamaGuard producer
LlamaGuard model identity
LlamaGuard pinned revision
HF_TOKEN
attestation signer identity
artifact-binding attestation
SLSA/VSA activation state
DOI and citation identity
Zenodo metadata
release metadata
```

## Verification

Run:

```text
python -m py_compile \
  tools/check_release_grade_package_complete_v1.py \
  tests/test_check_release_grade_package_complete_v1.py

python \
  tests/test_check_release_grade_package_complete_v1.py

python -m pytest -q \
  tests/test_check_release_grade_package_complete_v1.py

python \
  tests/test_release_grade_package_completeness_checker_ci_boundary_v1.py

python \
  tests/test_release_grade_package_completeness_workflow_wiring_v1.py

git diff --check

git diff --name-only origin/main...HEAD
```

Expected changed-file result:

```text
tests/test_check_release_grade_package_complete_v1.py
tools/check_release_grade_package_complete_v1.py
```

Expected standalone result:

```text
OK: check_release_grade_package_complete_v1 smoke passed
```

## Post-merge validation

After merge, run the hosted-access preflight against the new exact `main`
commit.

After the preflight passes, start a new workflow-dispatch run:

```text
strict_external_evidence:
true

llamaguard_evidence_mode:
hosted_full_runtime
```

Do not use `Re-run all jobs` from the previous source commit.

The expected path is:

```text
pulse
→ LlamaGuard current-run summary: attest and verify
→ Release-grade recorded path
→ Release-grade artifact binding v0: attest
→ Release-grade reference package: assemble complete package
→ Check release-grade package completeness
→ Verify complete release-grade reference package
→ Tools smoke tests
```

A later substantive package, verifier, digest, binding, status, gate, or
attestation failure remains a valid fail-closed result.