### PR TITLE
test(compute): add 6066 check-gates expectation

### DIFF
--- a/examples/compute/pulsemech_compute_subject_run_expectations_6066_v0.json
+++ b/examples/compute/pulsemech_compute_subject_run_expectations_6066_v0.json
@@ -1,0 +1,94 @@
+{
+  "expectation:execute-check-gates-consumed": {
+    "basis_records": [
+      {
+        "basis_id": "basis:plan-check-gates-v0",
+        "basis_kind": "integration_plan_operation",
+        "evidence_refs": [
+          "plan-operation:pulse_check_gates_v0",
+          "sha256:8226cc8235ed3f7a4262326232cf5a374b2d57b90f4e48538b164d6a116a762e"
+        ],
+        "source_path_or_uri": "examples/compute/pulsemech_compute_fixed_source_6066_integration_plan_v0.json#operation/8226cc8235ed3f7a4262326232cf5a374b2d57b90f4e48538b164d6a116a762e",
+        "source_revision": null,
+        "source_sha256": "8226cc8235ed3f7a4262326232cf5a374b2d57b90f4e48538b164d6a116a762e",
+        "subject_run_key": null,
+        "supports": [
+          "component_presence",
+          "source_identity"
+        ]
+      },
+      {
+        "basis_id": "basis:workflow-check-gates-transition",
+        "basis_kind": "workflow_execution_declaration",
+        "evidence_refs": [
+          "consumer:primary-ci-allow-block",
+          "workflow-tool:PULSE_safe_pack_v0/tools/check_gates.py",
+          "workflow:PULSE-CI"
+        ],
+        "source_path_or_uri": ".github/workflows/pulse_ci.yml",
+        "source_revision": "46b639706e23f80fe296a8893be18e2b5ab21f7e",
+        "source_sha256": "5fcf282d2ba4aeb9059593ebe131a622a8c233572b5bbb92f5f450809795b275",
+        "subject_run_key": "GITHUB_RUN_ID=29249887581|GITHUB_RUN_ATTEMPT=1|GITHUB_WORKFLOW=PULSE CI",
+        "supports": [
+          "declared_role",
+          "downstream_consumption_expectation",
+          "execution_expectation",
+          "mutation_authority"
+        ]
+      }
+    ],
+    "component_id": "pulse_check_gates_v0",
+    "evidence_refs": [
+      "component:pulse_check_gates_v0",
+      "consumer:primary-ci-allow-block",
+      "workflow-tool:PULSE_safe_pack_v0/tools/check_gates.py"
+    ],
+    "expectation_kind": "planned_execution_and_consumption_expected",
+    "expectation_scope": {
+      "release_candidate_id": "main",
+      "scope_kind": "subject_run",
+      "subject_run_key": "GITHUB_RUN_ID=29249887581|GITHUB_RUN_ATTEMPT=1|GITHUB_WORKFLOW=PULSE CI",
+      "subject_source_commit": "46b639706e23f80fe296a8893be18e2b5ab21f7e"
+    },
+    "expected_compute": {
+      "downstream_consumption_required": true,
+      "execution_required": true,
+      "selector": {
+        "command_sha256": null,
+        "job_name": null,
+        "node_type": "local_tool_execution",
+        "step_name": null,
+        "tool_id": "PULSE_safe_pack_v0/tools/check_gates.py",
+        "workflow_name": "PULSE CI"
+      }
+    },
+    "expected_declared_role": "transition",
+    "expected_mutation_authority": "release_decision",
+    "expected_source_identity": {
+      "action_commit_sha": null,
+      "action_ref": null,
+      "action_repository": null,
+      "container_image_digest": null,
+      "identity_status": "exact",
+      "source_kind": "repository_file",
+      "source_path_or_uri": "PULSE_safe_pack_v0/tools/check_gates.py",
+      "source_revision": "46b639706e23f80fe296a8893be18e2b5ab21f7e",
+      "source_sha256": "3a85ed757d5569e87364bd5de511dc1985c60d97e29ee3f782e08197fa4f5c8f"
+    },
+    "plan_operation_refs": [
+      {
+        "action": "preserve",
+        "component_id": "pulse_check_gates_v0",
+        "operation_canonicalization": "json-sort-keys-utf8-no-whitespace",
+        "operation_digest_scope": "pulsemech_integration_plan_operation_v0",
+        "operation_sha256": "8226cc8235ed3f7a4262326232cf5a374b2d57b90f4e48538b164d6a116a762e",
+        "reason": "target file already matches source digest",
+        "source_path": "PULSE_safe_pack_v0/tools/check_gates.py",
+        "source_sha256": "3a85ed757d5569e87364bd5de511dc1985c60d97e29ee3f782e08197fa4f5c8f",
+        "source_size_bytes": 2535,
+        "target_path": "PULSE_safe_pack_v0/tools/check_gates.py",
+        "target_state": "identical"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
test(compute): add 6066 check-gates expectation

Add the explicit subject-run expectation input for the preserved PULSE CI #6066 fixed-source planned-observed relation proof.

Declare exactly one expectation:

expectation:execute-check-gates-consumed

Bind the expectation to:

- repository: HKati/pulse-release-gates-0.1;

- subject run key: GITHUB_RUN_ID=29249887581|GITHUB_RUN_ATTEMPT=1|GITHUB_WORKFLOW=PULSE CI;

- subject source commit: 46b639706e23f80fe296a8893be18e2b5ab21f7e;

- release candidate: main.

Reference the exact fixed-source plan operation:

8226cc8235ed3f7a4262326232cf5a374b2d57b90f4e48538b164d6a116a762e

Bind the expected execution to:

PULSE_safe_pack_v0/tools/check_gates.py

using the historical source identity:

- source SHA-256: 3a85ed757d5569e87364bd5de511dc1985c60d97e29ee3f782e08197fa4f5c8f;

- source revision: 46b639706e23f80fe296a8893be18e2b5ab21f7e.

Require the observed execution identity to preserve:

- node_type=local_tool_execution;
- workflow_name=PULSE CI;
- exact tool path;
- exact repository-file source identity;
- declared_role=transition;
- expected_mutation_authority=release_decision.

Require downstream consumption of the check-gates result.

Bind the execution declaration to the historical PULSE CI workflow source using the exact workflow SHA-256:

5fcf282d2ba4aeb9059593ebe131a622a8c233572b5bbb92f5f450809795b275

Keep the integration-plan operation basis separate from the historical workflow basis.

The analysis-side plan basis does not claim that the plan file itself existed at the historical subject commit.

Do not declare complete planned-compute coverage.

All remaining generated #6066 compute observations must remain visible to the relation builder and be classified mechanically rather than hidden by this expectation input.

This commit adds only:

examples/compute/pulsemech_compute_subject_run_expectations_6066_v0.json

No fixed-source report builder, relation schema, relation validator, relation builder, candidate materializer, workflow, policy, registry, active or candidate gate membership, check_gates.py implementation, runtime observation, compute budget, release enforcement, release authority, SLSA/VSA activation, DOI, citation, Zenodo, tag, release, or release metadata is changed.

<!-- PULSE PR Template v1.0 — keep sections; fill what applies. -->

## Summary
<!-- Short: what changes and why? -->

## What’s included
- [ ] Code
- [ ] Docs
- [ ] CI / workflow
- Paths / files touched:

## CI usage
```yaml
# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json
```

## Impact
- Additive / backwards-compatible
- Breaking change — details:
- Performance / SLO impact:
- Security considerations:

What’s included
 Code
 Docs
 CI / workflow

Paths / files touched:

CI usage

# Minimal snippet — how this change runs in CI
name: PULSE CI (minimal)
on: [push, pull_request]
jobs:
  pulse:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.x'
      - run: python PULSE_safe_pack_v0/tools/run_all.py
      - uses: actions/upload-artifact@v4
        with:
          name: pulse-report
          path: |
            PULSE_safe_pack_v0/artifacts/**
            reports/*.xml
            reports/*.json

Impact
Additive / backwards-compatible

Breaking change — details:

Performance / SLO impact:

Security considerations:

### Security Intake (v0) — dependency / external code (if applicable)
**Intake v0:** PASS | REVIEW | HARD STOP  
**Isolation used (if REVIEW):** yes / no  

**Reasons (1–3 bullets):**
- 
- 
- 

**Checks**
- [ ] No password-protected ZIP / random binary download involved
- [ ] Repo age ≥ 12 months and maintainer history looks real
- [ ] No postinstall/preinstall scripts (or justified + reviewed)
- [ ] No obfuscation / base64 blobs / runtime-downloaded binaries
- [ ] No instructions like “disable Defender/AV”
- [ ] First run done in VM/container (if REVIEW)

> If any HIGH-risk signal appears → mark **HARD STOP** and do not merge.

Notes

Follow-ups:

Risks / mitigations:

PULSE checklist (release authority)
 PULSE CI is green on this PR
 Quality Ledger link (if enabled)
 Badges updated (PASS / RDSI / Q-Ledger)


## Notes
- Follow-ups:
- Risks / mitigations:

## PULSE checklist (release authority)
- [ ] PULSE CI is green on this PR
- [ ] Quality Ledger link (if enabled)
- [ ] Badges updated (PASS / RDSI / Q‑Ledger)
