### PR TITLE
fix(compute): align workflow-only cross-source anchors

### DIFF
--- a/tests/test_build_pulsemech_compute_planned_observed_relation_v0.py
+++ b/tests/test_build_pulsemech_compute_planned_observed_relation_v0.py
@@ -497,6 +497,56 @@ def test_workflow_only_selector_is_a_valid_anchor() -> None:
     assert BUILDER_MODULE.candidate_score(expectation, observation) == 25
 
 
+def test_workflow_only_selector_shares_artifact_and_runtime_relation() -> None:
+    selector = execution_identity(
+        node_type=None,  # type: ignore[arg-type]
+        workflow_name="PULSE CI",
+        job_name=None,
+        step_name=None,
+        tool_id=None,
+    )
+    expectation = {
+        "expected_compute": {"selector": selector},
+        "expected_declared_role": None,
+        "expected_mutation_authority": None,
+        "expected_source_identity": unknown_identity(),
+    }
+    shared_observation = {
+        "declared_role": "unknown",
+        "execution_identity": execution_identity(
+            workflow_name="PULSE CI",
+            job_name=None,
+            step_name=None,
+            tool_id=None,
+        ),
+        "execution_scope": "subject",
+        "mutation_authority": "none",
+        "source_identity": unknown_identity(),
+    }
+    observations = {
+        "observation:artifact": {
+            **shared_observation,
+            "source_record_kind": "compute_binding_report",
+        },
+        "observation:runtime": {
+            **shared_observation,
+            "source_record_kind": "runtime_observation_packet",
+        },
+    }
+
+    selected, ambiguous = BUILDER_MODULE.select_candidate_observations(
+        expectation,
+        observations,
+        set(observations),
+    )
+
+    assert selected == [
+        "observation:artifact",
+        "observation:runtime",
+    ]
+    assert ambiguous is False
+
+
 def test_node_type_alone_is_not_treated_as_a_strong_anchor() -> None:
     selector = execution_identity(
         node_type="workflow_step",

--- a/tools/build_pulsemech_compute_planned_observed_relation_v0.py
+++ b/tools/build_pulsemech_compute_planned_observed_relation_v0.py
@@ -2376,10 +2376,6 @@ def observation_anchor_labels(
     if (
         selector.get("workflow_name") is not None
         and actual.get("workflow_name") == selector.get("workflow_name")
-        and (
-            selector.get("job_name") is not None
-            or selector.get("node_type") == "workflow_job"
-        )
     ):
         labels.add("workflow_name")
 


### PR DESCRIPTION
Align workflow-name-only candidate matching with cross-source relation sharing
in the deterministic PULSEmech planned-observed relation builder.

The post-merge audit of PR #2743 identified one remaining inconsistency:

```text
candidate scoring
→ workflow_name alone is a valid strong anchor

cross-source relation sharing
→ workflow_name additionally required job_name or workflow_job
```

This could produce:

```text
valid workflow-name-only expectation
+ matching artifact observation
+ matching runtime observation
→ both observations selected
→ empty cross-source anchor intersection
→ ambiguous relation
```

## Correction

Use the same workflow-name anchor rule in both paths:

```text
expected workflow_name
= observed workflow_name
→ workflow_name anchor
```

No additional `job_name` or `node_type=workflow_job` condition is required.

The existing negative boundary remains:

```text
node_type alone
→ not a strong anchor
```

## Files

Modified:

```text
tools/build_pulsemech_compute_planned_observed_relation_v0.py

tests/test_build_pulsemech_compute_planned_observed_relation_v0.py
```

No other file is changed.

## Regression

Add a focused regression with:

```text
one explicit workflow-name-only expectation

one compute-binding-report observation
+ matching workflow_name

one runtime-observation-packet observation
+ matching workflow_name
```

Required result:

```text
both observation IDs selected
ambiguous = false
```

This exercises the complete path:

```text
candidate_score
→ per-source selection
→ observation_anchor_labels
→ observations_can_share_relation
→ select_candidate_observations
```

## Validation

Run:

```text
python -m pytest \
  tests/test_build_pulsemech_compute_planned_observed_relation_v0.py \
  -q
```

Then run the complete planned-observed regression set:

```text
python -m pytest \
  tests/test_pulsemech_compute_planned_observed_relation_schema_v0.py \
  tests/test_check_pulsemech_compute_planned_observed_relation_v0.py \
  tests/test_build_pulsemech_compute_planned_observed_relation_v0.py \
  -q
```

## Scope

This is a focused post-merge consistency correction.

It does not modify:

```text
relation schema
strict validator
ci/tools-tests.list
runtime-observation contract
compute-binding report contract
workflow YAML
policy
registry
active or candidate gates
compute budgets
status semantics
check_gates.py
release enforcement
release authority
SLSA/VSA activation
DOI
citation
Zenodo
tags
releases
release metadata
```

## Authority boundary

```text
runtime activation:
none

release-authority effect:
none
```