### PR TITLE
test(compute): close fixed-source builder P2 regressions

### DIFF
--- a/tests/test_build_pulsemech_compute_binding_report_v0.py
+++ b/tests/test_build_pulsemech_compute_binding_report_v0.py
@@ -26,6 +26,9 @@ PRESERVATION_DIR = ROOT / "preservation" / "pulse_ci_6066"
 MANIFEST = PRESERVATION_DIR / "PRESERVATION_MANIFEST_v0.json"
 README = PRESERVATION_DIR / "README.md"
 SHA256SUMS = PRESERVATION_DIR / "SHA256SUMS"
+GATE_POLICY = ROOT / "pulse_gate_policy_v0.yml"
+GATE_REGISTRY = ROOT / "pulse_gate_registry_v0.yml"
+PULSE_WORKFLOW = ROOT / ".github" / "workflows" / "pulse_ci.yml"
 EXPECTED_ARCHIVE_SHA256 = (
     "7949bfd00468e6f9347fddaae732bdcebff5527e87ecb379a6c84a47176db966"
 )
@@ -329,6 +332,9 @@ def cli_build(tmp_path_factory: pytest.TempPathFactory) -> CliBuild:
         SHA256SUMS,
         SCHEMA,
         VALIDATOR,
+        GATE_POLICY,
+        GATE_REGISTRY,
+        PULSE_WORKFLOW,
         BUILDER,
     )
     before = snapshot(protected_inputs)
@@ -373,6 +379,9 @@ def test_required_fixed_source_and_contract_files_exist() -> None:
         MANIFEST,
         README,
         SHA256SUMS,
+        GATE_POLICY,
+        GATE_REGISTRY,
+        PULSE_WORKFLOW,
     ):
         assert path.is_file(), path
         assert not path.is_symlink(), path
@@ -799,7 +808,17 @@ def test_output_inside_preservation_directory_is_rejected() -> None:
 
 @pytest.mark.parametrize(
     "protected_path",
-    [ARCHIVE, MANIFEST, README, SHA256SUMS, SCHEMA, VALIDATOR],
+    [
+        ARCHIVE,
+        MANIFEST,
+        README,
+        SHA256SUMS,
+        SCHEMA,
+        VALIDATOR,
+        GATE_POLICY,
+        GATE_REGISTRY,
+        PULSE_WORKFLOW,
+    ],
     ids=lambda path: path.name,
 )
 def test_protected_input_overwrite_is_rejected(protected_path: Path) -> None:
@@ -819,6 +838,40 @@ def test_protected_input_overwrite_is_rejected(protected_path: Path) -> None:
             validator=VALIDATOR,
         )
     assert snapshot((protected_path,)) == before
+
+
+def test_dangling_output_symlink_is_rejected_without_creating_target(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "missing-target.json"
+    link = tmp_path / "output.json"
+
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink unsupported: {exc}")
+
+    assert link.is_symlink()
+    assert not link.exists()
+    assert not target.exists()
+
+    with pytest.raises(
+        BUILDER_MODULE.BuilderError,
+        match="refusing_symlink_output_path",
+    ):
+        BUILDER_MODULE.reject_unsafe_output(
+            link,
+            archive=ARCHIVE,
+            manifest=MANIFEST,
+            readme=README,
+            sha256sums=SHA256SUMS,
+            schema=SCHEMA,
+            validator=VALIDATOR,
+        )
+
+    assert link.is_symlink()
+    assert not link.exists()
+    assert not target.exists()
 
 
 def test_symlink_output_file_and_parent_are_rejected(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Close the four direct regression-coverage gaps identified during the post-merge
Codex verification of the fixed-source PULSEmech compute-binding builder.

The merged builder implementation already rejects:

```text
dangling output symlinks
policy-source overwrite
gate-registry-source overwrite
workflow-source overwrite
```

This pull request records those existing protections through explicit,
permanent regressions.

## Changed file

```text
tests/test_build_pulsemech_compute_binding_report_v0.py
```

Expected changed-file count:

```text
1
```

## Dangling-symlink regression

Add a dedicated test for:

```text
output.json
→ symbolic link
→ missing-target.json
```

The regression verifies:

```text
output path is a symlink
target does not exist
Path.exists() on the symlink is false

reject_unsafe_output()
→ refusing_symlink_output_path

target remains absent
no report is written
symlink remains dangling
```

This directly preserves the distinction between:

```text
existing symlink target
≠ dangling symlink target
```

## Authority-source overwrite regressions

Extend protected-output coverage to:

```text
pulse_gate_policy_v0.yml

pulse_gate_registry_v0.yml

.github/workflows/pulse_ci.yml
```

For each source, the regression records the exact byte size and SHA-256 digest,
attempts to use the file as the builder output, and verifies:

```text
refusing_to_overwrite_input
→ output rejected
→ exact source bytes unchanged
```

## Successful-run read-only boundary

Include the same authority-source files in the successful builder-run snapshot:

```text
archive
manifest
README
SHA256SUMS
schema
validator
builder
policy
gate registry
workflow
```

The pre-run and post-run snapshots must remain identical.

## P2 closure

This pull request closes the direct regression requirements for:

```text
P2-A:
dangling output symlink rejection

P2-B:
pulse_gate_policy_v0.yml overwrite rejection
pulse_gate_registry_v0.yml overwrite rejection
.github/workflows/pulse_ci.yml overwrite rejection
```

## Validation

```text
Python compilation:
PASS

targeted output-guard regressions:
10 passed
```

## Scope

This is a test-only follow-up.

It does not modify:

```text
tools/build_pulsemech_compute_binding_report_v0.py
schemas/pulsemech_compute_binding_report_v0.schema.json
tools/check_pulsemech_compute_binding_report_v0.py
ci/tools-tests.list
workflow YAML
gate policy
gate registry
active gates
compute budget
status semantics
release authority
SLSA/VSA activation
DOI
citation
Zenodo
tag
release
release metadata
```

## Authority boundary

The pull request does not create or modify release authority.

It only locks the already implemented read-only output protections through
direct regression coverage.