### PR TITLE
feat(compute): add current-run export expectation validator

### DIFF
--- a/tools/check_pulsemech_compute_current_run_export_expectation_v0.py
+++ b/tools/check_pulsemech_compute_current_run_export_expectation_v0.py
@@ -1,0 +1,1325 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+
+TOOL_NAME = "check_pulsemech_compute_current_run_export_expectation_v0"
+TOOL_VERSION = "0.1.0"
+SCHEMA_VERSION = "pulsemech_compute_current_run_export_expectation_v0"
+DOCUMENT_TYPE = "pulsemech_compute_current_run_export_expectation"
+SUBJECT_INPUT_SCHEMA_VERSION = "pulsemech_compute_subject_input_packet_v0"
+SUBJECT_INPUT_PACKET_TYPE = "pulsemech_compute_subject_input_packet"
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SCHEMA = (
+    ROOT
+    / "schemas"
+    / "pulsemech_compute_current_run_export_expectation_v0.schema.json"
+)
+DEFAULT_EXPECTATION = (
+    ROOT
+    / "examples"
+    / "compute"
+    / "pulsemech_compute_current_run_export_expectation_example_v0.json"
+)
+DEFAULT_SUBJECT_INPUT_SCHEMA = (
+    ROOT
+    / "schemas"
+    / "pulsemech_compute_subject_input_packet_v0.schema.json"
+)
+
+EXPECTATION_SCHEMA_PATH = (
+    "schemas/pulsemech_compute_current_run_export_expectation_v0.schema.json"
+)
+EXPECTATION_VALIDATOR_PATH = (
+    "tools/check_pulsemech_compute_current_run_export_expectation_v0.py"
+)
+SUBJECT_INPUT_SCHEMA_PATH = (
+    "schemas/pulsemech_compute_subject_input_packet_v0.schema.json"
+)
+SUBJECT_INPUT_VALIDATOR_PATH = (
+    "tools/check_pulsemech_compute_subject_input_packet_v0.py"
+)
+SUBJECT_INPUT_PRODUCER_CORE_PATH = (
+    "tools/pulsemech_compute_subject_input_packet_producer_core_v0.py"
+)
+
+CONTROL_PLANE_COMPONENT_KEYS = (
+    "carrier_loader",
+    "control_plane_workflow",
+    "expectation_builder",
+    "expectation_schema",
+    "expectation_validator",
+    "subject_input_producer_core",
+    "subject_input_producer_wrapper",
+    "subject_input_schema",
+    "subject_input_validator",
+)
+
+CLOSED_CONTENT_BOUNDARY = {
+    "consumer_must_verify_carrier_bytes": True,
+    "contains_artifact_payloads": False,
+    "contains_resource_measurement": False,
+    "contains_runtime_observation": False,
+    "contains_secret_material": False,
+    "expectation_payload_mode": "metadata_only",
+}
+
+CLOSED_AUTHORITY_BOUNDARY = {
+    "activates_compute_gate": False,
+    "changes_gate_policy": False,
+    "changes_gate_semantics": False,
+    "changes_release_authority": False,
+    "creates_compute_budget": False,
+    "creates_gate_result": False,
+    "creates_release_decision": False,
+    "expectation_is_release_authority": False,
+    "mutates_carrier": False,
+    "produced_packet_is_release_authority": False,
+    "write_mode": "expectation_only",
+    "writes_subject_run": False,
+    "writes_target_repository": False,
+}
+
+MAX_EXPECTATION_SCHEMA_BYTES = 1024 * 1024
+MAX_SUBJECT_INPUT_SCHEMA_BYTES = 1024 * 1024
+MAX_EXPECTATION_BYTES = 8 * 1024 * 1024
+
+PROTECTED_OUTPUT_NAMES = frozenset(
+    {
+        "status.json",
+        "release_decision_v0.json",
+        "release_authority_v0.json",
+        "pulsemech_compute_current_run_export_expectation_v0.json",
+        "pulsemech_compute_subject_input_packet_v0.json",
+    }
+)
+
+
+class StrictJsonError(ValueError):
+    pass
+
+
+class SemanticError(RuntimeError):
+    pass
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise StrictJsonError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def reject_non_finite(value: str) -> None:
+    raise StrictJsonError(f"non-finite JSON value: {value}")
+
+
+def _normalized_absolute_path(path: Path) -> Path:
+    return Path(os.path.abspath(os.path.normpath(os.fspath(path))))
+
+
+def reject_symlink_components(path: Path, *, label: str) -> None:
+    cursor = _normalized_absolute_path(path)
+    while True:
+        try:
+            metadata = cursor.lstat()
+        except FileNotFoundError:
+            if cursor == _normalized_absolute_path(path):
+                raise SemanticError(f"{label}_missing: {cursor}")
+            raise SemanticError(f"{label}_parent_missing: {cursor}")
+        except OSError as exc:
+            raise SemanticError(f"{label}_component_unavailable: {cursor}: {exc}") from exc
+
+        if stat.S_ISLNK(metadata.st_mode):
+            raise SemanticError(f"{label}_symlink_rejected: {cursor}")
+        if cursor == cursor.parent:
+            return
+        cursor = cursor.parent
+
+
+def read_regular_file(
+    path: Path,
+    *,
+    label: str,
+    max_bytes: int,
+) -> bytes:
+    candidate = _normalized_absolute_path(path)
+    reject_symlink_components(candidate, label=label)
+    try:
+        metadata = candidate.lstat()
+    except OSError as exc:
+        raise SemanticError(f"{label}_unavailable: {candidate}: {exc}") from exc
+    if not stat.S_ISREG(metadata.st_mode):
+        raise SemanticError(f"{label}_not_regular_file: {candidate}")
+    if metadata.st_size > max_bytes:
+        raise SemanticError(
+            f"{label}_too_large: size={metadata.st_size} maximum={max_bytes}"
+        )
+    try:
+        payload = candidate.read_bytes()
+    except OSError as exc:
+        raise SemanticError(f"{label}_read_failed: {candidate}: {exc}") from exc
+    if len(payload) != metadata.st_size:
+        raise SemanticError(
+            f"{label}_size_changed_during_read: "
+            f"expected={metadata.st_size} actual={len(payload)}"
+        )
+    return payload
+
+
+def load_json(
+    path: Path,
+    *,
+    label: str,
+    max_bytes: int,
+) -> tuple[Any, str, bytes]:
+    payload = read_regular_file(path, label=label, max_bytes=max_bytes)
+    if payload.startswith(b"\xef\xbb\xbf"):
+        raise StrictJsonError(f"{label}: UTF-8 BOM is not permitted")
+    try:
+        text = payload.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise StrictJsonError(f"{label}: invalid UTF-8: {exc}") from exc
+    try:
+        value = json.loads(
+            text,
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=reject_non_finite,
+        )
+    except Exception as exc:
+        if isinstance(exc, StrictJsonError):
+            raise
+        raise StrictJsonError(f"{label}: invalid JSON: {exc}") from exc
+    return value, text, payload
+
+
+def render_json(value: dict[str, Any]) -> str:
+    return (
+        json.dumps(
+            value,
+            indent=2,
+            ensure_ascii=False,
+            sort_keys=True,
+            allow_nan=False,
+        )
+        + "\n"
+    )
+
+
+def schema_errors(schema: dict[str, Any], value: Any) -> list[str]:
+    validator = jsonschema.Draft202012Validator(
+        schema,
+        format_checker=jsonschema.FormatChecker(),
+    )
+    return [
+        f"schema_error[{list(error.path)}]: {error.message}"
+        for error in sorted(
+            validator.iter_errors(value),
+            key=lambda item: (
+                tuple(str(part) for part in item.path),
+                item.message,
+            ),
+        )
+    ]
+
+
+def _all_object_keys_sorted(value: Any) -> bool:
+    if isinstance(value, dict):
+        return (
+            list(value) == sorted(value)
+            and all(_all_object_keys_sorted(item) for item in value.values())
+        )
+    if isinstance(value, list):
+        return all(_all_object_keys_sorted(item) for item in value)
+    return True
+
+
+def _ordered_unique_non_empty_strings(value: Any) -> bool:
+    return (
+        isinstance(value, list)
+        and all(isinstance(item, str) and item for item in value)
+        and len(value) == len(set(value))
+    )
+
+
+def _sorted_unique_non_empty_strings(value: Any) -> bool:
+    return (
+        _ordered_unique_non_empty_strings(value)
+        and value == sorted(value)
+    )
+
+
+def _parse_utc(value: Any) -> datetime:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        raise ValueError(f"not canonical UTC: {value!r}")
+    parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    if parsed.tzinfo is None or parsed.utcoffset() != timezone.utc.utcoffset(parsed):
+        raise ValueError(f"not UTC: {value!r}")
+    return parsed
+
+
+def _canonical_subject_run_key(subject: dict[str, Any]) -> str:
+    return (
+        f"GITHUB_RUN_ID={subject.get('workflow_run_id')}"
+        f"|GITHUB_RUN_ATTEMPT={subject.get('workflow_run_attempt')}"
+        f"|GITHUB_WORKFLOW={subject.get('workflow_name')}"
+    )
+
+
+def _canonical_workflow_ref(subject: dict[str, Any]) -> str:
+    return (
+        f"{subject.get('repository')}/{subject.get('workflow_path')}"
+        f"@{subject.get('source_ref')}"
+    )
+
+
+def _flatten_authority_sources(
+    expectation: dict[str, Any],
+) -> list[tuple[str, dict[str, Any]]]:
+    authority_sources = expectation.get("authority_sources", {})
+    rows: list[tuple[str, dict[str, Any]]] = []
+    for name in ("workflow", "policy", "gate_registry"):
+        value = authority_sources.get(name)
+        if isinstance(value, dict):
+            rows.append((name, value))
+    additional = authority_sources.get("additional_sources", [])
+    if isinstance(additional, list):
+        for index, value in enumerate(additional):
+            if isinstance(value, dict):
+                rows.append((f"additional_sources[{index}]", value))
+    return rows
+
+
+def _relative_path(path: Path, repository_root: Path) -> str | None:
+    try:
+        resolved = path.resolve(strict=True)
+        root = repository_root.resolve(strict=True)
+        relative = resolved.relative_to(root).as_posix()
+    except (OSError, ValueError):
+        return None
+    return relative
+
+
+def _nested_value(value: dict[str, Any], *parts: str) -> Any:
+    cursor: Any = value
+    for part in parts:
+        if not isinstance(cursor, dict) or part not in cursor:
+            return None
+        cursor = cursor[part]
+    return cursor
+
+
+def _fullmatch(pattern: Any, value: Any) -> bool:
+    return (
+        isinstance(pattern, str)
+        and isinstance(value, str)
+        and re.fullmatch(pattern, value) is not None
+    )
+
+
+def _carrier_digest_key_count(value: Any) -> int:
+    if isinstance(value, dict):
+        return sum(
+            (1 if key == "carrier_sha256" else 0)
+            + _carrier_digest_key_count(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, list):
+        return sum(_carrier_digest_key_count(item) for item in value)
+    return 0
+
+
+def _provider_binding_ok(
+    carrier: dict[str, Any],
+) -> tuple[bool, str | None]:
+    provider = carrier.get("provider_binding")
+    if provider is None:
+        return True, None
+    if not isinstance(provider, dict):
+        return False, "provider_binding_not_object_or_null"
+
+    carrier_sha = carrier.get("sha256")
+    carrier_size = carrier.get("size_bytes")
+    provider_sha = provider.get("provider_sha256")
+    provider_size = provider.get("provider_size_bytes")
+    sha_match = provider.get("downloaded_sha256_matches")
+    size_match = provider.get("downloaded_size_matches")
+
+    if provider_sha is None:
+        if sha_match is not None:
+            return False, "provider_sha_absent_but_match_state_present"
+    elif provider_sha != carrier_sha or sha_match is not True:
+        return False, "provider_sha_binding_mismatch"
+
+    if provider_size is None:
+        if size_match is not None:
+            return False, "provider_size_absent_but_match_state_present"
+    elif provider_size != carrier_size or size_match is not True:
+        return False, "provider_size_binding_mismatch"
+
+    try:
+        finalized = _parse_utc(carrier.get("finalized_utc"))
+        created_value = provider.get("created_utc")
+        expires_value = provider.get("expires_utc")
+        if created_value is not None and _parse_utc(created_value) > finalized:
+            return False, "provider_created_after_carrier_finalization"
+        if expires_value is not None and finalized > _parse_utc(expires_value):
+            return False, "carrier_finalized_after_provider_expiration"
+    except Exception as exc:
+        return False, f"provider_time_binding_invalid: {exc}"
+
+    return True, None
+
+
+def _subject_input_cross_contract(
+    *,
+    expectation_schema: dict[str, Any],
+    subject_input_schema: dict[str, Any],
+    packet_contract: dict[str, Any],
+    profile: dict[str, Any],
+) -> tuple[bool, list[str]]:
+    errors: list[str] = []
+
+    expected_values = {
+        "schema_version": _nested_value(
+            subject_input_schema,
+            "properties",
+            "schema_version",
+            "const",
+        ),
+        "packet_type": _nested_value(
+            subject_input_schema,
+            "properties",
+            "packet_type",
+            "const",
+        ),
+        "record_status": "observed",
+        "production_mode": "current_run_export",
+        "packet_scope": "current_run",
+        "carrier_kind": "current_run_export_archive",
+        "artifact_payload_mode": _nested_value(
+            subject_input_schema,
+            "$defs",
+            "carrier",
+            "properties",
+            "artifact_payload_mode",
+            "const",
+        ),
+        "write_mode": _nested_value(
+            subject_input_schema,
+            "$defs",
+            "authority_boundary",
+            "properties",
+            "write_mode",
+            "const",
+        ),
+    }
+    for field, expected in expected_values.items():
+        if packet_contract.get(field) != expected:
+            errors.append(
+                f"packet_contract_{field}_mismatch: "
+                f"expected={expected!r} actual={packet_contract.get(field)!r}"
+            )
+
+    record_statuses = _nested_value(
+        subject_input_schema,
+        "properties",
+        "record_status",
+        "enum",
+    )
+    if not isinstance(record_statuses, list) or "observed" not in record_statuses:
+        errors.append("observed_status_not_supported_by_subject_input_schema")
+
+    production_modes = _nested_value(
+        subject_input_schema,
+        "$defs",
+        "producer",
+        "properties",
+        "production_mode",
+        "enum",
+    )
+    if (
+        not isinstance(production_modes, list)
+        or profile.get("expected_production_mode") not in production_modes
+    ):
+        errors.append("current_run_export_not_supported_by_subject_input_schema")
+
+    packet_scopes = _nested_value(
+        subject_input_schema,
+        "$defs",
+        "packet_identity",
+        "properties",
+        "packet_scope",
+        "enum",
+    )
+    if (
+        not isinstance(packet_scopes, list)
+        or profile.get("expected_packet_scope") not in packet_scopes
+    ):
+        errors.append("current_run_scope_not_supported_by_subject_input_schema")
+
+    carrier_kinds = _nested_value(
+        subject_input_schema,
+        "$defs",
+        "carrier",
+        "properties",
+        "carrier_kind",
+        "enum",
+    )
+    if (
+        not isinstance(carrier_kinds, list)
+        or profile.get("expected_carrier_kind") not in carrier_kinds
+    ):
+        errors.append("current_run_carrier_kind_not_supported_by_subject_input_schema")
+
+    expectation_source_pattern = _nested_value(
+        expectation_schema,
+        "$defs",
+        "source_id",
+        "pattern",
+    )
+    packet_source_pattern = _nested_value(
+        subject_input_schema,
+        "$defs",
+        "source_id",
+        "pattern",
+    )
+    if expectation_source_pattern != packet_source_pattern:
+        errors.append("source_id_pattern_cross_contract_mismatch")
+
+    carrier_pattern = _nested_value(
+        subject_input_schema,
+        "$defs",
+        "carrier_id",
+        "pattern",
+    )
+    derived_carrier_id = (
+        f"carrier:{profile.get('expected_carrier_id_namespace')}/generated-suffix"
+    )
+    if not _fullmatch(carrier_pattern, derived_carrier_id):
+        errors.append(
+            f"derived_carrier_id_not_packet_safe: {derived_carrier_id!r}"
+        )
+
+    return not errors, errors
+
+
+def semantic_checks(
+    expectation: dict[str, Any],
+    *,
+    expectation_text: str,
+    expectation_path: Path,
+    repository_root: Path,
+    expectation_schema: dict[str, Any],
+    subject_input_schema: dict[str, Any],
+) -> tuple[dict[str, bool], list[str], dict[str, Any]]:
+    checks: dict[str, bool] = {}
+    errors: list[str] = []
+
+    def record(name: str, condition: bool, detail: str | None = None) -> None:
+        checks[name] = bool(condition)
+        if not condition:
+            suffix = f": {detail}" if detail else ""
+            errors.append(f"check_failed: {name}{suffix}")
+
+    record(
+        "schema_version_ok",
+        expectation.get("schema_version") == SCHEMA_VERSION,
+    )
+    record(
+        "document_type_ok",
+        expectation.get("document_type") == DOCUMENT_TYPE,
+    )
+    record(
+        "canonical_json_key_ordering_ok",
+        _all_object_keys_sorted(expectation),
+    )
+    record(
+        "canonical_json_bytes_ok",
+        expectation_text == render_json(expectation),
+    )
+
+    status = expectation.get("record_status")
+    identity = expectation.get("expectation_identity", {})
+    fixture = expectation.get("fixture_provenance")
+    expectation_producer = expectation.get("expectation_producer")
+    subject = expectation.get("subject", {})
+    control_plane = expectation.get("trusted_control_plane", {})
+    components = control_plane.get("components", {})
+    profile = expectation.get("packet_producer_profile", {})
+    carrier = expectation.get("carrier", {})
+    carrier_producer = carrier.get("producer")
+    layout = expectation.get("archive_layout", {})
+    sources = expectation.get("authority_sources", {})
+    packet_contract = expectation.get("packet_contract", {})
+
+    branch_ok = False
+    if status == "example":
+        branch_ok = (
+            isinstance(fixture, dict)
+            and expectation_producer is None
+            and identity.get("expectation_scope") == "example"
+            and carrier.get("carrier_kind") == "example_archive"
+            and carrier_producer is None
+            and fixture.get("expectation_producer_execution_claimed") is False
+        )
+    elif status == "observed":
+        branch_ok = (
+            fixture is None
+            and isinstance(expectation_producer, dict)
+            and identity.get("expectation_scope") == "current_run_export"
+            and carrier.get("carrier_kind") == "current_run_export_archive"
+            and isinstance(carrier_producer, dict)
+        )
+    record("record_status_branch_ok", branch_ok)
+
+    if status == "example" and isinstance(fixture, dict):
+        actual_relative = _relative_path(expectation_path, repository_root)
+        record(
+            "fixture_source_path_binding_ok",
+            actual_relative == fixture.get("fixture_source_path"),
+            (
+                f"declared={fixture.get('fixture_source_path')!r} "
+                f"actual={actual_relative!r}"
+            ),
+        )
+        record(
+            "fixture_schema_identity_ok",
+            fixture.get("schema_identity") == expectation.get("schema_version"),
+        )
+    else:
+        record("fixture_source_path_binding_ok", status == "observed")
+        record("fixture_schema_identity_ok", status == "observed")
+
+    canonical_run_key = _canonical_subject_run_key(subject)
+    run_keys = (
+        identity.get("subject_run_key"),
+        subject.get("subject_run_key"),
+        profile.get("expected_subject_run_key"),
+    )
+    record(
+        "subject_run_key_binding_ok",
+        len(set(run_keys)) == 1 and run_keys[0] is not None,
+        repr(run_keys),
+    )
+    record(
+        "subject_run_key_canonical_ok",
+        subject.get("subject_run_key") == canonical_run_key,
+        f"expected={canonical_run_key!r}",
+    )
+
+    expected_workflow_ref = _canonical_workflow_ref(subject)
+    record(
+        "subject_workflow_ref_ok",
+        subject.get("workflow_ref") == expected_workflow_ref,
+        f"expected={expected_workflow_ref!r}",
+    )
+
+    record(
+        "producer_profile_subject_binding_ok",
+        profile.get("expected_repository") == subject.get("repository")
+        and profile.get("expected_source_commit") == subject.get("source_commit")
+        and profile.get("expected_subject_run_key")
+        == subject.get("subject_run_key"),
+    )
+    record(
+        "producer_profile_layout_binding_ok",
+        profile.get("expected_archive_layout_id") == layout.get("layout_id"),
+    )
+    record(
+        "packet_contract_profile_binding_ok",
+        packet_contract.get("production_mode")
+        == profile.get("expected_production_mode")
+        and packet_contract.get("packet_scope")
+        == profile.get("expected_packet_scope")
+        and packet_contract.get("carrier_kind")
+        == profile.get("expected_carrier_kind")
+        and packet_contract.get("artifact_payload_mode")
+        == profile.get("expected_carrier_artifact_payload_mode"),
+    )
+
+    workflow = sources.get("workflow", {})
+    workflow_ok = (
+        workflow.get("source_id") == "source:workflow"
+        and workflow.get("role") == "workflow"
+        and workflow.get("path_or_uri") == subject.get("workflow_path")
+        and workflow.get("source_revision") == subject.get("source_commit")
+        and workflow.get("workflow_name") == subject.get("workflow_name")
+        and workflow.get("workflow_ref") == subject.get("workflow_ref")
+    )
+    record("workflow_source_binding_ok", workflow_ok)
+
+    policy = sources.get("policy", {})
+    policy_ok = (
+        policy.get("source_id") == "source:policy"
+        and policy.get("role") == "policy"
+        and policy.get("source_revision") == subject.get("source_commit")
+        and policy.get("policy_id") == subject.get("policy_id")
+        and policy.get("sha256") == subject.get("policy_sha256")
+    )
+    record("policy_source_binding_ok", policy_ok)
+
+    registry = sources.get("gate_registry", {})
+    registry_ok = (
+        registry.get("source_id") == "source:gate-registry"
+        and registry.get("role") == "gate_registry"
+        and registry.get("source_revision") == subject.get("source_commit")
+    )
+    record("gate_registry_source_binding_ok", registry_ok)
+
+    flattened_sources = _flatten_authority_sources(expectation)
+    source_ids = [row.get("source_id") for _label, row in flattened_sources]
+    record(
+        "authority_source_ids_unique_ok",
+        all(isinstance(value, str) for value in source_ids)
+        and len(source_ids) == len(set(source_ids)),
+    )
+
+    expectation_source_pattern = _nested_value(
+        expectation_schema,
+        "$defs",
+        "source_id",
+        "pattern",
+    )
+    record(
+        "authority_source_ids_namespace_ok",
+        all(_fullmatch(expectation_source_pattern, value) for value in source_ids),
+    )
+
+    record(
+        "authority_source_revisions_ok",
+        all(
+            row.get("source_revision") == subject.get("source_commit")
+            for _label, row in flattened_sources
+        ),
+    )
+
+    additional_sources = sources.get("additional_sources", [])
+    additional_ids = (
+        [row.get("source_id") for row in additional_sources]
+        if isinstance(additional_sources, list)
+        else []
+    )
+    record(
+        "additional_sources_ordering_ok",
+        isinstance(additional_sources, list)
+        and additional_ids == sorted(additional_ids),
+    )
+
+    signer_rows = [
+        row
+        for row in additional_sources
+        if isinstance(row, dict)
+        and row.get("role") == "external_signer_policy"
+        and row.get("path_or_uri") == profile.get("expected_signer_policy_path")
+    ]
+    record(
+        "signer_policy_source_binding_ok",
+        len(signer_rows) == 1,
+        f"matches={len(signer_rows)}",
+    )
+
+    component_keys_ok = (
+        isinstance(components, dict)
+        and tuple(sorted(components)) == CONTROL_PLANE_COMPONENT_KEYS
+    )
+    record("control_plane_component_set_ok", component_keys_ok)
+
+    component_rows = [
+        row for row in components.values() if isinstance(row, dict)
+    ] if isinstance(components, dict) else []
+    record(
+        "control_plane_component_revisions_ok",
+        len(component_rows) == len(CONTROL_PLANE_COMPONENT_KEYS)
+        and all(
+            row.get("source_revision") == control_plane.get("revision")
+            for row in component_rows
+        ),
+    )
+    component_paths = [row.get("path") for row in component_rows]
+    record(
+        "control_plane_component_paths_unique_ok",
+        all(isinstance(path, str) for path in component_paths)
+        and len(component_paths) == len(set(component_paths)),
+    )
+
+    component_path_bindings_ok = (
+        isinstance(components, dict)
+        and components.get("expectation_schema", {}).get("path")
+        == EXPECTATION_SCHEMA_PATH
+        and components.get("expectation_validator", {}).get("path")
+        == EXPECTATION_VALIDATOR_PATH
+        and components.get("subject_input_schema", {}).get("path")
+        == SUBJECT_INPUT_SCHEMA_PATH
+        and components.get("subject_input_validator", {}).get("path")
+        == SUBJECT_INPUT_VALIDATOR_PATH
+        and components.get("subject_input_producer_core", {}).get("path")
+        == SUBJECT_INPUT_PRODUCER_CORE_PATH
+        and components.get("subject_input_producer_wrapper", {}).get("path")
+        == profile.get("expected_producer_source_path")
+    )
+    record(
+        "control_plane_component_path_bindings_ok",
+        component_path_bindings_ok,
+    )
+
+    observed_producer_ok = True
+    if status == "observed":
+        builder_component = components.get("expectation_builder", {})
+        observed_producer_ok = (
+            isinstance(expectation_producer, dict)
+            and expectation_producer.get("producer_run_key")
+            == subject.get("subject_run_key")
+            and expectation_producer.get("producer_source")
+            == builder_component.get("path")
+            and expectation_producer.get("producer_source_revision")
+            == builder_component.get("source_revision")
+            == control_plane.get("revision")
+            and expectation_producer.get("producer_source_sha256")
+            == builder_component.get("sha256")
+            and expectation_producer.get("producer_version")
+            == builder_component.get("version")
+            and isinstance(carrier_producer, dict)
+            and carrier_producer.get("producer_run_key")
+            == subject.get("subject_run_key")
+            and carrier_producer.get("producer_source_revision")
+            == control_plane.get("revision")
+        )
+    record("observed_producer_bindings_ok", observed_producer_ok)
+
+    record(
+        "carrier_id_namespace_binding_ok",
+        isinstance(carrier.get("carrier_id"), str)
+        and carrier.get("carrier_id").startswith(
+            f"carrier:{profile.get('expected_carrier_id_namespace')}/"
+        ),
+    )
+    record(
+        "carrier_layout_binding_ok",
+        carrier.get("root_prefix") == layout.get("outer_prefix"),
+    )
+
+    try:
+        carrier_finalized = _parse_utc(carrier.get("finalized_utc"))
+        expectation_created = _parse_utc(identity.get("expectation_created_utc"))
+        finalization_order_ok = carrier_finalized <= expectation_created
+        finalization_detail = None
+    except Exception as exc:
+        finalization_order_ok = False
+        finalization_detail = str(exc)
+    record(
+        "carrier_finalization_order_ok",
+        finalization_order_ok,
+        finalization_detail,
+    )
+
+    provider_ok, provider_detail = _provider_binding_ok(carrier)
+    record("provider_binding_semantics_ok", provider_ok, provider_detail)
+
+    outer_prefix = layout.get("outer_prefix")
+    original_prefix = layout.get("original_artifacts_prefix")
+    visible = layout.get("visible_members", {})
+    visible_names = list(visible.values()) if isinstance(visible, dict) else []
+    package_names = [
+        layout.get("complete_package_name"),
+        layout.get("completeness_archive_name"),
+        layout.get("verification_archive_name"),
+    ]
+    archive_layout_ok = (
+        isinstance(outer_prefix, str)
+        and isinstance(original_prefix, str)
+        and original_prefix.startswith(outer_prefix)
+        and original_prefix != outer_prefix
+        and outer_prefix.endswith("/")
+        and original_prefix.endswith("/")
+        and len(visible_names) == 3
+        and len(visible_names) == len(set(visible_names))
+        and all(isinstance(value, str) and value for value in package_names)
+        and len(package_names) == len(set(package_names))
+        and all(str(value).endswith(".zip") for value in package_names)
+        and not set(visible_names).intersection(package_names)
+    )
+    record("archive_layout_semantics_ok", archive_layout_ok)
+
+    provider_count = layout.get("expected_provider_artifact_count")
+    non_provider_count = layout.get("expected_non_provider_artifact_count")
+    derived_artifact_count = (
+        provider_count + non_provider_count
+        if isinstance(provider_count, int)
+        and isinstance(non_provider_count, int)
+        else None
+    )
+    record(
+        "artifact_count_derivation_ok",
+        layout.get("artifact_count_derivation") == "provider_plus_non_provider"
+        and isinstance(provider_count, int)
+        and provider_count >= 1
+        and isinstance(non_provider_count, int)
+        and non_provider_count >= len(visible_names)
+        and "expected_artifact_count" not in layout,
+    )
+
+    record(
+        "single_authoritative_carrier_digest_ok",
+        isinstance(carrier.get("sha256"), str)
+        and _carrier_digest_key_count(expectation) == 0,
+    )
+
+    cross_contract_ok, cross_contract_errors = _subject_input_cross_contract(
+        expectation_schema=expectation_schema,
+        subject_input_schema=subject_input_schema,
+        packet_contract=packet_contract,
+        profile=profile,
+    )
+    record(
+        "subject_input_cross_contract_ok",
+        cross_contract_ok,
+        " | ".join(cross_contract_errors) or None,
+    )
+
+    record(
+        "content_boundary_closed_ok",
+        expectation.get("content_boundary") == CLOSED_CONTENT_BOUNDARY,
+    )
+    record(
+        "authority_boundary_closed_ok",
+        expectation.get("authority_boundary") == CLOSED_AUTHORITY_BOUNDARY,
+    )
+
+    errors_field = expectation.get("errors")
+    ok_field = expectation.get("ok")
+    record(
+        "record_errors_ordering_ok",
+        _sorted_unique_non_empty_strings(errors_field),
+    )
+    record(
+        "record_ok_errors_semantics_ok",
+        isinstance(errors_field, list)
+        and (
+            (ok_field is True and errors_field == [])
+            or (ok_field is False and len(errors_field) > 0)
+        ),
+    )
+    record(
+        "active_policy_sets_identity_shape_ok",
+        _ordered_unique_non_empty_strings(subject.get("active_policy_sets")),
+    )
+
+    derived = {
+        "artifact_count": derived_artifact_count,
+        "authority_effect": "none",
+        "carrier_id_prefix": (
+            f"carrier:{profile.get('expected_carrier_id_namespace')}/"
+        ),
+        "control_plane_component_count": len(component_rows),
+        "record_status": status,
+        "source_count": len(flattened_sources),
+        "subject_run_key": subject.get("subject_run_key"),
+        "workflow_ref": subject.get("workflow_ref"),
+    }
+    return checks, errors, derived
+
+
+def make_diagnostic(
+    *,
+    ok: bool,
+    expectation_schema_valid: bool,
+    subject_input_schema_valid: bool,
+    record_status: Any,
+    checks: dict[str, bool],
+    derived: dict[str, Any],
+    input_identities: dict[str, Any],
+    errors: list[str],
+) -> dict[str, Any]:
+    return {
+        "tool": TOOL_NAME,
+        "tool_version": TOOL_VERSION,
+        "schema_version": SCHEMA_VERSION,
+        "document_type": DOCUMENT_TYPE,
+        "record_status": record_status,
+        "ok": ok,
+        "expectation_schema_valid": expectation_schema_valid,
+        "subject_input_schema_valid": subject_input_schema_valid,
+        "checks": dict(sorted(checks.items())),
+        "derived": dict(sorted(derived.items())),
+        "input_identities": dict(sorted(input_identities.items())),
+        "verification_boundary": {
+            "carrier_bytes_verified": False,
+            "control_plane_component_bytes_verified": False,
+            "contract_semantics_verified": bool(ok),
+            "subject_authority_source_bytes_verified": False,
+        },
+        "authority_effect": "none",
+        "errors": sorted(set(errors)),
+    }
+
+
+def build_diagnostic(
+    *,
+    schema_path: Path,
+    expectation_path: Path,
+    subject_input_schema_path: Path,
+    repository_root: Path,
+) -> tuple[dict[str, Any], int]:
+    try:
+        expectation_schema, _schema_text, schema_bytes = load_json(
+            schema_path,
+            label="expectation_schema",
+            max_bytes=MAX_EXPECTATION_SCHEMA_BYTES,
+        )
+        subject_input_schema, _packet_schema_text, packet_schema_bytes = load_json(
+            subject_input_schema_path,
+            label="subject_input_schema",
+            max_bytes=MAX_SUBJECT_INPUT_SCHEMA_BYTES,
+        )
+        expectation, expectation_text, expectation_bytes = load_json(
+            expectation_path,
+            label="expectation",
+            max_bytes=MAX_EXPECTATION_BYTES,
+        )
+    except Exception as exc:
+        diagnostic = make_diagnostic(
+            ok=False,
+            expectation_schema_valid=False,
+            subject_input_schema_valid=False,
+            record_status=None,
+            checks={},
+            derived={},
+            input_identities={},
+            errors=[f"read_error: {exc}"],
+        )
+        return diagnostic, 2
+
+    input_identities = {
+        "expectation": {
+            "sha256": hashlib.sha256(expectation_bytes).hexdigest(),
+            "size_bytes": len(expectation_bytes),
+        },
+        "expectation_schema": {
+            "sha256": hashlib.sha256(schema_bytes).hexdigest(),
+            "size_bytes": len(schema_bytes),
+        },
+        "subject_input_schema": {
+            "sha256": hashlib.sha256(packet_schema_bytes).hexdigest(),
+            "size_bytes": len(packet_schema_bytes),
+        },
+    }
+
+    if not isinstance(expectation_schema, dict):
+        diagnostic = make_diagnostic(
+            ok=False,
+            expectation_schema_valid=False,
+            subject_input_schema_valid=False,
+            record_status=(
+                expectation.get("record_status")
+                if isinstance(expectation, dict)
+                else None
+            ),
+            checks={},
+            derived={},
+            input_identities=input_identities,
+            errors=["expectation_schema_not_object"],
+        )
+        return diagnostic, 2
+
+    if not isinstance(subject_input_schema, dict):
+        diagnostic = make_diagnostic(
+            ok=False,
+            expectation_schema_valid=False,
+            subject_input_schema_valid=False,
+            record_status=(
+                expectation.get("record_status")
+                if isinstance(expectation, dict)
+                else None
+            ),
+            checks={},
+            derived={},
+            input_identities=input_identities,
+            errors=["subject_input_schema_not_object"],
+        )
+        return diagnostic, 2
+
+    expectation_schema_errors: list[str] = []
+    subject_input_schema_errors: list[str] = []
+    try:
+        jsonschema.Draft202012Validator.check_schema(expectation_schema)
+    except Exception as exc:
+        expectation_schema_errors.append(f"expectation_schema_invalid: {exc}")
+    try:
+        jsonschema.Draft202012Validator.check_schema(subject_input_schema)
+    except Exception as exc:
+        subject_input_schema_errors.append(f"subject_input_schema_invalid: {exc}")
+
+    expectation_schema_valid = not expectation_schema_errors
+    subject_input_schema_valid = not subject_input_schema_errors
+    errors = expectation_schema_errors + subject_input_schema_errors
+
+    if expectation_schema_valid:
+        errors.extend(schema_errors(expectation_schema, expectation))
+    record_schema_valid = (
+        expectation_schema_valid
+        and not any(error.startswith("schema_error[") for error in errors)
+    )
+
+    if not isinstance(expectation, dict):
+        diagnostic = make_diagnostic(
+            ok=False,
+            expectation_schema_valid=record_schema_valid,
+            subject_input_schema_valid=subject_input_schema_valid,
+            record_status=None,
+            checks={},
+            derived={},
+            input_identities=input_identities,
+            errors=errors + ["expectation_not_object"],
+        )
+        return diagnostic, 1
+
+    checks: dict[str, bool] = {}
+    derived: dict[str, Any] = {}
+    if record_schema_valid and subject_input_schema_valid:
+        semantic, semantic_errors_list, derived = semantic_checks(
+            expectation,
+            expectation_text=expectation_text,
+            expectation_path=expectation_path,
+            repository_root=repository_root,
+            expectation_schema=expectation_schema,
+            subject_input_schema=subject_input_schema,
+        )
+        checks.update(semantic)
+        errors.extend(semantic_errors_list)
+    else:
+        checks["semantic_checks_skipped_due_to_schema_errors"] = False
+
+    ok = (
+        record_schema_valid
+        and subject_input_schema_valid
+        and bool(checks)
+        and all(checks.values())
+        and not errors
+    )
+    diagnostic = make_diagnostic(
+        ok=ok,
+        expectation_schema_valid=record_schema_valid,
+        subject_input_schema_valid=subject_input_schema_valid,
+        record_status=expectation.get("record_status"),
+        checks=checks,
+        derived=derived,
+        input_identities=input_identities,
+        errors=errors,
+    )
+    return diagnostic, 0 if ok else 1
+
+
+def same_target(left: Path, right: Path) -> bool:
+    try:
+        return left.resolve(strict=False) == right.resolve(strict=False)
+    except OSError:
+        return False
+
+
+def reject_unsafe_output(
+    output: Path | None,
+    *,
+    schema_path: Path,
+    expectation_path: Path,
+    subject_input_schema_path: Path,
+    repository_root: Path,
+) -> None:
+    if output is None:
+        return
+
+    for protected in (
+        schema_path,
+        expectation_path,
+        subject_input_schema_path,
+        Path(__file__),
+    ):
+        if same_target(output, protected):
+            raise SemanticError(f"refusing_to_overwrite_input: {protected}")
+
+    if output.name in PROTECTED_OUTPUT_NAMES:
+        raise SemanticError(
+            f"refusing_authority_or_contract_surface_output: {output.name}"
+        )
+
+    candidate = _normalized_absolute_path(output)
+    cursor = candidate
+    while True:
+        try:
+            metadata = cursor.lstat()
+        except FileNotFoundError:
+            metadata = None
+        except OSError as exc:
+            raise SemanticError(
+                f"output_path_component_unavailable: {cursor}: {exc}"
+            ) from exc
+        if metadata is not None and stat.S_ISLNK(metadata.st_mode):
+            raise SemanticError(f"refusing_symlink_output_path: {cursor}")
+        if cursor == cursor.parent:
+            break
+        cursor = cursor.parent
+
+    try:
+        candidate.resolve(strict=False).relative_to(
+            repository_root.resolve(strict=True)
+        )
+    except (OSError, ValueError):
+        return
+    raise SemanticError(f"refusing_output_inside_repository: {candidate}")
+
+
+def atomic_write(path: Path, text: str) -> None:
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    if not parent.is_dir():
+        raise SemanticError(f"output_parent_not_directory: {parent}")
+
+    descriptor, raw_temp = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(parent),
+    )
+    temp = Path(raw_temp)
+    try:
+        with os.fdopen(
+            descriptor,
+            "w",
+            encoding="utf-8",
+            newline="\n",
+        ) as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp, path)
+    finally:
+        try:
+            temp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate a PULSEmech current-run export expectation v0 against "
+            "its Draft 2020-12 schema, semantic cross-bindings, and the "
+            "existing subject-input packet contract."
+        )
+    )
+    parser.add_argument(
+        "--schema",
+        default=str(DEFAULT_SCHEMA),
+        help="Path to the current-run export expectation schema.",
+    )
+    parser.add_argument(
+        "--expectation",
+        default=str(DEFAULT_EXPECTATION),
+        help="Path to the current-run export expectation JSON.",
+    )
+    parser.add_argument(
+        "--subject-input-schema",
+        default=str(DEFAULT_SUBJECT_INPUT_SCHEMA),
+        help="Path to the downstream subject-input packet schema.",
+    )
+    parser.add_argument(
+        "--repository-root",
+        default=str(ROOT),
+        help=(
+            "Repository root used only for checked-in fixture-path binding "
+            "and output non-interference."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        help=(
+            "Optional external path for the deterministic diagnostic JSON. "
+            "Repository-local output is rejected."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    schema_path = Path(args.schema)
+    expectation_path = Path(args.expectation)
+    subject_input_schema_path = Path(args.subject_input_schema)
+    repository_root = Path(args.repository_root)
+    output = Path(args.output) if args.output else None
+
+    try:
+        reject_unsafe_output(
+            output,
+            schema_path=schema_path,
+            expectation_path=expectation_path,
+            subject_input_schema_path=subject_input_schema_path,
+            repository_root=repository_root,
+        )
+    except SemanticError as exc:
+        diagnostic = make_diagnostic(
+            ok=False,
+            expectation_schema_valid=False,
+            subject_input_schema_valid=False,
+            record_status=None,
+            checks={},
+            derived={},
+            input_identities={},
+            errors=[str(exc)],
+        )
+        sys.stderr.write(render_json(diagnostic))
+        return 2
+
+    diagnostic, exit_code = build_diagnostic(
+        schema_path=schema_path,
+        expectation_path=expectation_path,
+        subject_input_schema_path=subject_input_schema_path,
+        repository_root=repository_root,
+    )
+    rendered = render_json(diagnostic)
+
+    if output is not None:
+        try:
+            atomic_write(output, rendered)
+        except Exception as exc:
+            failure = make_diagnostic(
+                ok=False,
+                expectation_schema_valid=diagnostic.get(
+                    "expectation_schema_valid",
+                    False,
+                ),
+                subject_input_schema_valid=diagnostic.get(
+                    "subject_input_schema_valid",
+                    False,
+                ),
+                record_status=diagnostic.get("record_status"),
+                checks=diagnostic.get("checks", {}),
+                derived=diagnostic.get("derived", {}),
+                input_identities=diagnostic.get("input_identities", {}),
+                errors=list(diagnostic.get("errors", []))
+                + [f"output_write_failed: {exc}"],
+            )
+            sys.stderr.write(render_json(failure))
+            return 2
+
+    sys.stdout.write(rendered)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_pulsemech_compute_current_run_export_expectation_v0.py
+++ b/tools/check_pulsemech_compute_current_run_export_expectation_v0.py
@@ -2,15 +2,18 @@
 from __future__ import annotations
 
 import argparse
+import copy
+import errno
 import hashlib
 import json
 import os
 import re
+import secrets
 import stat
 import sys
 import tempfile
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import jsonschema
@@ -67,6 +70,33 @@ CONTROL_PLANE_COMPONENT_KEYS = (
     "subject_input_producer_wrapper",
     "subject_input_schema",
     "subject_input_validator",
+)
+
+ROLE_BINDING_SCALAR_KEYS = (
+    "preservation_manifest",
+    "preservation_readme",
+    "preservation_checksums",
+    "complete_package",
+    "package_inventory",
+    "package_completeness_report",
+    "independent_verification_report",
+    "run_metadata",
+    "final_status",
+    "status_baseline",
+    "release_decision",
+    "release_authority",
+    "artifact_binding",
+    "evidence_manifest",
+    "recorded_verifier_report",
+    "required_gate_evidence",
+    "candidate_index",
+)
+
+ROLE_BINDING_LIST_KEYS = (
+    "candidate_records",
+    "external_evidence_records",
+    "attestation_records",
+    "reader_surfaces",
 )
 
 CLOSED_CONTENT_BOUNDARY = {
@@ -134,6 +164,35 @@ def _normalized_absolute_path(path: Path) -> Path:
     return Path(os.path.abspath(os.path.normpath(os.fspath(path))))
 
 
+def _validated_directory_root(path: Path, *, label: str) -> Path:
+    candidate = _normalized_absolute_path(path)
+    reject_symlink_components(candidate, label=label)
+    try:
+        metadata = candidate.lstat()
+    except OSError as exc:
+        raise SemanticError(f"{label}_unavailable: {candidate}: {exc}") from exc
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise SemanticError(f"{label}_not_directory: {candidate}")
+    try:
+        return candidate.resolve(strict=True)
+    except OSError as exc:
+        raise SemanticError(f"{label}_unresolvable: {candidate}: {exc}") from exc
+
+
+def _stat_identity(value: os.stat_result) -> tuple[Any, ...]:
+    return tuple(
+        getattr(value, name, None)
+        for name in (
+            "st_dev",
+            "st_ino",
+            "st_mode",
+            "st_size",
+            "st_mtime_ns",
+            "st_ctime_ns",
+        )
+    )
+
+
 def reject_symlink_components(path: Path, *, label: str) -> None:
     cursor = _normalized_absolute_path(path)
     while True:
@@ -144,13 +203,102 @@ def reject_symlink_components(path: Path, *, label: str) -> None:
                 raise SemanticError(f"{label}_missing: {cursor}")
             raise SemanticError(f"{label}_parent_missing: {cursor}")
         except OSError as exc:
-            raise SemanticError(f"{label}_component_unavailable: {cursor}: {exc}") from exc
+            raise SemanticError(
+                f"{label}_component_unavailable: {cursor}: {exc}"
+            ) from exc
 
         if stat.S_ISLNK(metadata.st_mode):
             raise SemanticError(f"{label}_symlink_rejected: {cursor}")
         if cursor == cursor.parent:
             return
         cursor = cursor.parent
+
+
+def _open_nofollow_posix(path: Path, *, label: str) -> int:
+    candidate = _normalized_absolute_path(path)
+    parts = candidate.parts
+    if not candidate.is_absolute() or not parts:
+        raise SemanticError(f"{label}_path_not_absolute: {candidate}")
+
+    directory_flags = os.O_RDONLY
+    directory_flags |= int(getattr(os, "O_DIRECTORY", 0))
+    directory_flags |= int(getattr(os, "O_CLOEXEC", 0))
+    directory_flags |= int(getattr(os, "O_NOFOLLOW", 0))
+    file_flags = os.O_RDONLY
+    file_flags |= int(getattr(os, "O_CLOEXEC", 0))
+    file_flags |= int(getattr(os, "O_NOFOLLOW", 0))
+    file_flags |= int(getattr(os, "O_BINARY", 0))
+
+    current_fd: int | None = None
+    try:
+        current_fd = os.open(parts[0], directory_flags)
+        for part in parts[1:-1]:
+            next_fd = os.open(
+                part,
+                directory_flags,
+                dir_fd=current_fd,
+            )
+            os.close(current_fd)
+            current_fd = next_fd
+        if len(parts) == 1:
+            raise SemanticError(f"{label}_path_is_root: {candidate}")
+        return os.open(parts[-1], file_flags, dir_fd=current_fd)
+    except OSError as exc:
+        if exc.errno in {
+            errno.ELOOP,
+            errno.ENOTDIR,
+        }:
+            raise SemanticError(
+                f"{label}_symlink_or_non_directory_component_rejected: "
+                f"{candidate}: {exc}"
+            ) from exc
+        if exc.errno == errno.ENOENT:
+            raise SemanticError(f"{label}_missing: {candidate}") from exc
+        raise SemanticError(f"{label}_open_failed: {candidate}: {exc}") from exc
+    finally:
+        if current_fd is not None:
+            try:
+                os.close(current_fd)
+            except OSError:
+                pass
+
+
+def _open_nofollow_fallback(path: Path, *, label: str) -> int:
+    candidate = _normalized_absolute_path(path)
+    reject_symlink_components(candidate, label=label)
+    try:
+        before = candidate.lstat()
+    except OSError as exc:
+        raise SemanticError(f"{label}_unavailable: {candidate}: {exc}") from exc
+    if not stat.S_ISREG(before.st_mode):
+        raise SemanticError(f"{label}_not_regular_file: {candidate}")
+
+    flags = os.O_RDONLY
+    flags |= int(getattr(os, "O_CLOEXEC", 0))
+    flags |= int(getattr(os, "O_NOFOLLOW", 0))
+    flags |= int(getattr(os, "O_BINARY", 0))
+    try:
+        descriptor = os.open(candidate, flags)
+    except OSError as exc:
+        raise SemanticError(f"{label}_open_failed: {candidate}: {exc}") from exc
+
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or _stat_identity(before) != _stat_identity(opened)
+        ):
+            raise SemanticError(f"{label}_changed_before_read: {candidate}")
+    except Exception:
+        os.close(descriptor)
+        raise
+    return descriptor
+
+
+def _open_nofollow(path: Path, *, label: str) -> int:
+    if os.name != "nt" and os.open in os.supports_dir_fd:
+        return _open_nofollow_posix(path, label=label)
+    return _open_nofollow_fallback(path, label=label)
 
 
 def read_regular_file(
@@ -160,27 +308,44 @@ def read_regular_file(
     max_bytes: int,
 ) -> bytes:
     candidate = _normalized_absolute_path(path)
-    reject_symlink_components(candidate, label=label)
+    descriptor = _open_nofollow(candidate, label=label)
     try:
-        metadata = candidate.lstat()
-    except OSError as exc:
-        raise SemanticError(f"{label}_unavailable: {candidate}: {exc}") from exc
-    if not stat.S_ISREG(metadata.st_mode):
-        raise SemanticError(f"{label}_not_regular_file: {candidate}")
-    if metadata.st_size > max_bytes:
-        raise SemanticError(
-            f"{label}_too_large: size={metadata.st_size} maximum={max_bytes}"
-        )
-    try:
-        payload = candidate.read_bytes()
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            raise SemanticError(f"{label}_not_regular_file: {candidate}")
+        if before.st_size > max_bytes:
+            raise SemanticError(
+                f"{label}_too_large: size={before.st_size} maximum={max_bytes}"
+            )
+
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            chunk = os.read(descriptor, min(1024 * 1024, max_bytes + 1))
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > max_bytes:
+                raise SemanticError(
+                    f"{label}_too_large_during_read: "
+                    f"size>{max_bytes}"
+                )
+            chunks.append(chunk)
+
+        after = os.fstat(descriptor)
+        if _stat_identity(before) != _stat_identity(after):
+            raise SemanticError(f"{label}_changed_during_read: {candidate}")
+        payload = b"".join(chunks)
+        if len(payload) != before.st_size:
+            raise SemanticError(
+                f"{label}_size_changed_during_read: "
+                f"expected={before.st_size} actual={len(payload)}"
+            )
+        return payload
     except OSError as exc:
         raise SemanticError(f"{label}_read_failed: {candidate}: {exc}") from exc
-    if len(payload) != metadata.st_size:
-        raise SemanticError(
-            f"{label}_size_changed_during_read: "
-            f"expected={metadata.st_size} actual={len(payload)}"
-        )
-    return payload
+    finally:
+        os.close(descriptor)
 
 
 def load_json(
@@ -222,21 +387,34 @@ def render_json(value: dict[str, Any]) -> str:
     )
 
 
-def schema_errors(schema: dict[str, Any], value: Any) -> list[str]:
-    validator = jsonschema.Draft202012Validator(
-        schema,
-        format_checker=jsonschema.FormatChecker(),
-    )
-    return [
-        f"schema_error[{list(error.path)}]: {error.message}"
-        for error in sorted(
-            validator.iter_errors(value),
+def validate_instance(
+    schema: dict[str, Any],
+    value: Any,
+    *,
+    label: str,
+) -> tuple[bool, list[str]]:
+    try:
+        validator = jsonschema.Draft202012Validator(
+            schema,
+            format_checker=jsonschema.FormatChecker(),
+        )
+        validation_errors = sorted(
+            list(validator.iter_errors(value)),
             key=lambda item: (
                 tuple(str(part) for part in item.path),
                 item.message,
             ),
         )
+    except Exception as exc:
+        return False, [
+            f"{label}_validation_failed: {type(exc).__name__}: {exc}"
+        ]
+
+    errors = [
+        f"{label}_error[{list(error.path)}]: {error.message}"
+        for error in validation_errors
     ]
+    return not errors, errors
 
 
 def _all_object_keys_sorted(value: Any) -> bool:
@@ -333,6 +511,189 @@ def _fullmatch(pattern: Any, value: Any) -> bool:
     )
 
 
+def _canonical_component_path(value: Any) -> str | None:
+    if not isinstance(value, str) or not value or "\\" in value:
+        return None
+    if value.startswith("/") or value.endswith("/") or "\x00" in value:
+        return None
+    pure = PurePosixPath(value)
+    if not pure.parts or any(part in {"", ".", ".."} for part in pure.parts):
+        return None
+    canonical = pure.as_posix()
+    return canonical if canonical == value else None
+
+
+def _subject_input_observed_witness(
+    expectation: dict[str, Any],
+    *,
+    packet_contract: dict[str, Any],
+    profile: dict[str, Any],
+) -> dict[str, Any]:
+    subject = copy.deepcopy(expectation.get("subject", {}))
+    authority_sources = copy.deepcopy(
+        expectation.get("authority_sources", {})
+    )
+    carrier = expectation.get("carrier", {})
+    identity = expectation.get("expectation_identity", {})
+    components = expectation.get("trusted_control_plane", {}).get(
+        "components",
+        {},
+    )
+    producer_component = (
+        components.get("subject_input_producer_wrapper", {})
+        if isinstance(components, dict)
+        else {}
+    )
+    layout = expectation.get("archive_layout", {})
+    visible = layout.get("visible_members", {})
+
+    artifact_id = "artifact:current-run-export-compatibility-probe/manifest"
+    manifest_name = (
+        visible.get("preservation_manifest_name")
+        if isinstance(visible, dict)
+        else None
+    ) or "PRESERVATION_MANIFEST_v0.json"
+    root_prefix = carrier.get("root_prefix") or "current-run-export-probe/"
+    member_path = f"{root_prefix}{manifest_name}"
+
+    role_bindings: dict[str, Any] = {
+        key: None for key in ROLE_BINDING_SCALAR_KEYS
+    }
+    role_bindings["preservation_manifest"] = artifact_id
+    role_bindings.update({key: [] for key in ROLE_BINDING_LIST_KEYS})
+
+    missing_roles = sorted(
+        key
+        for key in ROLE_BINDING_SCALAR_KEYS
+        if key != "preservation_manifest"
+    ) + list(ROLE_BINDING_LIST_KEYS)
+
+    producer_version = producer_component.get("version")
+    if not isinstance(producer_version, str):
+        producer_version = "0.1.0"
+
+    return {
+        "analysis_boundary": {
+            "current_repository_state_substitution_allowed": False,
+            "observer_in_subject_totals": False,
+            "packet_is_compute_report": False,
+            "packet_is_runtime_observation": False,
+            "runtime_observation_included": False,
+            "runtime_observation_required_for_runtime_classification": True,
+            "target_analysis_level": "artifact_observed",
+        },
+        "artifacts": [
+            {
+                "artifact_id": artifact_id,
+                "container_artifact_id": None,
+                "container_path_verified": True,
+                "content_kind": "json",
+                "digest_verified": True,
+                "display_path_or_uri": (
+                    f"{carrier.get('staged_relative_path', 'carrier.zip')}!/{member_path}"
+                ),
+                "media_type": "application/json",
+                "member_path": member_path,
+                "provider_binding": None,
+                "required_for_analysis": True,
+                "role": "preservation_manifest",
+                "sha256": hashlib.sha256(
+                    b"current-run-export-compatibility-probe"
+                ).hexdigest(),
+                "size_bytes": 1,
+                "size_verified": True,
+            }
+        ],
+        "authority_boundary": {
+            "activates_compute_gate": False,
+            "changes_gate_policy": False,
+            "changes_gate_semantics": False,
+            "changes_release_authority": False,
+            "creates_compute_budget": False,
+            "creates_gate_result": False,
+            "creates_release_decision": False,
+            "mutates_carrier": False,
+            "packet_is_release_authority": False,
+            "write_mode": "subject_input_only",
+            "writes_subject_run": False,
+            "writes_target_repository": False,
+        },
+        "authority_sources": authority_sources,
+        "carrier": {
+            "artifact_payload_mode": "external_carrier",
+            "carrier_id": carrier.get("carrier_id"),
+            "carrier_kind": "current_run_export_archive",
+            "immutable": True,
+            "media_type": "application/zip",
+            "path_or_uri": carrier.get(
+                "staged_relative_path",
+                "current-run-export-probe.zip",
+            ),
+            "provider_binding": copy.deepcopy(
+                carrier.get("provider_binding")
+            ),
+            "root_prefix": carrier.get("root_prefix"),
+            "sha256": carrier.get("sha256"),
+            "size_bytes": carrier.get("size_bytes"),
+        },
+        "content_boundary": {
+            "artifact_bytes_embedded": False,
+            "carrier_required_for_verification": True,
+            "packet_payload_mode": "metadata_only",
+            "raw_model_inputs_included": False,
+            "raw_model_outputs_included": False,
+            "raw_secrets_included": False,
+        },
+        "coverage": {
+            "artifact_graph_complete": False,
+            "artifacts_total": 1,
+            "carrier_binding_complete": True,
+            "coverage_status": "partial",
+            "missing_roles": missing_roles,
+            "provider_artifacts_bound": 0,
+            "provider_artifacts_total": 0,
+            "role_bindings_complete": False,
+            "role_bindings_resolved": 1,
+            "role_bindings_total": (
+                len(ROLE_BINDING_SCALAR_KEYS)
+                + len(ROLE_BINDING_LIST_KEYS)
+            ),
+            "source_bindings_complete": True,
+            "unresolved_artifact_ids": [],
+        },
+        "errors": [],
+        "ok": True,
+        "packet_identity": {
+            "canonicalization": "json-sort-keys-utf8-newline",
+            "carrier_id": carrier.get("carrier_id"),
+            "packet_created_utc": identity.get("expectation_created_utc"),
+            "packet_id": "subject-input:current-run-export-compatibility-probe",
+            "packet_scope": "current_run",
+            "subject_run_key": subject.get("subject_run_key"),
+        },
+        "packet_type": packet_contract.get("packet_type"),
+        "producer": {
+            "ci_workflow_or_job_identity": (
+                "current-run-export-cross-contract-probe"
+            ),
+            "producer_id": "producer:current-run-export-cross-contract-probe",
+            "producer_name": "PULSEmech current-run export cross-contract probe",
+            "producer_run_key": subject.get("subject_run_key"),
+            "producer_source": profile.get("expected_producer_source_path"),
+            "producer_source_revision": producer_component.get(
+                "source_revision"
+            ),
+            "producer_source_sha256": producer_component.get("sha256"),
+            "producer_version": producer_version,
+            "production_mode": "current_run_export",
+        },
+        "record_status": "observed",
+        "role_bindings": role_bindings,
+        "schema_version": packet_contract.get("schema_version"),
+        "subject": subject,
+    }
+
+
 def _carrier_digest_key_count(value: Any) -> int:
     if isinstance(value, dict):
         return sum(
@@ -389,11 +750,12 @@ def _provider_binding_ok(
 
 def _subject_input_cross_contract(
     *,
+    expectation: dict[str, Any],
     expectation_schema: dict[str, Any],
     subject_input_schema: dict[str, Any],
     packet_contract: dict[str, Any],
     profile: dict[str, Any],
-) -> tuple[bool, list[str]]:
+) -> tuple[bool, list[str], bool]:
     errors: list[str] = []
 
     expected_values = {
@@ -517,7 +879,19 @@ def _subject_input_cross_contract(
             f"derived_carrier_id_not_packet_safe: {derived_carrier_id!r}"
         )
 
-    return not errors, errors
+    witness = _subject_input_observed_witness(
+        expectation,
+        packet_contract=packet_contract,
+        profile=profile,
+    )
+    witness_valid, witness_errors = validate_instance(
+        subject_input_schema,
+        witness,
+        label="subject_input_observed_branch_witness",
+    )
+    errors.extend(witness_errors)
+
+    return not errors, errors, witness_valid
 
 
 def semantic_checks(
@@ -753,10 +1127,21 @@ def semantic_checks(
         ),
     )
     component_paths = [row.get("path") for row in component_rows]
+    canonical_component_paths = [
+        _canonical_component_path(path) for path in component_paths
+    ]
+    component_paths_canonical_ok = all(
+        path is not None for path in canonical_component_paths
+    )
+    record(
+        "control_plane_component_paths_canonical_ok",
+        component_paths_canonical_ok,
+    )
     record(
         "control_plane_component_paths_unique_ok",
-        all(isinstance(path, str) for path in component_paths)
-        and len(component_paths) == len(set(component_paths)),
+        component_paths_canonical_ok
+        and len(canonical_component_paths)
+        == len(set(canonical_component_paths)),
     )
 
     component_path_bindings_ok = (
@@ -803,12 +1188,21 @@ def semantic_checks(
         )
     record("observed_producer_bindings_ok", observed_producer_ok)
 
+    carrier_id = carrier.get("carrier_id")
+    carrier_prefix = (
+        f"carrier:{profile.get('expected_carrier_id_namespace')}/"
+    )
+    carrier_suffix = (
+        carrier_id[len(carrier_prefix):]
+        if isinstance(carrier_id, str)
+        and carrier_id.startswith(carrier_prefix)
+        else None
+    )
     record(
         "carrier_id_namespace_binding_ok",
-        isinstance(carrier.get("carrier_id"), str)
-        and carrier.get("carrier_id").startswith(
-            f"carrier:{profile.get('expected_carrier_id_namespace')}/"
-        ),
+        isinstance(carrier_suffix, str)
+        and bool(carrier_suffix)
+        and _canonical_component_path(carrier_suffix) is not None,
     )
     record(
         "carrier_layout_binding_ok",
@@ -881,11 +1275,21 @@ def semantic_checks(
         and _carrier_digest_key_count(expectation) == 0,
     )
 
-    cross_contract_ok, cross_contract_errors = _subject_input_cross_contract(
+    (
+        cross_contract_ok,
+        cross_contract_errors,
+        observed_branch_witness_ok,
+    ) = _subject_input_cross_contract(
+        expectation=expectation,
         expectation_schema=expectation_schema,
         subject_input_schema=subject_input_schema,
         packet_contract=packet_contract,
         profile=profile,
+    )
+    record(
+        "subject_input_observed_branch_witness_ok",
+        observed_branch_witness_ok,
+        " | ".join(cross_contract_errors) or None,
     )
     record(
         "subject_input_cross_contract_ok",
@@ -946,6 +1350,10 @@ def make_diagnostic(
     derived: dict[str, Any],
     input_identities: dict[str, Any],
     errors: list[str],
+    expectation_instance_valid: bool = False,
+    subject_input_observed_branch_valid: bool = False,
+    canonical_expectation_schema_path_verified: bool = False,
+    canonical_subject_input_schema_path_verified: bool = False,
 ) -> dict[str, Any]:
     return {
         "tool": TOOL_NAME,
@@ -955,15 +1363,30 @@ def make_diagnostic(
         "record_status": record_status,
         "ok": ok,
         "expectation_schema_valid": expectation_schema_valid,
+        "expectation_instance_valid": expectation_instance_valid,
         "subject_input_schema_valid": subject_input_schema_valid,
+        "subject_input_observed_branch_valid": (
+            subject_input_observed_branch_valid
+        ),
         "checks": dict(sorted(checks.items())),
         "derived": dict(sorted(derived.items())),
         "input_identities": dict(sorted(input_identities.items())),
         "verification_boundary": {
+            "canonical_expectation_schema_path_verified": (
+                canonical_expectation_schema_path_verified
+            ),
+            "canonical_subject_input_schema_path_verified": (
+                canonical_subject_input_schema_path_verified
+            ),
             "carrier_bytes_verified": False,
             "control_plane_component_bytes_verified": False,
-            "contract_semantics_verified": bool(ok),
+            "contract_semantics_verified": bool(
+                ok
+                and canonical_expectation_schema_path_verified
+                and canonical_subject_input_schema_path_verified
+            ),
             "subject_authority_source_bytes_verified": False,
+            "supplied_contract_semantics_verified": bool(ok),
         },
         "authority_effect": "none",
         "errors": sorted(set(errors)),
@@ -1005,6 +1428,15 @@ def build_diagnostic(
             errors=[f"read_error: {exc}"],
         )
         return diagnostic, 2
+
+    canonical_expectation_schema_path_verified = same_target(
+        schema_path,
+        DEFAULT_SCHEMA,
+    )
+    canonical_subject_input_schema_path_verified = same_target(
+        subject_input_schema_path,
+        DEFAULT_SUBJECT_INPUT_SCHEMA,
+    )
 
     input_identities = {
         "expectation": {
@@ -1060,39 +1492,40 @@ def build_diagnostic(
     try:
         jsonschema.Draft202012Validator.check_schema(expectation_schema)
     except Exception as exc:
-        expectation_schema_errors.append(f"expectation_schema_invalid: {exc}")
+        expectation_schema_errors.append(
+            f"expectation_schema_invalid: {type(exc).__name__}: {exc}"
+        )
     try:
         jsonschema.Draft202012Validator.check_schema(subject_input_schema)
     except Exception as exc:
-        subject_input_schema_errors.append(f"subject_input_schema_invalid: {exc}")
+        subject_input_schema_errors.append(
+            f"subject_input_schema_invalid: {type(exc).__name__}: {exc}"
+        )
 
     expectation_schema_valid = not expectation_schema_errors
     subject_input_schema_valid = not subject_input_schema_errors
     errors = expectation_schema_errors + subject_input_schema_errors
 
+    expectation_instance_valid = False
     if expectation_schema_valid:
-        errors.extend(schema_errors(expectation_schema, expectation))
-    record_schema_valid = (
-        expectation_schema_valid
-        and not any(error.startswith("schema_error[") for error in errors)
-    )
+        expectation_instance_valid, instance_errors = validate_instance(
+            expectation_schema,
+            expectation,
+            label="expectation_instance",
+        )
+        errors.extend(instance_errors)
 
     if not isinstance(expectation, dict):
-        diagnostic = make_diagnostic(
-            ok=False,
-            expectation_schema_valid=record_schema_valid,
-            subject_input_schema_valid=subject_input_schema_valid,
-            record_status=None,
-            checks={},
-            derived={},
-            input_identities=input_identities,
-            errors=errors + ["expectation_not_object"],
-        )
-        return diagnostic, 1
+        errors.append("expectation_not_object")
 
     checks: dict[str, bool] = {}
     derived: dict[str, Any] = {}
-    if record_schema_valid and subject_input_schema_valid:
+    subject_input_observed_branch_valid = False
+    if (
+        isinstance(expectation, dict)
+        and expectation_instance_valid
+        and subject_input_schema_valid
+    ):
         semantic, semantic_errors_list, derived = semantic_checks(
             expectation,
             expectation_text=expectation_text,
@@ -1103,11 +1536,15 @@ def build_diagnostic(
         )
         checks.update(semantic)
         errors.extend(semantic_errors_list)
+        subject_input_observed_branch_valid = bool(
+            checks.get("subject_input_observed_branch_witness_ok")
+        )
     else:
         checks["semantic_checks_skipped_due_to_schema_errors"] = False
 
     ok = (
-        record_schema_valid
+        expectation_schema_valid
+        and expectation_instance_valid
         and subject_input_schema_valid
         and bool(checks)
         and all(checks.values())
@@ -1115,9 +1552,23 @@ def build_diagnostic(
     )
     diagnostic = make_diagnostic(
         ok=ok,
-        expectation_schema_valid=record_schema_valid,
+        expectation_schema_valid=expectation_schema_valid,
+        expectation_instance_valid=expectation_instance_valid,
         subject_input_schema_valid=subject_input_schema_valid,
-        record_status=expectation.get("record_status"),
+        subject_input_observed_branch_valid=(
+            subject_input_observed_branch_valid
+        ),
+        canonical_expectation_schema_path_verified=(
+            canonical_expectation_schema_path_verified
+        ),
+        canonical_subject_input_schema_path_verified=(
+            canonical_subject_input_schema_path_verified
+        ),
+        record_status=(
+            expectation.get("record_status")
+            if isinstance(expectation, dict)
+            else None
+        ),
         checks=checks,
         derived=derived,
         input_identities=input_identities,
@@ -1128,7 +1579,12 @@ def build_diagnostic(
 
 def same_target(left: Path, right: Path) -> bool:
     try:
-        return left.resolve(strict=False) == right.resolve(strict=False)
+        if left.resolve(strict=False) == right.resolve(strict=False):
+            return True
+    except OSError:
+        pass
+    try:
+        return left.exists() and right.exists() and left.samefile(right)
     except OSError:
         return False
 
@@ -1139,7 +1595,7 @@ def reject_unsafe_output(
     schema_path: Path,
     expectation_path: Path,
     subject_input_schema_path: Path,
-    repository_root: Path,
+    repository_roots: tuple[Path, ...],
 ) -> None:
     if output is None:
         return
@@ -1176,17 +1632,126 @@ def reject_unsafe_output(
         cursor = cursor.parent
 
     try:
-        candidate.resolve(strict=False).relative_to(
-            repository_root.resolve(strict=True)
+        resolved_candidate = candidate.resolve(strict=False)
+    except OSError as exc:
+        raise SemanticError(
+            f"output_path_unresolvable: {candidate}: {exc}"
+        ) from exc
+
+    for repository_root in repository_roots:
+        try:
+            resolved_candidate.relative_to(repository_root)
+        except ValueError:
+            continue
+        raise SemanticError(
+            f"refusing_output_inside_repository: {resolved_candidate}"
         )
-    except (OSError, ValueError):
-        return
-    raise SemanticError(f"refusing_output_inside_repository: {candidate}")
 
 
-def atomic_write(path: Path, text: str) -> None:
+def _open_or_create_directory_posix(path: Path, *, label: str) -> int:
+    candidate = _normalized_absolute_path(path)
+    parts = candidate.parts
+    if not candidate.is_absolute() or not parts:
+        raise SemanticError(f"{label}_path_not_absolute: {candidate}")
+
+    flags = os.O_RDONLY
+    flags |= int(getattr(os, "O_DIRECTORY", 0))
+    flags |= int(getattr(os, "O_CLOEXEC", 0))
+    flags |= int(getattr(os, "O_NOFOLLOW", 0))
+
+    current_fd: int | None = None
+    try:
+        current_fd = os.open(parts[0], flags)
+        for part in parts[1:]:
+            try:
+                next_fd = os.open(part, flags, dir_fd=current_fd)
+            except FileNotFoundError:
+                try:
+                    os.mkdir(part, mode=0o700, dir_fd=current_fd)
+                except FileExistsError:
+                    pass
+                next_fd = os.open(part, flags, dir_fd=current_fd)
+            os.close(current_fd)
+            current_fd = next_fd
+        if current_fd is None:
+            raise SemanticError(f"{label}_open_failed: {candidate}")
+        result = current_fd
+        current_fd = None
+        return result
+    except OSError as exc:
+        if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+            raise SemanticError(
+                f"{label}_symlink_or_non_directory_component_rejected: "
+                f"{candidate}: {exc}"
+            ) from exc
+        raise SemanticError(f"{label}_open_failed: {candidate}: {exc}") from exc
+    finally:
+        if current_fd is not None:
+            try:
+                os.close(current_fd)
+            except OSError:
+                pass
+
+
+def _write_all(descriptor: int, payload: bytes) -> None:
+    offset = 0
+    while offset < len(payload):
+        written = os.write(descriptor, payload[offset:])
+        if written <= 0:
+            raise SemanticError("output_write_returned_zero")
+        offset += written
+
+
+def _atomic_write_posix(path: Path, payload: bytes) -> None:
+    candidate = _normalized_absolute_path(path)
+    if not candidate.name or candidate.name in {".", ".."}:
+        raise SemanticError(f"output_leaf_name_invalid: {candidate}")
+    parent_fd = _open_or_create_directory_posix(
+        candidate.parent,
+        label="output_parent",
+    )
+    temp_name = f".{candidate.name}.{secrets.token_hex(16)}.tmp"
+    descriptor: int | None = None
+    try:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        flags |= int(getattr(os, "O_CLOEXEC", 0))
+        flags |= int(getattr(os, "O_NOFOLLOW", 0))
+        flags |= int(getattr(os, "O_BINARY", 0))
+        descriptor = os.open(
+            temp_name,
+            flags,
+            0o600,
+            dir_fd=parent_fd,
+        )
+        _write_all(descriptor, payload)
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = None
+        os.replace(
+            temp_name,
+            candidate.name,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+        )
+        os.fsync(parent_fd)
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        try:
+            os.unlink(temp_name, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        finally:
+            os.close(parent_fd)
+
+
+def _atomic_write_fallback(path: Path, text: str) -> None:
     parent = path.parent
     parent.mkdir(parents=True, exist_ok=True)
+    reject_symlink_components(parent, label="output_parent")
     if not parent.is_dir():
         raise SemanticError(f"output_parent_not_directory: {parent}")
 
@@ -1206,12 +1771,26 @@ def atomic_write(path: Path, text: str) -> None:
             handle.write(text)
             handle.flush()
             os.fsync(handle.fileno())
+        reject_symlink_components(parent, label="output_parent")
         os.replace(temp, path)
     finally:
         try:
             temp.unlink()
         except FileNotFoundError:
             pass
+
+
+def atomic_write(path: Path, text: str) -> None:
+    candidate = _normalized_absolute_path(path)
+    payload = text.encode("utf-8")
+    if (
+        os.name != "nt"
+        and os.open in os.supports_dir_fd
+        and os.rename in os.supports_dir_fd
+    ):
+        _atomic_write_posix(candidate, payload)
+        return
+    _atomic_write_fallback(candidate, text)
 
 
 def parse_args() -> argparse.Namespace:
@@ -1260,16 +1839,28 @@ def main() -> int:
     schema_path = Path(args.schema)
     expectation_path = Path(args.expectation)
     subject_input_schema_path = Path(args.subject_input_schema)
-    repository_root = Path(args.repository_root)
+    repository_root_argument = Path(args.repository_root)
     output = Path(args.output) if args.output else None
 
     try:
+        repository_root = _validated_directory_root(
+            repository_root_argument,
+            label="repository_root",
+        )
+        validator_repository_root = _validated_directory_root(
+            ROOT,
+            label="validator_repository_root",
+        )
         reject_unsafe_output(
             output,
             schema_path=schema_path,
             expectation_path=expectation_path,
             subject_input_schema_path=subject_input_schema_path,
-            repository_root=repository_root,
+            repository_roots=tuple(
+                dict.fromkeys(
+                    (validator_repository_root, repository_root)
+                )
+            ),
         )
     except SemanticError as exc:
         diagnostic = make_diagnostic(
@@ -1305,6 +1896,28 @@ def main() -> int:
                 ),
                 subject_input_schema_valid=diagnostic.get(
                     "subject_input_schema_valid",
+                    False,
+                ),
+                expectation_instance_valid=diagnostic.get(
+                    "expectation_instance_valid",
+                    False,
+                ),
+                subject_input_observed_branch_valid=diagnostic.get(
+                    "subject_input_observed_branch_valid",
+                    False,
+                ),
+                canonical_expectation_schema_path_verified=diagnostic.get(
+                    "verification_boundary",
+                    {},
+                ).get(
+                    "canonical_expectation_schema_path_verified",
+                    False,
+                ),
+                canonical_subject_input_schema_path_verified=diagnostic.get(
+                    "verification_boundary",
+                    {},
+                ).get(
+                    "canonical_subject_input_schema_path_verified",
                     False,
                 ),
                 record_status=diagnostic.get("record_status"),


### PR DESCRIPTION
### Summary

Add the strict semantic validator for the merged PULSEmech current-run export
expectation contract:

```text
tools/check_pulsemech_compute_current_run_export_expectation_v0.py
```

The validator consumes:

```text
current-run export expectation schema
+
current-run export expectation record
+
existing subject-input packet schema
→ deterministic validation diagnostic
```

The tool verifies both:

```text
document shape
```

and:

```text
cross-field mechanical relations
```

This pull request adds the validator only.

It does not add its regression suite, tools-test registration, expectation
builder, carrier builder, carrier loader, current-run subject-input producer,
workflow integration, candidate materialization, runtime observation, compute
budget, gate activation, or release authority.

### Validator identity

```text
tool:
check_pulsemech_compute_current_run_export_expectation_v0

tool version:
0.1.0

schema version:
pulsemech_compute_current_run_export_expectation_v0

document type:
pulsemech_compute_current_run_export_expectation
```

Default inputs:

```text
schemas/
pulsemech_compute_current_run_export_expectation_v0.schema.json

examples/compute/
pulsemech_compute_current_run_export_expectation_example_v0.json

schemas/
pulsemech_compute_subject_input_packet_v0.schema.json
```

### Input-reading boundary

Each input is read as a bounded regular file.

The validator rejects:

```text
missing inputs
non-regular inputs
symlinked input files
symlinked input path components
oversized files
file-size changes during reading
invalid UTF-8
UTF-8 BOM
malformed JSON
duplicate object keys
NaN
Infinity
-Infinity
```

Maximum input sizes are fixed independently for:

```text
expectation schema:
1 MiB

subject-input packet schema:
1 MiB

expectation record:
8 MiB
```

The validator does not silently accept last-key-wins JSON parsing.

### JSON Schema validation

The tool performs:

```text
Draft 2020-12 schema self-check
+
format-aware expectation validation
```

for the exact supplied expectation schema.

It separately self-checks the downstream subject-input packet schema before
using it as a cross-contract source.

Semantic checks are not treated as successful when either schema is invalid.

### Canonical JSON validation

The validator requires the expectation record to satisfy its declared
canonicalization:

```text
json-sort-keys-utf8-newline
```

It verifies:

```text
all object keys recursively sorted
two-space JSON rendering
ensure_ascii=false
allow_nan=false
exact byte equality with canonical re-rendering
exactly one final newline
```

A schema-valid record with non-canonical bytes is rejected.

### Example-versus-observed branch

For a checked-in example, the validator requires:

```text
record_status:
example

expectation_identity.expectation_scope:
example

expectation_producer:
absent

fixture_provenance:
present

fixture_provenance.expectation_producer_execution_claimed:
false

carrier.carrier_kind:
example_archive

carrier.producer:
null
```

It also verifies that:

```text
fixture_provenance.schema_identity
=
root schema_version
```

and that:

```text
fixture_provenance.fixture_source_path
=
the expectation file's actual repository-relative path
```

For a machine-produced observed expectation, it requires:

```text
record_status:
observed

expectation_identity.expectation_scope:
current_run_export

fixture_provenance:
absent

expectation_producer:
present

carrier.carrier_kind:
current_run_export_archive

carrier.producer:
present
```

The root fixture state is therefore mechanically distinct from the nested
future packet contract.

### Subject-run binding

The validator recomputes the canonical subject-run key:

```text
GITHUB_RUN_ID=<workflow_run_id>
|
GITHUB_RUN_ATTEMPT=<workflow_run_attempt>
|
GITHUB_WORKFLOW=<workflow_name>
```

It requires exact equality among:

```text
expectation_identity.subject_run_key

subject.subject_run_key

packet_producer_profile.expected_subject_run_key

recomputed canonical subject-run key
```

It also requires:

```text
packet_producer_profile.expected_repository
=
subject.repository

packet_producer_profile.expected_source_commit
=
subject.source_commit
```

### Workflow reference binding

The canonical workflow reference is recomputed as:

```text
<repository>/<workflow_path>@<source_ref>
```

The validator requires:

```text
subject.workflow_ref
=
recomputed workflow ref
=
authority_sources.workflow.workflow_ref
```

The workflow authority-source record must also match:

```text
source_id:
source:workflow

role:
workflow

path_or_uri:
subject.workflow_path

source_revision:
subject.source_commit

workflow_name:
subject.workflow_name
```

### Policy and registry binding

The policy authority-source record must satisfy:

```text
source_id:
source:policy

role:
policy

source_revision:
subject.source_commit

policy_id:
subject.policy_id

sha256:
subject.policy_sha256
```

The gate-registry source must satisfy:

```text
source_id:
source:gate-registry

role:
gate_registry

source_revision:
subject.source_commit
```

All authority-source records must be bound to the exact subject revision
declared by the expectation.

### Authority-source identity checks

The validator flattens:

```text
workflow
policy
gate registry
additional sources
```

and enforces:

```text
globally unique source IDs
source: namespace compliance
subject-revision consistency
deterministic additional-source ordering
exactly one matching external-signer-policy source
```

The external signer-policy path must match:

```text
packet_producer_profile.expected_signer_policy_path
```

### Protected control-plane contract

The validator requires the complete component set:

```text
carrier_loader
control_plane_workflow
expectation_builder
expectation_schema
expectation_validator
subject_input_producer_core
subject_input_producer_wrapper
subject_input_schema
subject_input_validator
```

It verifies:

```text
all nine components are present
all component revisions equal the protected control-plane revision
all component paths are unique
```

It binds the canonical component paths for:

```text
expectation schema

expectation validator

subject-input packet schema

subject-input packet validator

subject-input producer core
```

The declared subject-input producer-wrapper component must match:

```text
packet_producer_profile.expected_producer_source_path
```

The validator checks control-plane identity relations.

It does not claim to authenticate or read the component bytes in this PR.

### Observed producer binding

For an observed expectation, the expectation producer must match the protected
`expectation_builder` component through:

```text
producer source path
producer source revision
producer source SHA-256
producer version
protected control-plane revision
subject-run key
```

The carrier producer must match:

```text
subject-run key
protected control-plane revision
```

Example fixtures bypass no producer rule; their producer fields must remain
absent or null according to the example branch.

### Producer-profile binding

The validator requires:

```text
packet_producer_profile.expected_repository
=
subject.repository

packet_producer_profile.expected_source_commit
=
subject.source_commit

packet_producer_profile.expected_subject_run_key
=
subject.subject_run_key

packet_producer_profile.expected_archive_layout_id
=
archive_layout.layout_id
```

The nested packet contract must match the profile through:

```text
production mode
packet scope
carrier kind
artifact payload mode
```

### Downstream subject-input contract

The validator independently reads the merged:

```text
schemas/pulsemech_compute_subject_input_packet_v0.schema.json
```

It requires the expectation's nested packet contract to remain compatible with
the downstream contract:

```text
schema_version:
pulsemech_compute_subject_input_packet_v0

packet_type:
pulsemech_compute_subject_input_packet

record_status:
observed

production_mode:
current_run_export

packet_scope:
current_run

carrier_kind:
current_run_export_archive

artifact_payload_mode:
external_carrier

write_mode:
subject_input_only
```

It also verifies that:

```text
source IDs satisfy the downstream source-ID pattern
```

and that a generated carrier ID of the form:

```text
carrier:<expected namespace>/generated-suffix
```

satisfies the downstream carrier-ID grammar.

### Carrier identity and namespace

The validator requires:

```text
carrier.carrier_id
```

to begin with:

```text
carrier:<packet_producer_profile.expected_carrier_id_namespace>/
```

It verifies that carrier byte identity is authoritative only at:

```text
carrier.sha256
```

A second field named:

```text
carrier_sha256
```

anywhere in the expectation is rejected semantically.

The validator does not open or hash the carrier payload in this PR.

### Carrier finalization and provider binding

The tool requires:

```text
carrier.finalized_utc
<=
expectation_identity.expectation_created_utc
```

When provider binding is present, it verifies:

```text
provider SHA-256
=
carrier SHA-256

provider size
=
carrier size

downloaded_sha256_matches:
true

downloaded_size_matches:
true
```

It also verifies the time relation:

```text
provider creation
<=
carrier finalization
<=
provider expiration
```

when the provider timestamps are present.

Null provider identities remain valid where the schema permits them.

### Archive-layout semantics

The validator requires:

```text
carrier.root_prefix
=
archive_layout.outer_prefix
```

It verifies:

```text
outer prefix ends with /
original-artifacts prefix begins with outer prefix
original-artifacts prefix is not equal to outer prefix
original-artifacts prefix ends with /
```

The three visible preservation members must be distinct.

The following archive names must also be distinct:

```text
complete package
package-completeness archive
independent-verification archive
```

Each package name must end with:

```text
.zip
```

Visible preservation members and package archive names must not collide.

### Artifact-count derivation

The only accepted derivation is:

```text
artifact_count_derivation:
provider_plus_non_provider
```

The validator computes:

```text
derived artifact count
=
expected provider-artifact count
+
expected non-provider artifact count
```

It requires:

```text
provider count >= 1

non-provider count >= number of visible preservation members

obsolete expected_artifact_count field absent
```

The calculated total is emitted in the diagnostic under:

```text
derived.artifact_count
```

### Content boundary

The validator requires the exact closed content boundary:

```text
expectation_payload_mode:
metadata_only

contains_artifact_payloads:
false

contains_runtime_observation:
false

contains_resource_measurement:
false

contains_secret_material:
false

consumer_must_verify_carrier_bytes:
true
```

Any additional or contradictory content claim fails validation.

### Authority boundary

The validator requires the exact closed authority boundary:

```text
write_mode:
expectation_only

writes_subject_run:
false

writes_target_repository:
false

mutates_carrier:
false

changes_release_authority:
false

changes_gate_policy:
false

changes_gate_semantics:
false

creates_release_decision:
false

creates_gate_result:
false

activates_compute_gate:
false

creates_compute_budget:
false

expectation_is_release_authority:
false

produced_packet_is_release_authority:
false
```

The validator diagnostic always records:

```text
authority_effect:
none
```

### Record terminal state

The tool verifies:

```text
active_policy_sets:
ordered, unique, non-empty strings
```

It requires deterministic error ordering and the terminal relation:

```text
ok=true
→ errors=[]

ok=false
→ one or more errors
```

### Deterministic diagnostic

The validator emits a canonical JSON diagnostic containing:

```text
tool identity
tool version
schema and document identity
record status
expectation-schema validity
subject-input-schema validity
sorted semantic checks
derived relations
input SHA-256 and byte sizes
explicit verification boundary
authority effect
sorted unique errors
terminal ok state
```

The input identity section records the digest and size of:

```text
expectation record
expectation schema
subject-input packet schema
```

### Explicit verification boundary

A successful diagnostic records:

```text
contract_semantics_verified:
true
```

It also records these limits:

```text
carrier_bytes_verified:
false

control_plane_component_bytes_verified:
false

subject_authority_source_bytes_verified:
false
```

This validator establishes contract and relation validity.

The later carrier loader, protected control-plane verifier, and source verifier
remain separate machines.

### Output boundary

The diagnostic is always written deterministically to standard output.

An optional output file may be written only outside the repository.

The validator rejects output that:

```text
overwrites an input
overwrites the validator
uses a protected authority or contract filename
is inside the repository
contains a symlinked path component
```

Protected output names include:

```text
status.json
release_decision_v0.json
release_authority_v0.json
pulsemech_compute_current_run_export_expectation_v0.json
pulsemech_compute_subject_input_packet_v0.json
```

External output uses temporary-file creation, flush, `fsync`, and atomic
replacement.

### Scope

This pull request adds exactly one new file:

```text
tools/check_pulsemech_compute_current_run_export_expectation_v0.py
```

It does not modify:

```text
current-run expectation schema
checked-in expectation example
subject-input packet schema
subject-input packet validator
fixed-source producer wrapper
reusable producer core
historical #6066 packet
preservation carrier
analyzer core
planned-observed relation
candidate materializer
tools-tests manifest
workflow files
gate policy
gate registry
status
release authority
```

### Non-implementation boundary

This pull request does not add:

```text
validator regression
tools-test registration
expectation builder
current-run carrier builder
current-run carrier loader
current-run subject-input producer wrapper
current-run carrier publication
workflow wiring
artifact-observed report production
planned-observed relation production
candidate materialization
runtime-observation production
resource measurement
compute budget
gate activation
release-required enforcement
release authority
```

Authority effect:

```text
none
```

Gate effect:

```text
none
```

Policy effect:

```text
none
```

Workflow effect:

```text
none
```

Release effect:

```text
none
```

### Validation

Local validation completed for the new tool:

```text
Python syntax compilation:
PASS

merged expectation schema:
PASS

merged checked-in example:
PASS

existing subject-input packet schema cross-contract check:
PASS

canonical JSON validation:
PASS

semantic relation checks:
PASS
```

Negative synthetic cases were rejected for:

```text
duplicate JSON key
subject-run mismatch
workflow-reference mismatch
duplicate authority-source ID
non-deterministic additional-source ordering
control-plane revision mismatch
producer-wrapper component mismatch
carrier namespace mismatch
carrier-finalization time inversion
policy digest mismatch
```

File identity:

```text
lines:
1325

bytes:
43686

SHA-256:
171b6f791a3cbc1ea11ae7afc4cce666fd2d14d8fa8721d33c40204ba841eb7d

final newline:
present
```

The next separate implementation item is:

```text
tests/test_check_pulsemech_compute_current_run_export_expectation_v0.py
```