### PR TITLE
fix(compute): verify subject-input producer core before execution

### DIFF
--- a/tests/test_build_pulsemech_compute_subject_input_packet_v0.py
+++ b/tests/test_build_pulsemech_compute_subject_input_packet_v0.py
@@ -49,10 +49,10 @@ THRESHOLD_POLICY = (
 )
 
 EXPECTED_PRODUCER_SHA256 = (
-    "13bb5ab8f0b7e08a016963c212144bc1190e96345ee19bb12847acaf5b3c14ff"
+    "d61c7bb6d158a2122463f366cfe12066fe5f909389113787728777d069ebe70f"
 )
-EXPECTED_PRODUCER_SIZE_BYTES = 2997
-EXPECTED_PRODUCER_LINE_COUNT = 111
+EXPECTED_PRODUCER_SIZE_BYTES = 20063
+EXPECTED_PRODUCER_LINE_COUNT = 658
 
 EXPECTED_CARRIER_SHA256 = (
     "7949bfd00468e6f9347fddaae732bdcebff5527e87ecb379a6c84a47176db966"
@@ -545,6 +545,16 @@ def test_producer_file_identity_is_pinned() -> None:
     assert sha256_bytes(payload) == EXPECTED_PRODUCER_SHA256
 
 
+def test_wrapper_verifies_committed_core_before_compile_and_execution() -> None:
+    source = PRODUCER.read_text(encoding="utf-8")
+    committed_check = source.index("producer_core_committed_bytes_mismatch")
+    compile_call = source.index("code = compile(")
+    execution_call = source.index("exec(code, module.__dict__)")
+    assert committed_check < compile_call < execution_call
+    assert "Path(__file__).resolve()" not in source
+    assert "_EXECUTED_WRAPPER_PATH" in source
+
+
 def test_compatibility_wrapper_loads_exact_current_committed_core() -> None:
     revision = current_head()
     committed_core = PRODUCER_MODULE._git_blob_bytes(
@@ -560,6 +570,9 @@ def test_compatibility_wrapper_loads_exact_current_committed_core() -> None:
     assert PRODUCER_CORE.read_bytes() == committed_core
     assert WRAPPER_MODULE.PRODUCER_CORE_SOURCE_SHA256 == core_sha256
     assert PRODUCER_MODULE.__pulsemech_source_sha256__ == core_sha256
+    assert PRODUCER_MODULE.__pulsemech_verified_revision__ == revision
+    assert WRAPPER_MODULE._BOOTSTRAP_REPOSITORY_ROOT == ROOT
+    assert WRAPPER_MODULE._EXECUTED_WRAPPER_PATH == PRODUCER
 
 
 def test_compatibility_wrapper_delegates_main_with_exact_provenance(
@@ -677,7 +690,10 @@ def test_out_of_tree_copied_producer_execution_is_rejected(
     shutil.copy2(PRODUCER, copied)
     module_name = "pulsemech_subject_input_packet_copied_producer_v0"
     try:
-        with pytest.raises(RuntimeError, match="producer_core_missing"):
+        with pytest.raises(
+            RuntimeError,
+            match="executed_wrapper_path_mismatch",
+        ):
             import_module(copied, module_name)
     finally:
         sys.modules.pop(module_name, None)

--- a/tests/test_pulsemech_compute_subject_input_packet_producer_core_v0.py
+++ b/tests/test_pulsemech_compute_subject_input_packet_producer_core_v0.py
@@ -5,6 +5,8 @@ import ast
 import hashlib
 import importlib.util
 import json
+import os
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -189,6 +191,119 @@ def run_direct_core(
     )
 
 
+BENIGN_SYNTHETIC_CORE = """from __future__ import annotations
+
+from pathlib import Path
+
+
+class Profile:
+    pass
+
+
+FIXED_SOURCE_6066_PROFILE = Profile()
+DEFAULT_PRODUCER_PROFILE = FIXED_SOURCE_6066_PROFILE
+
+
+def executed_producer_source_path(
+    repository_root: Path,
+    *,
+    revision: str,
+    executed_source_path: Path | None = None,
+    expected_relative_path: str = (
+        "tools/build_pulsemech_compute_subject_input_packet_v0.py"
+    ),
+) -> Path:
+    del repository_root, revision, expected_relative_path
+    assert executed_source_path is not None
+    return Path(executed_source_path)
+
+
+def main(
+    *,
+    profile: Profile = DEFAULT_PRODUCER_PROFILE,
+    producer_source_path: Path | None = None,
+    producer_core_source_sha256: str | None = None,
+) -> int:
+    del profile, producer_source_path, producer_core_source_sha256
+    print("synthetic-core-ok")
+    return 0
+"""
+
+
+def trusted_git_run(
+    wrapper_module: Any,
+    repository: Path,
+    *arguments: str,
+) -> subprocess.CompletedProcess[str]:
+    core = wrapper_module._PRODUCER_CORE
+    trusted_git = core._trusted_git_executable()
+    return subprocess.run(
+        [str(trusted_git), *arguments],
+        cwd=repository,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        env=core._sanitized_git_environment(trusted_git),
+    )
+
+
+def create_bootstrap_repository(
+    tmp_path: Path,
+    wrapper_module: Any,
+) -> tuple[Path, Path, Path]:
+    repository = tmp_path / "repository"
+    tools = repository / "tools"
+    tools.mkdir(parents=True)
+
+    wrapper = tools / WRAPPER.name
+    core = tools / PRODUCER_CORE.name
+    shutil.copy2(WRAPPER, wrapper)
+    core.write_text(BENIGN_SYNTHETIC_CORE, encoding="utf-8", newline="\n")
+
+    commands = (
+        ("init", "-q"),
+        ("add", "--", "."),
+        (
+            "-c",
+            "user.name=PULSEmech bootstrap regression",
+            "-c",
+            "user.email=pulsemech-bootstrap@example.invalid",
+            "commit",
+            "-q",
+            "-m",
+            "fixture",
+        ),
+    )
+    for command in commands:
+        result = trusted_git_run(wrapper_module, repository, *command)
+        assert result.returncode == 0, result.stdout + result.stderr
+    return repository, wrapper, core
+
+
+def run_synthetic_wrapper(
+    wrapper: Path,
+    *,
+    cwd: Path,
+    extra_env: dict[str, str | None] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    environment = dict(os.environ)
+    for key, value in dict(extra_env or {}).items():
+        if value is None:
+            environment.pop(key, None)
+        else:
+            environment[key] = value
+    return subprocess.run(
+        [sys.executable, "-S", str(wrapper)],
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        env=environment,
+    )
+
+
 @pytest.fixture(scope="module")
 def wrapper_module() -> Any:
     return import_module(
@@ -248,7 +363,12 @@ def test_wrapper_remains_thin_and_core_owns_packet_implementation() -> None:
 
     assert {
         "sha256_bytes",
-        "_load_producer_core",
+        "_read_regular_file_snapshot",
+        "_executed_wrapper_and_root",
+        "_trusted_git",
+        "_run_git",
+        "_git_blob",
+        "_load_verified_producer_core",
         "executed_producer_source_path",
         "main",
     } <= wrapper_functions
@@ -257,7 +377,9 @@ def test_wrapper_remains_thin_and_core_owns_packet_implementation() -> None:
 
     wrapper_source = WRAPPER.read_text(encoding="utf-8")
     assert EXPECTED_CORE_SOURCE_PATH.split("/")[-1] in wrapper_source
-    assert "producer_source_path=Path(__file__).resolve()" in wrapper_source
+    assert "producer_source_path=_EXECUTED_WRAPPER_PATH" in wrapper_source
+    assert "Path(__file__).resolve()" not in wrapper_source
+    assert "producer_core_committed_bytes_mismatch" in wrapper_source
     assert (
         "producer_core_source_sha256=PRODUCER_CORE_SOURCE_SHA256"
         in wrapper_source
@@ -277,6 +399,10 @@ def test_wrapper_loads_and_binds_the_exact_current_core_bytes(
     assert (
         wrapper_module._PRODUCER_CORE.__pulsemech_source_sha256__
         == core_sha256
+    )
+    assert (
+        wrapper_module._PRODUCER_CORE.__pulsemech_verified_revision__
+        == wrapper_module.current_head(ROOT)
     )
     assert Path(wrapper_module._PRODUCER_CORE.__file__).resolve(strict=True) == (
         PRODUCER_CORE.resolve(strict=True)
@@ -372,6 +498,177 @@ def test_wrapper_and_direct_core_failure_surfaces_are_both_machine_readable() ->
         results.append(diagnostic)
 
     assert results[0] == results[1]
+
+
+def test_uncommitted_core_top_level_code_is_rejected_before_execution(
+    tmp_path: Path,
+    wrapper_module: Any,
+) -> None:
+    repository, wrapper, core = create_bootstrap_repository(
+        tmp_path,
+        wrapper_module,
+    )
+    marker = tmp_path / "preverify-marker"
+    core.write_text(
+        (
+            "from pathlib import Path\n"
+            f"Path({str(marker)!r}).write_text('EXECUTED')\n"
+            + BENIGN_SYNTHETIC_CORE
+        ),
+        encoding="utf-8",
+        newline="\n",
+    )
+
+    result = run_synthetic_wrapper(wrapper, cwd=repository)
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "Traceback" not in result.stderr
+    diagnostic = strict_json_text(
+        result.stderr,
+        label="modified-core bootstrap diagnostic",
+    )
+    assert diagnostic["ok"] is False
+    assert any(
+        "producer_core_committed_bytes_mismatch" in str(error)
+        for error in diagnostic["errors"]
+    )
+    assert not marker.exists()
+
+
+def test_wrapper_file_symlink_is_rejected_before_core_loading(
+    tmp_path: Path,
+    wrapper_module: Any,
+) -> None:
+    repository, wrapper, _core = create_bootstrap_repository(
+        tmp_path,
+        wrapper_module,
+    )
+    alias = tmp_path / "wrapper.py"
+    try:
+        alias.symlink_to(wrapper)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink unsupported: {exc}")
+
+    result = run_synthetic_wrapper(alias, cwd=repository)
+    assert result.returncode == 1
+    assert result.stdout == ""
+    diagnostic = strict_json_text(
+        result.stderr,
+        label="wrapper-symlink diagnostic",
+    )
+    assert any(
+        "executed_wrapper_symlink_or_alias_rejected" in str(error)
+        for error in diagnostic["errors"]
+    )
+
+
+def test_symlinked_wrapper_parent_is_rejected_before_core_loading(
+    tmp_path: Path,
+    wrapper_module: Any,
+) -> None:
+    repository, wrapper, _core = create_bootstrap_repository(
+        tmp_path,
+        wrapper_module,
+    )
+    alias_root = tmp_path / "repository-alias"
+    try:
+        alias_root.symlink_to(repository, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"directory symlink unsupported: {exc}")
+
+    alias_wrapper = alias_root / "tools" / wrapper.name
+    result = run_synthetic_wrapper(alias_wrapper, cwd=repository)
+    assert result.returncode == 1
+    assert result.stdout == ""
+    diagnostic = strict_json_text(
+        result.stderr,
+        label="wrapper-parent-symlink diagnostic",
+    )
+    assert any(
+        "executed_wrapper_symlink_or_alias_rejected" in str(error)
+        for error in diagnostic["errors"]
+    )
+
+
+def test_core_file_symlink_is_rejected_before_source_read(
+    tmp_path: Path,
+    wrapper_module: Any,
+) -> None:
+    repository, wrapper, core = create_bootstrap_repository(
+        tmp_path,
+        wrapper_module,
+    )
+    external_core = tmp_path / "external-core.py"
+    shutil.copy2(core, external_core)
+    core.unlink()
+    try:
+        core.symlink_to(external_core)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink unsupported: {exc}")
+
+    result = run_synthetic_wrapper(wrapper, cwd=repository)
+    assert result.returncode == 1
+    assert result.stdout == ""
+    diagnostic = strict_json_text(
+        result.stderr,
+        label="core-symlink diagnostic",
+    )
+    assert any(
+        "producer_core_symlink_or_alias_rejected" in str(error)
+        for error in diagnostic["errors"]
+    )
+
+
+def test_bootstrap_ignores_fake_git_on_caller_path(
+    tmp_path: Path,
+    wrapper_module: Any,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("POSIX fake-Git fixture")
+    repository, wrapper, _core = create_bootstrap_repository(
+        tmp_path,
+        wrapper_module,
+    )
+    attacker_bin = tmp_path / "attacker-bin"
+    attacker_bin.mkdir()
+    marker = tmp_path / "fake-git-marker"
+    fake_git = attacker_bin / "git"
+    fake_git.write_text(
+        (
+            "#!/bin/sh\n"
+            f"printf invoked > {str(marker)!r}\n"
+            "exit 99\n"
+        ),
+        encoding="utf-8",
+        newline="\n",
+    )
+    fake_git.chmod(0o755)
+
+    result = run_synthetic_wrapper(
+        wrapper,
+        cwd=repository,
+        extra_env={"PATH": str(attacker_bin)},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout == "synthetic-core-ok\n"
+    assert not marker.exists()
+
+
+def test_bootstrap_does_not_require_caller_path(
+    tmp_path: Path,
+    wrapper_module: Any,
+) -> None:
+    repository, wrapper, _core = create_bootstrap_repository(
+        tmp_path,
+        wrapper_module,
+    )
+    result = run_synthetic_wrapper(
+        wrapper,
+        cwd=repository,
+        extra_env={"PATH": None, "PATHEXT": None},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout == "synthetic-core-ok\n"
 
 
 def check_pulsemech_compute_subject_input_packet_producer_core_v0() -> None:

--- a/tools/build_pulsemech_compute_subject_input_packet_v0.py
+++ b/tools/build_pulsemech_compute_subject_input_packet_v0.py
@@ -2,19 +2,47 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import os
+import stat
+import subprocess
 import sys
 import types
-from pathlib import Path
-from typing import Any
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any, Iterable
 
 
-ROOT = Path(__file__).resolve().parents[1]
-PRODUCER_CORE = (
-    ROOT
-    / "tools"
-    / "pulsemech_compute_subject_input_packet_producer_core_v0.py"
+TOOL_ID = "build_pulsemech_compute_subject_input_packet_v0"
+WRAPPER_SOURCE_PATH = "tools/build_pulsemech_compute_subject_input_packet_v0.py"
+PRODUCER_CORE_SOURCE_PATH = (
+    "tools/pulsemech_compute_subject_input_packet_producer_core_v0.py"
 )
 PRODUCER_CORE_MODULE = "pulsemech_compute_subject_input_packet_producer_core_v0"
+
+GIT_PROCESS_ENV_ALLOWLIST = (
+    "SYSTEMROOT",
+    "WINDIR",
+    "COMSPEC",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+)
+POSIX_TRUSTED_GIT_EXECUTABLE_CANDIDATES = (
+    Path("/usr/bin/git"),
+    Path("/usr/local/bin/git"),
+    Path("/opt/local/bin/git"),
+)
+WINDOWS_CURRENT_VERSION_REGISTRY_KEY = (
+    r"SOFTWARE\Microsoft\Windows\CurrentVersion"
+)
+WINDOWS_PROGRAM_FILES_REGISTRY_VALUES = (
+    "ProgramFilesDir",
+    "ProgramFilesDir (x86)",
+)
+WINDOWS_GIT_RELATIVE_EXECUTABLES = (
+    PureWindowsPath("Git") / "cmd" / "git.exe",
+    PureWindowsPath("Git") / "bin" / "git.exe",
+)
 
 
 class CompatibilityWrapperError(RuntimeError):
@@ -25,41 +53,541 @@ def sha256_bytes(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
 
 
-def _load_producer_core() -> tuple[Any, str]:
-    if not PRODUCER_CORE.is_file():
-        raise CompatibilityWrapperError(
-            f"producer_core_missing: {PRODUCER_CORE}"
+def render_diagnostic(error: Exception) -> str:
+    return (
+        json.dumps(
+            {"tool": TOOL_ID, "ok": False, "errors": [str(error)]},
+            indent=2,
+            ensure_ascii=False,
+            sort_keys=True,
+            allow_nan=False,
         )
-    if PRODUCER_CORE.is_symlink():
+        + "\n"
+    )
+
+
+def _normalized_absolute_path(path: Path) -> Path:
+    return Path(os.path.abspath(os.path.normpath(os.fspath(path))))
+
+
+def _stat_identity(value: os.stat_result) -> tuple[Any, ...]:
+    return tuple(
+        getattr(value, name, None)
+        for name in ("st_dev", "st_ino", "st_mode", "st_size", "st_mtime_ns")
+    )
+
+
+def _reject_symlink_components(path: Path, *, label: str) -> None:
+    cursor = _normalized_absolute_path(path)
+    while True:
+        try:
+            metadata = cursor.lstat()
+        except OSError as exc:
+            raise CompatibilityWrapperError(
+                f"{label}_component_unavailable: {cursor}: {exc}"
+            ) from exc
+        if stat.S_ISLNK(metadata.st_mode):
+            raise CompatibilityWrapperError(
+                f"{label}_symlink_or_alias_rejected: {cursor}"
+            )
+        if cursor == cursor.parent:
+            return
+        cursor = cursor.parent
+
+
+def _read_regular_file_snapshot(path: Path, *, label: str) -> bytes:
+    candidate = _normalized_absolute_path(path)
+    _reject_symlink_components(candidate, label=label)
+    try:
+        before = candidate.lstat()
+    except OSError as exc:
         raise CompatibilityWrapperError(
-            f"producer_core_symlink_rejected: {PRODUCER_CORE}"
+            f"{label}_unavailable: {candidate}: {exc}"
+        ) from exc
+    if not stat.S_ISREG(before.st_mode):
+        raise CompatibilityWrapperError(
+            f"{label}_not_regular_file: {candidate}"
         )
 
-    source = PRODUCER_CORE.read_bytes()
+    flags = os.O_RDONLY
+    for name in ("O_CLOEXEC", "O_BINARY", "O_NOFOLLOW"):
+        flags |= int(getattr(os, name, 0))
+    try:
+        descriptor = os.open(candidate, flags)
+    except OSError as exc:
+        raise CompatibilityWrapperError(
+            f"{label}_open_failed: {candidate}: {exc}"
+        ) from exc
+
+    try:
+        opened_before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened_before.st_mode)
+            or _stat_identity(before) != _stat_identity(opened_before)
+        ):
+            raise CompatibilityWrapperError(
+                f"{label}_changed_before_read: {candidate}"
+            )
+        chunks: list[bytes] = []
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        opened_after = os.fstat(descriptor)
+        if _stat_identity(opened_before) != _stat_identity(opened_after):
+            raise CompatibilityWrapperError(
+                f"{label}_changed_during_read: {candidate}"
+            )
+    finally:
+        os.close(descriptor)
+
+    try:
+        after = candidate.lstat()
+    except OSError as exc:
+        raise CompatibilityWrapperError(
+            f"{label}_unavailable_after_read: {candidate}: {exc}"
+        ) from exc
+    if _stat_identity(before) != _stat_identity(after):
+        raise CompatibilityWrapperError(
+            f"{label}_path_changed_during_read: {candidate}"
+        )
+
+    payload = b"".join(chunks)
+    if len(payload) != before.st_size:
+        raise CompatibilityWrapperError(
+            f"{label}_size_changed_during_read: "
+            f"expected={before.st_size} actual={len(payload)}"
+        )
+    return payload
+
+
+def _executed_wrapper_and_root() -> tuple[Path, Path]:
+    executed = _normalized_absolute_path(Path(__file__))
+    _reject_symlink_components(executed, label="executed_wrapper")
+    if not executed.is_file():
+        raise CompatibilityWrapperError(
+            f"executed_wrapper_not_regular_file: {executed}"
+        )
+    if len(executed.parents) < 2:
+        raise CompatibilityWrapperError(
+            f"executed_wrapper_repository_layout_invalid: {executed}"
+        )
+
+    root = executed.parents[1]
+    expected = _normalized_absolute_path(
+        root / PurePosixPath(WRAPPER_SOURCE_PATH)
+    )
+    if os.path.normcase(str(executed)) != os.path.normcase(str(expected)):
+        raise CompatibilityWrapperError(
+            "executed_wrapper_path_mismatch: "
+            f"executed={executed} expected={expected}"
+        )
+    if not root.is_dir():
+        raise CompatibilityWrapperError(
+            f"wrapper_repository_root_not_directory: {root}"
+        )
+    return executed, root
+
+
+def _dedupe_windows_paths(
+    values: Iterable[PureWindowsPath],
+) -> tuple[PureWindowsPath, ...]:
+    result: list[PureWindowsPath] = []
+    seen: set[str] = set()
+    for value in values:
+        key = str(value).rstrip("\\/").casefold()
+        if key not in seen:
+            seen.add(key)
+            result.append(value)
+    return tuple(result)
+
+
+def _windows_system_directory() -> PureWindowsPath:
+    if os.name != "nt":
+        raise CompatibilityWrapperError(
+            "windows_system_directory_unavailable: not_windows"
+        )
+    try:
+        import ctypes
+
+        buffer = ctypes.create_unicode_buffer(32768)
+        length = ctypes.windll.kernel32.GetSystemWindowsDirectoryW(
+            buffer,
+            len(buffer),
+        )
+    except Exception as exc:
+        raise CompatibilityWrapperError(
+            f"windows_system_directory_unavailable: {exc}"
+        ) from exc
+    if length <= 0 or length >= len(buffer):
+        raise CompatibilityWrapperError(
+            f"windows_system_directory_unavailable: invalid_length={length}"
+        )
+    directory = PureWindowsPath(buffer.value)
+    if not directory.is_absolute() or not directory.drive or not directory.root:
+        raise CompatibilityWrapperError(
+            f"windows_system_directory_invalid: {str(directory)!r}"
+        )
+    return directory
+
+
+def _windows_registry_program_files_roots() -> tuple[PureWindowsPath, ...]:
+    if os.name != "nt":
+        return ()
+    try:
+        import winreg
+    except ImportError:
+        return ()
+
+    views = [winreg.KEY_READ]
+    for flag_name in ("KEY_WOW64_64KEY", "KEY_WOW64_32KEY"):
+        access = winreg.KEY_READ | getattr(winreg, flag_name, 0)
+        if access not in views:
+            views.append(access)
+
+    roots: list[PureWindowsPath] = []
+    for access in views:
+        try:
+            key = winreg.OpenKey(
+                winreg.HKEY_LOCAL_MACHINE,
+                WINDOWS_CURRENT_VERSION_REGISTRY_KEY,
+                0,
+                access,
+            )
+        except OSError:
+            continue
+        with key:
+            for value_name in WINDOWS_PROGRAM_FILES_REGISTRY_VALUES:
+                try:
+                    raw, kind = winreg.QueryValueEx(key, value_name)
+                except OSError:
+                    continue
+                if (
+                    kind not in {winreg.REG_SZ, winreg.REG_EXPAND_SZ}
+                    or not isinstance(raw, str)
+                    or not raw.strip()
+                    or "%" in raw
+                ):
+                    continue
+                candidate = PureWindowsPath(raw.strip())
+                if candidate.is_absolute() and candidate.drive and candidate.root:
+                    roots.append(candidate)
+    return _dedupe_windows_paths(roots)
+
+
+def _windows_git_candidate_strings(
+    *,
+    system_windows_directory: str,
+    registry_program_files_roots: Iterable[str] = (),
+) -> tuple[str, ...]:
+    system_directory = PureWindowsPath(system_windows_directory)
+    if (
+        not system_directory.is_absolute()
+        or not system_directory.drive
+        or not system_directory.root
+    ):
+        raise CompatibilityWrapperError(
+            f"windows_system_directory_invalid: {system_windows_directory!r}"
+        )
+
+    roots = [
+        PureWindowsPath(value)
+        for value in registry_program_files_roots
+        if PureWindowsPath(value).is_absolute() and "%" not in value
+    ]
+    drive_root = PureWindowsPath(system_directory.anchor)
+    roots.extend(
+        (
+            drive_root / "Program Files",
+            drive_root / "Program Files (x86)",
+        )
+    )
+    return tuple(
+        str(root / relative)
+        for root in _dedupe_windows_paths(roots)
+        for relative in WINDOWS_GIT_RELATIVE_EXECUTABLES
+    )
+
+
+def _trusted_git_candidates() -> tuple[Path, ...]:
+    if os.name != "nt":
+        return POSIX_TRUSTED_GIT_EXECUTABLE_CANDIDATES
+    return tuple(
+        Path(value)
+        for value in _windows_git_candidate_strings(
+            system_windows_directory=str(_windows_system_directory()),
+            registry_program_files_roots=(
+                str(root) for root in _windows_registry_program_files_roots()
+            ),
+        )
+    )
+
+
+def _validate_trusted_git(candidate: Path) -> Path:
+    if not candidate.is_absolute():
+        raise CompatibilityWrapperError(
+            f"git_executable_untrusted: path_not_absolute: {candidate}"
+        )
+    normalized = _normalized_absolute_path(candidate)
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as exc:
+        raise CompatibilityWrapperError(
+            f"git_executable_untrusted: path_unresolvable: {candidate}: {exc}"
+        ) from exc
+    if os.path.normcase(str(normalized)) != os.path.normcase(str(resolved)):
+        raise CompatibilityWrapperError(
+            "git_executable_untrusted: symlink_or_alias_path: "
+            f"declared={normalized} resolved={resolved}"
+        )
+    if candidate.is_symlink() or not resolved.is_file():
+        raise CompatibilityWrapperError(
+            f"git_executable_untrusted: not_regular_file: {resolved}"
+        )
+    if not os.access(resolved, os.X_OK):
+        raise CompatibilityWrapperError(
+            f"git_executable_untrusted: not_executable: {resolved}"
+        )
+
+    cursor = resolved
+    while True:
+        try:
+            metadata = cursor.lstat()
+        except OSError as exc:
+            raise CompatibilityWrapperError(
+                "git_executable_untrusted: component_unavailable: "
+                f"{cursor}: {exc}"
+            ) from exc
+        if stat.S_ISLNK(metadata.st_mode):
+            raise CompatibilityWrapperError(
+                f"git_executable_untrusted: symlink_component: {cursor}"
+            )
+        if os.name != "nt" and metadata.st_mode & (
+            stat.S_IWGRP | stat.S_IWOTH
+        ):
+            raise CompatibilityWrapperError(
+                f"git_executable_untrusted: writable_component: {cursor}"
+            )
+        if cursor == cursor.parent:
+            break
+        cursor = cursor.parent
+
+    approved = {
+        os.path.normcase(str(_normalized_absolute_path(path)))
+        for path in _trusted_git_candidates()
+    }
+    if os.path.normcase(str(resolved)) not in approved:
+        raise CompatibilityWrapperError(
+            f"git_executable_untrusted: unapproved_candidate: {resolved}"
+        )
+    return resolved
+
+
+def _trusted_git() -> Path:
+    missing: list[str] = []
+    rejected: list[str] = []
+    for candidate in _trusted_git_candidates():
+        if not candidate.exists():
+            missing.append(str(candidate))
+            continue
+        try:
+            return _validate_trusted_git(candidate)
+        except CompatibilityWrapperError as exc:
+            rejected.append(str(exc))
+    if rejected:
+        raise CompatibilityWrapperError(
+            "git_process_executable_untrusted: " + " | ".join(rejected)
+        )
+    raise CompatibilityWrapperError(
+        "git_process_executable_unavailable: "
+        + (", ".join(missing) if missing else "no trusted candidates")
+    )
+
+
+def _git_environment(git_executable: Path) -> dict[str, str]:
+    environment = {
+        key: value
+        for key in GIT_PROCESS_ENV_ALLOWLIST
+        if (value := os.environ.get(key)) is not None
+    }
+    environment.update(
+        {
+            "PATH": str(git_executable.parent),
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_SYSTEM": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_COUNT": "0",
+            "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "GIT_TERMINAL_PROMPT": "0",
+            "LC_ALL": "C",
+            "LANG": "C",
+        }
+    )
+    return environment
+
+
+def _run_git(
+    root: Path,
+    git_executable: Path,
+    arguments: list[str],
+    *,
+    failure_prefix: str,
+) -> bytes:
+    completed = subprocess.run(
+        [
+            str(git_executable),
+            "--no-pager",
+            "--no-replace-objects",
+            "-c",
+            f"safe.directory={root}",
+            "-C",
+            str(root),
+            *arguments,
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=_git_environment(git_executable),
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise CompatibilityWrapperError(
+            f"{failure_prefix}: {detail or 'unknown error'}"
+        )
+    return completed.stdout
+
+
+def _single_line(value: bytes, *, label: str) -> str:
+    try:
+        decoded = value.decode("utf-8", errors="strict").strip()
+    except UnicodeDecodeError as exc:
+        raise CompatibilityWrapperError(
+            f"{label}_invalid_utf8: {exc}"
+        ) from exc
+    if not decoded or any(character in decoded for character in "\x00\n\r"):
+        raise CompatibilityWrapperError(
+            f"{label}_invalid_output: {decoded!r}"
+        )
+    return decoded
+
+
+def _verified_head(root: Path, git_executable: Path) -> str:
+    top_level_text = _single_line(
+        _run_git(
+            root,
+            git_executable,
+            ["rev-parse", "--show-toplevel"],
+            failure_prefix="git_repository_root_unavailable",
+        ),
+        label="git_repository_root",
+    )
+    try:
+        top_level = Path(top_level_text).resolve(strict=True)
+        expected = root.resolve(strict=True)
+        same_root = os.path.samefile(top_level, expected)
+    except OSError as exc:
+        raise CompatibilityWrapperError(
+            f"git_repository_root_unresolvable: {exc}"
+        ) from exc
+    if not same_root:
+        raise CompatibilityWrapperError(
+            "git_repository_root_mismatch: "
+            f"expected={expected} discovered={top_level}"
+        )
+
+    revision = _single_line(
+        _run_git(
+            root,
+            git_executable,
+            ["rev-parse", "HEAD"],
+            failure_prefix="repository_head_unavailable",
+        ),
+        label="repository_head",
+    )
+    if len(revision) != 40 or any(
+        character not in "0123456789abcdef" for character in revision
+    ):
+        raise CompatibilityWrapperError(
+            f"repository_head_invalid_sha40: {revision!r}"
+        )
+    return revision
+
+
+def _git_blob(
+    root: Path,
+    git_executable: Path,
+    revision: str,
+    relative_path: str,
+) -> bytes:
+    return _run_git(
+        root,
+        git_executable,
+        ["cat-file", "blob", f"{revision}:{relative_path}"],
+        failure_prefix=f"git_blob_unavailable: {revision}:{relative_path}",
+    )
+
+
+def _load_verified_producer_core() -> tuple[Any, str]:
+    executed_wrapper, root = _executed_wrapper_and_root()
+    git_executable = _trusted_git()
+    revision = _verified_head(root, git_executable)
+
+    wrapper_source = _read_regular_file_snapshot(
+        executed_wrapper,
+        label="executed_wrapper",
+    )
+    if wrapper_source != _git_blob(
+        root,
+        git_executable,
+        revision,
+        WRAPPER_SOURCE_PATH,
+    ):
+        raise CompatibilityWrapperError(
+            "executed_wrapper_committed_bytes_mismatch"
+        )
+
+    producer_core = _normalized_absolute_path(
+        root / PurePosixPath(PRODUCER_CORE_SOURCE_PATH)
+    )
+    source = _read_regular_file_snapshot(
+        producer_core,
+        label="producer_core",
+    )
+    if source != _git_blob(
+        root,
+        git_executable,
+        revision,
+        PRODUCER_CORE_SOURCE_PATH,
+    ):
+        raise CompatibilityWrapperError(
+            "producer_core_committed_bytes_mismatch"
+        )
+
     source_sha256 = sha256_bytes(source)
-
     try:
         code = compile(
             source,
-            str(PRODUCER_CORE),
+            str(producer_core),
             "exec",
             dont_inherit=True,
         )
     except Exception as exc:
         raise CompatibilityWrapperError(
-            f"producer_core_compile_failed: {PRODUCER_CORE}: {exc}"
+            f"producer_core_compile_failed: {producer_core}: {exc}"
         ) from exc
 
     previous = sys.modules.get(PRODUCER_CORE_MODULE)
     had_previous = PRODUCER_CORE_MODULE in sys.modules
-
     module = types.ModuleType(PRODUCER_CORE_MODULE)
-    module.__file__ = str(PRODUCER_CORE)
+    module.__file__ = str(producer_core)
     module.__cached__ = None
     module.__loader__ = None
     module.__package__ = ""
     module.__spec__ = None
     module.__pulsemech_source_sha256__ = source_sha256
+    module.__pulsemech_verified_revision__ = revision
     sys.modules[PRODUCER_CORE_MODULE] = module
 
     try:
@@ -70,18 +598,37 @@ def _load_producer_core() -> tuple[Any, str]:
         else:
             sys.modules.pop(PRODUCER_CORE_MODULE, None)
         raise CompatibilityWrapperError(
-            f"producer_core_execution_failed: {PRODUCER_CORE}: {exc}"
+            f"producer_core_execution_failed: {producer_core}: {exc}"
         ) from exc
 
+    globals()["_EXECUTED_WRAPPER_PATH"] = executed_wrapper
+    globals()["_BOOTSTRAP_REPOSITORY_ROOT"] = root
+    globals()["PRODUCER_CORE"] = producer_core
     return module, source_sha256
 
 
-_PRODUCER_CORE, PRODUCER_CORE_SOURCE_SHA256 = _load_producer_core()
+try:
+    _PRODUCER_CORE, PRODUCER_CORE_SOURCE_SHA256 = _load_verified_producer_core()
+except Exception as exc:
+    error = (
+        exc
+        if isinstance(exc, CompatibilityWrapperError)
+        else CompatibilityWrapperError(f"unexpected_wrapper_error: {exc}")
+    )
+    if __name__ == "__main__":
+        sys.stderr.write(render_diagnostic(error))
+        raise SystemExit(1)
+    if error is exc:
+        raise
+    raise error from exc
 
-# Preserve the established import surface for callers and regressions. Packet
-# production remains implemented only in the producer-core module.
+# Preserve the established import surface. Packet production remains
+# implemented only in the producer-core module.
 for _name, _value in vars(_PRODUCER_CORE).items():
-    if _name.startswith("__") or _name in {"main", "executed_producer_source_path"}:
+    if _name.startswith("__") or _name in {
+        "main",
+        "executed_producer_source_path",
+    }:
         continue
     globals()[_name] = _value
 
@@ -94,14 +641,14 @@ def executed_producer_source_path(
     return _PRODUCER_CORE.executed_producer_source_path(
         repository_root,
         revision=revision,
-        executed_source_path=Path(__file__).resolve(),
+        executed_source_path=_EXECUTED_WRAPPER_PATH,
     )
 
 
 def main() -> int:
     return int(
         _PRODUCER_CORE.main(
-            producer_source_path=Path(__file__).resolve(),
+            producer_source_path=_EXECUTED_WRAPPER_PATH,
             producer_core_source_sha256=PRODUCER_CORE_SOURCE_SHA256,
         )
     )


### PR DESCRIPTION
## Summary

Harden the stable subject-input packet compatibility wrapper so that the
reusable producer core is verified against its exact committed Git blob before
any core byte is compiled or executed.

This is a focused follow-up to the producer-core extraction merged through
PR #2778.

The corrected bootstrap order is:

```text
literal wrapper invocation path
→ non-resolving absolute normalization
→ wrapper and parent-component lstat checks
→ symlink and alias rejection
→ trusted absolute Git selection
→ isolated Git environment
→ exact repository root verification
→ exact current HEAD resolution
→ committed wrapper blob verification
→ symlink-safe single-read core snapshot
→ committed core blob comparison
→ digest calculation from the verified snapshot
→ compile the same verified snapshot
→ execute the same verified snapshot
→ producer-core defense-in-depth checks
→ fixed-source packet construction
```

The required invariant is:

```text
committed core bytes
=
verified core bytes
=
hashed core bytes
=
compiled core bytes
=
executed core bytes
```

## Problem closed

The previous compatibility wrapper performed:

```text
working-tree core read
→ digest
→ compile
→ exec
→ later committed-source verification inside core main
```

That ordering permitted uncommitted top-level core code to execute before the
later committed-byte mismatch rejected packet production.

The previous wrapper also passed:

```python
Path(__file__).resolve()
```

as the executed producer path.

Resolving the path before validation removed evidence that the wrapper had
been invoked through:

```text
a wrapper-file symlink
```

or:

```text
a symlinked parent directory
```

The revised wrapper closes both boundaries before producer-core execution.

## Pre-execution committed-source verification

The compatibility wrapper now independently verifies the bootstrap before
loading the reusable core.

It:

- identifies the literal wrapper path without resolving symlinks;
- normalizes the path to an absolute path without canonicalizing aliases;
- checks the wrapper and every parent component with `lstat`;
- rejects symlinked or non-regular wrapper paths;
- derives the expected repository layout from the literal wrapper location;
- verifies the repository root through an isolated Git invocation;
- resolves the exact current `HEAD`;
- reads the committed wrapper blob from Git;
- compares the executed wrapper snapshot with that committed blob;
- reads the core through a symlink-safe descriptor;
- reads the committed core blob from Git;
- compares the exact core snapshot with the committed core blob;
- compiles and executes only after byte equality is established.

A modified core therefore cannot execute a top-level side effect before the
committed-source check.

## Single-read core boundary

The wrapper opens the core with no-follow behavior where supported and records
the descriptor metadata before reading.

It then:

```text
checks regular-file state
→ reads one immutable byte snapshot
→ checks descriptor metadata after reading
→ checks path metadata after reading
→ verifies the snapshot against the committed Git blob
→ hashes that snapshot
→ compiles that snapshot
→ executes that snapshot
```

The wrapper does not verify one read and execute a later read.

Core replacement or mutation during the snapshot operation fails closed.

## Literal invocation-path boundary

The wrapper no longer calls:

```python
Path(__file__).resolve()
```

before provenance validation.

The literal invocation path and all parent components are checked first.

The following paths are rejected before core loading:

```text
wrapper-file symlink
symlinked wrapper parent
unexpected wrapper location
core-file symlink
non-regular core path
```

The canonical stable producer identity remains:

```text
tools/build_pulsemech_compute_subject_input_packet_v0.py
```

An alias path is not silently rewritten into that identity.

## Trusted Git bootstrap

The wrapper performs its own minimal pre-execution Git bootstrap because the
producer core cannot be trusted to verify itself before it executes.

The bootstrap:

- selects only approved absolute Git executable candidates;
- rejects symlinked or aliased Git paths;
- rejects unapproved Git locations;
- checks executable parent components;
- ignores caller-controlled `PATH` selection;
- does not require caller `PATH` or `PATHEXT`;
- removes poisoned Git repository and configuration variables;
- disables global and system Git configuration;
- disables replacement objects;
- disables terminal prompting;
- supplies an exact `safe.directory`;
- verifies the discovered repository top level;
- reads committed files through `git cat-file blob`.

This bootstrap contains no packet-production mechanics.

## Single-producer invariant

The reusable producer core remains unchanged:

```text
tools/pulsemech_compute_subject_input_packet_producer_core_v0.py
```

It remains the only implementation location for:

```text
carrier verification
archive extraction
artifact reconstruction
artifact record construction
provider binding
role binding
subject reconstruction
authority-source reconstruction
coverage derivation
producer identity construction
packet construction
canonical JSON rendering
semantic packet validation
output rejection
atomic output writing
```

The wrapper adds only the minimum trust bootstrap required before the core can
be executed.

It does not contain a second packet producer.

## Regression hardening

Update the existing producer regression:

```text
tests/test_build_pulsemech_compute_subject_input_packet_v0.py
```

The updated regression:

- pins the new wrapper identity;
- verifies that committed-core comparison precedes `compile` and `exec`;
- rejects the old early-`resolve()` bootstrap pattern;
- verifies the exact bootstrap repository root;
- verifies the literal wrapper execution path;
- verifies the revision recorded on the loaded core;
- preserves the complete fixed-source CLI and packet regression;
- preserves protected-input mutation checks;
- preserves Git environment, carrier, validator, output, and authority
  boundary tests.

Update the dedicated wrapper-core regression:

```text
tests/test_pulsemech_compute_subject_input_packet_producer_core_v0.py
```

The wrapper–core byte-equivalence proof remains:

```text
verified fixed-source wrapper
→ reusable producer core
→ packet A

direct reusable core
+ explicit FIXED_SOURCE_6066_PROFILE
+ identical deterministic inputs
→ packet B

packet A bytes
=
packet B bytes
```

The regression additionally proves:

```text
uncommitted core with top-level marker
→ committed-byte rejection
→ marker is not created

wrapper-file symlink
→ rejected before core loading

symlinked wrapper parent
→ rejected before core loading

core-file symlink
→ rejected before source reading

fake Git first on caller PATH
→ fake Git is not executed

missing caller PATH and PATHEXT
→ trusted Git selection still succeeds
```

## Files changed

This pull request changes exactly:

```text
tools/build_pulsemech_compute_subject_input_packet_v0.py

tests/test_build_pulsemech_compute_subject_input_packet_v0.py

tests/test_pulsemech_compute_subject_input_packet_producer_core_v0.py
```

## Files intentionally unchanged

This pull request does not modify:

```text
tools/pulsemech_compute_subject_input_packet_producer_core_v0.py

ci/tools-tests.list

schemas/pulsemech_compute_subject_input_packet_v0.schema.json

tools/check_pulsemech_compute_subject_input_packet_v0.py

examples/compute/pulsemech_compute_subject_input_packet_6066_observed_v0.json

tests/test_pulsemech_compute_subject_input_packet_6066_observed_v0.py

PULSE_CI_6066_release_grade_artifact_preservation_v0.zip

.github/workflows/*

pulse_gate_policy_v0.yml

pulse_gate_registry_v0.yml
```

The existing tools-tests manifest already registers both producer regressions.

## Historical artifact boundary

The existing observed PULSE CI #6066 packet remains bound to its original
producer revision:

```text
3cd57dc9e88e6f804dbb134c864f4207688bddc2
```

This pull request does not regenerate, overwrite, or reinterpret the historical
packet or preservation carrier.

The current wrapper bootstrap hardening does not replace historical
provenance.

## Non-activation boundary

This pull request does not implement or activate:

```text
current_run_export profile
current-run carrier production
current-run subject-input packet production
workflow integration
runtime observation
resource measurement
compute budget
candidate-gate activation
release-required compute enforcement
release authority
```

Authority effect:

```text
none
```

Gate effect:

```text
none
```

Policy effect:

```text
none
```

Workflow effect:

```text
none
```

Release effect:

```text
none
```

## Validation

Local syntax validation completed for all three changed Python files.

The pull request CI must independently run:

```text
existing fixed-source producer regression
wrapper–core equivalence regression
new pre-execution adversarial fixtures
tools-tests smoke suite
PULSE CI
PULSE Core CI
```

The pull request is complete only when the committed implementation proves:

```text
no unverified core byte executes
before exact committed identity is established
```