### PR TITLE
docs(theory): add data problem and system-indicator formulation

### DIFF
--- a/docs/PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md
+++ b/docs/PULSE_RELEASE_AUTHORITY_MECHANICS_BRIDGE_v0.md
@@ -293,3 +293,61 @@ Magyarul:
 
 A Pulsemechanika nem szűrő.
 A Pulsemechanika pontos illesztés.💡
+
+
+
+## 17. Az adat problémája
+
+A probléma nem az, hogy kevés adat áll rendelkezésre.
+
+A probléma az, hogy ha adatot égetnek rendszerfelismerés helyett.
+
+```text
+több adat
+→ több compute
+→ több zajfeldolgozás
+→ több költség
+→ ugyanaz a vakfolt
+```
+
+## A megoldás: a rendszermutató (egyszerű gép)
+
+```text
+bemenet
+→ kötés
+→ állapot
+→ átmenet
+→ kimenet
+→ következmény
+```
+
+A teljes rendszer és mindaz, ami abból nyílik, tartalmazza azt, ami szükséges.
+
+---
+
+## The Problem with Data
+
+The problem is not that too little data is available.
+
+The problem is that data is being burned in place of system recognition.
+
+```text
+more data
+→ more compute
+→ more noise processing
+→ more cost
+→ the same blind spot
+```
+
+## The Solution: the System Indicator (Simple Machine)
+
+```text
+input
+→ binding
+→ state
+→ transition
+→ output
+→ consequence
+```
+
+The complete system, together with everything that unfolds from it, contains what is necessary.


### PR DESCRIPTION
## Summary

Add the Hungarian and English formulation of the data problem and the
system indicator — the simple machine — to the canonical PULSEmech technical
note.

The new section records the structural problem:

```text
more data
→ more compute
→ more noise processing
→ more cost
→ the same blind spot
```

and places against it the system indicator:

```text
input
→ binding
→ state
→ transition
→ output
→ consequence
```

The formulation preserves the distinction between increasing the quantity of
observations and recognizing the operating structure that produces and binds
them.

## File

Modified:

```text
docs/PULSEMECH_RELATION_HALF_PARADOX_MATHEMATICAL_PHYSICAL_QUANTUM_FORMULATION_v0.md
```

No other file is changed.

## Added section

The same formulation is included in:

```text
Hungarian
English
```

The English version preserves the structure and meaning of the Hungarian
source.

## Technical boundary

The addition states:

```text
more data and compute
≠ automatic removal of a structural blind spot

system recognition
→ input
→ binding
→ state
→ transition
→ output
→ consequence
```

The system indicator is presented as a concise systems-engineering relation,
not as a new runtime component, policy mechanism, gate, or release authority.

## Scope

Documentation-only addition.

The change does not modify:

```text
existing equations
mathematical notation
physical or quantum-mechanical formulations
technical definitions
existing references
section semantics
PULSEmech decision relations
```

## Non-effects

No changes to:

```text
executable code
workflow YAML
gate policy
gate registry
active or candidate gates
verifiers
materializers
schemas
status semantics
check_gates.py
runtime behavior
package assembly
release authority
SLSA/VSA activation
DOI
citation
Zenodo
tag
release
release metadata
```

## Review boundary

Confirm that:

```text
the Hungarian section is preserved exactly
the English section preserves the same meaning
the fenced text blocks render correctly
the six-part system indicator remains unchanged
only the canonical technical note is modified
the change is documentation-only
release-authority effect is none
```