### PR TITLE
fix(compute): isolate Git source verification environment

### DIFF
--- a/tests/test_check_pulsemech_compute_subject_input_packet_v0.py
+++ b/tests/test_check_pulsemech_compute_subject_input_packet_v0.py
@@ -5,6 +5,7 @@ import copy
 import hashlib
 import importlib.util
 import json
+import os
 import stat
 import subprocess
 import sys
@@ -136,6 +137,7 @@ def run_tool(
     carrier_path: Path | None = None,
     repository_root: Path = ROOT,
     output: Path | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     command = [
         sys.executable,
@@ -152,6 +154,10 @@ def run_tool(
     if output is not None:
         command.extend(["--output", str(output)])
 
+    environment = dict(os.environ)
+    if extra_env is not None:
+        environment.update(extra_env)
+
     return subprocess.run(
         command,
         cwd=ROOT,
@@ -159,6 +165,7 @@ def run_tool(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
+        env=environment,
     )
 
 
@@ -392,6 +399,147 @@ def observed_packet(
     return value
 
 
+def isolated_test_git_environment() -> dict[str, str]:
+    required = ("PATH",)
+    missing = [key for key in required if not os.environ.get(key)]
+    if missing:
+        pytest.skip(
+            "Git regression requires process environment values: "
+            + ", ".join(missing)
+        )
+
+    preserved = (
+        "PATH",
+        "PATHEXT",
+        "SYSTEMROOT",
+        "WINDIR",
+        "COMSPEC",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+    )
+    environment = {
+        key: os.environ[key]
+        for key in preserved
+        if key in os.environ
+    }
+    environment.update(
+        {
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_COUNT": "0",
+            "GIT_TERMINAL_PROMPT": "0",
+            "LC_ALL": "C",
+            "LANG": "C",
+        }
+    )
+    return environment
+
+
+def create_git_repository(
+    tmp_path: Path,
+    *,
+    name: str,
+    tracked_bytes: bytes,
+) -> tuple[Path, str]:
+    repository = tmp_path / name
+    repository.mkdir()
+    environment = isolated_test_git_environment()
+
+    subprocess.run(
+        ["git", "init", "-q", str(repository)],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=environment,
+    )
+    (repository / "tracked.txt").write_bytes(tracked_bytes)
+    subprocess.run(
+        ["git", "-C", str(repository), "add", "--", "tracked.txt"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=environment,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repository),
+            "-c",
+            "user.name=PULSEmech validator regression",
+            "-c",
+            "user.email=pulsemech-validator@example.invalid",
+            "commit",
+            "-q",
+            "-m",
+            "fixture",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=environment,
+    )
+    revision = subprocess.run(
+        ["git", "-C", str(repository), "rev-parse", "HEAD"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=environment,
+    ).stdout.strip()
+    assert len(revision) == 40
+    return repository, revision
+
+
+def inherited_git_blob_read(
+    repository_root: Path,
+    *,
+    revision: str,
+    path: str,
+    attacker_environment: dict[str, str],
+) -> subprocess.CompletedProcess[bytes]:
+    environment = isolated_test_git_environment()
+    environment.update(attacker_environment)
+    return subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repository_root),
+            "cat-file",
+            "blob",
+            f"{revision}:{path}",
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=environment,
+    )
+
+
+def attacker_git_environments(
+    attacker_repository: Path,
+) -> dict[str, dict[str, str]]:
+    git_directory = attacker_repository / ".git"
+    object_directory = git_directory / "objects"
+    return {
+        "git_dir_and_work_tree": {
+            "GIT_DIR": str(git_directory),
+            "GIT_WORK_TREE": str(attacker_repository),
+        },
+        "git_object_directory": {
+            "GIT_OBJECT_DIRECTORY": str(object_directory),
+        },
+        "git_alternate_object_directories": {
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES": str(object_directory),
+        },
+        "git_common_directory": {
+            "GIT_COMMON_DIR": str(git_directory),
+        },
+    }
+
+
 # ---------------------------------------------------------------------------
 # Exact positive path and deterministic diagnostics
 # ---------------------------------------------------------------------------
@@ -494,6 +642,191 @@ def test_historical_sources_are_read_from_git_not_current_worktree() -> None:
         or current_workflow_sha
         != value["authority_sources"]["workflow"]["sha256"]
     )
+
+
+# ---------------------------------------------------------------------------
+# Git process isolation and repository-root binding
+# ---------------------------------------------------------------------------
+
+
+def test_sanitized_git_environment_drops_caller_controlled_git_variables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    poisoned = {
+        "GIT_DIR": "/attacker/repository/.git",
+        "GIT_WORK_TREE": "/attacker/repository",
+        "GIT_COMMON_DIR": "/attacker/common",
+        "GIT_OBJECT_DIRECTORY": "/attacker/objects",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES": "/attacker/alternates",
+        "GIT_INDEX_FILE": "/attacker/index",
+        "GIT_NAMESPACE": "attacker",
+        "GIT_CONFIG_PARAMETERS": "'core.worktree=/attacker/repository'",
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "core.worktree",
+        "GIT_CONFIG_VALUE_0": "/attacker/repository",
+        "GIT_EXEC_PATH": "/attacker/git-core",
+        "GIT_CEILING_DIRECTORIES": "/attacker",
+        "GIT_DISCOVERY_ACROSS_FILESYSTEM": "1",
+        "GIT_SHALLOW_FILE": "/attacker/shallow",
+    }
+    for key, value in poisoned.items():
+        monkeypatch.setenv(key, value)
+
+    child_environment = TOOL_MODULE._sanitized_git_environment()
+
+    fixed_keys = {
+        "GIT_CONFIG_GLOBAL",
+        "GIT_CONFIG_SYSTEM",
+        "GIT_CONFIG_NOSYSTEM",
+        "GIT_CONFIG_COUNT",
+        "GIT_OPTIONAL_LOCKS",
+        "GIT_NO_REPLACE_OBJECTS",
+        "GIT_TERMINAL_PROMPT",
+        "LC_ALL",
+        "LANG",
+    }
+    allowed_keys = set(TOOL_MODULE.GIT_PROCESS_ENV_ALLOWLIST) | fixed_keys
+    assert set(child_environment) <= allowed_keys
+    assert child_environment["PATH"] == os.environ["PATH"]
+    assert child_environment["GIT_CONFIG_GLOBAL"] == os.devnull
+    assert child_environment["GIT_CONFIG_SYSTEM"] == os.devnull
+    assert child_environment["GIT_CONFIG_NOSYSTEM"] == "1"
+    assert child_environment["GIT_CONFIG_COUNT"] == "0"
+    assert child_environment["GIT_OPTIONAL_LOCKS"] == "0"
+    assert child_environment["GIT_NO_REPLACE_OBJECTS"] == "1"
+    assert child_environment["GIT_TERMINAL_PROMPT"] == "0"
+    assert child_environment["LC_ALL"] == "C"
+    assert child_environment["LANG"] == "C"
+
+    for key in poisoned:
+        if key == "GIT_CONFIG_COUNT":
+            continue
+        assert key not in child_environment
+
+
+def test_missing_process_path_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PATH", raising=False)
+    with pytest.raises(
+        TOOL_MODULE.SemanticError,
+        match="git_process_path_unavailable",
+    ):
+        TOOL_MODULE._sanitized_git_environment()
+
+
+def test_git_blob_read_ignores_attacker_repository_and_object_stores(
+    tmp_path: Path,
+) -> None:
+    real_bytes = b"real repository bytes\n"
+    attacker_bytes = b"attacker repository bytes\n"
+    real_repository, real_revision = create_git_repository(
+        tmp_path,
+        name="real-repository",
+        tracked_bytes=real_bytes,
+    )
+    attacker_repository, attacker_revision = create_git_repository(
+        tmp_path,
+        name="attacker-repository",
+        tracked_bytes=attacker_bytes,
+    )
+    assert real_revision != attacker_revision
+
+    for label, attacker_environment in attacker_git_environments(
+        attacker_repository
+    ).items():
+        vulnerable_read = inherited_git_blob_read(
+            real_repository,
+            revision=attacker_revision,
+            path="tracked.txt",
+            attacker_environment=attacker_environment,
+        )
+        assert vulnerable_read.returncode == 0, (
+            label,
+            vulnerable_read.stderr.decode("utf-8", errors="replace"),
+        )
+        assert vulnerable_read.stdout == attacker_bytes, label
+
+        with pytest.MonkeyPatch.context() as poisoned:
+            for key, value in attacker_environment.items():
+                poisoned.setenv(key, value)
+
+            with pytest.raises(
+                TOOL_MODULE.SemanticError,
+                match="git_blob_unavailable",
+            ):
+                TOOL_MODULE._git_blob_bytes(
+                    real_repository,
+                    revision=attacker_revision,
+                    path="tracked.txt",
+                )
+
+            assert TOOL_MODULE._git_blob_bytes(
+                real_repository,
+                revision=real_revision,
+                path="tracked.txt",
+            ) == real_bytes
+
+
+def test_full_validator_ignores_poisoned_git_environment(
+    tmp_path: Path,
+) -> None:
+    attacker_repository, _attacker_revision = create_git_repository(
+        tmp_path,
+        name="full-validator-attacker",
+        tracked_bytes=b"unrelated attacker bytes\n",
+    )
+    attacker_git_directory = attacker_repository / ".git"
+    attacker_objects = attacker_git_directory / "objects"
+
+    result = run_tool(
+        extra_env={
+            "GIT_DIR": str(attacker_git_directory),
+            "GIT_WORK_TREE": str(attacker_repository),
+            "GIT_COMMON_DIR": str(attacker_git_directory),
+            "GIT_OBJECT_DIRECTORY": str(attacker_objects),
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES": str(attacker_objects),
+            "GIT_INDEX_FILE": str(attacker_git_directory / "index"),
+            "GIT_NAMESPACE": "attacker",
+            "GIT_CONFIG_PARAMETERS": (
+                "'core.worktree="
+                + str(attacker_repository)
+                + "'"
+            ),
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "core.worktree",
+            "GIT_CONFIG_VALUE_0": str(attacker_repository),
+            "GIT_CEILING_DIRECTORIES": str(tmp_path),
+            "GIT_DISCOVERY_ACROSS_FILESYSTEM": "1",
+        }
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stderr == ""
+    diagnostic = parse_json_text(result.stdout)
+    assert diagnostic["schema_valid"] is True
+    assert diagnostic["ok"] is True
+    assert diagnostic["errors"] == []
+    assert all(diagnostic["checks"].values())
+
+
+def test_repository_root_must_equal_git_top_level(tmp_path: Path) -> None:
+    repository, _revision = create_git_repository(
+        tmp_path,
+        name="root-verification-repository",
+        tracked_bytes=b"root verification bytes\n",
+    )
+    nested = repository / "nested"
+    nested.mkdir()
+
+    assert TOOL_MODULE._verified_git_repository_root(repository) == (
+        repository.resolve(strict=True)
+    )
+    with pytest.raises(
+        TOOL_MODULE.SemanticError,
+        match="git_repository_root_mismatch",
+    ):
+        TOOL_MODULE._verified_git_repository_root(nested)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/check_pulsemech_compute_subject_input_packet_v0.py
+++ b/tools/check_pulsemech_compute_subject_input_packet_v0.py
@@ -86,6 +86,17 @@ AUTHORITY_SURFACE_OUTPUT_NAMES = {
     "pulsemech_compute_subject_input_packet_v0.json",
 }
 
+GIT_PROCESS_ENV_ALLOWLIST = (
+    "PATH",
+    "PATHEXT",
+    "SYSTEMROOT",
+    "WINDIR",
+    "COMSPEC",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+)
+
 
 class StrictJsonError(ValueError):
     pass
@@ -349,6 +360,109 @@ def _relative_packet_path(packet_path: Path, repository_root: Path) -> str | Non
         return None
 
 
+def _sanitized_git_environment() -> dict[str, str]:
+    if not os.environ.get("PATH"):
+        raise SemanticError("git_process_path_unavailable")
+
+    env: dict[str, str] = {}
+    for key in GIT_PROCESS_ENV_ALLOWLIST:
+        value = os.environ.get(key)
+        if value is not None:
+            env[key] = value
+
+    env.update(
+        {
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_COUNT": "0",
+            "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "GIT_TERMINAL_PROMPT": "0",
+            "LC_ALL": "C",
+            "LANG": "C",
+        }
+    )
+    return env
+
+
+def _run_isolated_git(
+    repository_root: Path,
+    *,
+    arguments: list[str],
+    failure_prefix: str,
+) -> bytes:
+    resolved_root = repository_root.resolve(strict=True)
+    if not resolved_root.is_dir():
+        raise SemanticError(
+            f"git_repository_root_not_directory: {resolved_root}"
+        )
+
+    command = [
+        "git",
+        "--no-pager",
+        "--no-replace-objects",
+        "-c",
+        f"safe.directory={resolved_root}",
+        "-C",
+        str(resolved_root),
+        *arguments,
+    ]
+    completed = subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=_sanitized_git_environment(),
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise SemanticError(f"{failure_prefix}: {detail or 'unknown error'}")
+    return completed.stdout
+
+
+def _verified_git_repository_root(repository_root: Path) -> Path:
+    resolved_root = repository_root.resolve(strict=True)
+    top_level_bytes = _run_isolated_git(
+        resolved_root,
+        arguments=["rev-parse", "--show-toplevel"],
+        failure_prefix="git_repository_root_unavailable",
+    )
+    try:
+        top_level_text = top_level_bytes.decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as exc:
+        raise SemanticError(
+            f"git_repository_root_invalid_utf8: {exc}"
+        ) from exc
+
+    if (
+        not top_level_text
+        or "\x00" in top_level_text
+        or "\n" in top_level_text
+        or "\r" in top_level_text
+    ):
+        raise SemanticError(
+            f"git_repository_root_output_invalid: {top_level_text!r}"
+        )
+
+    try:
+        discovered_root = Path(top_level_text).resolve(strict=True)
+    except OSError as exc:
+        raise SemanticError(
+            f"git_repository_root_unresolvable: {top_level_text!r}: {exc}"
+        ) from exc
+
+    if not discovered_root.is_dir() or not same_target(
+        discovered_root,
+        resolved_root,
+    ):
+        raise SemanticError(
+            "git_repository_root_mismatch: "
+            f"requested={resolved_root} discovered={discovered_root}"
+        )
+    return resolved_root
+
+
 def _git_blob_bytes(
     repository_root: Path,
     *,
@@ -358,33 +472,12 @@ def _git_blob_bytes(
     if not _safe_relative_path(path):
         raise SemanticError(f"unsafe_source_path: {path!r}")
 
-    resolved_root = repository_root.resolve(strict=True)
-    env = dict(os.environ)
-    env["GIT_OPTIONAL_LOCKS"] = "0"
-    env["GIT_NO_REPLACE_OBJECTS"] = "1"
-    command = [
-        "git",
-        "-c",
-        f"safe.directory={resolved_root}",
-        "-C",
-        str(resolved_root),
-        "cat-file",
-        "blob",
-        f"{revision}:{path}",
-    ]
-    completed = subprocess.run(
-        command,
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=env,
+    resolved_root = _verified_git_repository_root(repository_root)
+    return _run_isolated_git(
+        resolved_root,
+        arguments=["cat-file", "blob", f"{revision}:{path}"],
+        failure_prefix=f"git_blob_unavailable: {revision}:{path}",
     )
-    if completed.returncode != 0:
-        detail = completed.stderr.decode("utf-8", errors="replace").strip()
-        raise SemanticError(
-            f"git_blob_unavailable: {revision}:{path}: {detail or 'unknown error'}"
-        )
-    return completed.stdout
 
 
 def _reject_symlink_path(path: Path, *, label: str) -> None:


### PR DESCRIPTION
## Summary

Close the post-merge P1 finding from the Codex review of PR #2752.

The merged subject-input packet validator reconstructs historical workflow,
policy, gate-registry, additional-source, and observed producer-source bytes
through `git cat-file`.

The original implementation disabled replacement objects but inherited the
caller's complete process environment. Caller-controlled Git repository and
object-store variables could therefore redirect Git away from the intended
`--repository-root`.

This pull request isolates Git execution from caller-controlled repository,
work-tree, configuration, namespace, index, and object-store environment
variables and adds a fail-closed two-repository regression.

## Planned pull-request boundary

The completed corrective pull request will modify exactly:

```text
1. tools/
   check_pulsemech_compute_subject_input_packet_v0.py

2. tests/
   test_check_pulsemech_compute_subject_input_packet_v0.py
```

No `ci/tools-tests.list` change is required because the validator regression is
already registered.

Current state:

```text
isolated Git execution:
complete

repository-root verification:
complete

environment-substitution regression:
pending

merge state:
not ready
```

## Finding

The previous Git helper used:

```text
env = dict(os.environ)
```

and passed that inherited environment to:

```text
git -C <repository-root> cat-file blob <revision>:<path>
```

This allowed caller-controlled values such as:

```text
GIT_DIR
GIT_WORK_TREE
GIT_COMMON_DIR
GIT_OBJECT_DIRECTORY
GIT_ALTERNATE_OBJECT_DIRECTORIES
GIT_INDEX_FILE
GIT_NAMESPACE
GIT_CONFIG_*
```

to change which repository or object database supplied the bytes.

The downstream digest and size checks could then validate attacker-selected
bytes against attacker-selected packet metadata.

## Correction

Construct a minimal Git process environment.

Preserve only basic process values required to execute Git:

```text
PATH
PATHEXT
SYSTEMROOT
WINDIR
COMSPEC
TEMP
TMP
TMPDIR
```

Set explicit Git controls:

```text
GIT_CONFIG_GLOBAL=<null device>
GIT_CONFIG_SYSTEM=<null device>
GIT_CONFIG_NOSYSTEM=1
GIT_CONFIG_COUNT=0
GIT_OPTIONAL_LOCKS=0
GIT_NO_REPLACE_OBJECTS=1
GIT_TERMINAL_PROMPT=0
LC_ALL=C
LANG=C
```

Do not copy any other parent-environment value into the Git child process.

Run Git with:

```text
--no-pager
--no-replace-objects
```

## Repository-root verification

Before each blob read, run under the same sanitized environment:

```text
git -C <resolved-root> rev-parse --show-toplevel
```

Require:

```text
discovered top-level repository
=
resolved requested --repository-root
```

Reject:

```text
missing or invalid repository root
non-directory root
subdirectory passed as repository root
invalid root output
requested/discovered root mismatch
unavailable revision/path blob
```

Only then read:

```text
git cat-file blob <revision>:<path>
```

## First commit

The first commit modifies only:

```text
tools/check_pulsemech_compute_subject_input_packet_v0.py
```

Replacement file identity:

```text
line count:
2369

byte size:
82633

SHA-256:
10b233db6b84396e74919bee95986f7f83c81d5454f995337d546b1fc71e633a
```

Completed local checks:

```text
Python compilation:
PASS

valid blob read from requested repository root:
PASS

repository subdirectory supplied as root:
REJECTED

GIT_DIR + GIT_WORK_TREE substitution:
REJECTED

GIT_OBJECT_DIRECTORY substitution:
REJECTED

GIT_ALTERNATE_OBJECT_DIRECTORIES substitution:
REJECTED

GIT_COMMON_DIR substitution:
REJECTED

GIT_NAMESPACE with redirected repository:
REJECTED

GIT_CONFIG_COUNT / KEY / VALUE injection:
REJECTED

inherited Git redirection values in child environment:
ABSENT
```

## Planned regression

The second file will create two temporary Git repositories:

```text
real repository root
→ lacks the attacker revision/path or contains different bytes

attacker repository/object store
→ contains the declared revision/path/bytes
```

It will invoke the validator with attacker-controlled variants including:

```text
GIT_DIR
GIT_WORK_TREE
GIT_OBJECT_DIRECTORY
GIT_ALTERNATE_OBJECT_DIRECTORIES
GIT_COMMON_DIR
GIT_NAMESPACE
GIT_CONFIG_COUNT / GIT_CONFIG_KEY_* / GIT_CONFIG_VALUE_*
```

Required result:

```text
attacker bytes are never admitted
→ source reconstruction fails closed against the real repository root
```

The regression will also verify that:

```text
a valid blob from the requested repository continues to pass

a repository subdirectory is rejected as the declared repository root

the validator child process does not inherit caller-controlled Git
repository or object-store variables
```

## Scope

This correction changes only Git source isolation.

It does not change:

```text
packet schema
fixture / producer provenance semantics
#6066 example data
carrier identity
artifact graph
provider bindings
role bindings
coverage semantics
subject identity
release decision semantics
gate policy
gate registry
workflow behavior
release authority
```

## Non-activation boundary

```text
packet producer:
not included

current-run integration:
none

runtime activation:
none

candidate-gate activation:
none

release-required compute enforcement:
none

compute budget:
not defined

release-authority effect:
none
```