### PR TITLE
docs(ref): repair completed-run record consistency

### DIFF
--- a/docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md
+++ b/docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md
@@ -92,7 +92,7 @@ workflow run attempt:
 workflow run URL:
 https://github.com/HKati/pulse-release-gates-0.1/actions/runs/29249887581
 
-run key:
+PULSE_RUN_KEY:
 GITHUB_RUN_ID=29249887581|GITHUB_RUN_ATTEMPT=1|GITHUB_WORKFLOW=PULSE CI
 
 run mode:
@@ -131,6 +131,7 @@ The current-run binding key is the exact machine value embedded in the
 evidence, candidate, verifier, status, and package artifacts:
 
 ```text
+PULSE_RUN_KEY:
 GITHUB_RUN_ID=29249887581|GITHUB_RUN_ATTEMPT=1|GITHUB_WORKFLOW=PULSE CI
 ```
 

--- a/docs/release_grade_reference_run_v0.md
+++ b/docs/release_grade_reference_run_v0.md
@@ -107,7 +107,7 @@ External release-grade evidence must pass the applicable:
 - envelope binding;
 - cryptographic attestation verification.
 
-TThe first completed public reference execution is:
+The first completed public reference execution is:
 
 ```text
 PULSE CI #6066
@@ -1417,40 +1417,6 @@ Completed public release-grade reference run
 
 ## Next operational steps
 
-The current-run evidence producer, canonical candidate replay, recorded release-evidence verifier, canonical verifier replay, release-required materializer, cryptographic attestation verifier, and advisory subset qualification checker are implemented.
-
-Baseline reference-bundle assembly is implemented.
-
-Complete evidence-chain reference packaging and complete-package verification remain pending.
-
-The next operational sequence is:
-
-1. replace deferred or wildcard release-grade signer identities with one exact operational workflow identity;
-2. implement the current-run canonical external-evidence producer lane;
-3. generate a cryptographic attestation bundle for the current-run external summary;
-4. build the canonical external-summary envelope from the verified run identity and summary digest;
-5. extend `release-grade-reference-run-v0` assembly to include:
-   - `required_gate_evidence_v0.json`;
-   - `status_baseline.json`;
-   - recorded-release candidate envelopes;
-   - the candidate index;
-   - the release-evidence input manifest;
-   - the recorded-evidence verifier report;
-   - external-summary envelopes;
-   - external-summary attestation bundles;
-   - `release_decision_v0.json`;
-   - `artifact_provenance_binding_v0.json`;
-6. add or extend package verification so the complete reference bundle is checked independently of the advisory subset qualification checker;
-7. execute the controlled strict release-grade workflow;
-8. preserve the complete current-run evidence, candidate, verifier, materialization, final-status, decision, and provenance-binding chain;
-9. publish the complete release-grade reference artifact bundle;
-10. complete `docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md` with concrete run identity, artifact URLs, and SHA-256 digests;
-11. link the completed public reference run from the README and documentation index;
-12. use the completed run as the baseline for independent reproduction and later portability work.
-
-The progression is:
-
-```text
 The first completed public non-stubbed hosted release-grade reference run now
 exists.
 


### PR DESCRIPTION
## Summary

Repair three documentation defects found during post-merge review of the
completed PULSE CI #6066 reference-run record.

## Files

```text
docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md
docs/release_grade_reference_run_v0.md
```

## Corrections

### Balanced Markdown structure

Replace the complete trailing `Next operational steps` section so that:

```text
all Markdown fences are balanced
the canonical baseline remains separately fenced
the post-reference progression remains separately fenced
the authority path remains separately fenced
```

### Current operational state

Remove the stale pre-execution wording that still described:

```text
complete packaging
package verification
controlled strict execution
public run-note completion
```

as pending work.

Those milestones were completed by PULSE CI #6066 and are already recorded in
the canonical run note.

### Public typo

Correct:

```text
TThe first completed public reference execution is:
```

to:

```text
The first completed public reference execution is:
```

### Exact machine-key label

Change the display label from:

```text
run key:
```

to:

```text
PULSE_RUN_KEY:
```

while preserving the exact recorded value:

```text
GITHUB_RUN_ID=29249887581|GITHUB_RUN_ATTEMPT=1|GITHUB_WORKFLOW=PULSE CI
```

## Authority boundary

No release mechanics are changed.

The authoritative path remains:

```text
recorded release evidence
→ final status.json
→ declared gate policy
→ workflow-effective materialized required gate set
→ PULSE_safe_pack_v0/tools/check_gates.py
→ primary CI allow/block result
```

## Non-effects

No changes to:

```text
.github/workflows/
tools/
PULSE_safe_pack_v0/tools/
policy
registry
schemas
gate sets
SLSA/VSA activation
GitHub Release state
version tags
Zenodo
DOI
citation metadata
release metadata
```