### PR TITLE
docs(readme): align hardening scope with completed run

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,12 +536,14 @@ recorded release evidence
 >
 > The current implementation includes current-run required-gate evidence production, non-stubbed candidate state, canonical candidate replay, recorded release-evidence verification, canonical verifier replay, policy-derived release-required materialization, external-summary schema and semantic validation, the exact LlamaGuard workflow identity, hosted current-run LlamaGuard raw-evidence and canonical-summary production capability, GitHub attestation bundle and canonical-envelope wiring, cryptographic attestation verification, complete release-grade package assembly, structural package-completeness checking, and independent package verification.
 >
-> The remaining active hardening surfaces include successful qualifying execution of the implemented hosted lane from one fixed source commit, exact operational signer identities for any additional detector lanes, the first completed public non-stubbed release-grade run record, independent external reproduction, portability, and further evidence-packet hardening.
+> PULSE CI #6066 is the completed fixed-source hosted release-grade baseline.
 >
-> Implemented workflow capability does not itself establish a completed current-run proof. Evidence contributes to release authority only when it is produced for the qualifying run, admitted through recorded evidence, declared policy, workflow-effective materialized required gates, and strict fail-closed CI enforcement.
->
-> Open work is tracked as hardening work. It is not treated as release authority by assumption.
 
+> The remaining active hardening surfaces include exact operational signer identities and current-run evidence paths for additional detector lanes, independent external reproduction, artifact-retention and portability verification, controlled failure variants, and further evidence-packet hardening.
+> 
+> Implemented workflow capability does not itself establish a completed current-run proof. The #6066 record establishes that proof for the hosted LlamaGuard lane; every future detector lane and reproduction must independently preserve current-run evidence, recorded admission, declared policy, workflow-effective materialized required gates, and strict fail-closed CI enforcement.
+>
+> Open work is tracked as post-reference hardening work. It is not treated as release authority by assumption.
 ---
 
 ## Start here

--- a/tests/test_readme_release_authority_category_signal_v0.py
+++ b/tests/test_readme_release_authority_category_signal_v0.py
@@ -126,6 +126,10 @@ REQUIRED_FRONT_DOOR_ANCHORS = [
     ),
     "Completed public non-stubbed release-grade run record",
     "PULSE CI #6066",
+    (
+        "PULSE CI #6066 is the completed fixed-source "
+        "hosted release-grade baseline"
+    ),
     "46b639706e23f80fe296a8893be18e2b5ab21f7e",
     "RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md",
     "hosted_full_runtime",
@@ -168,6 +172,16 @@ FORBIDDEN_FRONT_DOOR_PHRASES = [
     "\n+ check_gates.py\n",
     "pending template; not a completed run record",
     "Pending controlled hosted execution",
+    (
+        "The remaining active hardening surfaces include "
+        "successful qualifying execution of the implemented "
+        "hosted lane from one fixed source commit"
+    ),
+    (
+        "the first completed public non-stubbed "
+        "release-grade run record, independent external "
+        "reproduction"
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

Remove the final public-surface contradiction around the completed hosted
release-grade reference run.

The README already records:

```text
PULSE CI #6066
→ completed hosted release-grade reference run
```

but its later `Continuous expansion and scoped authority` block still listed:

```text
successful fixed-source hosted execution
first completed public non-stubbed release-grade run record
```

as remaining work.

## Files

```text
README.md
tests/test_readme_release_authority_category_signal_v0.py
```

## Correction

The README now records:

```text
PULSE CI #6066
→ completed fixed-source hosted release-grade baseline
```

Remaining hardening is limited to:

```text
additional detector lanes
independent external reproduction
artifact-retention and portability verification
controlled failure variants
further evidence-packet hardening
```

## Regression coverage

The README guard now:

```text
requires the completed #6066 baseline wording
rejects the old fixed-source hosted execution as remaining work
rejects the first completed public run record as remaining work
```

## Authority boundary

The normative path remains unchanged:

```text
recorded release evidence
→ final status.json
→ declared gate policy
→ workflow-effective materialized required gate set
→ PULSE_safe_pack_v0/tools/check_gates.py
→ primary CI allow/block result
```

No runtime, workflow, policy, gate, verifier, materializer, schema, release,
SLSA/VSA, DOI, citation, or Zenodo change.