### PR TITLE
docs(zenodo): remove resolved DOI incident notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,6 @@
 
 > **Public origin / prior-art notice:** PULSE has a minimum public origin record. For the visible provenance anchors and attribution boundary, see the [Public Origin / Prior Art Notice](docs/quality_ledger.md#10-public-origin--prior-art-notice).
 
-> [!NOTE]
-> The following three Zenodo version records currently have incorrect DOI/citation routing metadata:
->
-> - `pulsemech-tier0-floor-preservation-20260629` — `10.5281/zenodo.21031131`
-> - `pulsemech-tier0-floor-20260628-b` — `10.5281/zenodo.21006429`
-> - `tier0-self-contained-evidence-floor-2026-06-27` — `10.5281/zenodo.21003082`
->
-> This notice applies only to the three records listed above.
->
-> We are working to correct the affected records.
-
 ## Canonical <img src="assets/brand/pulsemech-dark-badge.svg" alt="PULSEmech" height="30"> implementation path
 
 PULSEmech is the artifact-bound release-authority mechanism for AI release decisions.


### PR DESCRIPTION
## Summary

Remove the temporary README notice for the three incorrect Zenodo version
records after Zenodo Support deleted those versions.

## Scope

This PR changes only `README.md` and removes the resolved incident notice.

It does not change:

- the canonical concept DOI `10.5281/zenodo.17214908`;
- any valid version DOI;
- `.zenodo.json`;
- GitHub–Zenodo integration;
- citation metadata;
- release metadata;
- repository identity;
- PULSE release-authority mechanics.

## Identity continuity

```text
one continuously evolving PULSE
→ one GitHub repository
→ one canonical Zenodo concept DOI
→ 10.5281/zenodo.17214908
→ successive archived release versions under the same concept DOI
```

No new PULSE identity or concept DOI is introduced.
