### PR TITLE
fix(ci): restore first-party SARIF upload path

### DIFF
--- a/.github/workflows/upload_sarif.yml
+++ b/.github/workflows/upload_sarif.yml
@@ -54,7 +54,9 @@ jobs:
 
           echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
 
-          api_get "https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}" > run.json
+          api_get \
+            "https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}" \
+            > run.json
 
           RUN_NAME="$(jq -r '.name // ""' run.json)"
           if [[ "${RUN_NAME}" != "PULSE CI" ]]; then
@@ -63,12 +65,13 @@ jobs:
           fi
 
       - name: Download pulse-report artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          github-token: ${{ github.token }}
-          run-id: ${{ steps.src.outputs.run_id }}
           name: pulse-report
           path: _pulse_artifacts
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.src.outputs.run_id }}
 
       - name: Read source SARIF metadata
         id: target
@@ -78,7 +81,11 @@ jobs:
 
           mapfile -t meta_files < <(
             find _pulse_artifacts -type f \
-              \( -path '*/meta/sarif_upload.json' -o -path '*/artifacts/meta/sarif_upload.json' \) \
+              \( \
+                -path '*/meta/sarif_upload.json' \
+                -o \
+                -path '*/artifacts/meta/sarif_upload.json' \
+              \) \
               | sort
           )
 
@@ -109,14 +116,18 @@ jobs:
           fi
 
           case "${REF}" in
-            refs/heads/*|refs/tags/*|refs/pull/*/merge|refs/pull/*/head) ;;
+            refs/heads/*|refs/tags/*|refs/pull/*/merge|refs/pull/*/head)
+              ;;
             *)
               echo "::error::Unsupported ref in source SARIF metadata: ${REF}"
               exit 1
               ;;
           esac
 
-          if [[ "${EVENT_NAME}" == "pull_request" && "${IS_FORK}" == "true" ]]; then
+          if [[ \
+            "${EVENT_NAME}" == "pull_request" \
+            && "${IS_FORK}" == "true" \
+          ]]; then
             echo "::notice::Skipping SARIF upload for fork PR run."
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "reason=fork_pr" >> "$GITHUB_OUTPUT"
@@ -135,7 +146,11 @@ jobs:
 
           mapfile -t sarif_files < <(
             find _pulse_artifacts -type f \
-              \( -path '*/reports/sarif.json' -o -path '*/artifacts/reports/sarif.json' \) \
+              \( \
+                -path '*/reports/sarif.json' \
+                -o \
+                -path '*/artifacts/reports/sarif.json' \
+              \) \
               | sort
           )
 
@@ -154,8 +169,13 @@ jobs:
           echo "present=true" >> "$GITHUB_OUTPUT"
           echo "path=${sarif_files[0]}" >> "$GITHUB_OUTPUT"
 
-          - name: Upload SARIF to GitHub code scanning
-            if: steps.target.outputs.skip != 'true' && steps.sarif.outputs.present == 'true'
-            uses: github/codeql-action/upload-sarif@28deaeda66b76a949e644c285e6f08b9d0a95327 # v3.28.10
-            with:
-              sarif_file: ${{ steps.sarif.outputs.path }}
+      - name: Upload SARIF to GitHub code scanning
+        if: >-
+          steps.target.outputs.skip != 'true' &&
+          steps.sarif.outputs.present == 'true'
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        with:
+          sarif_file: ${{ steps.sarif.outputs.path }}
+          ref: ${{ steps.target.outputs.ref }}
+          sha: ${{ steps.target.outputs.sha }}
+          category: pulse-gates

--- a/.github/workflows/upload_sarif.yml
+++ b/.github/workflows/upload_sarif.yml
@@ -63,13 +63,12 @@ jobs:
           fi
 
       - name: Download pulse-report artifact
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          github_token: ${{ github.token }}
-          run_id: ${{ steps.src.outputs.run_id }}
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.src.outputs.run_id }}
           name: pulse-report
           path: _pulse_artifacts
-          if_no_artifact_found: fail
 
       - name: Read source SARIF metadata
         id: target
@@ -155,40 +154,8 @@ jobs:
           echo "present=true" >> "$GITHUB_OUTPUT"
           echo "path=${sarif_files[0]}" >> "$GITHUB_OUTPUT"
 
-      - name: Upload SARIF to GitHub code scanning
-        if: steps.target.outputs.skip != 'true' && steps.sarif.outputs.present == 'true'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          SARIF_FILE: ${{ steps.sarif.outputs.path }}
-          SARIF_REF: ${{ steps.target.outputs.ref }}
-          SARIF_SHA: ${{ steps.target.outputs.sha }}
-        run: |
-          set -euo pipefail
-
-          python3 - <<'PY' > sarif-upload.json
-          import base64
-          import gzip
-          import json
-          import os
-          from pathlib import Path
-
-          sarif = Path(os.environ["SARIF_FILE"]).read_bytes()
-          payload = {
-              "commit_sha": os.environ["SARIF_SHA"],
-              "ref": os.environ["SARIF_REF"],
-              "sarif": base64.b64encode(gzip.compress(sarif)).decode("ascii"),
-              "tool_name": "pulse-gates",
-          }
-          print(json.dumps(payload, separators=(",", ":")))
-          PY
-
-          curl -fsSL --retry 3 \
-            -X POST \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -H "Content-Type: application/json" \
-            --data-binary @sarif-upload.json \
-            "https://api.github.com/repos/${REPO}/code-scanning/sarifs"
+          - name: Upload SARIF to GitHub code scanning
+            if: steps.target.outputs.skip != 'true' && steps.sarif.outputs.present == 'true'
+            uses: github/codeql-action/upload-sarif@28deaeda66b76a949e644c285e6f08b9d0a95327 # v3.28.10
+            with:
+              sarif_file: ${{ steps.sarif.outputs.path }}


### PR DESCRIPTION
## Summary

Correct the SARIF workflow mechanism introduced during the repository-wide
GitHub Actions supply-chain hardening merged through PR #2803.

Restore the official first-party GitHub Actions for:

```text
cross-run artifact download
+
SARIF processing and code-scanning upload
```

Preserve the full 40-character commit-SHA pinning established by the preceding
security change.

## Exact file boundary

Modify exactly:

```text
.github/workflows/upload_sarif.yml
```

No other file is changed.

## Artifact-download correction

Replace:

```text
dawidd6/action-download-artifact
```

with:

```yaml
uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
```

Preserve the original first-party cross-run binding:

```yaml
with:
  name: pulse-report
  path: _pulse_artifacts
  github-token: ${{ github.token }}
  repository: ${{ github.repository }}
  run-id: ${{ steps.src.outputs.run_id }}
```

The corrected relation is:

```text
independently resolved PULSE CI run ID
+
current repository identity
+
GitHub token with actions: read
→
first-party pulse-report artifact download
```

Do not retain a third-party artifact-download substitution in this workflow.

## SARIF-upload correction

Replace the manual shell-based upload mechanism with:

```yaml
- name: Upload SARIF to GitHub code scanning
  if: steps.target.outputs.skip != 'true' && steps.sarif.outputs.present == 'true'
  uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
  with:
    sarif_file: ${{ steps.sarif.outputs.path }}
    ref: ${{ steps.target.outputs.ref }}
    sha: ${{ steps.target.outputs.sha }}
    category: pulse-gates
```

Remove completely:

```text
manual gzip processing
manual base64 encoding
sarif-upload.json generation
direct curl-based SARIF submission
direct POST to /code-scanning/sarifs
```

The corrected relation is:

```text
validated SARIF file
+
validated source ref
+
validated source SHA
+
category pulse-gates
→
official CodeQL SARIF upload Action
→
GitHub code scanning
```

## Preserved workflow behavior

Preserve unchanged:

```text
workflow_run trigger
workflow_dispatch trigger
contents: read
actions: read
security-events: write
15-minute job timeout
source-run ID resolution
source run API retrieval
PULSE CI workflow-name verification
pulse-report artifact name
_pulse_artifacts destination
single metadata-file requirement
single SARIF-file requirement
supported-ref validation
fork pull-request skip behavior
missing metadata skip behavior
missing ref or SHA skip behavior
missing SARIF skip behavior
duplicate metadata rejection
duplicate SARIF rejection
code-scanning category pulse-gates
```

## Relationship to PR #2803

Keep the repository-wide hardening from PR #2803 intact:

```text
external Actions
→ complete immutable commit SHAs

actions/checkout
→ persist-credentials: false

workflow_lint
→ fail-closed mutable-Action rejection

zenodo-jsonlint
→ explicit contents: read
```

This pull request corrects only the unnecessary functional substitution inside
`upload_sarif.yml`.

It does not reverse immutable pinning or checkout credential hardening.

## Residual security boundary

This pull request does not claim closure of the separate privileged
`workflow_run` artifact-provenance boundary:

```text
privileged upload_sarif workflow
+
downloaded upstream artifact
+
artifact-carried ref, SHA and fork state
→
security-events write
```

A later focused change must independently bind the artifact metadata to the
GitHub workflow-run and pull-request API identities.

## Validation

Require:

```text
workflow YAML parsing:
PASS

workflow-lint:
PASS

repo-hygiene:
PASS

git diff --check:
PASS

changed files:
exactly one

actions/download-artifact:
present at exact 40-character commit SHA

github/codeql-action/upload-sarif:
present at exact 40-character commit SHA

dawidd6/action-download-artifact in upload_sarif.yml:
absent

manual gzip SARIF processing:
absent

manual base64 SARIF processing:
absent

sarif-upload.json generation:
absent

direct /code-scanning/sarifs POST:
absent

category pulse-gates:
preserved
```

## Effects

```text
first-party artifact download:
restored

official CodeQL SARIF upload:
restored

immutable Action pinning:
preserved

manual REST SARIF upload:
removed

third-party artifact downloader:
removed from upload_sarif.yml

workflow triggers:
unchanged

workflow permissions:
unchanged

PULSE runtime:
unchanged

schemas:
unchanged

policy:
unchanged

gate registry:
unchanged

active gate sets:
unchanged

release decision:
unchanged

release authority:
unchanged

DOIs and publication records:
unchanged
```