### PR TITLE
fix(compute): pin trusted absolute Git executable

### DIFF
--- a/tests/test_check_pulsemech_compute_subject_input_packet_v0.py
+++ b/tests/test_check_pulsemech_compute_subject_input_packet_v0.py
@@ -6,13 +6,15 @@ import hashlib
 import importlib.util
 import json
 import os
+import shlex
+import shutil
 import stat
 import subprocess
 import sys
 import warnings
 import zipfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 import jsonschema
 import pytest
@@ -138,6 +140,7 @@ def run_tool(
     repository_root: Path = ROOT,
     output: Path | None = None,
     extra_env: dict[str, str] | None = None,
+    remove_env: Iterable[str] = (),
 ) -> subprocess.CompletedProcess[str]:
     command = [
         sys.executable,
@@ -155,6 +158,8 @@ def run_tool(
         command.extend(["--output", str(output)])
 
     environment = dict(os.environ)
+    for key in remove_env:
+        environment.pop(key, None)
     if extra_env is not None:
         environment.update(extra_env)
 
@@ -400,63 +405,35 @@ def observed_packet(
 
 
 def isolated_test_git_environment() -> dict[str, str]:
-    required = ("PATH",)
-    missing = [key for key in required if not os.environ.get(key)]
-    if missing:
-        pytest.skip(
-            "Git regression requires process environment values: "
-            + ", ".join(missing)
-        )
-
-    preserved = (
-        "PATH",
-        "PATHEXT",
-        "SYSTEMROOT",
-        "WINDIR",
-        "COMSPEC",
-        "TEMP",
-        "TMP",
-        "TMPDIR",
-    )
-    environment = {
-        key: os.environ[key]
-        for key in preserved
-        if key in os.environ
-    }
-    environment.update(
-        {
-            "GIT_CONFIG_GLOBAL": os.devnull,
-            "GIT_CONFIG_SYSTEM": os.devnull,
-            "GIT_CONFIG_NOSYSTEM": "1",
-            "GIT_CONFIG_COUNT": "0",
-            "GIT_TERMINAL_PROMPT": "0",
-            "LC_ALL": "C",
-            "LANG": "C",
-        }
-    )
-    return environment
+    trusted_git = TOOL_MODULE._trusted_git_executable()
+    return TOOL_MODULE._sanitized_git_environment(trusted_git)
 
 
-def create_git_repository(
+def create_git_repository_with_files(
     tmp_path: Path,
     *,
     name: str,
-    tracked_bytes: bytes,
+    files: dict[str, bytes],
 ) -> tuple[Path, str]:
     repository = tmp_path / name
     repository.mkdir()
     environment = isolated_test_git_environment()
+    trusted_git = str(TOOL_MODULE._trusted_git_executable())
 
     subprocess.run(
-        ["git", "init", "-q", str(repository)],
+        [trusted_git, "init", "-q", str(repository)],
         check=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=environment,
     )
-    (repository / "tracked.txt").write_bytes(tracked_bytes)
+    for relative, payload in files.items():
+        path = repository / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(payload)
+
     subprocess.run(
-        ["git", "-C", str(repository), "add", "--", "tracked.txt"],
+        [trusted_git, "-C", str(repository), "add", "--", "."],
         check=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -464,7 +441,7 @@ def create_git_repository(
     )
     subprocess.run(
         [
-            "git",
+            trusted_git,
             "-C",
             str(repository),
             "-c",
@@ -482,7 +459,7 @@ def create_git_repository(
         env=environment,
     )
     revision = subprocess.run(
-        ["git", "-C", str(repository), "rev-parse", "HEAD"],
+        [trusted_git, "-C", str(repository), "rev-parse", "HEAD"],
         check=True,
         text=True,
         stdout=subprocess.PIPE,
@@ -491,6 +468,19 @@ def create_git_repository(
     ).stdout.strip()
     assert len(revision) == 40
     return repository, revision
+
+
+def create_git_repository(
+    tmp_path: Path,
+    *,
+    name: str,
+    tracked_bytes: bytes,
+) -> tuple[Path, str]:
+    return create_git_repository_with_files(
+        tmp_path,
+        name=name,
+        files={"tracked.txt": tracked_bytes},
+    )
 
 
 def inherited_git_blob_read(
@@ -502,9 +492,10 @@ def inherited_git_blob_read(
 ) -> subprocess.CompletedProcess[bytes]:
     environment = isolated_test_git_environment()
     environment.update(attacker_environment)
+    trusted_git = str(TOOL_MODULE._trusted_git_executable())
     return subprocess.run(
         [
-            "git",
+            trusted_git,
             "-C",
             str(repository_root),
             "cat-file",
@@ -516,6 +507,116 @@ def inherited_git_blob_read(
         stderr=subprocess.PIPE,
         env=environment,
     )
+
+
+def create_fake_git_executable(
+    tmp_path: Path,
+    *,
+    repository_root: Path,
+    forged_revision: str,
+    forged_path: str,
+    forged_bytes: bytes,
+) -> tuple[Path, Path, Path]:
+    if os.name == "nt":
+        pytest.skip("POSIX fake-executable regression uses /bin/sh")
+
+    attacker_bin = tmp_path / "attacker-bin"
+    attacker_bin.mkdir()
+    marker = tmp_path / "fake-git-invoked.marker"
+    payload = tmp_path / "forged-git-blob.bin"
+    payload.write_bytes(forged_bytes)
+    fake_git = attacker_bin / "git"
+    trusted_git = TOOL_MODULE._trusted_git_executable()
+    pattern = f"{forged_revision}:{forged_path}"
+
+    script_lines = [
+        "#!/bin/sh",
+        f"printf 'invoked\\n' >> {shlex.quote(str(marker))}",
+        'case "$*" in',
+        '  *"rev-parse --show-toplevel"*)',
+        f"    printf '%s\\n' {shlex.quote(str(repository_root))}",
+        "    exit 0",
+        "    ;;",
+        f'  *"cat-file blob {pattern}"*)',
+        f"    cat {shlex.quote(str(payload))}",
+        "    exit 0",
+        "    ;;",
+        "esac",
+        f'exec {shlex.quote(str(trusted_git))} "$@"',
+        "",
+    ]
+    fake_git.write_text("\n".join(script_lines), encoding="utf-8")
+    fake_git.chmod(0o755)
+    return fake_git, marker, payload
+
+
+def source_binding_packet(
+    *,
+    revision: str,
+    real_files: dict[str, bytes],
+    forged_revision: str,
+    forged_path: str,
+    forged_bytes: bytes,
+) -> dict[str, Any]:
+    repository = "example/community-validator"
+    workflow_path = "workflow.yml"
+    workflow_name = "PULSE CI"
+    source_ref = "refs/heads/main"
+    workflow_ref = f"{repository}/{workflow_path}@{source_ref}"
+    policy_id = "policy-v0"
+
+    return {
+        "subject": {
+            "repository": repository,
+            "workflow_path": workflow_path,
+            "workflow_name": workflow_name,
+            "workflow_ref": workflow_ref,
+            "source_ref": source_ref,
+            "source_commit": revision,
+            "policy_id": policy_id,
+            "policy_sha256": sha256_bytes(real_files["policy.yml"]),
+        },
+        "authority_sources": {
+            "workflow": {
+                "source_id": "source:workflow",
+                "role": "workflow",
+                "path_or_uri": workflow_path,
+                "source_revision": revision,
+                "sha256": sha256_bytes(real_files[workflow_path]),
+                "size_bytes": len(real_files[workflow_path]),
+                "workflow_name": workflow_name,
+                "workflow_ref": workflow_ref,
+            },
+            "policy": {
+                "source_id": "source:policy",
+                "role": "policy",
+                "path_or_uri": "policy.yml",
+                "source_revision": revision,
+                "sha256": sha256_bytes(real_files["policy.yml"]),
+                "size_bytes": len(real_files["policy.yml"]),
+                "policy_id": policy_id,
+            },
+            "gate_registry": {
+                "source_id": "source:registry",
+                "role": "gate_registry",
+                "path_or_uri": "registry.yml",
+                "source_revision": revision,
+                "sha256": sha256_bytes(real_files["registry.yml"]),
+                "size_bytes": len(real_files["registry.yml"]),
+                "registry_id": "registry-v0",
+            },
+            "additional_sources": [
+                {
+                    "source_id": "source:additional:forged",
+                    "role": "other",
+                    "path_or_uri": forged_path,
+                    "source_revision": forged_revision,
+                    "sha256": sha256_bytes(forged_bytes),
+                    "size_bytes": len(forged_bytes),
+                }
+            ],
+        },
+    }
 
 
 def attacker_git_environments(
@@ -651,8 +752,12 @@ def test_historical_sources_are_read_from_git_not_current_worktree() -> None:
 
 def test_sanitized_git_environment_drops_caller_controlled_git_variables(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
+    attacker_path = str(tmp_path / "attacker-bin")
     poisoned = {
+        "PATH": attacker_path,
+        "PATHEXT": ".ATTACKER",
         "GIT_DIR": "/attacker/repository/.git",
         "GIT_WORK_TREE": "/attacker/repository",
         "GIT_COMMON_DIR": "/attacker/common",
@@ -672,9 +777,11 @@ def test_sanitized_git_environment_drops_caller_controlled_git_variables(
     for key, value in poisoned.items():
         monkeypatch.setenv(key, value)
 
+    trusted_git = TOOL_MODULE._trusted_git_executable()
     child_environment = TOOL_MODULE._sanitized_git_environment()
 
     fixed_keys = {
+        "PATH",
         "GIT_CONFIG_GLOBAL",
         "GIT_CONFIG_SYSTEM",
         "GIT_CONFIG_NOSYSTEM",
@@ -687,7 +794,11 @@ def test_sanitized_git_environment_drops_caller_controlled_git_variables(
     }
     allowed_keys = set(TOOL_MODULE.GIT_PROCESS_ENV_ALLOWLIST) | fixed_keys
     assert set(child_environment) <= allowed_keys
-    assert child_environment["PATH"] == os.environ["PATH"]
+    assert "PATH" not in TOOL_MODULE.GIT_PROCESS_ENV_ALLOWLIST
+    assert "PATHEXT" not in TOOL_MODULE.GIT_PROCESS_ENV_ALLOWLIST
+    assert child_environment["PATH"] == str(trusted_git.parent)
+    assert child_environment["PATH"] != attacker_path
+    assert "PATHEXT" not in child_environment
     assert child_environment["GIT_CONFIG_GLOBAL"] == os.devnull
     assert child_environment["GIT_CONFIG_SYSTEM"] == os.devnull
     assert child_environment["GIT_CONFIG_NOSYSTEM"] == "1"
@@ -699,20 +810,277 @@ def test_sanitized_git_environment_drops_caller_controlled_git_variables(
     assert child_environment["LANG"] == "C"
 
     for key in poisoned:
-        if key == "GIT_CONFIG_COUNT":
+        if key in {"PATH", "GIT_CONFIG_COUNT"}:
             continue
         assert key not in child_environment
 
 
-def test_missing_process_path_fails_closed(
+def test_missing_caller_path_does_not_affect_trusted_git_selection(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     monkeypatch.delenv("PATH", raising=False)
+    monkeypatch.delenv("PATHEXT", raising=False)
+
+    trusted_git = TOOL_MODULE._trusted_git_executable()
+    child_environment = TOOL_MODULE._sanitized_git_environment()
+    assert child_environment["PATH"] == str(trusted_git.parent)
+
+    repository, revision = create_git_repository(
+        tmp_path,
+        name="missing-caller-path-repository",
+        tracked_bytes=b"trusted path-independent bytes\n",
+    )
+    assert TOOL_MODULE._git_blob_bytes(
+        repository,
+        revision=revision,
+        path="tracked.txt",
+    ) == b"trusted path-independent bytes\n"
+
+
+def test_trusted_git_executable_is_absolute_and_child_path_is_fixed() -> None:
+    trusted_git = TOOL_MODULE._trusted_git_executable()
+    assert trusted_git.is_absolute()
+    assert trusted_git == trusted_git.resolve(strict=True)
+    assert trusted_git.is_file()
+    assert not trusted_git.is_symlink()
+    assert os.access(trusted_git, os.X_OK)
+    assert TOOL_MODULE._sanitized_git_environment()["PATH"] == str(
+        trusted_git.parent
+    )
+
+
+def test_relative_git_executable_candidate_is_rejected() -> None:
     with pytest.raises(
         TOOL_MODULE.SemanticError,
-        match="git_process_path_unavailable",
+        match="git_executable_untrusted: path_not_absolute",
     ):
-        TOOL_MODULE._sanitized_git_environment()
+        TOOL_MODULE._validate_trusted_git_executable(Path("git"))
+
+
+def test_symlink_git_executable_candidate_is_rejected(tmp_path: Path) -> None:
+    link = tmp_path / "git"
+    try:
+        link.symlink_to(TOOL_MODULE._trusted_git_executable())
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable: {exc}")
+
+    with pytest.raises(
+        TOOL_MODULE.SemanticError,
+        match="git_executable_untrusted: symlink_or_alias_path",
+    ):
+        TOOL_MODULE._validate_trusted_git_executable(link)
+
+
+def test_untrusted_writable_or_non_system_git_candidate_is_rejected(
+    tmp_path: Path,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("POSIX ownership and writable-component policy")
+
+    candidate = tmp_path / "git"
+    candidate.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    candidate.chmod(0o755)
+
+    with pytest.raises(
+        TOOL_MODULE.SemanticError,
+        match=(
+            "git_executable_untrusted: "
+            "(non_root_owned_component|writable_component)"
+        ),
+    ):
+        TOOL_MODULE._validate_trusted_git_executable(candidate)
+
+
+def test_no_trusted_git_candidate_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "missing-git"
+    monkeypatch.setattr(
+        TOOL_MODULE,
+        "_trusted_git_executable_candidates",
+        lambda: (missing,),
+    )
+    TOOL_MODULE._trusted_git_executable.cache_clear()
+    try:
+        with pytest.raises(
+            TOOL_MODULE.SemanticError,
+            match="git_process_executable_unavailable",
+        ):
+            TOOL_MODULE._trusted_git_executable()
+    finally:
+        TOOL_MODULE._trusted_git_executable.cache_clear()
+
+
+def test_windows_git_candidates_use_os_system_drive_not_python_drive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        TOOL_MODULE.sys,
+        "executable",
+        r"D:\hostedtoolcache\Python\3.11\python.exe",
+    )
+
+    candidates = TOOL_MODULE._windows_trusted_git_executable_candidate_strings(
+        system_windows_directory=r"C:\Windows",
+    )
+    assert candidates == (
+        r"C:\Program Files\Git\cmd\git.exe",
+        r"C:\Program Files\Git\bin\git.exe",
+        r"C:\Program Files (x86)\Git\cmd\git.exe",
+        r"C:\Program Files (x86)\Git\bin\git.exe",
+    )
+    assert all(not candidate.casefold().startswith("d:") for candidate in candidates)
+
+
+def test_windows_git_candidates_prefer_machine_roots_and_dedupe() -> None:
+    candidates = TOOL_MODULE._windows_trusted_git_executable_candidate_strings(
+        system_windows_directory=r"C:\Windows",
+        registry_program_files_roots=(
+            r"E:\Trusted Programs",
+            r"C:\Program Files",
+            r"e:\trusted programs",
+            r"relative\programs",
+            r"%ProgramFiles%",
+        ),
+    )
+
+    assert candidates[:2] == (
+        r"E:\Trusted Programs\Git\cmd\git.exe",
+        r"E:\Trusted Programs\Git\bin\git.exe",
+    )
+    assert candidates[2:] == (
+        r"C:\Program Files\Git\cmd\git.exe",
+        r"C:\Program Files\Git\bin\git.exe",
+        r"C:\Program Files (x86)\Git\cmd\git.exe",
+        r"C:\Program Files (x86)\Git\bin\git.exe",
+    )
+    assert len(candidates) == len({candidate.casefold() for candidate in candidates})
+
+
+def test_windows_git_candidate_builder_rejects_invalid_system_directory() -> None:
+    with pytest.raises(
+        TOOL_MODULE.SemanticError,
+        match="windows_system_directory_invalid",
+    ):
+        TOOL_MODULE._windows_trusted_git_executable_candidate_strings(
+            system_windows_directory=r"Windows",
+        )
+
+
+def test_fake_git_on_caller_path_cannot_forge_authority_source(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    real_files = {
+        "workflow.yml": b"name: PULSE CI\n",
+        "policy.yml": b"policy:\n  id: policy-v0\n",
+        "registry.yml": b"version: registry-v0\n",
+    }
+    repository, revision = create_git_repository_with_files(
+        tmp_path,
+        name="trusted-source-repository",
+        files=real_files,
+    )
+    forged_revision = "f" * 40
+    forged_path = "forged-source.yml"
+    forged_bytes = b"attacker_controlled: true\n"
+    fake_git, marker, _payload = create_fake_git_executable(
+        tmp_path,
+        repository_root=repository,
+        forged_revision=forged_revision,
+        forged_path=forged_path,
+        forged_bytes=forged_bytes,
+    )
+    original_path = os.environ.get("PATH", "")
+    poisoned_path = str(fake_git.parent) + (
+        os.pathsep + original_path if original_path else ""
+    )
+    assert shutil.which("git", path=poisoned_path) == str(fake_git)
+
+    vulnerable = subprocess.run(
+        [
+            "git",
+            "--no-pager",
+            "--no-replace-objects",
+            "-C",
+            str(repository),
+            "cat-file",
+            "blob",
+            f"{forged_revision}:{forged_path}",
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={**os.environ, "PATH": poisoned_path},
+    )
+    assert vulnerable.returncode == 0
+    assert vulnerable.stdout == forged_bytes
+    assert marker.is_file()
+    marker.unlink()
+
+    monkeypatch.setenv("PATH", poisoned_path)
+    value = source_binding_packet(
+        revision=revision,
+        real_files=real_files,
+        forged_revision=forged_revision,
+        forged_path=forged_path,
+        forged_bytes=forged_bytes,
+    )
+    semantic_ok, complete, source_bytes, errors = (
+        TOOL_MODULE._verify_source_records(
+            value,
+            repository_root=repository,
+        )
+    )
+
+    assert semantic_ok is False
+    assert complete is False
+    assert "source:additional:forged" not in source_bytes
+    assert any(
+        f"git_blob_unavailable: {forged_revision}:{forged_path}" in error
+        for error in errors
+    )
+    assert not marker.exists()
+
+
+def test_full_validator_ignores_fake_git_on_caller_path(
+    tmp_path: Path,
+) -> None:
+    forged_revision = "f" * 40
+    fake_git, marker, _payload = create_fake_git_executable(
+        tmp_path,
+        repository_root=ROOT,
+        forged_revision=forged_revision,
+        forged_path="unused.yml",
+        forged_bytes=b"unused: true\n",
+    )
+    original_path = os.environ.get("PATH", "")
+    poisoned_path = str(fake_git.parent) + (
+        os.pathsep + original_path if original_path else ""
+    )
+
+    result = run_tool(extra_env={"PATH": poisoned_path, "PATHEXT": ".ATTACKER"})
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stderr == ""
+    diagnostic = parse_json_text(result.stdout)
+    assert diagnostic["schema_valid"] is True
+    assert diagnostic["ok"] is True
+    assert diagnostic["errors"] == []
+    assert all(diagnostic["checks"].values())
+    assert not marker.exists()
+
+
+def test_full_validator_succeeds_without_caller_path() -> None:
+    result = run_tool(remove_env=("PATH", "PATHEXT"))
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stderr == ""
+    diagnostic = parse_json_text(result.stdout)
+    assert diagnostic["schema_valid"] is True
+    assert diagnostic["ok"] is True
+    assert diagnostic["errors"] == []
+    assert all(diagnostic["checks"].values())
 
 
 def test_git_blob_read_ignores_attacker_repository_and_object_stores(
@@ -1344,8 +1712,13 @@ def test_artifact_display_path_is_derived_from_carrier_and_container() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_output_cannot_overwrite_schema_packet_or_carrier() -> None:
-    protected = (SCHEMA, EXAMPLE, ARCHIVE)
+def test_output_cannot_overwrite_schema_packet_carrier_or_git() -> None:
+    protected = (
+        SCHEMA,
+        EXAMPLE,
+        ARCHIVE,
+        TOOL_MODULE._trusted_git_executable(),
+    )
     before = snapshot(protected)
 
     for output in protected:

--- a/tools/check_pulsemech_compute_subject_input_packet_v0.py
+++ b/tools/check_pulsemech_compute_subject_input_packet_v0.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+from functools import lru_cache
 import io
 import json
 import math
@@ -87,14 +88,18 @@ AUTHORITY_SURFACE_OUTPUT_NAMES = {
 }
 
 GIT_PROCESS_ENV_ALLOWLIST = (
-    "PATH",
-    "PATHEXT",
     "SYSTEMROOT",
     "WINDIR",
     "COMSPEC",
     "TEMP",
     "TMP",
     "TMPDIR",
+)
+
+POSIX_TRUSTED_GIT_EXECUTABLE_CANDIDATES = (
+    Path("/usr/bin/git"),
+    Path("/usr/local/bin/git"),
+    Path("/opt/local/bin/git"),
 )
 
 
@@ -369,9 +374,131 @@ def _relative_packet_path(packet_path: Path, repository_root: Path) -> str | Non
         return None
 
 
-def _sanitized_git_environment() -> dict[str, str]:
-    if not os.environ.get("PATH"):
-        raise SemanticError("git_process_path_unavailable")
+def _trusted_git_executable_candidates() -> tuple[Path, ...]:
+    if os.name != "nt":
+        return POSIX_TRUSTED_GIT_EXECUTABLE_CANDIDATES
+
+    system_anchor = Path(sys.executable).anchor
+    if not system_anchor:
+        return ()
+
+    system_drive = Path(system_anchor)
+    return (
+        system_drive / "Program Files" / "Git" / "cmd" / "git.exe",
+        system_drive / "Program Files" / "Git" / "bin" / "git.exe",
+        system_drive / "Program Files (x86)" / "Git" / "cmd" / "git.exe",
+        system_drive / "Program Files (x86)" / "Git" / "bin" / "git.exe",
+    )
+
+
+def _normalized_absolute_path(path: Path) -> Path:
+    return Path(os.path.abspath(os.path.normpath(str(path))))
+
+
+def _validate_trusted_git_executable(candidate: Path) -> Path:
+    if not candidate.is_absolute():
+        raise SemanticError(
+            f"git_executable_untrusted: path_not_absolute: {candidate}"
+        )
+
+    normalized = _normalized_absolute_path(candidate)
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise SemanticError(
+            f"git_executable_untrusted: path_unresolvable: {candidate}: {exc}"
+        ) from exc
+
+    if os.path.normcase(str(normalized)) != os.path.normcase(str(resolved)):
+        raise SemanticError(
+            "git_executable_untrusted: symlink_or_alias_path: "
+            f"declared={normalized} resolved={resolved}"
+        )
+    if candidate.is_symlink() or not resolved.is_file():
+        raise SemanticError(
+            f"git_executable_untrusted: not_regular_non_symlink_file: {resolved}"
+        )
+    if not os.access(resolved, os.X_OK):
+        raise SemanticError(
+            f"git_executable_untrusted: not_executable: {resolved}"
+        )
+
+    components: list[Path] = [resolved]
+    cursor = resolved.parent
+    while True:
+        components.append(cursor)
+        if cursor == cursor.parent:
+            break
+        cursor = cursor.parent
+
+    for component in components:
+        try:
+            metadata = component.lstat()
+        except OSError as exc:
+            raise SemanticError(
+                f"git_executable_untrusted: component_unavailable: {component}: {exc}"
+            ) from exc
+        if stat.S_ISLNK(metadata.st_mode):
+            raise SemanticError(
+                f"git_executable_untrusted: symlink_component: {component}"
+            )
+        if component == resolved:
+            if not stat.S_ISREG(metadata.st_mode):
+                raise SemanticError(
+                    f"git_executable_untrusted: executable_not_regular: {component}"
+                )
+        elif not stat.S_ISDIR(metadata.st_mode):
+            raise SemanticError(
+                f"git_executable_untrusted: parent_not_directory: {component}"
+            )
+
+        if os.name != "nt":
+            if metadata.st_uid != 0:
+                raise SemanticError(
+                    "git_executable_untrusted: non_root_owned_component: "
+                    f"{component}"
+                )
+            if metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+                raise SemanticError(
+                    "git_executable_untrusted: writable_component: "
+                    f"{component}"
+                )
+
+    return resolved
+
+
+@lru_cache(maxsize=1)
+def _trusted_git_executable() -> Path:
+    unavailable: list[str] = []
+    untrusted: list[str] = []
+
+    for candidate in _trusted_git_executable_candidates():
+        if not candidate.exists():
+            unavailable.append(str(candidate))
+            continue
+        try:
+            return _validate_trusted_git_executable(candidate)
+        except SemanticError as exc:
+            untrusted.append(str(exc))
+
+    if untrusted:
+        raise SemanticError(
+            "git_process_executable_untrusted: " + " | ".join(untrusted)
+        )
+    raise SemanticError(
+        "git_process_executable_unavailable: "
+        + (", ".join(unavailable) if unavailable else "no trusted candidates")
+    )
+
+
+def _sanitized_git_environment(
+    git_executable: Path | None = None,
+) -> dict[str, str]:
+    trusted_git = (
+        _trusted_git_executable()
+        if git_executable is None
+        else _validate_trusted_git_executable(git_executable)
+    )
 
     env: dict[str, str] = {}
     for key in GIT_PROCESS_ENV_ALLOWLIST:
@@ -381,6 +508,7 @@ def _sanitized_git_environment() -> dict[str, str]:
 
     env.update(
         {
+            "PATH": str(trusted_git.parent),
             "GIT_CONFIG_GLOBAL": os.devnull,
             "GIT_CONFIG_SYSTEM": os.devnull,
             "GIT_CONFIG_NOSYSTEM": "1",
@@ -407,8 +535,9 @@ def _run_isolated_git(
             f"git_repository_root_not_directory: {resolved_root}"
         )
 
+    git_executable = _trusted_git_executable()
     command = [
-        "git",
+        str(git_executable),
         "--no-pager",
         "--no-replace-objects",
         "-c",
@@ -422,7 +551,7 @@ def _run_isolated_git(
         check=False,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        env=_sanitized_git_environment(),
+        env=_sanitized_git_environment(git_executable),
     )
     if completed.returncode != 0:
         detail = completed.stderr.decode("utf-8", errors="replace").strip()
@@ -515,6 +644,7 @@ def reject_unsafe_output(
         schema_path,
         packet_path,
         carrier_path,
+        _trusted_git_executable(),
         Path(__file__),
         DEFAULT_GATE_POLICY,
         DEFAULT_GATE_REGISTRY,

--- a/tools/check_pulsemech_compute_subject_input_packet_v0.py
+++ b/tools/check_pulsemech_compute_subject_input_packet_v0.py
@@ -13,7 +13,7 @@ import subprocess
 import sys
 import zipfile
 from datetime import datetime, timezone
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Iterable
 from urllib.parse import unquote, urlparse
 
@@ -100,6 +100,18 @@ POSIX_TRUSTED_GIT_EXECUTABLE_CANDIDATES = (
     Path("/usr/bin/git"),
     Path("/usr/local/bin/git"),
     Path("/opt/local/bin/git"),
+)
+
+WINDOWS_CURRENT_VERSION_REGISTRY_KEY = (
+    r"SOFTWARE\Microsoft\Windows\CurrentVersion"
+)
+WINDOWS_PROGRAM_FILES_REGISTRY_VALUES = (
+    "ProgramFilesDir",
+    "ProgramFilesDir (x86)",
+)
+WINDOWS_GIT_RELATIVE_EXECUTABLES = (
+    PureWindowsPath("Git") / "cmd" / "git.exe",
+    PureWindowsPath("Git") / "bin" / "git.exe",
 )
 
 
@@ -374,21 +386,152 @@ def _relative_packet_path(packet_path: Path, repository_root: Path) -> str | Non
         return None
 
 
+def _dedupe_windows_paths(
+    values: Iterable[PureWindowsPath],
+) -> tuple[PureWindowsPath, ...]:
+    result: list[PureWindowsPath] = []
+    seen: set[str] = set()
+    for value in values:
+        key = str(value).rstrip("\\/").casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(value)
+    return tuple(result)
+
+
+def _windows_system_directory() -> PureWindowsPath:
+    if os.name != "nt":
+        raise SemanticError("windows_system_directory_unavailable: not_windows")
+
+    try:
+        import ctypes
+
+        buffer_size = 32768
+        buffer = ctypes.create_unicode_buffer(buffer_size)
+        length = ctypes.windll.kernel32.GetSystemWindowsDirectoryW(
+            buffer,
+            buffer_size,
+        )
+    except Exception as exc:
+        raise SemanticError(
+            f"windows_system_directory_unavailable: {exc}"
+        ) from exc
+
+    if length <= 0 or length >= buffer_size:
+        raise SemanticError(
+            "windows_system_directory_unavailable: "
+            f"invalid_length={length}"
+        )
+
+    directory = PureWindowsPath(buffer.value)
+    if not directory.is_absolute() or not directory.drive or not directory.root:
+        raise SemanticError(
+            "windows_system_directory_invalid: "
+            f"{str(directory)!r}"
+        )
+    return directory
+
+
+def _windows_registry_program_files_roots() -> tuple[PureWindowsPath, ...]:
+    if os.name != "nt":
+        return ()
+
+    try:
+        import winreg
+    except ImportError:
+        return ()
+
+    views: list[int] = [winreg.KEY_READ]
+    for flag_name in ("KEY_WOW64_64KEY", "KEY_WOW64_32KEY"):
+        flag = getattr(winreg, flag_name, 0)
+        access = winreg.KEY_READ | flag
+        if access not in views:
+            views.append(access)
+
+    roots: list[PureWindowsPath] = []
+    accepted_types = {winreg.REG_SZ, winreg.REG_EXPAND_SZ}
+    for access in views:
+        try:
+            key = winreg.OpenKey(
+                winreg.HKEY_LOCAL_MACHINE,
+                WINDOWS_CURRENT_VERSION_REGISTRY_KEY,
+                0,
+                access,
+            )
+        except OSError:
+            continue
+
+        with key:
+            for value_name in WINDOWS_PROGRAM_FILES_REGISTRY_VALUES:
+                try:
+                    raw_value, value_type = winreg.QueryValueEx(key, value_name)
+                except OSError:
+                    continue
+                if value_type not in accepted_types:
+                    continue
+                if not isinstance(raw_value, str):
+                    continue
+                value = raw_value.strip()
+                if not value or "%" in value:
+                    continue
+                candidate = PureWindowsPath(value)
+                if candidate.is_absolute() and candidate.drive and candidate.root:
+                    roots.append(candidate)
+
+    return _dedupe_windows_paths(roots)
+
+
+def _windows_trusted_git_executable_candidate_strings(
+    *,
+    system_windows_directory: str,
+    registry_program_files_roots: Iterable[str] = (),
+) -> tuple[str, ...]:
+    system_directory = PureWindowsPath(system_windows_directory)
+    if (
+        not system_directory.is_absolute()
+        or not system_directory.drive
+        or not system_directory.root
+    ):
+        raise SemanticError(
+            "windows_system_directory_invalid: "
+            f"{system_windows_directory!r}"
+        )
+
+    roots: list[PureWindowsPath] = []
+    for value in registry_program_files_roots:
+        root = PureWindowsPath(value)
+        if root.is_absolute() and root.drive and root.root and "%" not in value:
+            roots.append(root)
+
+    system_drive_root = PureWindowsPath(system_directory.anchor)
+    roots.extend(
+        (
+            system_drive_root / "Program Files",
+            system_drive_root / "Program Files (x86)",
+        )
+    )
+
+    candidates: list[PureWindowsPath] = []
+    for root in _dedupe_windows_paths(roots):
+        candidates.extend(
+            root / relative
+            for relative in WINDOWS_GIT_RELATIVE_EXECUTABLES
+        )
+    return tuple(str(candidate) for candidate in _dedupe_windows_paths(candidates))
+
+
 def _trusted_git_executable_candidates() -> tuple[Path, ...]:
     if os.name != "nt":
         return POSIX_TRUSTED_GIT_EXECUTABLE_CANDIDATES
 
-    system_anchor = Path(sys.executable).anchor
-    if not system_anchor:
-        return ()
-
-    system_drive = Path(system_anchor)
-    return (
-        system_drive / "Program Files" / "Git" / "cmd" / "git.exe",
-        system_drive / "Program Files" / "Git" / "bin" / "git.exe",
-        system_drive / "Program Files (x86)" / "Git" / "cmd" / "git.exe",
-        system_drive / "Program Files (x86)" / "Git" / "bin" / "git.exe",
+    system_directory = _windows_system_directory()
+    registry_roots = _windows_registry_program_files_roots()
+    candidate_strings = _windows_trusted_git_executable_candidate_strings(
+        system_windows_directory=str(system_directory),
+        registry_program_files_roots=(str(root) for root in registry_roots),
     )
+    return tuple(Path(value) for value in candidate_strings)
 
 
 def _normalized_absolute_path(path: Path) -> Path:


### PR DESCRIPTION
## Summary

Close the post-merge P1 finding from the complete review of the PULSEmech
compute subject-input packet v0 implementation.

The validator already isolates historical Git source reconstruction from
caller-controlled repository, work-tree, namespace, configuration, index, and
object-store variables.

However, the Git executable itself was still invoked by the command name:

```text
git
```

while the child process inherited the caller-provided:

```text
PATH
PATHEXT
```

A caller could prepend an attacker-controlled directory containing a fake
executable named `git`.

That executable could return:

```text
a forged rev-parse --show-toplevel result
and
forged cat-file blob bytes
```

matching attacker-selected packet digests and sizes.

This pull request removes caller-controlled executable discovery from the Git
source-verification path.

## Exact pull-request boundary

The completed corrective pull request modifies exactly:

```text
1. tools/
   check_pulsemech_compute_subject_input_packet_v0.py

2. tests/
   test_check_pulsemech_compute_subject_input_packet_v0.py
```

No `ci/tools-tests.list` change is required because the validator regression is
already registered.

Current state:

```text
trusted absolute Git executable selection:
complete

caller PATH removal:
complete

trusted executable path validation:
complete

fake-PATH regression:
pending

complete registered validation:
pending

merge state:
not ready
```

## Root cause

The previously corrected Git environment removed caller-controlled Git
repository and object-store variables, but retained:

```text
PATH
PATHEXT
```

The subprocess command still began with:

```text
git
```

Therefore:

```text
sanitized GIT_* environment
+ caller-controlled PATH
+ fake executable named git
→ attacker-controlled Git process
```

The fake executable did not need to redirect a real Git object store. It could
directly fabricate the output of:

```text
git rev-parse --show-toplevel
git cat-file blob <revision>:<path>
```

This weakened the repository-root-bound historical source proof.

## Trusted executable boundary

Do not discover Git through caller PATH.

Do not accept a Git executable path from:

```text
the packet
the carrier
a general CLI option
an inherited environment variable
the current working directory
```

Select Git only from fixed platform-specific absolute system candidates.

On POSIX platforms, inspect fixed candidates such as:

```text
/usr/bin/git
/usr/local/bin/git
/opt/local/bin/git
```

On Windows, derive the system-drive anchor from the running Python executable
and inspect fixed Git for Windows installation locations under the trusted
Program Files surfaces.

No PATH fallback is permitted.

## Executable validation

Before using a candidate, require:

```text
absolute path
successful strict resolution
resolved path equals the declared candidate
regular file
non-symlink file
executable permission
no symlink path component
regular directory parents
```

On POSIX, also require the executable and every parent path component to be:

```text
owned by root
not group-writable
not world-writable
```

Reject:

```text
relative candidate
missing candidate
unresolvable candidate
symlink candidate
path-alias candidate
non-regular executable
non-executable file
symlink parent
untrusted writable parent
non-system-owned candidate
```

If no trusted candidate is available:

```text
fail closed
```

Do not fall back to caller PATH.

## Absolute process invocation

Cache the validated trusted Git executable once per validator process.

Invoke Git through its absolute path:

```text
/trusted/system/path/git
```

Do not invoke:

```text
git
```

by command name.

Continue to use:

```text
--no-pager
--no-replace-objects
-c safe.directory=<exact resolved repository root>
-C <exact resolved repository root>
```

## Child process environment

Remove `PATH` and `PATHEXT` from the inherited process-environment allowlist.

Construct the child Git environment independently from caller PATH.

Set the Git child `PATH` only to:

```text
trusted_git_executable.parent
```

This permits Git to resolve its trusted system companion executables without
admitting caller-selected directories.

Preserve the existing explicit controls:

```text
GIT_CONFIG_GLOBAL=<null device>
GIT_CONFIG_SYSTEM=<null device>
GIT_CONFIG_NOSYSTEM=1
GIT_CONFIG_COUNT=0
GIT_OPTIONAL_LOCKS=0
GIT_NO_REPLACE_OBJECTS=1
GIT_TERMINAL_PROMPT=0
LC_ALL=C
LANG=C
```

Continue to exclude inherited:

```text
GIT_DIR
GIT_WORK_TREE
GIT_COMMON_DIR
GIT_OBJECT_DIRECTORY
GIT_ALTERNATE_OBJECT_DIRECTORIES
GIT_INDEX_FILE
GIT_NAMESPACE
GIT_CONFIG_PARAMETERS
GIT_CONFIG_COUNT
GIT_CONFIG_KEY_*
GIT_CONFIG_VALUE_*
GIT_EXEC_PATH
GIT_CEILING_DIRECTORIES
GIT_DISCOVERY_ACROSS_FILESYSTEM
GIT_SHALLOW_FILE
other inherited GIT_* variables
```

## Repository-root and source reconstruction

Preserve the current sequence:

```text
trusted absolute Git executable
+ sanitized Git environment
→ git rev-parse --show-toplevel
→ exact requested repository-root equality
→ git cat-file blob <revision>:<path>
→ exact SHA-256
→ exact byte size
```

Continue to reject:

```text
repository-root mismatch
repository subdirectory supplied as root
missing revision
missing source path
current-working-tree substitution
replacement-object substitution
alternate object-store substitution
namespace substitution
configuration injection
```

## Protected executable boundary

Add the trusted Git executable itself to the protected output targets.

The validator must refuse an `--output` path that aliases or overwrites:

```text
the trusted Git executable
```

using the existing same-target, symlink, and protected-output mechanisms.

## First commit

The first commit modifies only:

```text
tools/check_pulsemech_compute_subject_input_packet_v0.py
```

Replacement identity:

```text
line count:
2516

byte size:
87754

SHA-256:
35e858de4d9c0da41161324a48d8dd202d36c26c2517803fd19cbf148ab98fc2
```

Completed construction checks:

```text
Python compilation:
PASS

trusted Git executable:
resolved to /usr/bin/git

exact blob read through trusted absolute Git:
PASS

fake git prepended to caller PATH:
ignored

fake executable marker:
absent

Git child PATH:
trusted executable parent only

focused Git executable / environment /
object-store / repository-root regressions:
5 passed
```

## Planned regression

The second file will add a real fake-executable substitution proof.

Create:

```text
temporary attacker-bin directory
→ fake executable named git
→ executable writes an invocation marker
→ fake rev-parse output claims the requested repository root
→ fake cat-file output returns attacker-selected bytes
```

Prepend the attacker directory to caller PATH:

```text
PATH=<attacker-bin>:<original PATH>
```

Use packet metadata that could pass only if the fake Git bytes were admitted.

Require:

```text
fake executable is never invoked
fake invocation marker remains absent
trusted absolute Git executable is used
attacker-selected blob bytes are never admitted
authority-source verification fails closed when the real repository lacks the
attacker revision or path
```

Also require a normal source reconstruction through the trusted executable to
continue passing.

Add regressions for:

```text
no trusted fixed candidate available
relative candidate
symlink candidate
untrusted writable candidate or parent
trusted executable output-overwrite attempt
caller PATH poisoning during the complete #6066 CLI run
```

The exact platform-specific negative cases may be skipped only when the
platform cannot construct the required filesystem condition.

## Required complete validation

The final two-file PR head must run:

```text
python tools/check_pulsemech_compute_subject_input_packet_v0.py
```

Required result:

```text
exit 0
schema_valid=true
ok=true
errors=[]
every semantic check=true
```

Then:

```text
python -m pytest -q \
  tests/test_pulsemech_compute_subject_input_packet_schema_v0.py \
  tests/test_check_pulsemech_compute_subject_input_packet_v0.py
```

Required result:

```text
all registered subject-input packet tests pass
```

The complete tools-tests CI job must also remain green.

No merge is permitted from the intermediate one-file head.

## Trust boundary

This correction makes the validator trust boundary explicit.

Trusted computing base:

```text
checked-in validator bytes
running Python interpreter
operating-system process and filesystem mechanics
validated fixed-system Git executable
```

Untrusted inputs:

```text
packet
carrier metadata
CLI paths
caller PATH
caller PATHEXT
caller GIT_* variables
working-tree source bytes
declared packet digests
declared verification booleans
```

This pull request does not attempt to attest the Python interpreter or operating
system itself.

## Non-changes

Do not modify:

```text
schemas/pulsemech_compute_subject_input_packet_v0.schema.json
examples/compute/pulsemech_compute_subject_input_packet_6066_example_v0.json
ci/tools-tests.list
PULSE_CI_6066_release_grade_artifact_preservation_v0.zip

historical active-policy-set sequence
fixture / producer provenance semantics
carrier identity
nested artifact graph semantics
provider bindings
role bindings
coverage semantics
release authority
```

## Non-activation boundary

```text
packet producer:
not included

reusable analyzer core:
not included

current-run integration:
none

runtime activation:
none

candidate-gate activation:
none

release-required compute enforcement:
none

compute budget:
not defined

release-authority effect:
none
```