### PR TITLE
chore(deps): bump actions/attest to 4.2.0 with exact-pin alignment

### DIFF
--- a/.github/workflows/pulse_ci.yml
+++ b/.github/workflows/pulse_ci.yml
@@ -2358,7 +2358,7 @@ jobs:
           sha256sum "attestation-subject/artifact_provenance_binding_v0.json"
 
       - name: Attest release authority artifact binding v0
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6
         with:
           subject-path: attestation-subject/artifact_provenance_binding_v0.json
           show-summary: true
@@ -2449,7 +2449,7 @@ jobs:
 
       - name: Attest canonical LlamaGuard summary
         id: attest_llamaguard_summary
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6
         with:
           subject-path: PULSE_safe_pack_v0/artifacts/external/llamaguard_summary.json
           show-summary: true
@@ -2472,7 +2472,7 @@ jobs:
             --verified-at "${PULSE_ATTESTATION_VERIFIED_AT}" \
             --attestation-id "${{ steps.attest_llamaguard_summary.outputs.attestation-id }}" \
             --attestation-url "${{ steps.attest_llamaguard_summary.outputs.attestation-url }}" \
-            --attestation-action-ref "actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26"
+            --attestation-action-ref "actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6"
 
       - name: Verify canonical LlamaGuard external-summary attestation
         shell: bash
@@ -3270,7 +3270,7 @@ jobs:
           sha256sum "attestation-subject/artifact_provenance_binding_v0.json"
 
       - name: Attest final release-grade artifact binding v0
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6
         with:
           subject-path: attestation-subject/artifact_provenance_binding_v0.json
           show-summary: true

--- a/tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
+++ b/tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
@@ -8,7 +8,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pulse_ci.yml"
 TOOLS_TESTS_LIST = REPO_ROOT / "ci" / "tools-tests.list"
 
-ATTEST_SHA = "59d89421af93a897026c735860bf21b6eb4f7b26"
+ATTEST_SHA = "f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6"
 
 CORE_ATTEST_JOB = "attest_release_authority_artifact_binding"
 RELEASE_ATTEST_JOB = "attest_release_grade_artifact_binding"

--- a/tests/test_build_llamaguard_attestation_envelope_v1.py
+++ b/tests/test_build_llamaguard_attestation_envelope_v1.py
@@ -46,7 +46,7 @@ ATTESTATION_URL = (
 )
 ATTEST_ACTION_REF = (
     "actions/attest@"
-    "59d89421af93a897026c735860bf21b6eb4f7b26"
+    "7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6"
 )
 MODEL_REVISION = (
     "acf7aafa60f0410f8f42b1fa35e077d705892029"

--- a/tests/test_build_llamaguard_attestation_envelope_v1.py
+++ b/tests/test_build_llamaguard_attestation_envelope_v1.py
@@ -46,7 +46,7 @@ ATTESTATION_URL = (
 )
 ATTEST_ACTION_REF = (
     "actions/attest@"
-    "7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6"
+    "f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6"
 )
 MODEL_REVISION = (
     "acf7aafa60f0410f8f42b1fa35e077d705892029"


### PR DESCRIPTION
## Summary

Update `actions/attest` from 4.1.0 to 4.2.0 using the exact immutable commit:

```text
f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6
```

Move the production workflow pin and its checked exact-identity contracts
together.

## Workflow update

Update all current `actions/attest` uses in:

```text
.github/workflows/pulse_ci.yml
```

from:

```text
actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
```

to:

```text
actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6
```

The updated uses cover:

```text
release-authority artifact-binding attestation
LlamaGuard summary attestation
release-grade artifact-binding attestation
```

Also update the exact action identity passed to the LlamaGuard envelope builder:

```text
--attestation-action-ref
actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6
```

## Exact-pin contract alignment

Update:

```text
tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
```

so the workflow-wiring contract requires:

```text
ATTEST_SHA =
f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6
```

Update:

```text
tests/test_build_llamaguard_attestation_envelope_v1.py
```

so the positive envelope path records:

```text
ATTEST_ACTION_REF =
actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6
```

## Mechanical invariant

Preserve one exact identity across the connected path:

```text
workflow action invocation
= workflow-provided attestation action reference
= artifact-binding wiring expectation
= LlamaGuard envelope expectation
```

Mutable action tags remain inadmissible.

An uncoordinated pin change continues to fail closed.

## Exact file boundary

This pull request modifies exactly:

```text
.github/workflows/pulse_ci.yml

tests/test_artifact_provenance_binding_attestation_wiring_smoke.py

tests/test_build_llamaguard_attestation_envelope_v1.py
```

No other file is changed.

## Historical provenance boundary

Do not modify:

```text
docs/RELEASE_GRADE_REFERENCE_RUN_NOTE_v0.md
```

The older `actions/attest` SHA recorded there belongs to the completed
PULSE CI #6066 execution and remains the exact historical provenance of that
run.

Historical execution identity is not rewritten as current workflow
configuration.

## Validation

Run:

```text
python -m pytest \
  tests/test_artifact_provenance_binding_attestation_wiring_smoke.py \
  tests/test_build_llamaguard_attestation_envelope_v1.py \
  -q
```

Result:

```text
PASS
```

The complete repository checks must also pass on the final three-file PR head.

## Preserved boundaries

This update does not change:

```text
attestation signer identity
GitHub OIDC issuer
attestation subject binding
artifact digest semantics
workflow authority
release-required evidence semantics
status materialization
gate policy
required gate sets
check_gates.py
release-decision semantics
release authority
SLSA/VSA activation
DOI
citation
Zenodo
tags
releases
release metadata
```

## Authority effect

```text
release-authority effect:
none
```

This is an exact dependency-pin and contract-alignment update.