### PR TITLE
test(compute): preserve historical active-policy-set order

### DIFF
--- a/tests/test_check_pulsemech_compute_subject_input_packet_v0.py
+++ b/tests/test_check_pulsemech_compute_subject_input_packet_v0.py
@@ -1249,7 +1249,42 @@ def test_coverage_counter_drift_is_rejected() -> None:
     )
 
 
-def test_reference_list_order_is_reconstructed_not_trusted() -> None:
+def test_historical_active_policy_set_order_is_preserved() -> None:
+    value = packet()
+
+    assert value["subject"]["active_policy_sets"] == [
+        "required",
+        "release_required",
+    ]
+    assert TOOL_MODULE._sorted_unique_strings(
+        value["subject"]["active_policy_sets"]
+    ) is False
+
+    subject_ok, subject_errors = TOOL_MODULE._verify_subject_identity(value)
+    assert subject_ok is True
+    assert subject_errors == []
+
+
+def test_active_policy_sets_require_non_empty_unique_strings() -> None:
+    invalid_values: tuple[list[Any], ...] = (
+        [],
+        ["required", "required"],
+        ["required", ""],
+        ["required", 1],
+    )
+
+    for active_policy_sets in invalid_values:
+        value = packet()
+        value["subject"]["active_policy_sets"] = active_policy_sets
+
+        subject_ok, subject_errors = TOOL_MODULE._verify_subject_identity(value)
+        assert subject_ok is False
+        assert subject_errors == [
+            "active_policy_sets_not_unique_non_empty"
+        ]
+
+
+def test_reordered_active_policy_sets_fail_exact_subject_artifact_binding() -> None:
     value = packet()
     value["subject"]["active_policy_sets"] = list(
         reversed(value["subject"]["active_policy_sets"])
@@ -1257,13 +1292,36 @@ def test_reference_list_order_is_reconstructed_not_trusted() -> None:
 
     diagnostic = assert_semantic_failure(
         value,
+        "subject_artifact_bindings_ok",
+        expected_fragment="release_decision_subject_binding_mismatch",
+    )
+    assert diagnostic["checks"]["deterministic_reference_ordering_ok"] is True
+    assert diagnostic["checks"]["subject_identity_ok"] is True
+
+    expected_errors = {
+        "release_decision_subject_binding_mismatch",
+        "release_authority_subject_binding_mismatch",
+        "artifact_binding_subject_mismatch",
+        "preservation_manifest_subject_binding_mismatch",
+    }
+    assert expected_errors.issubset(set(diagnostic["errors"]))
+
+
+def test_set_like_reference_list_order_remains_fail_closed() -> None:
+    value = packet()
+    references = value["role_bindings"]["candidate_records"]
+    assert references == sorted(references)
+    value["role_bindings"]["candidate_records"] = list(reversed(references))
+
+    diagnostic = assert_semantic_failure(
+        value,
         "deterministic_reference_ordering_ok",
+        expected_fragment=(
+            "role_binding_list_not_sorted_unique: candidate_records"
+        ),
     )
-    assert diagnostic["checks"]["subject_identity_ok"] is False
-    assert any(
-        "active_policy_sets_not_sorted_unique" in str(error)
-        for error in diagnostic["errors"]
-    )
+    assert diagnostic["checks"]["subject_identity_ok"] is True
+    assert diagnostic["checks"]["role_bindings_ok"] is False
 
 
 def test_artifact_display_path_is_derived_from_carrier_and_container() -> None:

--- a/tools/check_pulsemech_compute_subject_input_packet_v0.py
+++ b/tools/check_pulsemech_compute_subject_input_packet_v0.py
@@ -294,6 +294,15 @@ def _sorted_unique_strings(values: Any) -> bool:
     )
 
 
+def _ordered_unique_non_empty_strings(values: Any) -> bool:
+    return (
+        isinstance(values, list)
+        and bool(values)
+        and all(isinstance(item, str) and bool(item) for item in values)
+        and len(values) == len(set(values))
+    )
+
+
 def _all_object_keys_sorted(value: Any) -> bool:
     if isinstance(value, dict):
         return (
@@ -950,8 +959,11 @@ def _verify_subject_identity(packet: dict[str, Any]) -> tuple[bool, list[str]]:
         errors.append("packet_carrier_id_mismatch")
     if subject.get("workflow_ref") != expected_workflow_ref:
         errors.append("subject_workflow_ref_mismatch")
-    if not _sorted_unique_strings(subject.get("active_policy_sets")):
-        errors.append("active_policy_sets_not_sorted_unique")
+    # Active policy sets are an ordered part of the historical subject identity.
+    # Preserve their recorded order; require only non-empty unique string values
+    # here, then verify the exact order against the bound subject artifacts.
+    if not _ordered_unique_non_empty_strings(subject.get("active_policy_sets")):
+        errors.append("active_policy_sets_not_unique_non_empty")
     try:
         parse_utc(identity.get("packet_created_utc"))
     except Exception as exc:
@@ -1926,19 +1938,24 @@ def semantic_checks(
     )
     record("canonical_packet_serialization_ok", canonical_ok)
 
-    reference_lists = [
-        packet.get("subject", {}).get("active_policy_sets"),
+    # These arrays are set-like diagnostic/reference surfaces and therefore use
+    # lexical ordering. subject.active_policy_sets is deliberately excluded: it
+    # is an ordered historical identity sequence, not a lexically sorted set.
+    set_like_reference_lists = [
         packet.get("coverage", {}).get("missing_roles"),
         packet.get("coverage", {}).get("unresolved_artifact_ids"),
         packet.get("errors"),
     ]
-    reference_lists.extend(
+    set_like_reference_lists.extend(
         packet.get("role_bindings", {}).get(name)
         for name in LIST_ROLE_BINDINGS
     )
     record(
         "deterministic_reference_ordering_ok",
-        all(_sorted_unique_strings(values) for values in reference_lists),
+        all(
+            _sorted_unique_strings(values)
+            for values in set_like_reference_lists
+        ),
     )
 
     provenance_ok, provenance_errors = _verify_provenance(


### PR DESCRIPTION
## Summary

Correct the PULSEmech compute subject-input packet validator after the complete
post-merge review found that the canonical PULSE CI #6066 example failed the
validator's own deterministic-ordering and subject-identity checks.

The validator incorrectly treated:

```text
subject.active_policy_sets
```

as a lexicographically sorted set.

The #6066 subject actually records the exact historical sequence:

```text
required
→ release_required
```

That sequence is preserved by the release decision, release authority,
artifact-provenance binding, and preservation manifest. It is an ordered part
of the historical subject identity, not a presentation list that may be
re-sorted.

## Exact pull-request boundary

This corrective pull request modifies exactly:

```text
1. tools/
   check_pulsemech_compute_subject_input_packet_v0.py

2. tests/
   test_check_pulsemech_compute_subject_input_packet_v0.py
```

No schema, example, preservation artifact, or CI-manifest change is required.

## Root cause

The validator applied `_sorted_unique_strings()` to
`subject.active_policy_sets` in two places:

```text
subject identity validation
and
deterministic reference-list ordering
```

This caused the exact checked-in sequence:

```text
["required", "release_required"]
```

to fail because its lexical order would be:

```text
["release_required", "required"]
```

Reordering the checked-in example would be incorrect because it would break the
exact sequence preserved in the historical subject artifacts.

## Validator correction

Introduce a separate ordered-list predicate for active policy sets.

Require:

```text
non-empty list
+ string-only entries
+ no empty entry
+ unique entries
+ declared order preserved
```

Remove `subject.active_policy_sets` from the generic lexically sorted reference
arrays.

Continue to require sorted-and-unique order for genuinely set-like surfaces:

```text
coverage.missing_roles
coverage.unresolved_artifact_ids
errors
candidate_records
external_evidence_records
attestation_records
reader_surfaces
```

Continue to verify the exact active-policy-set sequence against:

```text
release_decision.active_gate_sets
release_authority.authority.policy_set
artifact-provenance workflow-effective policy sets
preservation_manifest.active_policy_sets
```

Therefore:

```text
historical ["required", "release_required"]
→ accepted

duplicate, empty, or non-string policy-set entry
→ rejected

reordered ["release_required", "required"]
→ subject identity remains structurally valid
→ exact subject-artifact binding fails closed
```

## Regression correction

Replace the old negative regression that reversed the baseline list and
mistakenly expected a lexical-order failure.

Add coverage proving:

```text
exact historical sequence
→ accepted

duplicate / empty / non-string sequence
→ rejected by subject identity

reordered historical sequence
→ deterministic_reference_ordering_ok=true
→ subject_identity_ok=true
→ subject_artifact_bindings_ok=false

reordered set-like candidate-record references
→ deterministic_reference_ordering_ok=false
→ role_bindings_ok=false
```

Require exact mismatch evidence from the release decision, release authority,
artifact-provenance binding, and preservation manifest when the historical
sequence is reordered.

## File identities

Validator:

```text
line count:
2386

byte size:
83380

SHA-256:
2f28c9b373233333cf1b0992c96de4e3b0a65246474620ad8dfaae26382e780f
```

Validator regression:

```text
line count:
1424

byte size:
42984

SHA-256:
f162e34b407faf6bdad05465e22587fb448dd69f14bac7ddd3faf049091900b4

test cases:
46
```

## Local construction checks

```text
validator Python compilation:
PASS

regression Python compilation:
PASS

validator regression collection:
46 tests collected

targeted active-policy-set ordering mechanics:
PASS
```

## Required complete PR validation

The pull-request head must run:

```text
python tools/check_pulsemech_compute_subject_input_packet_v0.py
```

Required result:

```text
exit 0
schema_valid=true
ok=true
errors=[]
every semantic check=true
```

Then run:

```text
python -m pytest -q \
  tests/test_pulsemech_compute_subject_input_packet_schema_v0.py \
  tests/test_check_pulsemech_compute_subject_input_packet_v0.py
```

Expected result:

```text
76 passed
```

The complete tools-tests CI job must also remain green.

## Preserved Git isolation correction

This pull request does not weaken or remove the Git source-environment
isolation merged through PR #2754.

The validator continues to:

```text
sanitize inherited Git environment variables
verify the exact requested repository root
read historical source bytes through Git object identity
reject repository and object-store substitution
```

## Non-changes

Do not modify:

```text
schemas/pulsemech_compute_subject_input_packet_v0.schema.json
examples/compute/pulsemech_compute_subject_input_packet_6066_example_v0.json
ci/tools-tests.list
PULSE_CI_6066_release_grade_artifact_preservation_v0.zip

packet producer
reusable analyzer core
current-run integration
runtime-observation production
resource measurement
compute budget
candidate-gate membership
release-required enforcement
release authority
```

## Non-activation boundary

```text
packet producer:
not included

current-run integration:
none

runtime activation:
none

candidate-gate activation:
none

release-required compute enforcement:
none

compute budget:
not defined

release-authority effect:
none
```