### PR TITLE
fix(zenodo): defer release identity to GitHub metadata

### DIFF
--- a/.github/workflows/zenodo-jsonlint.yml
+++ b/.github/workflows/zenodo-jsonlint.yml
@@ -10,8 +10,211 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
       - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
-      - name: Validate .zenodo.json
-        run: python -m json.tool .zenodo.json > /dev/null
+
+      - name: Validate Zenodo metadata boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+
+          def object_without_duplicate_keys(pairs):
+              result = {}
+
+              for key, value in pairs:
+                  if key in result:
+                      raise ValueError(f"duplicate JSON key: {key}")
+
+                  result[key] = value
+
+              return result
+
+
+          def reject_non_finite(value):
+              raise ValueError(f"non-finite JSON number: {value}")
+
+
+          path = Path(".zenodo.json")
+          raw = path.read_bytes()
+
+          if raw.startswith(b"\xef\xbb\xbf"):
+              raise SystemExit(
+                  "ERROR: .zenodo.json must not contain a UTF-8 BOM"
+              )
+
+          try:
+              text = raw.decode("utf-8")
+              metadata = json.loads(
+                  text,
+                  object_pairs_hook=object_without_duplicate_keys,
+                  parse_constant=reject_non_finite,
+              )
+          except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+              raise SystemExit(
+                  f"ERROR: invalid .zenodo.json: {exc}"
+              ) from exc
+
+          if not isinstance(metadata, dict):
+              raise SystemExit(
+                  "ERROR: .zenodo.json root must be an object"
+              )
+
+          release_specific_fields = (
+              "title",
+              "description",
+              "version",
+              "publication_date",
+          )
+
+          present_release_specific_fields = sorted(
+              field
+              for field in release_specific_fields
+              if field in metadata
+          )
+
+          if present_release_specific_fields:
+              raise SystemExit(
+                  "ERROR: .zenodo.json must not hardcode release-specific "
+                  "metadata: "
+                  + ", ".join(present_release_specific_fields)
+              )
+
+          expected_scalars = {
+              "upload_type": "software",
+              "language": "eng",
+              "license": "Apache-2.0",
+          }
+
+          for field, expected_value in expected_scalars.items():
+              actual_value = metadata.get(field)
+
+              if actual_value != expected_value:
+                  raise SystemExit(
+                      f"ERROR: {field} must equal {expected_value!r}; "
+                      f"observed {actual_value!r}"
+                  )
+
+          creators = metadata.get("creators")
+
+          if not isinstance(creators, list) or not creators:
+              raise SystemExit(
+                  "ERROR: creators must be a non-empty array"
+              )
+
+          creator_identity_present = any(
+              isinstance(creator, dict)
+              and creator.get("name") == "Horvat, Katalin"
+              and creator.get("orcid") == "0009-0001-9745-3764"
+              for creator in creators
+          )
+
+          if not creator_identity_present:
+              raise SystemExit(
+                  "ERROR: canonical creator and ORCID identity are missing"
+              )
+
+          keywords = metadata.get("keywords")
+
+          if (
+              not isinstance(keywords, list)
+              or not keywords
+              or any(
+                  not isinstance(keyword, str) or not keyword
+                  for keyword in keywords
+              )
+          ):
+              raise SystemExit(
+                  "ERROR: keywords must be a non-empty array of "
+                  "non-empty strings"
+              )
+
+          if len(keywords) != len(set(keywords)):
+              raise SystemExit(
+                  "ERROR: keywords must not contain duplicates"
+              )
+
+          required_keywords = {
+              "pulsemech",
+              "transition-measurement",
+              "transition-meter",
+              "transition-identity",
+          }
+
+          missing_keywords = sorted(
+              required_keywords.difference(keywords)
+          )
+
+          if missing_keywords:
+              raise SystemExit(
+                  "ERROR: missing required Zenodo keywords: "
+                  + ", ".join(missing_keywords)
+              )
+
+          related_identifiers = metadata.get("related_identifiers")
+
+          if not isinstance(related_identifiers, list):
+              raise SystemExit(
+                  "ERROR: related_identifiers must be an array"
+              )
+
+          observed_relations = {
+              (
+                  item.get("identifier"),
+                  item.get("relation"),
+                  item.get("scheme"),
+              )
+              for item in related_identifiers
+              if isinstance(item, dict)
+          }
+
+          required_relations = {
+              (
+                  "10.5281/zenodo.17833583",
+                  "isDocumentedBy",
+                  "doi",
+              ),
+              (
+                  "10.5281/zenodo.17214908",
+                  "isVersionOf",
+                  "doi",
+              ),
+              (
+                  "https://github.com/HKati/pulse-release-gates-0.1",
+                  "isSupplementTo",
+                  "url",
+              ),
+              (
+                  "https://github.com/HKati/pulse-guard-pack",
+                  "hasPart",
+                  "url",
+              ),
+          }
+
+          missing_relations = sorted(
+              required_relations.difference(observed_relations)
+          )
+
+          if missing_relations:
+              rendered = ", ".join(
+                  f"{identifier} | {relation} | {scheme}"
+                  for identifier, relation, scheme in missing_relations
+              )
+
+              raise SystemExit(
+                  "ERROR: missing required Zenodo relations: " + rendered
+              )
+
+          print(
+              "OK: .zenodo.json contains stable repository metadata, "
+              "preserves the canonical PULSE lineage, and leaves release "
+              "title, description, version, and publication date to the "
+              "GitHub release."
+          )
+          PY

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,4 @@
 {
-  "title": "PULSE: Artifact-Bound Release Authority for AI Release Decisions",
-  "description": "PULSE is an artifact-bound release-authority system for AI release decisions. It structures recorded safety, quality, detector, stability, CI, and review evidence into deterministic, fail-closed CI allow/block release decisions under declared policy. Release authority is bound to recorded evidence, status.json, declared gate policy, a materialized required gate set, and strict fail-closed CI enforcement.",
   "upload_type": "software",
   "language": "eng",
   "license": "Apache-2.0",
@@ -32,7 +30,10 @@
     "auditability",
     "reproducibility",
     "hpc-evidence",
-    "recognition-surface-drift"
+    "recognition-surface-drift",
+    "transition-measurement",
+    "transition-meter",
+    "transition-identity"
   ],
   "related_identifiers": [
     {


### PR DESCRIPTION
# PR title

```text
fix(zenodo): defer release identity to GitHub metadata
```

# PR body

## Summary

Remove release-specific title and description overrides from `.zenodo.json` so
future Zenodo GitHub archives derive their release identity from the exact
GitHub release instead of reusing stale repository-level metadata.

Strengthen the Zenodo metadata workflow from JSON syntax validation into a
semantic release-metadata boundary.

The corrected relation is:

```text
GitHub release title
+
GitHub release description
+
GitHub release tag
+
GitHub release publication event
→
Zenodo version-record identity
```

The prohibited relation is:

```text
static historical .zenodo.json title
+
new GitHub release
→
new Zenodo version with stale title
```

## Incident addressed

The GitHub release:

```text
PULSE v1.2.0 — PULSEmech: Transition Measurement Foundation
```

was archived under the correct version DOI and the correct PULSE concept DOI,
but Zenodo displayed the older title:

```text
PULSE: Artifact-Bound Release Authority for AI Release Decisions
```

The archived ZIP, release tag, version DOI and concept lineage were correct.

The stale title and description came from `.zenodo.json`, which overrode the
current GitHub release metadata.

The existing Zenodo record was corrected manually without creating:

```text
a new DOI
a new version
a new project identity
a new concept lineage
```

This pull request removes the repository-side source of recurrence.

## Exact file boundary

Modify exactly:

```text
.zenodo.json
.github/workflows/zenodo-jsonlint.yml
```

No other file is changed.

## `.zenodo.json`

Remove the release-specific fields:

```text
title
description
```

Do not introduce static values for:

```text
version
publication_date
```

Preserve the stable repository-level metadata:

```text
upload type
language
license
creators
contributors
keywords
preprint relation
PULSE concept DOI relation
repository relation
pulse-guard-pack relation
```

Add the transition-measurement keywords recorded on the corrected `v1.2.0`
Zenodo version:

```text
transition-measurement
transition-meter
transition-identity
```

The resulting metadata boundary is:

```text
stable project metadata
→ .zenodo.json

release-specific identity
→ GitHub release
```

## Semantic Zenodo metadata validation

Replace syntax-only JSON validation with a strict semantic check.

The workflow continues to verify that `.zenodo.json` is valid UTF-8 JSON and
also rejects:

```text
UTF-8 BOM
duplicate JSON keys
NaN
Infinity
non-object root
static title
static description
static version
static publication date
missing software upload type
incorrect language
incorrect license
missing canonical creator identity
missing canonical ORCID
empty or duplicate keywords
missing transition-measurement keywords
missing PULSE concept DOI relation
missing preprint relation
missing repository relation
missing pulse-guard-pack relation
```

The workflow requires:

```text
upload_type:
software

language:
eng

license:
Apache-2.0

creator:
Horvat, Katalin

ORCID:
0009-0001-9745-3764
```

It also preserves these exact relations:

```text
10.5281/zenodo.17833583
→ isDocumentedBy
→ doi

10.5281/zenodo.17214908
→ isVersionOf
→ doi

https://github.com/HKati/pulse-release-gates-0.1
→ isSupplementTo
→ url

https://github.com/HKati/pulse-guard-pack
→ hasPart
→ url
```

## Citation boundary

This pull request intentionally does not modify:

```text
CITATION.cff
README.md
README_HOW_TO_CITE.md
ORCID_add_work.json
docs/index.html
citation regression tests
DOI badge contracts
```

Those surfaces currently form a separate citation-history and DOI-hygiene
boundary and must be synchronized in a separate, complete change rather than
partially modified here.

## Preserved identity

Preserve unchanged:

```text
PULSE continuous project identity

PULSE concept DOI:
10.5281/zenodo.17214908

PULSE v1.2.0 version DOI:
10.5281/zenodo.21798667

PULSE v1.2.0 tag

PULSE v1.2.0 archived ZIP

GitHub–Zenodo repository integration

preprint DOI:
10.5281/zenodo.17833583
```

## Effects

```text
Zenodo metadata source:
corrected

future release-title inheritance:
restored

future release-description inheritance:
restored

semantic metadata regression:
added

CITATION.cff:
unchanged

repository citation surfaces:
unchanged

existing Zenodo record:
unchanged by this PR

DOI:
unchanged

concept DOI:
unchanged

tag:
unchanged

release:
unchanged

archived files:
unchanged

runtime:
unchanged

dependencies:
unchanged

policy:
unchanged

gate registry:
unchanged

active gate sets:
unchanged

release decision:
unchanged

release authority:
unchanged
```

## Validation

The pull request must prove:

```text
.zenodo.json parses as strict UTF-8 JSON

.zenodo.json contains no release-specific title

.zenodo.json contains no release-specific description

.zenodo.json contains no static version

.zenodo.json contains no static publication date

stable project metadata remains present

canonical creator and ORCID remain present

PULSE concept DOI relation remains present

preprint relation remains present

repository and guard-pack relations remain present

transition-measurement keywords remain present

zenodo-jsonlint passes
```

# Squash merge title

```text
fix(zenodo): defer release identity to GitHub metadata
```

# Squash merge description

Remove stale release-specific title and description overrides from
`.zenodo.json`.

Restore the intended Zenodo GitHub archival relation:

```text
GitHub release title
+
GitHub release description
+
GitHub release tag
+
GitHub release publication event
→
Zenodo version-record identity
```

Prevent a historical repository-level title from overriding future GitHub
release identities.

Preserve stable Zenodo project metadata:

```text
software resource type
English language
Apache-2.0 license
canonical creator and ORCID
EPLabsAI contributor
PULSE concept DOI relation
preprint relation
repository relation
pulse-guard-pack relation
```

Add the transition-measurement, transition-meter, and transition-identity
keywords recorded on the corrected PULSE `v1.2.0` Zenodo version.

Strengthen `.github/workflows/zenodo-jsonlint.yml` from syntax-only parsing into
a semantic release-metadata boundary.

Reject:

```text
UTF-8 BOM
duplicate JSON keys
non-finite JSON numbers
non-object metadata roots
static title
static description
static version
static publication date
incorrect stable metadata
missing canonical creator identity
missing canonical ORCID
empty or duplicate keywords
missing transition-measurement keywords
missing PULSE lineage relations
```

Modify exactly:

```text
.zenodo.json
.github/workflows/zenodo-jsonlint.yml
```

Keep `CITATION.cff` and all wider repository citation surfaces unchanged for a
separate complete synchronization change.

Preserve unchanged:

```text
PULSE continuous project identity
concept DOI 10.5281/zenodo.17214908
v1.2.0 version DOI 10.5281/zenodo.21798667
preprint DOI 10.5281/zenodo.17833583
GitHub release
release tag
archived ZIP
GitHub–Zenodo integration
runtime
dependencies
policy
gate registry
active gate sets
release decision
release authority
```

No DOI, version, release, tag, archived file, publication record or project
identity is created, deleted or replaced.