### PR TITLE
test(ci): align the attest pin smoke expectation

### DIFF
--- a/tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
+++ b/tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
@@ -8,7 +8,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pulse_ci.yml"
 TOOLS_TESTS_LIST = REPO_ROOT / "ci" / "tools-tests.list"
 
-ATTEST_SHA = "f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6"
+ATTEST_SHA = "508db95dd578ae2727ebd6217d5ba78e4fbda05d""
 
 CORE_ATTEST_JOB = "attest_release_authority_artifact_binding"
 RELEASE_ATTEST_JOB = "attest_release_grade_artifact_binding"

--- a/tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
+++ b/tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
@@ -8,7 +8,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pulse_ci.yml"
 TOOLS_TESTS_LIST = REPO_ROOT / "ci" / "tools-tests.list"
 
-ATTEST_SHA = "508db95dd578ae2727ebd6217d5ba78e4fbda05d""
+ATTEST_SHA = "508db95dd578ae2727ebd6217d5ba78e4fbda05d"
 
 CORE_ATTEST_JOB = "attest_release_authority_artifact_binding"
 RELEASE_ATTEST_JOB = "attest_release_grade_artifact_binding"


### PR DESCRIPTION
## Repository compatibility closure

This PR updates the immutable `actions/attest` workflow pin from:

```text
f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6
```

to:

```text
508db95dd578ae2727ebd6217d5ba78e4fbda05d
```

The workflow update changes the pinned source identity in:

```text
.github/workflows/pulse_ci.yml
```

The repository also carries an exact workflow-wiring regression
expectation in:

```text
tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
```

That test still expected the previous immutable commit and therefore
failed before the targeted pytest suite could run.

This PR aligns only that current-workflow expectation:

```python
ATTEST_SHA = "508db95dd578ae2727ebd6217d5ba78e4fbda05d"
```

The exact equality assertions remain unchanged.

## Preserved boundary

The following independent fixture is intentionally not modified:

```text
tests/test_build_llamaguard_attestation_envelope_v1.py
```

Its `ATTEST_ACTION_REF` supplies a valid exact-SHA fixture for envelope
construction tests. It does not define the current workflow-source
identity and does not need to change to admit the new workflow pin.

## Files

### Dependabot update

```text
.github/workflows/pulse_ci.yml
```

### Compatibility regression update

```text
tests/test_artifact_provenance_binding_attestation_wiring_smoke.py
```

## Mechanical result

```text
new immutable workflow pin
+
matching exact workflow-source regression expectation
→ consistent attestation action identity
```

This PR does not:

```text
replace the immutable SHA with a moving tag
broaden accepted action identities
skip the smoke test
weaken exact source verification
change artifact or verifier binding
change release-authority semantics
activate release-grade execution
change policy or gate materialization
```

The update preserves the existing fail-closed behavior: a workflow pin
and its exact regression expectation must identify the same reviewed
action source.