### PR TITLE
docs(identity): align the primary repository title with PULSEmech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# PULSE — Artifact-Bound Release Authority for AI Release Decisions
+# PULSEmech — Artifact-Bound Release Authority for AI Release Decisions
+
+PULSEmech is the canonical mechanical implementation of PULSE.
 
 > **Public origin / prior-art notice:** PULSE has a minimum public origin record. For the visible provenance anchors and attribution boundary, see the [Public Origin / Prior Art Notice](docs/quality_ledger.md#10-public-origin--prior-art-notice).
 

--- a/docs/PULSE_TITLE_CONTINUITY_v0.md
+++ b/docs/PULSE_TITLE_CONTINUITY_v0.md
@@ -2,18 +2,28 @@
 
 ## Title continuity
 
-The current repository-facing title is:
+The continuous project identity is:
 
-**PULSE — Artifact-Bound Release Authority for AI Release Decisions**
+**PULSE**
+
+The current repository-facing mechanism title is:
+
+**PULSEmech — Artifact-Bound Release Authority for AI Release Decisions**
 
 Earlier Kaggle-facing, publication-facing, and external reference material used the title:
 
 **PULSE: Deterministic Release Gates for Safe & Useful AI**
 
-These titles refer to the same continuous work line, provenance path, and workshop relationship.
+These names and titles refer to the same continuous work line, provenance path, and workshop relationship.
 
-The current title clarifies the mechanism more precisely: PULSE is an artifact-bound release-authority system for AI release decisions. The earlier title remains a valid historical and publication-facing reference for the same project trajectory.
+PULSE remains the continuous project and publication identity.
 
-**PULSEmech** names the explicit mechanism inside this continuity: recorded release evidence, `status.json`, declared gate policy, workflow-effective materialized required gates, and strict fail-closed CI enforcement.
+PULSEmech is the canonical mechanical implementation of PULSE.
+
+The current mechanism title identifies the implemented system more precisely: PULSEmech is an artifact-bound release-authority mechanism for AI release decisions.
+
+The earlier title remains a valid historical and publication-facing reference for the same project trajectory.
+
+PULSEmech carries the explicit mechanism within this continuity: recorded release evidence, `status.json`, declared gate policy, workflow-effective materialized required gates, and strict fail-closed CI enforcement.
 
 This note preserves title continuity across repository history, Kaggle material, publication records, and external references.

--- a/docs/PULSE_TITLE_CONTINUITY_v0.md
+++ b/docs/PULSE_TITLE_CONTINUITY_v0.md
@@ -2,28 +2,20 @@
 
 ## Title continuity
 
-The continuous project identity is:
-
-**PULSE**
-
 The current repository-facing mechanism title is:
 
 **PULSEmech — Artifact-Bound Release Authority for AI Release Decisions**
+
+PULSE remains the continuous project identity. PULSEmech is the canonical mechanical implementation of PULSE.
 
 Earlier Kaggle-facing, publication-facing, and external reference material used the title:
 
 **PULSE: Deterministic Release Gates for Safe & Useful AI**
 
-These names and titles refer to the same continuous work line, provenance path, and workshop relationship.
+These titles refer to the same continuous work line, provenance path, and workshop relationship.
 
-PULSE remains the continuous project and publication identity.
+The current title clarifies the mechanism more precisely: PULSEmech is an artifact-bound release-authority system for AI release decisions. The earlier title remains a valid historical and publication-facing reference for the same project trajectory.
 
-PULSEmech is the canonical mechanical implementation of PULSE.
-
-The current mechanism title identifies the implemented system more precisely: PULSEmech is an artifact-bound release-authority mechanism for AI release decisions.
-
-The earlier title remains a valid historical and publication-facing reference for the same project trajectory.
-
-PULSEmech carries the explicit mechanism within this continuity: recorded release evidence, `status.json`, declared gate policy, workflow-effective materialized required gates, and strict fail-closed CI enforcement.
+**PULSEmech** names the explicit mechanism inside this continuity: recorded release evidence, `status.json`, declared gate policy, workflow-effective materialized required gates, and strict fail-closed CI enforcement.
 
 This note preserves title continuity across repository history, Kaggle material, publication records, and external references.

--- a/tests/test_readme_release_authority_category_signal_v0.py
+++ b/tests/test_readme_release_authority_category_signal_v0.py
@@ -38,6 +38,7 @@ FRONT_DOOR_END_MARKERS = [
 REQUIRED_FRONT_DOOR_ANCHORS = [
     (
         "PULSE — Artifact-Bound Release Authority "
+        "PULSEmech — Artifact-Bound Release Authority "
         "for AI Release Decisions"
     ),
     "Canonical PULSEmech implementation path",

--- a/tests/test_readme_release_authority_category_signal_v0.py
+++ b/tests/test_readme_release_authority_category_signal_v0.py
@@ -37,7 +37,6 @@ FRONT_DOOR_END_MARKERS = [
 
 REQUIRED_FRONT_DOOR_ANCHORS = [
     (
-        "PULSE — Artifact-Bound Release Authority "
         "PULSEmech — Artifact-Bound Release Authority "
         "for AI Release Decisions"
     ),


### PR DESCRIPTION
## Summary

Align the repository-facing primary title with the already established
PULSEmech public and mechanical identity.

## Changes

- change the README H1 to:

  `PULSEmech — Artifact-Bound Release Authority for AI Release Decisions`

- state explicitly that PULSEmech is the canonical mechanical implementation
  of the continuous PULSE project identity

- update the title-continuity note so that it preserves the relation between:
  - PULSE as the continuous project and publication identity
  - PULSEmech as the canonical mechanical implementation
  - the historical publication-facing title
  - the existing concept DOI and provenance line

## Boundary

This change does not:

- create a new project identity
- create or modify a DOI
- alter citation metadata
- rename historical publication records
- modify runtime behavior
- modify release authority
- modify gate evaluation or CI enforcement

The change preserves the already working public search relation among
PULSEmech, Artifact-Bound Release Authority, EPLabsAI, the canonical
repository, and the existing DOI family.

## Validation

Documentation-only identity alignment.

No executable or authority-bearing path is changed.