### PR TITLE
feat(adopt): add PULSEmech integration planner v0

### DIFF
--- a/schemas/pulsemech_integration_component_manifest_v0.schema.json
+++ b/schemas/pulsemech_integration_component_manifest_v0.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/HKati/pulse-release-gates-0.1/schemas/pulsemech_integration_component_manifest_v0.schema.json",
+  "title": "PULSEmech integration component manifest v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "manifest_type",
+    "source_repository",
+    "policy_path",
+    "components",
+    "component_sets"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "pulsemech_integration_component_manifest_v0"
+    },
+    "manifest_type": {
+      "const": "pulsemech_integration_component_manifest"
+    },
+    "source_repository": {
+      "$ref": "#/$defs/non_empty_string"
+    },
+    "policy_path": {
+      "$ref": "#/$defs/relative_path"
+    },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/component"
+      }
+    },
+    "component_sets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/component_set"
+      }
+    }
+  },
+  "$defs": {
+    "non_empty_string": {
+      "type": "string",
+      "minLength": 1
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z0-9][a-z0-9._-]*$"
+    },
+    "relative_path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*\\\\)(?!.*(^|/)\\.\\.(/|$)).+$"
+    },
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "source_path",
+        "target_path",
+        "requires"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/id"
+        },
+        "kind": {
+          "enum": [
+            "file",
+            "tree"
+          ]
+        },
+        "source_path": {
+          "$ref": "#/$defs/relative_path"
+        },
+        "target_path": {
+          "$ref": "#/$defs/relative_path"
+        },
+        "requires": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/id"
+          }
+        },
+        "exclude_patterns": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/non_empty_string"
+          },
+          "default": []
+        }
+      }
+    },
+    "component_set": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "description",
+        "root_components",
+        "declared_gate_sets",
+        "supported_ci_providers",
+        "authority_boundary"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/id"
+        },
+        "description": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "root_components": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/id"
+          }
+        },
+        "declared_gate_sets": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/id"
+          }
+        },
+        "supported_ci_providers": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "github_actions",
+              "gitlab_ci",
+              "circleci",
+              "jenkins",
+              "azure_pipelines",
+              "buildkite"
+            ]
+          }
+        },
+        "authority_boundary": {
+          "$ref": "#/$defs/non_empty_string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add the first deterministic automation layer for PULSEmech adoption.

Introduce a schema-bound integration request, a dependency-aware canonical component manifest, and a read-only target-repository planner.

The planner:

- resolves the complete component dependency closure from the requested set;
- derives gate identities from the declared policy instead of copied gate lists;
- records exact source revision and file digests;
- classifies target files as create, preserve, or conflict;
- detects symlink, non-regular, path-parent, and CI-provider conflicts;
- emits a deterministic machine-readable integration plan;
- refuses to write the plan inside the target repository;
- performs no target-repository mutation and creates no release decision.

Add regression coverage for deterministic planning, zero target writes, identical-file preservation, conflicting-file rejection, symlink and parent-path rejection, unsupported CI reporting, policy-derived gate materialization, and repository contract registration.

Register the regression in ci/tools-tests.list.

No workflow, gate policy, gate registry, verifier, materializer, status semantics, release-authority, SLSA/VSA activation, DOI, citation, Zenodo, tag, release, or release-metadata behavior changes.

<!-- PULSE PR Template v1.0 — keep sections; fill what applies. -->

## Summary
<!-- Short: what changes and why? -->

## What’s included
- [ ] Code
- [ ] Docs
- [ ] CI / workflow
- Paths / files touched:

## CI usage
```yaml
# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json
```

## Impact
- Additive / backwards-compatible
- Breaking change — details:
- Performance / SLO impact:
- Security considerations:

What’s included
 Code
 Docs
 CI / workflow

Paths / files touched:

CI usage

# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json

Impact
Additive / backwards-compatible

Breaking change — details:

Performance / SLO impact:

Security considerations:

### Security Intake (v0) — dependency / external code (if applicable)
**Intake v0:** PASS | REVIEW | HARD STOP  
**Isolation used (if REVIEW):** yes / no  

**Reasons (1–3 bullets):**
- 
- 
- 

**Checks**
- [ ] No password-protected ZIP / random binary download involved
- [ ] Repo age ≥ 12 months and maintainer history looks real
- [ ] No postinstall/preinstall scripts (or justified + reviewed)
- [ ] No obfuscation / base64 blobs / runtime-downloaded binaries
- [ ] No instructions like “disable Defender/AV”
- [ ] First run done in VM/container (if REVIEW)

> If any HIGH-risk signal appears → mark **HARD STOP** and do not merge.

Notes

Follow-ups:

Risks / mitigations:

PULSE checklist (release authority)
 PULSE CI is green on this PR
 Quality Ledger link (if enabled)
 Badges updated (PASS / RDSI / Q-Ledger)


## Notes
- Follow-ups:
- Risks / mitigations:

## PULSE checklist (release authority)
- [ ] PULSE CI is green on this PR
- [ ] Quality Ledger link (if enabled)
- [ ] Badges updated (PASS / RDSI / Q‑Ledger)
