### PR TITLE
docs(readme): position PULSEmech as a transition-measurement architec…

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ source state
 → changed relation
 → opened or closed path
 → target state
+```
+
+Artifact-bound AI release authority is the first concrete
+implementation domain of this broader architecture.
+
+See:
+
+- [PULSEmech Transition Meter](PULSEMECH_TRANSITION_METER.md)
+- [PULSEmech Technical Overview](PULSEMECH_TECHNICAL_OVERVIEW.md)
 
 ## Canonical <img src="assets/brand/pulsemech-dark-badge.svg" alt="PULSEmech" height="30"> implementation path
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ architecture.
 
 **[Open the central PULSEmech Transition Meter architecture document](PULSEMECH_TRANSITION_METER.md)**
 
+## Beyond AI release authority
+
+PULSEmech is developing beyond a single AI release mechanism into an
+evidence-bound transition-measurement architecture.
+
+Its broader purpose is to identify and verify not only system states,
+but the transition between them:
+
+```text
+source state
+→ changed relation
+→ opened or closed path
+→ target state
+
 ## Canonical <img src="assets/brand/pulsemech-dark-badge.svg" alt="PULSEmech" height="30"> implementation path
 
 PULSEmech is the artifact-bound release-authority mechanism for AI release decisions.


### PR DESCRIPTION
## Summary

This PR adds a concise central positioning statement to `README.md`.

PULSEmech is no longer presented only as an artifact-bound AI release
mechanism.

The README now identifies its broader architectural direction:

```text
evidence-bound transition measurement
```

## Central position

The added section states that PULSEmech is developing from a single
application domain into a broader transition-measurement architecture.

Its general measured structure is:

```text
source state
→ changed relation
→ opened or closed path
→ target state
```

This distinguishes:

```text
measured states
```

from:

```text
the evidence-bound transition connecting those states
```

## Implementation continuity

The new positioning does not claim that a complete generalized
cross-domain implementation already exists.

It preserves the current concrete implementation boundary:

```text
artifact-bound AI release authority
→ first concrete PULSEmech implementation domain
```

The release-authority mechanism therefore remains the implemented
reference domain of the broader Transition Meter architecture.

## Documentation links

The README section links directly to the two complementary central
documents:

```text
PULSEMECH_TRANSITION_METER.md
→ foundational transition-measurement architecture

PULSEMECH_TECHNICAL_OVERVIEW.md
→ current checked-in implementation and verified-state overview
```

## File

```text
README.md
```

## Authority boundary

This PR changes documentation and repository positioning only.

It does not:

```text
activate a policy set
materialize a required gate
change runtime behavior
change verifier behavior
change release authority
authorize external execution
claim completed generalized implementation
```

## Result

The repository now states the broader PULSEmech identity directly:

> PULSEmech is developing beyond a single AI release mechanism into an
> evidence-bound transition-measurement architecture.

Artifact-bound AI release authority remains its first concrete
implementation domain.