### PR TITLE
test(compute): align container-cycle diagnostic regression

### DIFF
--- a/tests/test_check_pulsemech_compute_subject_input_packet_v0.py
+++ b/tests/test_check_pulsemech_compute_subject_input_packet_v0.py
@@ -1122,7 +1122,7 @@ def test_artifact_container_cycle_is_rejected() -> None:
     assert_semantic_failure(
         value,
         "artifact_graph_ok",
-        expected_fragment="container_cycle",
+        expected_fragment="artifact_container_graph_cycle_or_unresolved_parent",
     )
 
 


### PR DESCRIPTION
## Summary

Close the post-merge P2 finding from the complete review of the PULSEmech
compute subject-input packet v0 implementation.

The validator correctly rejects a self-referential artifact-container graph and
emits:

```text
artifact_container_graph_cycle_or_unresolved_parent
```

The registered regression still expected the stale fragment:

```text
container_cycle
```

As a result, the test suite failed even though the validator itself failed
closed correctly.

## Exact pull-request boundary

This pull request modifies exactly one file:

```text
tests/test_check_pulsemech_compute_subject_input_packet_v0.py
```

No validator, schema, example, carrier, or CI-manifest change is required.

## Correction

Keep the existing self-cycle test input unchanged:

```text
artifact_binding.container_artifact_id
=
artifact_binding.artifact_id
```

Replace only the stale expected diagnostic fragment:

```text
container_cycle
```

with the validator's current stable diagnostic:

```text
artifact_container_graph_cycle_or_unresolved_parent
```

The regression therefore proves:

```text
self-referential container_artifact_id
→ cyclic artifact-container graph
→ artifact_graph_ok=false
→ exact cycle-or-unresolved-parent diagnostic present
```

## File identity

```text
line count:
1424

byte size:
43020

SHA-256:
808ce229dfd20ee455c1eaf9221da757a12475d35db2fff37b228c70e2c1be55

test cases:
46
```

## Local checks

```text
Python compilation:
PASS

focused container-cycle regression:
PASS

stale container_cycle expectation:
absent

current cycle-or-unresolved-parent expectation:
present exactly once
```

## Required pull-request validation

Run:

```text
python tools/check_pulsemech_compute_subject_input_packet_v0.py
```

Required result:

```text
exit 0
schema_valid=true
ok=true
errors=[]
every semantic check=true
```

Then run:

```text
python -m pytest -q \
  tests/test_pulsemech_compute_subject_input_packet_schema_v0.py \
  tests/test_check_pulsemech_compute_subject_input_packet_v0.py
```

Required result:

```text
all registered subject-input packet tests pass
```

The complete tools-tests CI job must also remain green.

## Non-changes

Do not modify:

```text
tools/check_pulsemech_compute_subject_input_packet_v0.py
schemas/pulsemech_compute_subject_input_packet_v0.schema.json
examples/compute/pulsemech_compute_subject_input_packet_6066_example_v0.json
ci/tools-tests.list
PULSE_CI_6066_release_grade_artifact_preservation_v0.zip
```

Preserve:

```text
Git source-environment isolation
historical active-policy-set ordering
carrier and nested artifact verification
provider and role bindings
coverage semantics
read-only and non-authority boundaries
```

## Non-activation boundary

```text
packet producer:
not included

current-run integration:
none

runtime activation:
none

candidate-gate activation:
none

release-required compute enforcement:
none

compute budget:
not defined

release-authority effect:
none
```