### PR TITLE
fix(compute): close expectation validator trust boundaries

### DIFF
--- a/tools/check_pulsemech_compute_current_run_export_expectation_v0.py
+++ b/tools/check_pulsemech_compute_current_run_export_expectation_v0.py
@@ -5,6 +5,7 @@ import argparse
 import copy
 import errno
 import hashlib
+import inspect
 import json
 import os
 import re
@@ -12,13 +13,20 @@ import secrets
 import stat
 import sys
 import tempfile
+import warnings
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Any
+from urllib.parse import unquote
 
 import jsonschema
-from referencing import Registry
-from referencing.exceptions import NoSuchResource
+
+try:
+    from referencing import Registry as ReferencingRegistry
+    from referencing.exceptions import NoSuchResource
+except ImportError:
+    ReferencingRegistry = None
+    NoSuchResource = None
 
 
 TOOL_NAME = "check_pulsemech_compute_current_run_export_expectation_v0"
@@ -72,6 +80,39 @@ SCHEMA_REFERENCE_KEYWORDS = frozenset(
     {"$ref", "$dynamicRef", "$recursiveRef"}
 )
 SCHEMA_REFERENCE_POLICY = "internal_fragment_only"
+
+SCHEMA_SINGLE_SUBSCHEMA_KEYWORDS = frozenset(
+    {
+        "additionalProperties",
+        "contains",
+        "contentSchema",
+        "else",
+        "if",
+        "items",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    }
+)
+SCHEMA_ARRAY_SUBSCHEMA_KEYWORDS = frozenset(
+    {
+        "allOf",
+        "anyOf",
+        "oneOf",
+        "prefixItems",
+    }
+)
+SCHEMA_MAPPING_SUBSCHEMA_KEYWORDS = frozenset(
+    {
+        "$defs",
+        "definitions",
+        "dependentSchemas",
+        "patternProperties",
+        "properties",
+    }
+)
 
 CONTROL_PLANE_COMPONENT_KEYS = (
     "carrier_loader",
@@ -206,11 +247,81 @@ def _external_output_mode() -> str:
     )
 
 
+class ClosedSchemaReferenceError(RuntimeError):
+    pass
+
+
+def _registry_api_available() -> bool:
+    if ReferencingRegistry is None or NoSuchResource is None:
+        return False
+    try:
+        parameters = inspect.signature(
+            jsonschema.Draft202012Validator.__init__
+        ).parameters
+    except (TypeError, ValueError):
+        return False
+    return "registry" in parameters
+
+
 def _deny_schema_retrieval(uri: str) -> Any:
+    if NoSuchResource is None:
+        raise ClosedSchemaReferenceError(
+            f"external schema retrieval denied: {uri}"
+        )
     raise NoSuchResource(ref=uri)
 
 
-CLOSED_SCHEMA_REGISTRY = Registry(retrieve=_deny_schema_retrieval)
+CLOSED_SCHEMA_REGISTRY = (
+    ReferencingRegistry(retrieve=_deny_schema_retrieval)
+    if _registry_api_available()
+    else None
+)
+
+
+def _jsonschema_ref_resolver_class() -> type[Any]:
+    # jsonschema>=4.0 exposes RefResolver. jsonschema>=4.18 deprecates it,
+    # but the repository supports the full >=4.0,<5 range. This fallback is
+    # used only when the newer registry constructor API is unavailable.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        resolver_class = getattr(jsonschema, "RefResolver", None)
+    if resolver_class is None:
+        raise RuntimeError("jsonschema_compatible_ref_resolver_unavailable")
+    return resolver_class
+
+
+_JSONSCHEMA_REF_RESOLVER = _jsonschema_ref_resolver_class()
+
+
+class ClosedSchemaRefResolver(_JSONSCHEMA_REF_RESOLVER):
+    def resolve_remote(self, uri: str) -> Any:
+        raise ClosedSchemaReferenceError(
+            f"external schema retrieval denied: {uri}"
+        )
+
+
+def _closed_schema_resolver(schema: dict[str, Any]) -> Any:
+    return ClosedSchemaRefResolver.from_schema(
+        schema,
+        cache_remote=False,
+    )
+
+
+def _build_closed_validator(schema: dict[str, Any]) -> Any:
+    common = {
+        "format_checker": jsonschema.FormatChecker(),
+    }
+    if CLOSED_SCHEMA_REGISTRY is not None:
+        return jsonschema.Draft202012Validator(
+            schema,
+            registry=CLOSED_SCHEMA_REGISTRY,
+            **common,
+        )
+    return jsonschema.Draft202012Validator(
+        schema,
+        resolver=_closed_schema_resolver(schema),
+        **common,
+    )
 
 
 def _json_pointer(parts: tuple[Any, ...]) -> str:
@@ -222,45 +333,197 @@ def _json_pointer(parts: tuple[Any, ...]) -> str:
     )
 
 
+def _decode_json_pointer_token(value: str) -> str:
+    return value.replace("~1", "/").replace("~0", "~")
+
+
+def _find_internal_anchor_targets(
+    root: Any,
+    reference: str,
+) -> list[tuple[Any, tuple[Any, ...]]]:
+    if not reference.startswith("#") or reference in {"#"} or reference.startswith("#/"):
+        return []
+
+    fragment = unquote(reference[1:])
+    if not fragment:
+        return []
+
+    matches: list[tuple[Any, tuple[Any, ...]]] = []
+    pending: list[tuple[Any, tuple[Any, ...]]] = [(root, ())]
+    visited: set[int] = set()
+    while pending:
+        value, value_path = pending.pop()
+        if isinstance(value, (dict, list)):
+            identity = id(value)
+            if identity in visited:
+                continue
+            visited.add(identity)
+        if isinstance(value, dict):
+            if (
+                value.get("$anchor") == fragment
+                or value.get("$dynamicAnchor") == fragment
+                or value.get("$id") == f"#{fragment}"
+                or value.get("id") == f"#{fragment}"
+            ):
+                matches.append((value, value_path))
+            pending.extend(
+                (item, value_path + (key,))
+                for key, item in sorted(value.items(), reverse=True)
+            )
+        elif isinstance(value, list):
+            pending.extend(
+                (item, value_path + (index,))
+                for index, item in reversed(list(enumerate(value)))
+            )
+    return matches
+
+
+def _resolve_internal_pointer(
+    root: Any,
+    reference: str,
+) -> tuple[Any, tuple[Any, ...]] | None:
+    if reference == "#":
+        return root, ()
+    if not reference.startswith("#/"):
+        return None
+
+    fragment = unquote(reference[1:])
+    if not fragment.startswith("/"):
+        return None
+
+    cursor = root
+    resolved_path: list[Any] = []
+    for raw_token in fragment[1:].split("/"):
+        token = _decode_json_pointer_token(raw_token)
+        if isinstance(cursor, dict):
+            if token not in cursor:
+                return None
+            cursor = cursor[token]
+            resolved_path.append(token)
+            continue
+        if isinstance(cursor, list):
+            if not token.isdigit():
+                return None
+            index = int(token, 10)
+            if index < 0 or index >= len(cursor):
+                return None
+            cursor = cursor[index]
+            resolved_path.append(index)
+            continue
+        return None
+    return cursor, tuple(resolved_path)
+
+
+def _schema_children(
+    schema: dict[str, Any],
+    *,
+    path: tuple[Any, ...],
+) -> list[tuple[Any, tuple[Any, ...]]]:
+    children: list[tuple[Any, tuple[Any, ...]]] = []
+
+    for keyword in sorted(SCHEMA_SINGLE_SUBSCHEMA_KEYWORDS):
+        if keyword not in schema:
+            continue
+        value = schema[keyword]
+        keyword_path = path + (keyword,)
+        if isinstance(value, (dict, bool)):
+            children.append((value, keyword_path))
+        elif keyword == "items" and isinstance(value, list):
+            # An array-valued items keyword is not valid Draft 2020-12, but
+            # each entry is still scanned as a schema-shaped value before the
+            # schema self-check reports the draft violation.
+            children.extend(
+                (item, keyword_path + (index,))
+                for index, item in enumerate(value)
+                if isinstance(item, (dict, bool))
+            )
+
+    for keyword in sorted(SCHEMA_ARRAY_SUBSCHEMA_KEYWORDS):
+        value = schema.get(keyword)
+        if not isinstance(value, list):
+            continue
+        keyword_path = path + (keyword,)
+        children.extend(
+            (item, keyword_path + (index,))
+            for index, item in enumerate(value)
+            if isinstance(item, (dict, bool))
+        )
+
+    for keyword in sorted(SCHEMA_MAPPING_SUBSCHEMA_KEYWORDS):
+        value = schema.get(keyword)
+        if not isinstance(value, dict):
+            continue
+        keyword_path = path + (keyword,)
+        children.extend(
+            (item, keyword_path + (name,))
+            for name, item in sorted(value.items())
+            if isinstance(item, (dict, bool))
+        )
+
+    return children
+
+
 def schema_reference_policy_errors(
     value: Any,
     *,
     label: str,
     path: tuple[Any, ...] = (),
 ) -> list[str]:
+    # Traverse only positions which Draft 2020-12 evaluates as schemas.
+    # Property names such as properties["$ref"] and instance/annotation data
+    # under const, enum, default, or examples are not reference keywords.
+    # Internal JSON-Pointer references are followed so a schema reached
+    # through a local pointer cannot hide an external reference in data that
+    # becomes schema-valued only through that pointer.
     errors: list[str] = []
-    if isinstance(value, dict):
-        for key in sorted(value):
-            item = value[key]
-            item_path = path + (key,)
-            if key in SCHEMA_REFERENCE_KEYWORDS:
-                if not isinstance(item, str):
-                    errors.append(
-                        f"{label}_reference_not_string"
-                        f"[{_json_pointer(item_path)}]"
-                    )
-                elif not item.startswith("#"):
-                    errors.append(
-                        f"{label}_external_reference_not_permitted"
-                        f"[{_json_pointer(item_path)}]: {item!r}"
-                    )
-            errors.extend(
-                schema_reference_policy_errors(
-                    item,
-                    label=label,
-                    path=item_path,
+    pending: list[tuple[Any, tuple[Any, ...]]] = [(value, path)]
+    visited: set[int] = set()
+
+    while pending:
+        schema, schema_path = pending.pop()
+        if isinstance(schema, bool):
+            continue
+        if not isinstance(schema, dict):
+            continue
+
+        identity = id(schema)
+        if identity in visited:
+            continue
+        visited.add(identity)
+
+        for keyword in sorted(SCHEMA_REFERENCE_KEYWORDS):
+            if keyword not in schema:
+                continue
+            reference = schema[keyword]
+            reference_path = schema_path + (keyword,)
+            if not isinstance(reference, str):
+                errors.append(
+                    f"{label}_reference_not_string"
+                    f"[{_json_pointer(reference_path)}]"
                 )
-            )
-    elif isinstance(value, list):
-        for index, item in enumerate(value):
-            errors.extend(
-                schema_reference_policy_errors(
-                    item,
-                    label=label,
-                    path=path + (index,),
+                continue
+            if not reference.startswith("#"):
+                errors.append(
+                    f"{label}_external_reference_not_permitted"
+                    f"[{_json_pointer(reference_path)}]: {reference!r}"
                 )
+                continue
+
+            resolved = _resolve_internal_pointer(value, reference)
+            if resolved is not None:
+                pending.append(resolved)
+            pending.extend(
+                _find_internal_anchor_targets(value, reference)
             )
-    return errors
+
+        pending.extend(
+            _schema_children(
+                schema,
+                path=schema_path,
+            )
+        )
+
+    return sorted(set(errors))
 
 
 def git_blob_sha1(payload: bytes) -> str:
@@ -512,11 +775,7 @@ def validate_instance(
         return False, reference_errors
 
     try:
-        validator = jsonschema.Draft202012Validator(
-            schema,
-            format_checker=jsonschema.FormatChecker(),
-            registry=CLOSED_SCHEMA_REGISTRY,
-        )
+        validator = _build_closed_validator(schema)
         validation_errors = sorted(
             list(validator.iter_errors(value)),
             key=lambda item: (

--- a/tools/check_pulsemech_compute_current_run_export_expectation_v0.py
+++ b/tools/check_pulsemech_compute_current_run_export_expectation_v0.py
@@ -17,6 +17,8 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 import jsonschema
+from referencing import Registry
+from referencing.exceptions import NoSuchResource
 
 
 TOOL_NAME = "check_pulsemech_compute_current_run_export_expectation_v0"
@@ -59,6 +61,17 @@ SUBJECT_INPUT_VALIDATOR_PATH = (
 SUBJECT_INPUT_PRODUCER_CORE_PATH = (
     "tools/pulsemech_compute_subject_input_packet_producer_core_v0.py"
 )
+
+CANONICAL_EXPECTATION_SCHEMA_GIT_BLOB_SHA1 = (
+    "c0bc5a21f5bf46c529341d2e805f26525c70c7f4"
+)
+CANONICAL_SUBJECT_INPUT_SCHEMA_GIT_BLOB_SHA1 = (
+    "e1f982ffaf900c6c17745624d80f9f38b374448b"
+)
+SCHEMA_REFERENCE_KEYWORDS = frozenset(
+    {"$ref", "$dynamicRef", "$recursiveRef"}
+)
+SCHEMA_REFERENCE_POLICY = "internal_fragment_only"
 
 CONTROL_PLANE_COMPONENT_KEYS = (
     "carrier_loader",
@@ -158,6 +171,104 @@ def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
 
 def reject_non_finite(value: str) -> None:
     raise StrictJsonError(f"non-finite JSON value: {value}")
+
+
+def _strict_descriptor_snapshot_available() -> bool:
+    return (
+        os.name != "nt"
+        and os.open in os.supports_dir_fd
+        and hasattr(os, "O_DIRECTORY")
+        and hasattr(os, "O_NOFOLLOW")
+    )
+
+
+def _strict_output_descriptor_binding_available() -> bool:
+    return (
+        _strict_descriptor_snapshot_available()
+        and os.rename in os.supports_dir_fd
+        and os.unlink in os.supports_dir_fd
+    )
+
+
+def _input_snapshot_mode() -> str:
+    return (
+        "posix_descriptor_chain"
+        if _strict_descriptor_snapshot_available()
+        else "path_identity_fallback"
+    )
+
+
+def _external_output_mode() -> str:
+    return (
+        "posix_directory_descriptor_atomic_replace"
+        if _strict_output_descriptor_binding_available()
+        else "path_atomic_replace_fallback"
+    )
+
+
+def _deny_schema_retrieval(uri: str) -> Any:
+    raise NoSuchResource(ref=uri)
+
+
+CLOSED_SCHEMA_REGISTRY = Registry(retrieve=_deny_schema_retrieval)
+
+
+def _json_pointer(parts: tuple[Any, ...]) -> str:
+    if not parts:
+        return "/"
+    return "/" + "/".join(
+        str(part).replace("~", "~0").replace("/", "~1")
+        for part in parts
+    )
+
+
+def schema_reference_policy_errors(
+    value: Any,
+    *,
+    label: str,
+    path: tuple[Any, ...] = (),
+) -> list[str]:
+    errors: list[str] = []
+    if isinstance(value, dict):
+        for key in sorted(value):
+            item = value[key]
+            item_path = path + (key,)
+            if key in SCHEMA_REFERENCE_KEYWORDS:
+                if not isinstance(item, str):
+                    errors.append(
+                        f"{label}_reference_not_string"
+                        f"[{_json_pointer(item_path)}]"
+                    )
+                elif not item.startswith("#"):
+                    errors.append(
+                        f"{label}_external_reference_not_permitted"
+                        f"[{_json_pointer(item_path)}]: {item!r}"
+                    )
+            errors.extend(
+                schema_reference_policy_errors(
+                    item,
+                    label=label,
+                    path=item_path,
+                )
+            )
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            errors.extend(
+                schema_reference_policy_errors(
+                    item,
+                    label=label,
+                    path=path + (index,),
+                )
+            )
+    return errors
+
+
+def git_blob_sha1(payload: bytes) -> str:
+    encoded = f"blob {len(payload)}\0".encode("ascii") + payload
+    try:
+        return hashlib.sha1(encoded, usedforsecurity=False).hexdigest()
+    except TypeError:
+        return hashlib.sha1(encoded).hexdigest()
 
 
 def _normalized_absolute_path(path: Path) -> Path:
@@ -296,7 +407,7 @@ def _open_nofollow_fallback(path: Path, *, label: str) -> int:
 
 
 def _open_nofollow(path: Path, *, label: str) -> int:
-    if os.name != "nt" and os.open in os.supports_dir_fd:
+    if _strict_descriptor_snapshot_available():
         return _open_nofollow_posix(path, label=label)
     return _open_nofollow_fallback(path, label=label)
 
@@ -393,10 +504,18 @@ def validate_instance(
     *,
     label: str,
 ) -> tuple[bool, list[str]]:
+    reference_errors = schema_reference_policy_errors(
+        schema,
+        label=f"{label}_schema",
+    )
+    if reference_errors:
+        return False, reference_errors
+
     try:
         validator = jsonschema.Draft202012Validator(
             schema,
             format_checker=jsonschema.FormatChecker(),
+            registry=CLOSED_SCHEMA_REGISTRY,
         )
         validation_errors = sorted(
             list(validator.iter_errors(value)),
@@ -406,8 +525,9 @@ def validate_instance(
             ),
         )
     except Exception as exc:
+        detail = " ".join(str(exc).split())
         return False, [
-            f"{label}_validation_failed: {type(exc).__name__}: {exc}"
+            f"{label}_validation_failed: {type(exc).__name__}: {detail}"
         ]
 
     errors = [
@@ -1352,9 +1472,21 @@ def make_diagnostic(
     errors: list[str],
     expectation_instance_valid: bool = False,
     subject_input_observed_branch_valid: bool = False,
+    expectation_schema_reference_policy_valid: bool = False,
+    subject_input_schema_reference_policy_valid: bool = False,
     canonical_expectation_schema_path_verified: bool = False,
+    canonical_expectation_schema_git_blob_verified: bool = False,
     canonical_subject_input_schema_path_verified: bool = False,
+    canonical_subject_input_schema_git_blob_verified: bool = False,
+    supplied_contract_semantics_verified: bool = False,
 ) -> dict[str, Any]:
+    canonical_contract_semantics_verified = bool(
+        supplied_contract_semantics_verified
+        and canonical_expectation_schema_path_verified
+        and canonical_expectation_schema_git_blob_verified
+        and canonical_subject_input_schema_path_verified
+        and canonical_subject_input_schema_git_blob_verified
+    )
     return {
         "tool": TOOL_NAME,
         "tool_version": TOOL_VERSION,
@@ -1363,8 +1495,14 @@ def make_diagnostic(
         "record_status": record_status,
         "ok": ok,
         "expectation_schema_valid": expectation_schema_valid,
+        "expectation_schema_reference_policy_valid": (
+            expectation_schema_reference_policy_valid
+        ),
         "expectation_instance_valid": expectation_instance_valid,
         "subject_input_schema_valid": subject_input_schema_valid,
+        "subject_input_schema_reference_policy_valid": (
+            subject_input_schema_reference_policy_valid
+        ),
         "subject_input_observed_branch_valid": (
             subject_input_observed_branch_valid
         ),
@@ -1372,25 +1510,45 @@ def make_diagnostic(
         "derived": dict(sorted(derived.items())),
         "input_identities": dict(sorted(input_identities.items())),
         "verification_boundary": {
+            "canonical_contract_semantics_verified": (
+                canonical_contract_semantics_verified
+            ),
+            "canonical_expectation_schema_git_blob_verified": (
+                canonical_expectation_schema_git_blob_verified
+            ),
             "canonical_expectation_schema_path_verified": (
                 canonical_expectation_schema_path_verified
+            ),
+            "canonical_subject_input_schema_git_blob_verified": (
+                canonical_subject_input_schema_git_blob_verified
             ),
             "canonical_subject_input_schema_path_verified": (
                 canonical_subject_input_schema_path_verified
             ),
             "carrier_bytes_verified": False,
+            "contract_semantics_verified": (
+                canonical_contract_semantics_verified
+            ),
             "control_plane_component_bytes_verified": False,
-            "contract_semantics_verified": bool(
-                ok
-                and canonical_expectation_schema_path_verified
-                and canonical_subject_input_schema_path_verified
+            "external_output_mode": _external_output_mode(),
+            "external_schema_retrieval_allowed": False,
+            "input_snapshot_mode": _input_snapshot_mode(),
+            "schema_reference_policy": SCHEMA_REFERENCE_POLICY,
+            "strict_descriptor_snapshot_verified": (
+                _strict_descriptor_snapshot_available()
+            ),
+            "strict_output_descriptor_binding_available": (
+                _strict_output_descriptor_binding_available()
             ),
             "subject_authority_source_bytes_verified": False,
-            "supplied_contract_semantics_verified": bool(ok),
+            "supplied_contract_semantics_verified": (
+                supplied_contract_semantics_verified
+            ),
         },
         "authority_effect": "none",
         "errors": sorted(set(errors)),
     }
+
 
 
 def build_diagnostic(
@@ -1400,114 +1558,187 @@ def build_diagnostic(
     subject_input_schema_path: Path,
     repository_root: Path,
 ) -> tuple[dict[str, Any], int]:
-    try:
-        expectation_schema, _schema_text, schema_bytes = load_json(
+    values: dict[str, Any] = {}
+    texts: dict[str, str] = {}
+    payloads: dict[str, bytes] = {}
+    errors: list[str] = []
+    read_failure = False
+
+    input_specs = (
+        (
+            "expectation_schema",
             schema_path,
-            label="expectation_schema",
-            max_bytes=MAX_EXPECTATION_SCHEMA_BYTES,
-        )
-        subject_input_schema, _packet_schema_text, packet_schema_bytes = load_json(
+            MAX_EXPECTATION_SCHEMA_BYTES,
+        ),
+        (
+            "subject_input_schema",
             subject_input_schema_path,
-            label="subject_input_schema",
-            max_bytes=MAX_SUBJECT_INPUT_SCHEMA_BYTES,
-        )
-        expectation, expectation_text, expectation_bytes = load_json(
+            MAX_SUBJECT_INPUT_SCHEMA_BYTES,
+        ),
+        (
+            "expectation",
             expectation_path,
-            label="expectation",
-            max_bytes=MAX_EXPECTATION_BYTES,
-        )
-    except Exception as exc:
-        diagnostic = make_diagnostic(
-            ok=False,
-            expectation_schema_valid=False,
-            subject_input_schema_valid=False,
-            record_status=None,
-            checks={},
-            derived={},
-            input_identities={},
-            errors=[f"read_error: {exc}"],
-        )
-        return diagnostic, 2
-
-    canonical_expectation_schema_path_verified = same_target(
-        schema_path,
-        DEFAULT_SCHEMA,
+            MAX_EXPECTATION_BYTES,
+        ),
     )
-    canonical_subject_input_schema_path_verified = same_target(
-        subject_input_schema_path,
-        DEFAULT_SUBJECT_INPUT_SCHEMA,
+    for label, path, maximum in input_specs:
+        try:
+            value, text_value, payload = load_json(
+                path,
+                label=label,
+                max_bytes=maximum,
+            )
+            values[label] = value
+            texts[label] = text_value
+            payloads[label] = payload
+        except Exception as exc:
+            read_failure = True
+            detail = " ".join(str(exc).split())
+            errors.append(
+                f"read_error: {label}: {type(exc).__name__}: {detail}"
+            )
+
+    expectation_schema = values.get("expectation_schema")
+    subject_input_schema = values.get("subject_input_schema")
+    expectation = values.get("expectation")
+    expectation_text = texts.get("expectation", "")
+    schema_bytes = payloads.get("expectation_schema")
+    packet_schema_bytes = payloads.get("subject_input_schema")
+    expectation_bytes = payloads.get("expectation")
+
+    canonical_expectation_schema_path_verified = bool(
+        schema_bytes is not None
+        and same_target(schema_path, DEFAULT_SCHEMA)
+    )
+    canonical_subject_input_schema_path_verified = bool(
+        packet_schema_bytes is not None
+        and same_target(
+            subject_input_schema_path,
+            DEFAULT_SUBJECT_INPUT_SCHEMA,
+        )
     )
 
-    input_identities = {
-        "expectation": {
+    expectation_schema_git_blob = (
+        git_blob_sha1(schema_bytes) if schema_bytes is not None else None
+    )
+    subject_input_schema_git_blob = (
+        git_blob_sha1(packet_schema_bytes)
+        if packet_schema_bytes is not None
+        else None
+    )
+    canonical_expectation_schema_git_blob_verified = (
+        expectation_schema_git_blob
+        == CANONICAL_EXPECTATION_SCHEMA_GIT_BLOB_SHA1
+    )
+    canonical_subject_input_schema_git_blob_verified = (
+        subject_input_schema_git_blob
+        == CANONICAL_SUBJECT_INPUT_SCHEMA_GIT_BLOB_SHA1
+    )
+
+    input_identities: dict[str, Any] = {}
+    if expectation_bytes is not None:
+        input_identities["expectation"] = {
             "sha256": hashlib.sha256(expectation_bytes).hexdigest(),
             "size_bytes": len(expectation_bytes),
-        },
-        "expectation_schema": {
+        }
+    if schema_bytes is not None:
+        input_identities["expectation_schema"] = {
+            "git_blob_sha1": expectation_schema_git_blob,
+            "reviewed_git_blob_sha1": (
+                CANONICAL_EXPECTATION_SCHEMA_GIT_BLOB_SHA1
+            ),
             "sha256": hashlib.sha256(schema_bytes).hexdigest(),
             "size_bytes": len(schema_bytes),
-        },
-        "subject_input_schema": {
+        }
+    if packet_schema_bytes is not None:
+        input_identities["subject_input_schema"] = {
+            "git_blob_sha1": subject_input_schema_git_blob,
+            "reviewed_git_blob_sha1": (
+                CANONICAL_SUBJECT_INPUT_SCHEMA_GIT_BLOB_SHA1
+            ),
             "sha256": hashlib.sha256(packet_schema_bytes).hexdigest(),
             "size_bytes": len(packet_schema_bytes),
-        },
-    }
+        }
 
-    if not isinstance(expectation_schema, dict):
-        diagnostic = make_diagnostic(
-            ok=False,
-            expectation_schema_valid=False,
-            subject_input_schema_valid=False,
-            record_status=(
-                expectation.get("record_status")
-                if isinstance(expectation, dict)
-                else None
-            ),
-            checks={},
-            derived={},
-            input_identities=input_identities,
-            errors=["expectation_schema_not_object"],
-        )
-        return diagnostic, 2
+    expectation_schema_is_object = isinstance(expectation_schema, dict)
+    subject_input_schema_is_object = isinstance(subject_input_schema, dict)
+    expectation_is_object = isinstance(expectation, dict)
 
-    if not isinstance(subject_input_schema, dict):
-        diagnostic = make_diagnostic(
-            ok=False,
-            expectation_schema_valid=False,
-            subject_input_schema_valid=False,
-            record_status=(
-                expectation.get("record_status")
-                if isinstance(expectation, dict)
-                else None
-            ),
-            checks={},
-            derived={},
-            input_identities=input_identities,
-            errors=["subject_input_schema_not_object"],
-        )
-        return diagnostic, 2
-
+    expectation_schema_reference_errors: list[str] = []
+    subject_input_schema_reference_errors: list[str] = []
     expectation_schema_errors: list[str] = []
     subject_input_schema_errors: list[str] = []
-    try:
-        jsonschema.Draft202012Validator.check_schema(expectation_schema)
-    except Exception as exc:
-        expectation_schema_errors.append(
-            f"expectation_schema_invalid: {type(exc).__name__}: {exc}"
-        )
-    try:
-        jsonschema.Draft202012Validator.check_schema(subject_input_schema)
-    except Exception as exc:
-        subject_input_schema_errors.append(
-            f"subject_input_schema_invalid: {type(exc).__name__}: {exc}"
-        )
 
-    expectation_schema_valid = not expectation_schema_errors
-    subject_input_schema_valid = not subject_input_schema_errors
-    errors = expectation_schema_errors + subject_input_schema_errors
+    if "expectation_schema" in values:
+        if not expectation_schema_is_object:
+            expectation_schema_errors.append("expectation_schema_not_object")
+        else:
+            expectation_schema_reference_errors = (
+                schema_reference_policy_errors(
+                    expectation_schema,
+                    label="expectation_schema",
+                )
+            )
+            try:
+                jsonschema.Draft202012Validator.check_schema(
+                    expectation_schema
+                )
+            except Exception as exc:
+                detail = " ".join(str(exc).split())
+                expectation_schema_errors.append(
+                    "expectation_schema_invalid: "
+                    f"{type(exc).__name__}: {detail}"
+                )
+
+    if "subject_input_schema" in values:
+        if not subject_input_schema_is_object:
+            subject_input_schema_errors.append(
+                "subject_input_schema_not_object"
+            )
+        else:
+            subject_input_schema_reference_errors = (
+                schema_reference_policy_errors(
+                    subject_input_schema,
+                    label="subject_input_schema",
+                )
+            )
+            try:
+                jsonschema.Draft202012Validator.check_schema(
+                    subject_input_schema
+                )
+            except Exception as exc:
+                detail = " ".join(str(exc).split())
+                subject_input_schema_errors.append(
+                    "subject_input_schema_invalid: "
+                    f"{type(exc).__name__}: {detail}"
+                )
+
+    expectation_schema_valid = bool(
+        expectation_schema_is_object and not expectation_schema_errors
+    )
+    subject_input_schema_valid = bool(
+        subject_input_schema_is_object and not subject_input_schema_errors
+    )
+    expectation_schema_reference_policy_valid = bool(
+        expectation_schema_is_object
+        and not expectation_schema_reference_errors
+    )
+    subject_input_schema_reference_policy_valid = bool(
+        subject_input_schema_is_object
+        and not subject_input_schema_reference_errors
+    )
+
+    errors.extend(expectation_schema_errors)
+    errors.extend(subject_input_schema_errors)
+    errors.extend(expectation_schema_reference_errors)
+    errors.extend(subject_input_schema_reference_errors)
 
     expectation_instance_valid = False
-    if expectation_schema_valid:
+    if (
+        expectation_schema_valid
+        and expectation_schema_reference_policy_valid
+        and "expectation" in values
+    ):
         expectation_instance_valid, instance_errors = validate_instance(
             expectation_schema,
             expectation,
@@ -1515,16 +1746,17 @@ def build_diagnostic(
         )
         errors.extend(instance_errors)
 
-    if not isinstance(expectation, dict):
+    if "expectation" in values and not expectation_is_object:
         errors.append("expectation_not_object")
 
     checks: dict[str, bool] = {}
     derived: dict[str, Any] = {}
     subject_input_observed_branch_valid = False
     if (
-        isinstance(expectation, dict)
+        expectation_is_object
         and expectation_instance_valid
         and subject_input_schema_valid
+        and subject_input_schema_reference_policy_valid
     ):
         semantic, semantic_errors_list, derived = semantic_checks(
             expectation,
@@ -1540,12 +1772,18 @@ def build_diagnostic(
             checks.get("subject_input_observed_branch_witness_ok")
         )
     else:
-        checks["semantic_checks_skipped_due_to_schema_errors"] = False
+        checks[
+            "semantic_checks_skipped_due_to_invalid_contract_inputs"
+        ] = False
 
     ok = (
-        expectation_schema_valid
+        not read_failure
+        and expectation_schema_valid
+        and expectation_schema_reference_policy_valid
         and expectation_instance_valid
         and subject_input_schema_valid
+        and subject_input_schema_reference_policy_valid
+        and subject_input_observed_branch_valid
         and bool(checks)
         and all(checks.values())
         and not errors
@@ -1553,8 +1791,14 @@ def build_diagnostic(
     diagnostic = make_diagnostic(
         ok=ok,
         expectation_schema_valid=expectation_schema_valid,
+        expectation_schema_reference_policy_valid=(
+            expectation_schema_reference_policy_valid
+        ),
         expectation_instance_valid=expectation_instance_valid,
         subject_input_schema_valid=subject_input_schema_valid,
+        subject_input_schema_reference_policy_valid=(
+            subject_input_schema_reference_policy_valid
+        ),
         subject_input_observed_branch_valid=(
             subject_input_observed_branch_valid
         ),
@@ -1564,9 +1808,16 @@ def build_diagnostic(
         canonical_subject_input_schema_path_verified=(
             canonical_subject_input_schema_path_verified
         ),
+        canonical_expectation_schema_git_blob_verified=(
+            canonical_expectation_schema_git_blob_verified
+        ),
+        canonical_subject_input_schema_git_blob_verified=(
+            canonical_subject_input_schema_git_blob_verified
+        ),
+        supplied_contract_semantics_verified=ok,
         record_status=(
             expectation.get("record_status")
-            if isinstance(expectation, dict)
+            if expectation_is_object
             else None
         ),
         checks=checks,
@@ -1574,7 +1825,19 @@ def build_diagnostic(
         input_identities=input_identities,
         errors=errors,
     )
-    return diagnostic, 0 if ok else 1
+
+    structural_failure = (
+        read_failure
+        or (
+            "expectation_schema" in values
+            and not expectation_schema_is_object
+        )
+        or (
+            "subject_input_schema" in values
+            and not subject_input_schema_is_object
+        )
+    )
+    return diagnostic, 0 if ok else (2 if structural_failure else 1)
 
 
 def same_target(left: Path, right: Path) -> bool:
@@ -1783,11 +2046,7 @@ def _atomic_write_fallback(path: Path, text: str) -> None:
 def atomic_write(path: Path, text: str) -> None:
     candidate = _normalized_absolute_path(path)
     payload = text.encode("utf-8")
-    if (
-        os.name != "nt"
-        and os.open in os.supports_dir_fd
-        and os.rename in os.supports_dir_fd
-    ):
+    if _strict_output_descriptor_binding_available():
         _atomic_write_posix(candidate, payload)
         return
     _atomic_write_fallback(candidate, text)
@@ -1798,7 +2057,8 @@ def parse_args() -> argparse.Namespace:
         description=(
             "Validate a PULSEmech current-run export expectation v0 against "
             "its Draft 2020-12 schema, semantic cross-bindings, and the "
-            "existing subject-input packet contract."
+            "existing subject-input packet contract under an "
+            "internal-fragment-only schema-reference policy."
         )
     )
     parser.add_argument(
@@ -1888,44 +2148,13 @@ def main() -> int:
         try:
             atomic_write(output, rendered)
         except Exception as exc:
-            failure = make_diagnostic(
-                ok=False,
-                expectation_schema_valid=diagnostic.get(
-                    "expectation_schema_valid",
-                    False,
-                ),
-                subject_input_schema_valid=diagnostic.get(
-                    "subject_input_schema_valid",
-                    False,
-                ),
-                expectation_instance_valid=diagnostic.get(
-                    "expectation_instance_valid",
-                    False,
-                ),
-                subject_input_observed_branch_valid=diagnostic.get(
-                    "subject_input_observed_branch_valid",
-                    False,
-                ),
-                canonical_expectation_schema_path_verified=diagnostic.get(
-                    "verification_boundary",
-                    {},
-                ).get(
-                    "canonical_expectation_schema_path_verified",
-                    False,
-                ),
-                canonical_subject_input_schema_path_verified=diagnostic.get(
-                    "verification_boundary",
-                    {},
-                ).get(
-                    "canonical_subject_input_schema_path_verified",
-                    False,
-                ),
-                record_status=diagnostic.get("record_status"),
-                checks=diagnostic.get("checks", {}),
-                derived=diagnostic.get("derived", {}),
-                input_identities=diagnostic.get("input_identities", {}),
-                errors=list(diagnostic.get("errors", []))
-                + [f"output_write_failed: {exc}"],
+            failure = copy.deepcopy(diagnostic)
+            failure["ok"] = False
+            failure["errors"] = sorted(
+                set(
+                    list(failure.get("errors", []))
+                    + [f"output_write_failed: {exc}"]
+                )
             )
             sys.stderr.write(render_json(failure))
             return 2


### PR DESCRIPTION
### Summary

Harden the merged PULSEmech current-run export expectation validator against
the trust-boundary defects found by its post-merge mechanical review.

This pull request overwrites exactly:

```text
tools/check_pulsemech_compute_current_run_export_expectation_v0.py
```

The corrected validator now establishes four distinct relations:

```text
supplied schemas are structurally valid

supplied expectation and downstream witness satisfy those schemas

schema references cannot escape the captured documents

canonical contract verification is bound to reviewed schema bytes
```

The change remains validator-only.

It does not add the validator regression, tools-test registration, expectation
builder, carrier builder, carrier loader, current-run packet producer, workflow
wiring, gate activation, compute budget, candidate materialization, or release
authority.

### Defect 1 — external schema retrieval

The previous validator passed caller-supplied schemas to the JSON Schema
runtime without first closing the reference-resolution boundary.

A schema containing:

```text
relative external $ref
HTTPS $ref
file:// $ref
```

could cause the installed resolver layer to attempt external resource access
before returning a validation error.

Catching the later exception prevented a Python traceback, but did not prevent:

```text
network resolution attempts
local-file resolution attempts
dependency-generated stderr
external-state-dependent latency and behavior
```

### Closed schema-reference policy

The validator now recursively inventories these schema keywords:

```text
$ref
$dynamicRef
$recursiveRef
```

The only accepted references are internal JSON fragments:

```text
#
#/...
```

Every non-fragment reference is rejected before JSON Schema validator
construction.

Examples rejected before retrieval:

```text
missing.json

https://127.0.0.1:9/schema.json

file:///etc/passwd
```

The validator additionally constructs Draft 2020-12 validators with a closed
reference registry:

```text
retrieve:
deny every requested resource
```

The two boundaries are independent:

```text
recursive pre-validation reference scan
+
deny-all runtime registry
```

No schema reference can initiate network or local-file retrieval.

The diagnostic records:

```text
schema_reference_policy:
internal_fragment_only

external_schema_retrieval_allowed:
false
```

Reference-policy state is reported independently for both schemas:

```text
expectation_schema_reference_policy_valid

subject_input_schema_reference_policy_valid
```

### Defect 2 — canonical path was not canonical contract identity

The previous validator treated this relation as sufficient:

```text
supplied schema path
=
canonical repository schema path
```

A dirty or replaced schema at that path could still produce:

```text
canonical_*_schema_path_verified:
true

contract_semantics_verified:
true
```

A filesystem location does not establish reviewed schema-byte identity.

### Reviewed schema-blob binding

The validator now pins the reviewed Git blob identities of the two canonical
schemas:

```text
current-run export expectation schema:
c0bc5a21f5bf46c529341d2e805f26525c70c7f4

subject-input packet schema:
e1f982ffaf900c6c17745624d80f9f38b374448b
```

For each descriptor-captured schema byte buffer, it calculates:

```text
Git blob identity
=
SHA-1(
  b"blob "
  + decimal byte length
  + NUL
  + exact captured bytes
)
```

The calculated identity is included in the input diagnostic beside the reviewed
expected blob identity.

The validator separately reports:

```text
canonical_expectation_schema_path_verified

canonical_expectation_schema_git_blob_verified

canonical_subject_input_schema_path_verified

canonical_subject_input_schema_git_blob_verified
```

### Supplied versus canonical verification

Successful validation of caller-selected schemas now means only:

```text
supplied_contract_semantics_verified:
true
```

Canonical contract verification requires:

```text
supplied contract semantics verified
+
canonical expectation-schema path
+
exact reviewed expectation-schema Git blob
+
canonical subject-input-schema path
+
exact reviewed subject-input-schema Git blob
```

The result is exposed as:

```text
canonical_contract_semantics_verified
```

The compatibility field:

```text
contract_semantics_verified
```

is true only when that complete canonical relation is true.

A dirty canonical schema may still be evaluated as supplied input, but it
cannot receive canonical-contract status.

Expected dirty-schema result:

```text
supplied_contract_semantics_verified:
true

canonical_expectation_schema_path_verified:
true

canonical_expectation_schema_git_blob_verified:
false

canonical_contract_semantics_verified:
false

contract_semantics_verified:
false
```

This binds the authority-relevant claim to exact reviewed bytes rather than a
mutable path.

### Defect 3 — independent schema states were lost

The previous validator contained early branches where a malformed or non-object
subject-input schema caused both schema-validity fields to be reported as
false.

For example:

```text
valid expectation schema
+
subject-input schema = []
```

could incorrectly report:

```text
expectation_schema_valid:
false

subject_input_schema_valid:
false
```

The expectation schema did not cause that failure.

### Independent schema-state calculation

The revised validator reads and classifies all three inputs independently:

```text
expectation schema
subject-input schema
expectation record
```

For each schema it independently establishes:

```text
input read state
root object state
reference-policy state
Draft 2020-12 self-check state
```

Only after both schema states have been preserved does the validator perform:

```text
expectation instance validation
downstream observed-branch witness validation
semantic cross-binding checks
```

A subject-input schema failure cannot reset the expectation-schema state.

Expected result for a non-object subject-input schema:

```text
expectation_schema_valid:
true

subject_input_schema_valid:
false

errors:
subject_input_schema_not_object
```

Expected result for a missing subject-input schema:

```text
expectation_schema_valid:
true

subject_input_schema_valid:
false
```

The diagnostic now keeps these states mechanically distinct:

```text
expectation_schema_valid

expectation_schema_reference_policy_valid

expectation_instance_valid

subject_input_schema_valid

subject_input_schema_reference_policy_valid

subject_input_observed_branch_valid
```

### Platform-boundary reporting

The POSIX input path retains:

```text
root directory descriptor
→ no-follow parent traversal
→ no-follow final-file open
→ fstat before reading
→ descriptor-only bounded read
→ fstat after reading
```

The diagnostic reports:

```text
input_snapshot_mode:
posix_descriptor_chain

strict_descriptor_snapshot_verified:
true
```

The POSIX external-output path retains:

```text
stable directory descriptor
→ exclusive random temporary leaf
→ descriptor-bound write
→ file fsync
→ same-directory descriptor-relative replacement
→ directory fsync
```

The diagnostic reports:

```text
external_output_mode:
posix_directory_descriptor_atomic_replace

strict_output_descriptor_binding_available:
true
```

On platforms without those descriptor primitives, the validator explicitly
reports the weaker modes:

```text
input_snapshot_mode:
path_identity_fallback

external_output_mode:
path_atomic_replace_fallback
```

It no longer presents the fallback as mechanically equivalent to the POSIX
descriptor-chain guarantee.

### Preserved strict input boundary

The validator continues to reject:

```text
missing inputs
non-regular inputs
symlinked input files
symlinked POSIX parent components
oversized inputs
descriptor identity changes during reading
invalid UTF-8
UTF-8 BOM
malformed JSON
duplicate keys
NaN
Infinity
-Infinity
```

The same captured byte buffers are used for:

```text
input identity
UTF-8 decoding
JSON parsing
schema validation
semantic validation
```

### Preserved downstream observed-branch proof

The validator continues to construct a complete observed
`current_run_export` subject-input packet witness and validate it against the
entire supplied downstream schema.

The witness covers all required packet surfaces:

```text
schema identity
record status
producer
packet identity
subject
analysis boundary
authority sources
carrier
artifacts
role bindings
coverage
content boundary
authority boundary
errors
terminal ok state
```

A downstream schema that lists selected values but makes the observed branch
impossible through:

```text
not
allOf
oneOf
if / then / else
other complete-schema constraints
```

produces:

```text
subject_input_schema_valid:
true

subject_input_observed_branch_valid:
false

ok:
false
```

### Preserved expectation semantics

The validator continues to recompute:

```text
canonical subject-run key

canonical workflow reference

subject/profile repository and revision binding

policy identity and digest binding

workflow and registry source binding

globally unique source IDs

deterministic additional-source ordering

protected control-plane component set

canonical component paths and path uniqueness

expectation-producer binding

carrier-producer run and revision binding

carrier namespace and non-empty suffix

carrier finalization ordering

provider digest, size, and time relations

archive-layout relations

provider-plus-non-provider artifact-count derivation

closed content boundary

closed authority boundary
```

### Deterministic diagnostic

The output continues to contain:

```text
tool and contract identity

record status

independent schema states

expectation instance state

downstream observed-branch state

sorted semantic checks

derived relations

exact input SHA-256 and byte sizes

schema Git blob identities

reference-policy state

platform snapshot and output mode

explicit unverified byte surfaces

authority effect none

sorted unique errors
```

The successful diagnostic remains canonical JSON with:

```text
sorted keys
two-space indentation
UTF-8
finite numbers only
one final newline
```

### Explicit verification boundary

The validator verifies contract structure and relations.

It still explicitly does not verify:

```text
carrier payload bytes

protected control-plane component bytes

subject authority-source bytes

validator source authenticity before execution
```

The diagnostic retains:

```text
carrier_bytes_verified:
false

control_plane_component_bytes_verified:
false

subject_authority_source_bytes_verified:
false
```

### Output non-interference

The validator continues to validate both:

```text
its actual repository root

the caller-declared repository root
```

before allowing output.

It rejects output that:

```text
overwrites an input

overwrites the validator

uses a protected authority or contract filename

is inside either protected repository root

uses a symlinked output path
```

Permitted output remains external and non-authoritative.

### Scope

This pull request modifies exactly:

```text
tools/check_pulsemech_compute_current_run_export_expectation_v0.py
```

It does not modify:

```text
current-run expectation schema

checked-in expectation example

subject-input packet schema

subject-input packet validator

fixed-source producer wrapper

reusable producer core

historical #6066 packet

preservation carrier

binding analyzer core

planned-observed relation

candidate materializer

ci/tools-tests.list

workflow files

gate policy

gate registry

status

release authority
```

### Non-implementation boundary

This pull request does not add:

```text
validator regression

tools-test registration

expectation builder

current-run carrier builder

current-run carrier loader

current-run subject-input producer

current-run carrier publication

workflow wiring

artifact-observed report production

planned-observed relation production

candidate materialization

runtime-observation production

resource measurement

compute budget

gate activation

release-required enforcement

release authority
```

Authority effect:

```text
none
```

Gate effect:

```text
none
```

Policy effect:

```text
none
```

Workflow effect:

```text
none
```

Release effect:

```text
none
```

### Validation

Local checks completed:

```text
Python compilation:
PASS

merged expectation schema and checked-in example:
PASS

deterministic positive diagnostic:
PASS

HTTPS external reference:
REJECTED before retrieval

file external reference:
REJECTED before retrieval

relative external reference:
REJECTED before retrieval

dirty canonical expectation schema:
canonical Git blob verification false

non-object subject-input schema:
expectation-schema state preserved

missing subject-input schema:
expectation-schema state preserved

external diagnostic output:
stdout bytes equal output-file bytes
```

File identity:

```text
lines:
2167

bytes:
72609

SHA-256:
28d5cccb01d7c0635f1cef5c735dba43cbb767032e06da1d37c2154884a0bea7

final newline:
present
```

The next separate implementation item remains:

```text
tests/test_check_pulsemech_compute_current_run_export_expectation_v0.py
```