### PR TITLE
fix(ci): bind SARIF upload to GitHub run identity

### DIFF
--- a/.github/workflows/upload_sarif.yml
+++ b/.github/workflows/upload_sarif.yml
@@ -5,13 +5,6 @@ on:
     workflows: ["PULSE CI"]
     types: [completed]
 
-  workflow_dispatch:
-    inputs:
-      run_id:
-        description: "Completed PULSE CI run ID"
-        required: true
-        type: string
-
 permissions:
   contents: read
   actions: read
@@ -23,46 +16,11 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Resolve source run
-        id: src
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          INPUT_RUN_ID: ${{ github.event.inputs.run_id }}
-        run: |
-          set -euo pipefail
-
-          api_get() {
-            curl -fsSL \
-              -H "Authorization: Bearer ${GH_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "$1"
-          }
-
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            RUN_ID="${INPUT_RUN_ID}"
-          else
-            RUN_ID="${{ github.event.workflow_run.id }}"
-          fi
-
-          if [[ -z "${RUN_ID}" ]]; then
-            echo "::error::Missing source workflow run id."
-            exit 1
-          fi
-
-          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
-
-          api_get \
-            "https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}" \
-            > run.json
-
-          RUN_NAME="$(jq -r '.name // ""' run.json)"
-          if [[ "${RUN_NAME}" != "PULSE CI" ]]; then
-            echo "::error::Expected workflow name 'PULSE CI', got '${RUN_NAME}'."
-            exit 1
-          fi
+      - name: Checkout trusted SARIF binding verifier
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Download pulse-report artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -71,111 +29,27 @@ jobs:
           path: _pulse_artifacts
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
-          run-id: ${{ steps.src.outputs.run_id }}
+          run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Read source SARIF metadata
+      - name: Verify workflow-run and SARIF artifact binding
         id: target
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          mapfile -t meta_files < <(
-            find _pulse_artifacts -type f \
-              \( \
-                -path '*/meta/sarif_upload.json' \
-                -o \
-                -path '*/artifacts/meta/sarif_upload.json' \
-              \) \
-              | sort
-          )
-
-          if [[ "${#meta_files[@]}" -eq 0 ]]; then
-            echo "::warning::No SARIF upload metadata artifact found; skipping upload."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "reason=missing_metadata" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ "${#meta_files[@]}" -gt 1 ]]; then
-            echo "::error::Multiple SARIF upload metadata files found."
-            printf ' - %s\n' "${meta_files[@]}"
-            exit 1
-          fi
-
-          META="${meta_files[0]}"
-          EVENT_NAME="$(jq -r '.event_name // ""' "${META}")"
-          REF="$(jq -r '.ref // ""' "${META}")"
-          SHA="$(jq -r '.sha // ""' "${META}")"
-          IS_FORK="$(jq -r '.is_fork // false' "${META}")"
-
-          if [[ -z "${REF}" || -z "${SHA}" ]]; then
-            echo "::warning::Source SARIF metadata is missing ref/sha; skipping upload."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "reason=missing_ref_or_sha" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          case "${REF}" in
-            refs/heads/*|refs/tags/*|refs/pull/*/merge|refs/pull/*/head)
-              ;;
-            *)
-              echo "::error::Unsupported ref in source SARIF metadata: ${REF}"
-              exit 1
-              ;;
-          esac
-
-          if [[ \
-            "${EVENT_NAME}" == "pull_request" \
-            && "${IS_FORK}" == "true" \
-          ]]; then
-            echo "::notice::Skipping SARIF upload for fork PR run."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "reason=fork_pr" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
-          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
-
-      - name: Check SARIF presence
-        id: sarif
-        if: steps.target.outputs.skip != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          mapfile -t sarif_files < <(
-            find _pulse_artifacts -type f \
-              \( \
-                -path '*/reports/sarif.json' \
-                -o \
-                -path '*/artifacts/reports/sarif.json' \
-              \) \
-              | sort
-          )
-
-          if [[ "${#sarif_files[@]}" -eq 0 ]]; then
-            echo "::notice::No reports/sarif.json artifact found in run ${{ steps.src.outputs.run_id }}; nothing to upload."
-            echo "present=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ "${#sarif_files[@]}" -gt 1 ]]; then
-            echo "::error::Multiple reports/sarif.json files found."
-            printf ' - %s\n' "${sarif_files[@]}"
-            exit 1
-          fi
-
-          echo "present=true" >> "$GITHUB_OUTPUT"
-          echo "path=${sarif_files[0]}" >> "$GITHUB_OUTPUT"
+          python tools/check_sarif_workflow_run_binding_v0.py \
+            --repository "${{ github.repository }}" \
+            --run-id "${{ github.event.workflow_run.id }}" \
+            --artifact-root "_pulse_artifacts" \
+            --github-output "${GITHUB_OUTPUT}"
 
       - name: Upload SARIF to GitHub code scanning
-        if: >-
-          steps.target.outputs.skip != 'true' &&
-          steps.sarif.outputs.present == 'true'
+        if: steps.target.outputs.skip == 'false'
         uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
-          sarif_file: ${{ steps.sarif.outputs.path }}
+          sarif_file: ${{ steps.target.outputs.sarif_path }}
           ref: ${{ steps.target.outputs.ref }}
           sha: ${{ steps.target.outputs.sha }}
           category: pulse-gates

--- a/ci/tools-tests.list
+++ b/ci/tools-tests.list
@@ -6,6 +6,7 @@
 tests/test_exporters.py
 tests/test_tools_tests_list_smoke.py
 tests/test_workflow_no_embedded_steps_smoke.py
+tests/test_check_sarif_workflow_run_binding_v0.py
 tests/test_status_to_junit_smoke.py
 tests/test_status_to_sarif_smoke.py
 tests/test_policy_to_require_args_smoke.py

--- a/tests/test_check_sarif_workflow_run_binding_v0.py
+++ b/tests/test_check_sarif_workflow_run_binding_v0.py
@@ -1,0 +1,650 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, Callable
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL_PATH = ROOT / "tools" / "check_sarif_workflow_run_binding_v0.py"
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "upload_sarif.yml"
+
+REPOSITORY = "HKati/pulse-release-gates-0.1"
+RUN_ID = 123456789
+BASE_SHA = "1" * 40
+HEAD_SHA = "2" * 40
+MERGE_SHA = "3" * 40
+MAIN_SHA = "4" * 40
+TAG_SHA = "5" * 40
+
+
+def _load_tool() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "_check_sarif_workflow_run_binding_v0",
+        TOOL_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError("tool module spec unavailable")
+    module = importlib.util.module_from_spec(spec)
+    import sys
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+tool = _load_tool()
+
+
+def _run(
+    *,
+    event: str,
+    head_branch: str,
+    head_sha: str,
+    head_repository: str = REPOSITORY,
+    pull_requests: list[dict[str, Any]] | None = None,
+    path: str = ".github/workflows/pulse_ci.yml",
+) -> dict[str, Any]:
+    return {
+        "id": RUN_ID,
+        "name": "PULSE CI",
+        "path": path,
+        "status": "completed",
+        "conclusion": "success",
+        "event": event,
+        "head_branch": head_branch,
+        "head_sha": head_sha,
+        "repository": {"full_name": REPOSITORY},
+        "head_repository": {"full_name": head_repository},
+        "pull_requests": pull_requests or [],
+    }
+
+
+def _metadata(
+    *,
+    event: str,
+    ref: str,
+    sha: str,
+    pr_number: int | None = None,
+    is_fork: bool = False,
+) -> dict[str, Any]:
+    return {
+        "event_name": event,
+        "ref": ref,
+        "sha": sha,
+        "pr_number": pr_number,
+        "is_fork": is_fork,
+    }
+
+
+def _pull_request_snapshot(
+    *,
+    number: int = 42,
+    head_repository: str = REPOSITORY,
+    head_sha: str = HEAD_SHA,
+    head_ref: str = "feature",
+    base_sha: str = BASE_SHA,
+    base_ref: str = "main",
+) -> dict[str, Any]:
+    return {
+        "number": number,
+        "head": {
+            "repo": {
+                "url": "https://api.github.com/repos/"
+                + head_repository,
+            },
+            "sha": head_sha,
+            "ref": head_ref,
+        },
+        "base": {
+            "repo": {
+                "url": "https://api.github.com/repos/"
+                + REPOSITORY,
+            },
+            "sha": base_sha,
+            "ref": base_ref,
+        },
+    }
+
+
+def _merge_commit(
+    *,
+    sha: str = MERGE_SHA,
+    base_sha: str = BASE_SHA,
+    head_sha: str = HEAD_SHA,
+) -> dict[str, Any]:
+    return {
+        "sha": sha,
+        "parents": [
+            {"sha": base_sha},
+            {"sha": head_sha},
+        ],
+    }
+
+
+def _expect_error(
+    expected: str,
+    function: Callable[[], Any],
+) -> None:
+    try:
+        function()
+    except tool.BindingError as exc:
+        if expected not in str(exc):
+            raise AssertionError(
+                f"expected error containing {expected!r}, observed {exc!r}"
+            ) from exc
+    else:
+        raise AssertionError(f"expected BindingError containing {expected!r}")
+
+
+def test_workflow_path_without_suffix_passes() -> None:
+    result = tool.verify_binding(
+        repository=REPOSITORY,
+        run_id=RUN_ID,
+        run=_run(
+            event="push",
+            head_branch="main",
+            head_sha=MAIN_SHA,
+            path=".github/workflows/pulse_ci.yml",
+        ),
+        metadata=_metadata(
+            event="push",
+            ref="refs/heads/main",
+            sha=MAIN_SHA,
+        ),
+    )
+    assert result.skip is False
+
+
+def test_workflow_path_with_suffix_passes() -> None:
+    result = tool.verify_binding(
+        repository=REPOSITORY,
+        run_id=RUN_ID,
+        run=_run(
+            event="push",
+            head_branch="main",
+            head_sha=MAIN_SHA,
+            path=".github/workflows/pulse_ci.yml@refs/heads/main",
+        ),
+        metadata=_metadata(
+            event="push",
+            ref="refs/heads/main",
+            sha=MAIN_SHA,
+        ),
+    )
+    assert result.skip is False
+
+
+def test_workflow_path_prefix_substitution_fails() -> None:
+    _expect_error(
+        "workflow_run_path_mismatch",
+        lambda: tool.verify_binding(
+            repository=REPOSITORY,
+            run_id=RUN_ID,
+            run=_run(
+                event="push",
+                head_branch="main",
+                head_sha=MAIN_SHA,
+                path=".github/workflows/pulse_ci.yml.evil@main",
+            ),
+            metadata=_metadata(
+                event="push",
+                ref="refs/heads/main",
+                sha=MAIN_SHA,
+            ),
+        ),
+    )
+
+
+def test_push_main_passes() -> None:
+    result = tool.verify_binding(
+        repository=REPOSITORY,
+        run_id=RUN_ID,
+        run=_run(
+            event="push",
+            head_branch="main",
+            head_sha=MAIN_SHA,
+        ),
+        metadata=_metadata(
+            event="push",
+            ref="refs/heads/main",
+            sha=MAIN_SHA,
+        ),
+    )
+    assert result.ok is True
+    assert result.skip is False
+    assert result.reason == "verified_push"
+    assert result.ref == "refs/heads/main"
+    assert result.sha == MAIN_SHA
+
+
+def test_push_tag_passes() -> None:
+    result = tool.verify_binding(
+        repository=REPOSITORY,
+        run_id=RUN_ID,
+        run=_run(
+            event="push",
+            head_branch="v1.2.0",
+            head_sha=TAG_SHA,
+        ),
+        metadata=_metadata(
+            event="push",
+            ref="refs/tags/v1.2.0",
+            sha=TAG_SHA,
+        ),
+    )
+    assert result.skip is False
+    assert result.ref == "refs/tags/v1.2.0"
+    assert result.sha == TAG_SHA
+
+
+def test_push_hyphenated_tag_passes() -> None:
+    result = tool.verify_binding(
+        repository=REPOSITORY,
+        run_id=RUN_ID,
+        run=_run(
+            event="push",
+            head_branch="v-rc1",
+            head_sha=TAG_SHA,
+        ),
+        metadata=_metadata(
+            event="push",
+            ref="refs/tags/v-rc1",
+            sha=TAG_SHA,
+        ),
+    )
+    assert result.skip is False
+    assert result.ref == "refs/tags/v-rc1"
+
+
+def test_push_metadata_mismatch_fails() -> None:
+    _expect_error(
+        "sarif_metadata_sha_mismatch",
+        lambda: tool.verify_binding(
+            repository=REPOSITORY,
+            run_id=RUN_ID,
+            run=_run(
+                event="push",
+                head_branch="main",
+                head_sha=MAIN_SHA,
+            ),
+            metadata=_metadata(
+                event="push",
+                ref="refs/heads/main",
+                sha=TAG_SHA,
+            ),
+        ),
+    )
+
+
+def test_workflow_dispatch_main_passes() -> None:
+    result = tool.verify_binding(
+        repository=REPOSITORY,
+        run_id=RUN_ID,
+        run=_run(
+            event="workflow_dispatch",
+            head_branch="main",
+            head_sha=MAIN_SHA,
+        ),
+        metadata=_metadata(
+            event="workflow_dispatch",
+            ref="refs/heads/main",
+            sha=MAIN_SHA,
+        ),
+    )
+    assert result.skip is False
+    assert result.reason == "verified_workflow_dispatch_main"
+
+
+def test_workflow_dispatch_feature_skips() -> None:
+    result = tool.verify_binding(
+        repository=REPOSITORY,
+        run_id=RUN_ID,
+        run=_run(
+            event="workflow_dispatch",
+            head_branch="feature",
+            head_sha=HEAD_SHA,
+        ),
+        metadata=_metadata(
+            event="workflow_dispatch",
+            ref="refs/heads/feature",
+            sha=HEAD_SHA,
+        ),
+    )
+    assert result.skip is True
+    assert result.reason == "workflow_dispatch_ref_not_main"
+    assert result.ref is None
+    assert result.sha is None
+
+
+def test_same_repository_pull_request_snapshot_passes() -> None:
+    result = tool.verify_binding(
+        repository=REPOSITORY,
+        run_id=RUN_ID,
+        run=_run(
+            event="pull_request",
+            head_branch="feature",
+            head_sha=HEAD_SHA,
+            pull_requests=[_pull_request_snapshot()],
+        ),
+        metadata=_metadata(
+            event="pull_request",
+            ref="refs/pull/42/merge",
+            sha=MERGE_SHA,
+            pr_number=42,
+            is_fork=False,
+        ),
+        merge_commit=_merge_commit(),
+    )
+    assert result.skip is False
+    assert result.reason == "verified_pull_request_merge_snapshot"
+    assert result.ref == "refs/pull/42/merge"
+    assert result.sha == MERGE_SHA
+
+
+def test_fork_pull_request_snapshot_skips() -> None:
+    fork_repository = "contributor/pulse-release-gates-0.1"
+    result = tool.verify_binding(
+        repository=REPOSITORY,
+        run_id=RUN_ID,
+        run=_run(
+            event="pull_request",
+            head_branch="feature",
+            head_sha=HEAD_SHA,
+            head_repository=fork_repository,
+            pull_requests=[
+                _pull_request_snapshot(
+                    head_repository=fork_repository,
+                )
+            ],
+        ),
+        metadata=_metadata(
+            event="pull_request",
+            ref="refs/pull/42/merge",
+            sha=MERGE_SHA,
+            pr_number=42,
+            is_fork=True,
+        ),
+    )
+    assert result.skip is True
+    assert result.reason == "fork_pull_request"
+    assert result.ref is None
+    assert result.sha is None
+
+
+def test_pull_request_number_substitution_fails() -> None:
+    _expect_error(
+        "sarif_metadata_pr_number_mismatch",
+        lambda: tool.verify_binding(
+            repository=REPOSITORY,
+            run_id=RUN_ID,
+            run=_run(
+                event="pull_request",
+                head_branch="feature",
+                head_sha=HEAD_SHA,
+                pull_requests=[_pull_request_snapshot(number=41)],
+            ),
+            metadata=_metadata(
+                event="pull_request",
+                ref="refs/pull/42/merge",
+                sha=MERGE_SHA,
+                pr_number=42,
+                is_fork=False,
+            ),
+            merge_commit=_merge_commit(),
+        ),
+    )
+
+
+def test_pull_request_snapshot_head_substitution_fails() -> None:
+    _expect_error(
+        "workflow_run_pull_request_head_sha_mismatch",
+        lambda: tool.verify_binding(
+            repository=REPOSITORY,
+            run_id=RUN_ID,
+            run=_run(
+                event="pull_request",
+                head_branch="feature",
+                head_sha=HEAD_SHA,
+                pull_requests=[
+                    _pull_request_snapshot(head_sha="6" * 40)
+                ],
+            ),
+            metadata=_metadata(
+                event="pull_request",
+                ref="refs/pull/42/merge",
+                sha=MERGE_SHA,
+                pr_number=42,
+                is_fork=False,
+            ),
+            merge_commit=_merge_commit(),
+        ),
+    )
+
+
+def test_pull_request_merge_parent_substitution_fails() -> None:
+    _expect_error(
+        "pull_request_merge_commit_parents_mismatch",
+        lambda: tool.verify_binding(
+            repository=REPOSITORY,
+            run_id=RUN_ID,
+            run=_run(
+                event="pull_request",
+                head_branch="feature",
+                head_sha=HEAD_SHA,
+                pull_requests=[_pull_request_snapshot()],
+            ),
+            metadata=_metadata(
+                event="pull_request",
+                ref="refs/pull/42/merge",
+                sha=MERGE_SHA,
+                pr_number=42,
+                is_fork=False,
+            ),
+            merge_commit=_merge_commit(base_sha="7" * 40),
+        ),
+    )
+
+
+def test_pull_request_live_state_is_not_required() -> None:
+    result = tool.verify_binding(
+        repository=REPOSITORY,
+        run_id=RUN_ID,
+        run=_run(
+            event="pull_request",
+            head_branch="feature",
+            head_sha=HEAD_SHA,
+            pull_requests=[_pull_request_snapshot()],
+        ),
+        metadata=_metadata(
+            event="pull_request",
+            ref="refs/pull/42/merge",
+            sha=MERGE_SHA,
+            pr_number=42,
+            is_fork=False,
+        ),
+        merge_commit=_merge_commit(),
+    )
+    assert result.reason == "verified_pull_request_merge_snapshot"
+
+
+def test_event_substitution_fails() -> None:
+    _expect_error(
+        "sarif_metadata_event_mismatch",
+        lambda: tool.verify_binding(
+            repository=REPOSITORY,
+            run_id=RUN_ID,
+            run=_run(
+                event="push",
+                head_branch="main",
+                head_sha=MAIN_SHA,
+            ),
+            metadata=_metadata(
+                event="workflow_dispatch",
+                ref="refs/heads/main",
+                sha=MAIN_SHA,
+            ),
+        ),
+    )
+
+
+def test_strict_metadata_json_rejects_duplicate_keys() -> None:
+    payload = (
+        b'{"event_name":"push","event_name":"pull_request",'
+        b'"ref":"refs/heads/main","sha":"'
+        + MAIN_SHA.encode("ascii")
+        + b'","pr_number":null,"is_fork":false}'
+    )
+    _expect_error(
+        "duplicate JSON key",
+        lambda: tool.parse_json_bytes(
+            payload,
+            label="sarif_metadata",
+        ),
+    )
+
+
+def test_artifact_selection_fails_closed() -> None:
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        (root / "a" / "meta").mkdir(parents=True)
+        (root / "b" / "artifacts" / "meta").mkdir(parents=True)
+        content = json.dumps(
+            _metadata(
+                event="push",
+                ref="refs/heads/main",
+                sha=MAIN_SHA,
+            )
+        )
+        (root / "a" / "meta" / "sarif_upload.json").write_text(content)
+        (
+            root
+            / "b"
+            / "artifacts"
+            / "meta"
+            / "sarif_upload.json"
+        ).write_text(content)
+        _expect_error(
+            "sarif_metadata_file_count_invalid",
+            lambda: tool._select_metadata(root),
+        )
+
+
+def test_verifier_uses_completed_run_snapshot() -> None:
+    source = TOOL_PATH.read_text(encoding="utf-8")
+    assert "?exclude_pull_requests=false" in source
+    assert 'f"/git/commits/{merge_sha}"' in source
+    assert 'f"/pulls/{pr_number}"' not in source
+    assert 'f"/git/ref/{encoded_ref}"' not in source
+
+
+def test_workflow_wiring() -> None:
+    data = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+
+    trigger = data.get(True)
+    if trigger is None:
+        trigger = data.get("on")
+    assert isinstance(trigger, dict)
+    assert "workflow_run" in trigger
+    assert "workflow_dispatch" not in trigger
+
+    permissions = data["permissions"]
+    assert permissions == {
+        "contents": "read",
+        "actions": "read",
+        "security-events": "write",
+    }
+
+    steps = data["jobs"]["upload-sarif"]["steps"]
+    assert [step["name"] for step in steps] == [
+        "Checkout trusted SARIF binding verifier",
+        "Download pulse-report artifact",
+        "Verify workflow-run and SARIF artifact binding",
+        "Upload SARIF to GitHub code scanning",
+    ]
+
+    checkout = steps[0]
+    assert re.fullmatch(
+        r"actions/checkout@[0-9a-f]{40}",
+        checkout["uses"],
+    )
+    assert checkout["with"] == {
+        "ref": "${{ github.event.repository.default_branch }}",
+        "persist-credentials": False,
+    }
+
+    download = steps[1]
+    assert re.fullmatch(
+        r"actions/download-artifact@[0-9a-f]{40}",
+        download["uses"],
+    )
+    assert download["with"]["run-id"] == "${{ github.event.workflow_run.id }}"
+
+    verify = steps[2]
+    assert verify["id"] == "target"
+    assert (
+        "tools/check_sarif_workflow_run_binding_v0.py"
+        in verify["run"]
+    )
+    assert (
+        '--run-id "${{ github.event.workflow_run.id }}"'
+        in verify["run"]
+    )
+
+    upload = steps[3]
+    assert re.fullmatch(
+        r"github/codeql-action/upload-sarif@[0-9a-f]{40}",
+        upload["uses"],
+    )
+    assert upload["if"] == "steps.target.outputs.skip == 'false'"
+    assert upload["with"] == {
+        "sarif_file": "${{ steps.target.outputs.sarif_path }}",
+        "ref": "${{ steps.target.outputs.ref }}",
+        "sha": "${{ steps.target.outputs.sha }}",
+        "category": "pulse-gates",
+    }
+
+
+def main() -> int:
+    tests = [
+        test_workflow_path_without_suffix_passes,
+        test_workflow_path_with_suffix_passes,
+        test_workflow_path_prefix_substitution_fails,
+        test_push_main_passes,
+        test_push_tag_passes,
+        test_push_hyphenated_tag_passes,
+        test_push_metadata_mismatch_fails,
+        test_workflow_dispatch_main_passes,
+        test_workflow_dispatch_feature_skips,
+        test_same_repository_pull_request_snapshot_passes,
+        test_fork_pull_request_snapshot_skips,
+        test_pull_request_number_substitution_fails,
+        test_pull_request_snapshot_head_substitution_fails,
+        test_pull_request_merge_parent_substitution_fails,
+        test_pull_request_live_state_is_not_required,
+        test_event_substitution_fails,
+        test_strict_metadata_json_rejects_duplicate_keys,
+        test_artifact_selection_fails_closed,
+        test_verifier_uses_completed_run_snapshot,
+        test_workflow_wiring,
+    ]
+    for test in tests:
+        test()
+    print(
+        "OK: SARIF workflow-run binding verifies API-derived event, repository, "
+        "historical PR snapshot, immutable merge-parent, ref, SHA and fork "
+        "identities; preserves "
+        "immutable first-party upload wiring; skips fork and unprivileged "
+        "manual runs; and fails closed on substitution or duplicate metadata."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_sarif_workflow_run_binding_v0.py
+++ b/tools/check_sarif_workflow_run_binding_v0.py
@@ -26,7 +26,6 @@ MAX_METADATA_BYTES = 64 * 1024
 MAX_SARIF_BYTES = 128 * 1024 * 1024
 
 SHA40_RE = re.compile(r"^[0-9a-f]{40}$")
-VERSION_TAG_RE = re.compile(r"^[vV][A-Za-z0-9][A-Za-z0-9._-]*$")
 
 METADATA_SUFFIXES = (
     "/meta/sarif_upload.json",
@@ -258,11 +257,11 @@ def _validate_run(
         )
 
     path = _require_string(value.get("path"), label="workflow_run_path")
-    expected_prefix = f"{EXPECTED_WORKFLOW_PATH}@"
-    if not path.startswith(expected_prefix):
+    path_identity, separator, path_ref = path.partition("@")
+    if path_identity != EXPECTED_WORKFLOW_PATH or (separator and not path_ref):
         raise BindingError(
             "workflow_run_path_mismatch: "
-            f"expected_prefix={expected_prefix!r} observed={path!r}"
+            f"expected_path={EXPECTED_WORKFLOW_PATH!r} observed={path!r}"
         )
 
     status = _require_string(
@@ -325,167 +324,143 @@ def _validate_run(
     }
 
 
-def _api_pull_request_numbers(run: dict[str, Any]) -> list[int]:
-    numbers: list[int] = []
-    for index, item in enumerate(run["pull_requests"]):
-        if not isinstance(item, dict):
-            raise BindingError(
-                f"workflow_run_pull_requests_item_not_object: index={index}"
-            )
-        number = _require_int(
-            item.get("number"),
-            label=f"workflow_run_pull_requests_{index}_number",
-            positive=True,
+def _repository_identity_from_snapshot(
+    value: Any,
+    *,
+    label: str,
+) -> str | None:
+    if value is None:
+        return None
+    repository = _require_object(value, label=label)
+    full_name = repository.get("full_name")
+    if full_name is not None:
+        return _require_string(full_name, label=f"{label}_full_name")
+
+    url = repository.get("url")
+    if url is None:
+        return None
+    url_text = _require_string(url, label=f"{label}_url")
+    parsed = urllib.parse.urlparse(url_text)
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) < 3 or parts[-3] != "repos":
+        raise BindingError(
+            f"{label}_url_not_repository_api_identity: {url_text!r}"
         )
-        numbers.append(number)
-    if len(numbers) != len(set(numbers)):
-        raise BindingError("workflow_run_pull_request_numbers_not_unique")
-    return numbers
+    return (
+        urllib.parse.unquote(parts[-2])
+        + "/"
+        + urllib.parse.unquote(parts[-1])
+    )
 
 
-def _validate_pull_request(
-    pull_request: Any,
+def _validate_pull_request_snapshot(
+    snapshot: Any,
     *,
     repository: str,
-    pr_number: int,
     run: dict[str, Any],
 ) -> dict[str, Any]:
-    pr = _require_object(pull_request, label="pull_request")
-    observed_number = _require_int(
-        pr.get("number"),
-        label="pull_request_number",
+    value = _require_object(snapshot, label="workflow_run_pull_request")
+    number = _require_int(
+        value.get("number"),
+        label="workflow_run_pull_request_number",
         positive=True,
     )
-    if observed_number != pr_number:
-        raise BindingError(
-            "pull_request_number_mismatch: "
-            f"expected={pr_number} observed={observed_number}"
-        )
 
-    base_repo = _nested_string(
-        pr,
-        "base",
-        "repo",
-        "full_name",
-        label="pull_request_base_repository",
+    head = _require_object(
+        value.get("head"),
+        label="workflow_run_pull_request_head",
     )
-    if base_repo != repository:
-        raise BindingError(
-            "pull_request_base_repository_mismatch: "
-            f"expected={repository!r} observed={base_repo!r}"
-        )
+    base = _require_object(
+        value.get("base"),
+        label="workflow_run_pull_request_base",
+    )
 
-    head_repo = _nested_string(
-        pr,
-        "head",
-        "repo",
-        "full_name",
-        label="pull_request_head_repository",
-    )
     head_sha = _require_sha40(
-        _nested_string(
-            pr,
-            "head",
-            "sha",
-            label="pull_request_head_sha",
-        ),
-        label="pull_request_head_sha",
+        head.get("sha"),
+        label="workflow_run_pull_request_head_sha",
     )
-    head_ref = _nested_string(
-        pr,
-        "head",
-        "ref",
-        label="pull_request_head_ref",
+    head_ref = _require_string(
+        head.get("ref"),
+        label="workflow_run_pull_request_head_ref",
     )
     base_sha = _require_sha40(
-        _nested_string(
-            pr,
-            "base",
-            "sha",
-            label="pull_request_base_sha",
-        ),
-        label="pull_request_base_sha",
+        base.get("sha"),
+        label="workflow_run_pull_request_base_sha",
+    )
+    base_ref = _require_string(
+        base.get("ref"),
+        label="workflow_run_pull_request_base_ref",
     )
 
     if head_sha != run["head_sha"]:
         raise BindingError(
-            "pull_request_head_sha_mismatch: "
-            f"run={run['head_sha']!r} pull_request={head_sha!r}"
+            "workflow_run_pull_request_head_sha_mismatch: "
+            f"run={run['head_sha']!r} snapshot={head_sha!r}"
         )
     if head_ref != run["head_branch"]:
         raise BindingError(
-            "pull_request_head_branch_mismatch: "
-            f"run={run['head_branch']!r} pull_request={head_ref!r}"
+            "workflow_run_pull_request_head_branch_mismatch: "
+            f"run={run['head_branch']!r} snapshot={head_ref!r}"
         )
-    if head_repo != run["head_repository"]:
+    if base_ref != "main":
         raise BindingError(
-            "pull_request_head_repository_mismatch: "
-            f"run={run['head_repository']!r} pull_request={head_repo!r}"
+            "workflow_run_pull_request_base_ref_mismatch: "
+            f"expected='main' observed={base_ref!r}"
         )
 
-    api_numbers = _api_pull_request_numbers(run)
-    is_fork = head_repo != base_repo
-    if is_fork:
-        if api_numbers and api_numbers != [pr_number]:
-            raise BindingError(
-                "workflow_run_pull_request_binding_mismatch: "
-                f"expected_empty_or={[pr_number]!r} observed={api_numbers!r}"
-            )
-    elif api_numbers != [pr_number]:
+    snapshot_head_repository = _repository_identity_from_snapshot(
+        head.get("repo"),
+        label="workflow_run_pull_request_head_repository",
+    )
+    if (
+        snapshot_head_repository is not None
+        and snapshot_head_repository != run["head_repository"]
+    ):
         raise BindingError(
-            "workflow_run_pull_request_binding_mismatch: "
-            f"expected={[pr_number]!r} observed={api_numbers!r}"
+            "workflow_run_pull_request_head_repository_mismatch: "
+            f"run={run['head_repository']!r} "
+            f"snapshot={snapshot_head_repository!r}"
         )
 
-    merge_commit_sha = pr.get("merge_commit_sha")
-    if merge_commit_sha is not None:
-        merge_commit_sha = _require_sha40(
-            merge_commit_sha,
-            label="pull_request_merge_commit_sha",
+    snapshot_base_repository = _repository_identity_from_snapshot(
+        base.get("repo"),
+        label="workflow_run_pull_request_base_repository",
+    )
+    if (
+        snapshot_base_repository is not None
+        and snapshot_base_repository != repository
+    ):
+        raise BindingError(
+            "workflow_run_pull_request_base_repository_mismatch: "
+            f"expected={repository!r} "
+            f"snapshot={snapshot_base_repository!r}"
         )
 
     return {
-        "head_repository": head_repo,
+        "number": number,
         "head_sha": head_sha,
         "head_ref": head_ref,
         "base_sha": base_sha,
-        "is_fork": is_fork,
-        "merge_commit_sha": merge_commit_sha,
+        "base_ref": base_ref,
+        "is_fork": run["head_repository"] != repository,
     }
 
 
-def _validate_merge_ref(
-    merge_ref: Any,
+def _select_pull_request_snapshot(
+    run: dict[str, Any],
     *,
-    expected_ref: str,
-) -> str:
-    value = _require_object(merge_ref, label="pull_request_merge_ref")
-    observed_ref = _require_string(
-        value.get("ref"),
-        label="pull_request_merge_ref_name",
-    )
-    if observed_ref != expected_ref:
+    repository: str,
+) -> dict[str, Any]:
+    snapshots = run["pull_requests"]
+    if len(snapshots) != 1:
         raise BindingError(
-            "pull_request_merge_ref_name_mismatch: "
-            f"expected={expected_ref!r} observed={observed_ref!r}"
+            "workflow_run_pull_request_snapshot_count_invalid: "
+            f"observed={len(snapshots)}"
         )
-
-    ref_object = _require_object(
-        value.get("object"),
-        label="pull_request_merge_ref_object",
-    )
-    object_type = _require_string(
-        ref_object.get("type"),
-        label="pull_request_merge_ref_object_type",
-    )
-    if object_type != "commit":
-        raise BindingError(
-            "pull_request_merge_ref_not_commit: "
-            f"observed={object_type!r}"
-        )
-    return _require_sha40(
-        ref_object.get("sha"),
-        label="pull_request_merge_ref_sha",
+    return _validate_pull_request_snapshot(
+        snapshots[0],
+        repository=repository,
+        run=run,
     )
 
 
@@ -544,8 +519,6 @@ def verify_binding(
     run_id: int,
     run: Any,
     metadata: Any,
-    pull_request: Any | None = None,
-    merge_ref: Any | None = None,
     merge_commit: Any | None = None,
 ) -> BindingResult:
     repository = _require_string(
@@ -572,45 +545,16 @@ def verify_binding(
     if event_name == "pull_request":
         if meta["pr_number"] is None:
             raise BindingError("sarif_metadata_pr_number_required")
-        if pull_request is None:
-            raise BindingError("pull_request_api_snapshot_required")
-        if merge_ref is None:
-            raise BindingError("pull_request_merge_ref_snapshot_required")
-        if merge_commit is None:
-            raise BindingError("pull_request_merge_commit_snapshot_required")
 
-        pr = _validate_pull_request(
-            pull_request,
+        snapshot = _select_pull_request_snapshot(
+            run_state,
             repository=repository,
-            pr_number=meta["pr_number"],
-            run=run_state,
         )
-        expected_ref = f"refs/pull/{meta['pr_number']}/merge"
-        merge_sha = _validate_merge_ref(
-            merge_ref,
-            expected_ref=expected_ref,
-        )
-        _validate_merge_commit(
-            merge_commit,
-            merge_sha=merge_sha,
-            base_sha=pr["base_sha"],
-            head_sha=pr["head_sha"],
-        )
-        if (
-            pr["merge_commit_sha"] is not None
-            and pr["merge_commit_sha"] != merge_sha
-        ):
-            raise BindingError(
-                "pull_request_merge_commit_sha_mismatch: "
-                f"pull_request={pr['merge_commit_sha']!r} "
-                f"merge_ref={merge_sha!r}"
-            )
-
+        expected_ref = f"refs/pull/{snapshot['number']}/merge"
         expected = {
+            "pr_number": snapshot["number"],
             "ref": expected_ref,
-            "sha": merge_sha,
-            "pr_number": meta["pr_number"],
-            "is_fork": pr["is_fork"],
+            "is_fork": snapshot["is_fork"],
         }
         for field, expected_value in expected.items():
             if meta[field] != expected_value:
@@ -620,7 +564,7 @@ def verify_binding(
                     f"observed={meta[field]!r}"
                 )
 
-        if pr["is_fork"]:
+        if snapshot["is_fork"]:
             return BindingResult(
                 ok=True,
                 skip=True,
@@ -628,21 +572,30 @@ def verify_binding(
                 event_name=event_name,
                 ref=None,
                 sha=None,
-                pr_number=meta["pr_number"],
+                pr_number=snapshot["number"],
                 is_fork=True,
                 source_run_id=run_id,
                 source_head_sha=run_state["head_sha"],
                 source_head_branch=run_state["head_branch"],
             )
 
+        if merge_commit is None:
+            raise BindingError("pull_request_merge_commit_snapshot_required")
+        _validate_merge_commit(
+            merge_commit,
+            merge_sha=meta["sha"],
+            base_sha=snapshot["base_sha"],
+            head_sha=snapshot["head_sha"],
+        )
+
         return BindingResult(
             ok=True,
             skip=False,
-            reason="verified_pull_request_merge",
+            reason="verified_pull_request_merge_snapshot",
             event_name=event_name,
             ref=expected_ref,
-            sha=merge_sha,
-            pr_number=meta["pr_number"],
+            sha=meta["sha"],
+            pr_number=snapshot["number"],
             is_fork=False,
             source_run_id=run_id,
             source_head_sha=run_state["head_sha"],
@@ -667,7 +620,7 @@ def verify_binding(
     if event_name == "push":
         if run_state["head_branch"] == "main":
             expected_ref = "refs/heads/main"
-        elif VERSION_TAG_RE.fullmatch(run_state["head_branch"]):
+        elif run_state["head_branch"].startswith(("v", "V")):
             expected_ref = f"refs/tags/{run_state['head_branch']}"
         else:
             raise BindingError(
@@ -993,45 +946,28 @@ def main() -> int:
         return 0
 
     run = api.get(
-        _api_path(repository, f"/actions/runs/{run_id}"),
+        _api_path(
+            repository,
+            f"/actions/runs/{run_id}?exclude_pull_requests=false",
+        ),
         label="workflow_run_api",
     )
     validated_meta = _validate_metadata(metadata)
 
-    pull_request: Any | None = None
-    merge_ref: Any | None = None
     merge_commit: Any | None = None
 
     run_object = _require_object(run, label="workflow_run_api")
-    event_name = run_object.get("event")
-    if event_name == "pull_request":
-        pr_number = validated_meta.get("pr_number")
-        if isinstance(pr_number, bool) or not isinstance(pr_number, int):
-            raise BindingError("sarif_metadata_pr_number_required")
-        pull_request = api.get(
-            _api_path(repository, f"/pulls/{pr_number}"),
-            label="pull_request_api",
-        )
-        expected_ref = f"refs/pull/{pr_number}/merge"
-        encoded_ref = urllib.parse.quote(
-            expected_ref.removeprefix("refs/"),
-            safe="/",
-        )
-        merge_ref = api.get(
-            _api_path(repository, f"/git/ref/{encoded_ref}"),
-            label="pull_request_merge_ref_api",
-        )
-        merge_ref_object = _require_object(
-            _require_object(
-                merge_ref,
-                label="pull_request_merge_ref_api",
-            ).get("object"),
-            label="pull_request_merge_ref_api_object",
-        )
-        merge_sha = _require_sha40(
-            merge_ref_object.get("sha"),
-            label="pull_request_merge_ref_api_sha",
-        )
+    run_state = _validate_run(
+        run_object,
+        repository=repository,
+        run_id=run_id,
+    )
+    event_name = run_state["event_name"]
+    if (
+        event_name == "pull_request"
+        and run_state["head_repository"] == repository
+    ):
+        merge_sha = validated_meta["sha"]
         merge_commit = api.get(
             _api_path(repository, f"/git/commits/{merge_sha}"),
             label="pull_request_merge_commit_api",
@@ -1042,8 +978,6 @@ def main() -> int:
         run_id=run_id,
         run=run,
         metadata=metadata,
-        pull_request=pull_request,
-        merge_ref=merge_ref,
         merge_commit=merge_commit,
     )
 

--- a/tools/check_sarif_workflow_run_binding_v0.py
+++ b/tools/check_sarif_workflow_run_binding_v0.py
@@ -1,0 +1,1113 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import stat
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+TOOL_NAME = "check_sarif_workflow_run_binding_v0"
+TOOL_VERSION = "0.1.0"
+EXPECTED_WORKFLOW_NAME = "PULSE CI"
+EXPECTED_WORKFLOW_PATH = ".github/workflows/pulse_ci.yml"
+SUPPORTED_EVENTS = frozenset({"pull_request", "push", "workflow_dispatch"})
+
+MAX_API_RESPONSE_BYTES = 8 * 1024 * 1024
+MAX_METADATA_BYTES = 64 * 1024
+MAX_SARIF_BYTES = 128 * 1024 * 1024
+
+SHA40_RE = re.compile(r"^[0-9a-f]{40}$")
+VERSION_TAG_RE = re.compile(r"^[vV][A-Za-z0-9][A-Za-z0-9._-]*$")
+
+METADATA_SUFFIXES = (
+    "/meta/sarif_upload.json",
+    "/artifacts/meta/sarif_upload.json",
+)
+SARIF_SUFFIXES = (
+    "/reports/sarif.json",
+    "/artifacts/reports/sarif.json",
+)
+METADATA_KEYS = frozenset(
+    {
+        "event_name",
+        "ref",
+        "sha",
+        "pr_number",
+        "is_fork",
+    }
+)
+
+
+class BindingError(RuntimeError):
+    pass
+
+
+class StrictJsonError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class BindingResult:
+    ok: bool
+    skip: bool
+    reason: str
+    event_name: str
+    ref: str | None
+    sha: str | None
+    pr_number: int | None
+    is_fork: bool
+    source_run_id: int
+    source_head_sha: str
+    source_head_branch: str
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise StrictJsonError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_non_finite(value: str) -> None:
+    raise StrictJsonError(f"non-finite JSON value: {value}")
+
+
+def parse_json_bytes(payload: bytes, *, label: str) -> Any:
+    if payload.startswith(b"\xef\xbb\xbf"):
+        raise BindingError(f"{label}_utf8_bom_not_permitted")
+    try:
+        text = payload.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise BindingError(f"{label}_invalid_utf8: {exc}") from exc
+    try:
+        return json.loads(
+            text,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_non_finite,
+        )
+    except (json.JSONDecodeError, StrictJsonError) as exc:
+        raise BindingError(f"{label}_invalid_json: {exc}") from exc
+
+
+def _read_bounded_regular_file(
+    path: Path,
+    *,
+    label: str,
+    maximum: int,
+) -> bytes:
+    candidate = path.absolute()
+    try:
+        metadata = candidate.lstat()
+    except OSError as exc:
+        raise BindingError(f"{label}_unavailable: {candidate}: {exc}") from exc
+    if stat.S_ISLNK(metadata.st_mode):
+        raise BindingError(f"{label}_symlink_rejected: {candidate}")
+    if not stat.S_ISREG(metadata.st_mode):
+        raise BindingError(f"{label}_not_regular_file: {candidate}")
+    if metadata.st_size > maximum:
+        raise BindingError(
+            f"{label}_too_large: size={metadata.st_size} maximum={maximum}"
+        )
+    payload = candidate.read_bytes()
+    if len(payload) != metadata.st_size:
+        raise BindingError(
+            f"{label}_size_changed: expected={metadata.st_size} "
+            f"observed={len(payload)}"
+        )
+    return payload
+
+
+def _require_object(value: Any, *, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise BindingError(f"{label}_not_object")
+    return value
+
+
+def _require_string(
+    value: Any,
+    *,
+    label: str,
+    non_empty: bool = True,
+) -> str:
+    if not isinstance(value, str):
+        raise BindingError(f"{label}_not_string: {value!r}")
+    if non_empty and not value:
+        raise BindingError(f"{label}_empty")
+    if "\n" in value or "\r" in value or "\x00" in value:
+        raise BindingError(f"{label}_control_character_rejected")
+    return value
+
+
+def _require_int(value: Any, *, label: str, positive: bool = False) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise BindingError(f"{label}_not_integer: {value!r}")
+    if positive and value <= 0:
+        raise BindingError(f"{label}_not_positive: {value!r}")
+    return value
+
+
+def _require_sha40(value: Any, *, label: str) -> str:
+    text = _require_string(value, label=label)
+    if SHA40_RE.fullmatch(text) is None:
+        raise BindingError(f"{label}_not_lowercase_sha40: {text!r}")
+    return text
+
+
+def _nested_object(
+    value: dict[str, Any],
+    *keys: str,
+    label: str,
+) -> dict[str, Any]:
+    cursor: Any = value
+    for key in keys:
+        if not isinstance(cursor, dict):
+            raise BindingError(f"{label}_not_object")
+        cursor = cursor.get(key)
+    return _require_object(cursor, label=label)
+
+
+def _nested_string(
+    value: dict[str, Any],
+    *keys: str,
+    label: str,
+) -> str:
+    cursor: Any = value
+    for key in keys:
+        if not isinstance(cursor, dict):
+            raise BindingError(f"{label}_parent_not_object")
+        cursor = cursor.get(key)
+    return _require_string(cursor, label=label)
+
+
+def _validate_metadata(metadata: Any) -> dict[str, Any]:
+    value = _require_object(metadata, label="sarif_metadata")
+    observed_keys = frozenset(value)
+    if observed_keys != METADATA_KEYS:
+        missing = sorted(METADATA_KEYS.difference(observed_keys))
+        unexpected = sorted(observed_keys.difference(METADATA_KEYS))
+        raise BindingError(
+            "sarif_metadata_key_set_mismatch: "
+            f"missing={missing!r} unexpected={unexpected!r}"
+        )
+
+    event_name = _require_string(
+        value.get("event_name"),
+        label="sarif_metadata_event_name",
+    )
+    ref = _require_string(value.get("ref"), label="sarif_metadata_ref")
+    sha = _require_sha40(value.get("sha"), label="sarif_metadata_sha")
+
+    pr_number = value.get("pr_number")
+    if pr_number is not None:
+        pr_number = _require_int(
+            pr_number,
+            label="sarif_metadata_pr_number",
+            positive=True,
+        )
+
+    is_fork = value.get("is_fork")
+    if not isinstance(is_fork, bool):
+        raise BindingError(
+            f"sarif_metadata_is_fork_not_boolean: {is_fork!r}"
+        )
+
+    return {
+        "event_name": event_name,
+        "ref": ref,
+        "sha": sha,
+        "pr_number": pr_number,
+        "is_fork": is_fork,
+    }
+
+
+def _validate_run(
+    run: Any,
+    *,
+    repository: str,
+    run_id: int,
+) -> dict[str, Any]:
+    value = _require_object(run, label="workflow_run")
+
+    observed_id = _require_int(
+        value.get("id"),
+        label="workflow_run_id",
+        positive=True,
+    )
+    if observed_id != run_id:
+        raise BindingError(
+            f"workflow_run_id_mismatch: expected={run_id} "
+            f"observed={observed_id}"
+        )
+
+    name = _require_string(value.get("name"), label="workflow_run_name")
+    if name != EXPECTED_WORKFLOW_NAME:
+        raise BindingError(
+            "workflow_run_name_mismatch: "
+            f"expected={EXPECTED_WORKFLOW_NAME!r} observed={name!r}"
+        )
+
+    path = _require_string(value.get("path"), label="workflow_run_path")
+    expected_prefix = f"{EXPECTED_WORKFLOW_PATH}@"
+    if not path.startswith(expected_prefix):
+        raise BindingError(
+            "workflow_run_path_mismatch: "
+            f"expected_prefix={expected_prefix!r} observed={path!r}"
+        )
+
+    status = _require_string(
+        value.get("status"),
+        label="workflow_run_status",
+    )
+    if status != "completed":
+        raise BindingError(
+            f"workflow_run_not_completed: observed={status!r}"
+        )
+
+    event_name = _require_string(
+        value.get("event"),
+        label="workflow_run_event",
+    )
+    if event_name not in SUPPORTED_EVENTS:
+        raise BindingError(
+            f"workflow_run_event_unsupported: {event_name!r}"
+        )
+
+    run_repository = _nested_string(
+        value,
+        "repository",
+        "full_name",
+        label="workflow_run_repository",
+    )
+    if run_repository != repository:
+        raise BindingError(
+            "workflow_run_repository_mismatch: "
+            f"expected={repository!r} observed={run_repository!r}"
+        )
+
+    head_repository = _nested_string(
+        value,
+        "head_repository",
+        "full_name",
+        label="workflow_run_head_repository",
+    )
+    head_sha = _require_sha40(
+        value.get("head_sha"),
+        label="workflow_run_head_sha",
+    )
+    head_branch = _require_string(
+        value.get("head_branch"),
+        label="workflow_run_head_branch",
+    )
+
+    pull_requests = value.get("pull_requests")
+    if not isinstance(pull_requests, list):
+        raise BindingError("workflow_run_pull_requests_not_array")
+
+    return {
+        "raw": value,
+        "event_name": event_name,
+        "repository": run_repository,
+        "head_repository": head_repository,
+        "head_sha": head_sha,
+        "head_branch": head_branch,
+        "pull_requests": pull_requests,
+    }
+
+
+def _api_pull_request_numbers(run: dict[str, Any]) -> list[int]:
+    numbers: list[int] = []
+    for index, item in enumerate(run["pull_requests"]):
+        if not isinstance(item, dict):
+            raise BindingError(
+                f"workflow_run_pull_requests_item_not_object: index={index}"
+            )
+        number = _require_int(
+            item.get("number"),
+            label=f"workflow_run_pull_requests_{index}_number",
+            positive=True,
+        )
+        numbers.append(number)
+    if len(numbers) != len(set(numbers)):
+        raise BindingError("workflow_run_pull_request_numbers_not_unique")
+    return numbers
+
+
+def _validate_pull_request(
+    pull_request: Any,
+    *,
+    repository: str,
+    pr_number: int,
+    run: dict[str, Any],
+) -> dict[str, Any]:
+    pr = _require_object(pull_request, label="pull_request")
+    observed_number = _require_int(
+        pr.get("number"),
+        label="pull_request_number",
+        positive=True,
+    )
+    if observed_number != pr_number:
+        raise BindingError(
+            "pull_request_number_mismatch: "
+            f"expected={pr_number} observed={observed_number}"
+        )
+
+    base_repo = _nested_string(
+        pr,
+        "base",
+        "repo",
+        "full_name",
+        label="pull_request_base_repository",
+    )
+    if base_repo != repository:
+        raise BindingError(
+            "pull_request_base_repository_mismatch: "
+            f"expected={repository!r} observed={base_repo!r}"
+        )
+
+    head_repo = _nested_string(
+        pr,
+        "head",
+        "repo",
+        "full_name",
+        label="pull_request_head_repository",
+    )
+    head_sha = _require_sha40(
+        _nested_string(
+            pr,
+            "head",
+            "sha",
+            label="pull_request_head_sha",
+        ),
+        label="pull_request_head_sha",
+    )
+    head_ref = _nested_string(
+        pr,
+        "head",
+        "ref",
+        label="pull_request_head_ref",
+    )
+    base_sha = _require_sha40(
+        _nested_string(
+            pr,
+            "base",
+            "sha",
+            label="pull_request_base_sha",
+        ),
+        label="pull_request_base_sha",
+    )
+
+    if head_sha != run["head_sha"]:
+        raise BindingError(
+            "pull_request_head_sha_mismatch: "
+            f"run={run['head_sha']!r} pull_request={head_sha!r}"
+        )
+    if head_ref != run["head_branch"]:
+        raise BindingError(
+            "pull_request_head_branch_mismatch: "
+            f"run={run['head_branch']!r} pull_request={head_ref!r}"
+        )
+    if head_repo != run["head_repository"]:
+        raise BindingError(
+            "pull_request_head_repository_mismatch: "
+            f"run={run['head_repository']!r} pull_request={head_repo!r}"
+        )
+
+    api_numbers = _api_pull_request_numbers(run)
+    is_fork = head_repo != base_repo
+    if is_fork:
+        if api_numbers and api_numbers != [pr_number]:
+            raise BindingError(
+                "workflow_run_pull_request_binding_mismatch: "
+                f"expected_empty_or={[pr_number]!r} observed={api_numbers!r}"
+            )
+    elif api_numbers != [pr_number]:
+        raise BindingError(
+            "workflow_run_pull_request_binding_mismatch: "
+            f"expected={[pr_number]!r} observed={api_numbers!r}"
+        )
+
+    merge_commit_sha = pr.get("merge_commit_sha")
+    if merge_commit_sha is not None:
+        merge_commit_sha = _require_sha40(
+            merge_commit_sha,
+            label="pull_request_merge_commit_sha",
+        )
+
+    return {
+        "head_repository": head_repo,
+        "head_sha": head_sha,
+        "head_ref": head_ref,
+        "base_sha": base_sha,
+        "is_fork": is_fork,
+        "merge_commit_sha": merge_commit_sha,
+    }
+
+
+def _validate_merge_ref(
+    merge_ref: Any,
+    *,
+    expected_ref: str,
+) -> str:
+    value = _require_object(merge_ref, label="pull_request_merge_ref")
+    observed_ref = _require_string(
+        value.get("ref"),
+        label="pull_request_merge_ref_name",
+    )
+    if observed_ref != expected_ref:
+        raise BindingError(
+            "pull_request_merge_ref_name_mismatch: "
+            f"expected={expected_ref!r} observed={observed_ref!r}"
+        )
+
+    ref_object = _require_object(
+        value.get("object"),
+        label="pull_request_merge_ref_object",
+    )
+    object_type = _require_string(
+        ref_object.get("type"),
+        label="pull_request_merge_ref_object_type",
+    )
+    if object_type != "commit":
+        raise BindingError(
+            "pull_request_merge_ref_not_commit: "
+            f"observed={object_type!r}"
+        )
+    return _require_sha40(
+        ref_object.get("sha"),
+        label="pull_request_merge_ref_sha",
+    )
+
+
+def _validate_merge_commit(
+    merge_commit: Any,
+    *,
+    merge_sha: str,
+    base_sha: str,
+    head_sha: str,
+) -> None:
+    value = _require_object(
+        merge_commit,
+        label="pull_request_merge_commit",
+    )
+    observed_sha = _require_sha40(
+        value.get("sha"),
+        label="pull_request_merge_commit_sha",
+    )
+    if observed_sha != merge_sha:
+        raise BindingError(
+            "pull_request_merge_commit_identity_mismatch: "
+            f"expected={merge_sha!r} observed={observed_sha!r}"
+        )
+
+    parents = value.get("parents")
+    if not isinstance(parents, list) or len(parents) != 2:
+        raise BindingError(
+            "pull_request_merge_commit_parent_count_invalid: "
+            f"observed={len(parents) if isinstance(parents, list) else None}"
+        )
+
+    parent_shas: list[str] = []
+    for index, parent in enumerate(parents):
+        parent_object = _require_object(
+            parent,
+            label=f"pull_request_merge_commit_parent_{index}",
+        )
+        parent_shas.append(
+            _require_sha40(
+                parent_object.get("sha"),
+                label=f"pull_request_merge_commit_parent_{index}_sha",
+            )
+        )
+
+    expected = [base_sha, head_sha]
+    if parent_shas != expected:
+        raise BindingError(
+            "pull_request_merge_commit_parents_mismatch: "
+            f"expected={expected!r} observed={parent_shas!r}"
+        )
+
+
+def verify_binding(
+    *,
+    repository: str,
+    run_id: int,
+    run: Any,
+    metadata: Any,
+    pull_request: Any | None = None,
+    merge_ref: Any | None = None,
+    merge_commit: Any | None = None,
+) -> BindingResult:
+    repository = _require_string(
+        repository,
+        label="repository",
+    )
+    run_id = _require_int(run_id, label="run_id", positive=True)
+    run_state = _validate_run(
+        run,
+        repository=repository,
+        run_id=run_id,
+    )
+    meta = _validate_metadata(metadata)
+
+    if meta["event_name"] != run_state["event_name"]:
+        raise BindingError(
+            "sarif_metadata_event_mismatch: "
+            f"expected={run_state['event_name']!r} "
+            f"observed={meta['event_name']!r}"
+        )
+
+    event_name = run_state["event_name"]
+
+    if event_name == "pull_request":
+        if meta["pr_number"] is None:
+            raise BindingError("sarif_metadata_pr_number_required")
+        if pull_request is None:
+            raise BindingError("pull_request_api_snapshot_required")
+        if merge_ref is None:
+            raise BindingError("pull_request_merge_ref_snapshot_required")
+        if merge_commit is None:
+            raise BindingError("pull_request_merge_commit_snapshot_required")
+
+        pr = _validate_pull_request(
+            pull_request,
+            repository=repository,
+            pr_number=meta["pr_number"],
+            run=run_state,
+        )
+        expected_ref = f"refs/pull/{meta['pr_number']}/merge"
+        merge_sha = _validate_merge_ref(
+            merge_ref,
+            expected_ref=expected_ref,
+        )
+        _validate_merge_commit(
+            merge_commit,
+            merge_sha=merge_sha,
+            base_sha=pr["base_sha"],
+            head_sha=pr["head_sha"],
+        )
+        if (
+            pr["merge_commit_sha"] is not None
+            and pr["merge_commit_sha"] != merge_sha
+        ):
+            raise BindingError(
+                "pull_request_merge_commit_sha_mismatch: "
+                f"pull_request={pr['merge_commit_sha']!r} "
+                f"merge_ref={merge_sha!r}"
+            )
+
+        expected = {
+            "ref": expected_ref,
+            "sha": merge_sha,
+            "pr_number": meta["pr_number"],
+            "is_fork": pr["is_fork"],
+        }
+        for field, expected_value in expected.items():
+            if meta[field] != expected_value:
+                raise BindingError(
+                    f"sarif_metadata_{field}_mismatch: "
+                    f"expected={expected_value!r} "
+                    f"observed={meta[field]!r}"
+                )
+
+        if pr["is_fork"]:
+            return BindingResult(
+                ok=True,
+                skip=True,
+                reason="fork_pull_request",
+                event_name=event_name,
+                ref=None,
+                sha=None,
+                pr_number=meta["pr_number"],
+                is_fork=True,
+                source_run_id=run_id,
+                source_head_sha=run_state["head_sha"],
+                source_head_branch=run_state["head_branch"],
+            )
+
+        return BindingResult(
+            ok=True,
+            skip=False,
+            reason="verified_pull_request_merge",
+            event_name=event_name,
+            ref=expected_ref,
+            sha=merge_sha,
+            pr_number=meta["pr_number"],
+            is_fork=False,
+            source_run_id=run_id,
+            source_head_sha=run_state["head_sha"],
+            source_head_branch=run_state["head_branch"],
+        )
+
+    if meta["pr_number"] is not None:
+        raise BindingError(
+            "sarif_metadata_pr_number_must_be_null_for_non_pr_event"
+        )
+    if meta["is_fork"] is not False:
+        raise BindingError(
+            "sarif_metadata_is_fork_must_be_false_for_non_pr_event"
+        )
+    if run_state["head_repository"] != repository:
+        raise BindingError(
+            "workflow_run_head_repository_must_equal_repository: "
+            f"expected={repository!r} "
+            f"observed={run_state['head_repository']!r}"
+        )
+
+    if event_name == "push":
+        if run_state["head_branch"] == "main":
+            expected_ref = "refs/heads/main"
+        elif VERSION_TAG_RE.fullmatch(run_state["head_branch"]):
+            expected_ref = f"refs/tags/{run_state['head_branch']}"
+        else:
+            raise BindingError(
+                "push_source_ref_outside_pulse_ci_contract: "
+                f"head_branch={run_state['head_branch']!r}"
+            )
+        expected_sha = run_state["head_sha"]
+        if meta["ref"] != expected_ref:
+            raise BindingError(
+                "sarif_metadata_ref_mismatch: "
+                f"expected={expected_ref!r} observed={meta['ref']!r}"
+            )
+        if meta["sha"] != expected_sha:
+            raise BindingError(
+                "sarif_metadata_sha_mismatch: "
+                f"expected={expected_sha!r} observed={meta['sha']!r}"
+            )
+        return BindingResult(
+            ok=True,
+            skip=False,
+            reason="verified_push",
+            event_name=event_name,
+            ref=expected_ref,
+            sha=expected_sha,
+            pr_number=None,
+            is_fork=False,
+            source_run_id=run_id,
+            source_head_sha=run_state["head_sha"],
+            source_head_branch=run_state["head_branch"],
+        )
+
+    if event_name == "workflow_dispatch":
+        branch_ref = f"refs/heads/{run_state['head_branch']}"
+        tag_ref = f"refs/tags/{run_state['head_branch']}"
+        if meta["ref"] not in {branch_ref, tag_ref}:
+            raise BindingError(
+                "sarif_metadata_ref_mismatch: "
+                f"expected_one_of={[branch_ref, tag_ref]!r} "
+                f"observed={meta['ref']!r}"
+            )
+        if meta["sha"] != run_state["head_sha"]:
+            raise BindingError(
+                "sarif_metadata_sha_mismatch: "
+                f"expected={run_state['head_sha']!r} "
+                f"observed={meta['sha']!r}"
+            )
+        if run_state["head_branch"] != "main" or meta["ref"] != "refs/heads/main":
+            return BindingResult(
+                ok=True,
+                skip=True,
+                reason="workflow_dispatch_ref_not_main",
+                event_name=event_name,
+                ref=None,
+                sha=None,
+                pr_number=None,
+                is_fork=False,
+                source_run_id=run_id,
+                source_head_sha=run_state["head_sha"],
+                source_head_branch=run_state["head_branch"],
+            )
+        return BindingResult(
+            ok=True,
+            skip=False,
+            reason="verified_workflow_dispatch_main",
+            event_name=event_name,
+            ref="refs/heads/main",
+            sha=run_state["head_sha"],
+            pr_number=None,
+            is_fork=False,
+            source_run_id=run_id,
+            source_head_sha=run_state["head_sha"],
+            source_head_branch=run_state["head_branch"],
+        )
+
+    raise BindingError(f"unreachable_event: {event_name!r}")
+
+
+def _find_files(
+    root: Path,
+    *,
+    suffixes: Iterable[str],
+    label: str,
+) -> list[Path]:
+    root = root.absolute()
+    try:
+        root_metadata = root.lstat()
+    except OSError as exc:
+        raise BindingError(f"{label}_root_unavailable: {root}: {exc}") from exc
+    if stat.S_ISLNK(root_metadata.st_mode):
+        raise BindingError(f"{label}_root_symlink_rejected: {root}")
+    if not stat.S_ISDIR(root_metadata.st_mode):
+        raise BindingError(f"{label}_root_not_directory: {root}")
+
+    matches: list[Path] = []
+    for candidate in root.rglob("*"):
+        if candidate.is_symlink():
+            raise BindingError(f"{label}_symlink_rejected: {candidate}")
+        if not candidate.is_file():
+            continue
+        identity = "/" + candidate.relative_to(root).as_posix()
+        if any(identity.endswith(suffix) for suffix in suffixes):
+            matches.append(candidate)
+    return sorted(matches, key=lambda item: item.as_posix())
+
+
+def _select_metadata(root: Path) -> tuple[dict[str, Any] | None, Path | None]:
+    matches = _find_files(
+        root,
+        suffixes=METADATA_SUFFIXES,
+        label="sarif_metadata",
+    )
+    if not matches:
+        return None, None
+    if len(matches) != 1:
+        raise BindingError(
+            "sarif_metadata_file_count_invalid: "
+            f"observed={len(matches)} paths="
+            f"{[item.as_posix() for item in matches]!r}"
+        )
+    path = matches[0]
+    payload = _read_bounded_regular_file(
+        path,
+        label="sarif_metadata",
+        maximum=MAX_METADATA_BYTES,
+    )
+    return _require_object(
+        parse_json_bytes(payload, label="sarif_metadata"),
+        label="sarif_metadata",
+    ), path
+
+
+def _select_sarif(root: Path) -> Path | None:
+    matches = _find_files(
+        root,
+        suffixes=SARIF_SUFFIXES,
+        label="sarif",
+    )
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise BindingError(
+            "sarif_file_count_invalid: "
+            f"observed={len(matches)} paths="
+            f"{[item.as_posix() for item in matches]!r}"
+        )
+    path = matches[0]
+    _read_bounded_regular_file(
+        path,
+        label="sarif",
+        maximum=MAX_SARIF_BYTES,
+    )
+    return path
+
+
+class GitHubApi:
+    def __init__(
+        self,
+        *,
+        api_url: str,
+        token: str,
+        api_version: str,
+    ) -> None:
+        self.api_url = api_url.rstrip("/")
+        self.token = token
+        self.api_version = api_version
+
+    def get(self, path: str, *, label: str) -> Any:
+        url = f"{self.api_url}{path}"
+        request = urllib.request.Request(
+            url,
+            method="GET",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "User-Agent": TOOL_NAME,
+                "X-GitHub-Api-Version": self.api_version,
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = response.read(MAX_API_RESPONSE_BYTES + 1)
+        except urllib.error.HTTPError as exc:
+            raise BindingError(
+                f"{label}_http_error: status={exc.code}"
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise BindingError(f"{label}_network_error: {exc.reason}") from exc
+        if len(payload) > MAX_API_RESPONSE_BYTES:
+            raise BindingError(
+                f"{label}_response_too_large: maximum={MAX_API_RESPONSE_BYTES}"
+            )
+        return parse_json_bytes(payload, label=label)
+
+
+def _api_path(repository: str, suffix: str) -> str:
+    owner, name = repository.split("/", 1)
+    return (
+        "/repos/"
+        + urllib.parse.quote(owner, safe="")
+        + "/"
+        + urllib.parse.quote(name, safe="")
+        + suffix
+    )
+
+
+def _write_outputs(path: Path, values: dict[str, str]) -> None:
+    rendered: list[str] = []
+    for key in sorted(values):
+        value = values[key]
+        if "\n" in value or "\r" in value:
+            raise BindingError(f"github_output_value_newline_rejected: {key}")
+        rendered.append(f"{key}={value}")
+    with path.open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write("\n".join(rendered) + "\n")
+
+
+def _render_diagnostic(
+    *,
+    result: BindingResult,
+    metadata_path: Path | None,
+    sarif_path: Path | None,
+) -> str:
+    payload = {
+        "artifact": {
+            "metadata_path": (
+                metadata_path.as_posix() if metadata_path is not None else None
+            ),
+            "sarif_path": (
+                sarif_path.as_posix() if sarif_path is not None else None
+            ),
+        },
+        "binding": asdict(result),
+        "tool": TOOL_NAME,
+        "tool_version": TOOL_VERSION,
+    }
+    return json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Bind a downloaded PULSE SARIF artifact to independently "
+            "retrieved GitHub workflow-run identity."
+        )
+    )
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--run-id", required=True, type=int)
+    parser.add_argument("--artifact-root", required=True)
+    parser.add_argument(
+        "--github-api-url",
+        default=os.environ.get("GITHUB_API_URL", "https://api.github.com"),
+    )
+    parser.add_argument(
+        "--github-api-version",
+        default=os.environ.get("GITHUB_API_VERSION", "2022-11-28"),
+    )
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT", ""),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repository = _require_string(args.repository, label="repository")
+    if repository.count("/") != 1:
+        raise BindingError(
+            f"repository_identity_invalid: {repository!r}"
+        )
+    run_id = _require_int(args.run_id, label="run_id", positive=True)
+    artifact_root = Path(args.artifact_root).absolute()
+
+    token = os.environ.get("GH_TOKEN", "")
+    if not token:
+        raise BindingError("GH_TOKEN_missing")
+
+    api = GitHubApi(
+        api_url=_require_string(
+            args.github_api_url,
+            label="github_api_url",
+        ),
+        token=token,
+        api_version=_require_string(
+            args.github_api_version,
+            label="github_api_version",
+        ),
+    )
+
+    metadata, metadata_path = _select_metadata(artifact_root)
+    if metadata is None:
+        result = BindingResult(
+            ok=True,
+            skip=True,
+            reason="missing_metadata",
+            event_name="unknown",
+            ref=None,
+            sha=None,
+            pr_number=None,
+            is_fork=False,
+            source_run_id=run_id,
+            source_head_sha="unknown",
+            source_head_branch="unknown",
+        )
+        outputs = {
+            "reason": result.reason,
+            "skip": "true",
+        }
+        if args.github_output:
+            _write_outputs(Path(args.github_output), outputs)
+        sys.stdout.write(
+            _render_diagnostic(
+                result=result,
+                metadata_path=None,
+                sarif_path=None,
+            )
+        )
+        return 0
+
+    run = api.get(
+        _api_path(repository, f"/actions/runs/{run_id}"),
+        label="workflow_run_api",
+    )
+    validated_meta = _validate_metadata(metadata)
+
+    pull_request: Any | None = None
+    merge_ref: Any | None = None
+    merge_commit: Any | None = None
+
+    run_object = _require_object(run, label="workflow_run_api")
+    event_name = run_object.get("event")
+    if event_name == "pull_request":
+        pr_number = validated_meta.get("pr_number")
+        if isinstance(pr_number, bool) or not isinstance(pr_number, int):
+            raise BindingError("sarif_metadata_pr_number_required")
+        pull_request = api.get(
+            _api_path(repository, f"/pulls/{pr_number}"),
+            label="pull_request_api",
+        )
+        expected_ref = f"refs/pull/{pr_number}/merge"
+        encoded_ref = urllib.parse.quote(
+            expected_ref.removeprefix("refs/"),
+            safe="/",
+        )
+        merge_ref = api.get(
+            _api_path(repository, f"/git/ref/{encoded_ref}"),
+            label="pull_request_merge_ref_api",
+        )
+        merge_ref_object = _require_object(
+            _require_object(
+                merge_ref,
+                label="pull_request_merge_ref_api",
+            ).get("object"),
+            label="pull_request_merge_ref_api_object",
+        )
+        merge_sha = _require_sha40(
+            merge_ref_object.get("sha"),
+            label="pull_request_merge_ref_api_sha",
+        )
+        merge_commit = api.get(
+            _api_path(repository, f"/git/commits/{merge_sha}"),
+            label="pull_request_merge_commit_api",
+        )
+
+    result = verify_binding(
+        repository=repository,
+        run_id=run_id,
+        run=run,
+        metadata=metadata,
+        pull_request=pull_request,
+        merge_ref=merge_ref,
+        merge_commit=merge_commit,
+    )
+
+    sarif_path = None if result.skip else _select_sarif(artifact_root)
+    if not result.skip and sarif_path is None:
+        result = BindingResult(
+            ok=True,
+            skip=True,
+            reason="missing_sarif",
+            event_name=result.event_name,
+            ref=None,
+            sha=None,
+            pr_number=result.pr_number,
+            is_fork=result.is_fork,
+            source_run_id=result.source_run_id,
+            source_head_sha=result.source_head_sha,
+            source_head_branch=result.source_head_branch,
+        )
+
+    outputs = {
+        "reason": result.reason,
+        "skip": "true" if result.skip else "false",
+    }
+    if not result.skip:
+        if result.ref is None or result.sha is None or sarif_path is None:
+            raise BindingError("verified_upload_output_incomplete")
+        outputs.update(
+            {
+                "ref": result.ref,
+                "sarif_path": sarif_path.as_posix(),
+                "sha": result.sha,
+            }
+        )
+
+    if args.github_output:
+        _write_outputs(Path(args.github_output), outputs)
+
+    sys.stdout.write(
+        _render_diagnostic(
+            result=result,
+            metadata_path=metadata_path,
+            sarif_path=sarif_path,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except BindingError as exc:
+        diagnostic = {
+            "error": str(exc),
+            "ok": False,
+            "tool": TOOL_NAME,
+            "tool_version": TOOL_VERSION,
+        }
+        sys.stderr.write(
+            json.dumps(
+                diagnostic,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        )
+        raise SystemExit(2)


### PR DESCRIPTION
## Summary

Close the remaining privileged `workflow_run` provenance boundary in the PULSE
SARIF upload path.

The current upload workflow independently verifies only the source workflow
name. The downloaded artifact still supplies its own:

```text
event_name
ref
sha
pr_number
is_fork
```

Those values currently select the Code Scanning upload target and fork-skip
state under `security-events: write`.

This pull request changes the authority relation to:

```text
GitHub workflow-run API identity
+
GitHub pull-request API identity where applicable
+
GitHub merge-ref and merge-commit identities where applicable
+
strict downloaded artifact comparison
→
verified upload ref and SHA
→
official CodeQL SARIF upload
```

The artifact remains evidence. It no longer serves as the source of its own
privileged upload identity.

## Exact file boundary

Modify exactly:

```text
tools/check_sarif_workflow_run_binding_v0.py
.github/workflows/upload_sarif.yml
tests/test_check_sarif_workflow_run_binding_v0.py
ci/tools-tests.list
```

No other file is changed.

## Trusted verifier

Add:

```text
tools/check_sarif_workflow_run_binding_v0.py
```

The verifier uses only the Python standard library and performs bounded,
strict, machine-readable verification.

It retrieves the exact source run through:

```text
GET /repos/{owner}/{repository}/actions/runs/{run_id}
```

It requires:

```text
run.id
=
workflow_run.id supplied by the trusted trigger

run.name
=
PULSE CI

run.path
starts with
.github/workflows/pulse_ci.yml@

run.status
=
completed

run.repository.full_name
=
current repository
```

The verifier accepts only source events already supported by PULSE CI:

```text
push
pull_request
workflow_dispatch
```

## Push binding

For a main-branch push, require:

```text
API event
=
push

API head_branch
=
main

artifact event_name
=
push

artifact ref
=
refs/heads/main

artifact sha
=
API head_sha
```

For a PULSE version-tag push, require:

```text
API event
=
push

API head branch or tag identity
matches the v*/V* PULSE tag contract

artifact ref
=
refs/tags/<verified tag>

artifact sha
=
API head_sha
```

A push outside the PULSE CI main-or-version-tag contract fails closed.

## Source workflow_dispatch binding

PULSE CI may itself be started through `workflow_dispatch`.

The verifier permits an upload only when the independently retrieved source run
is bound to:

```text
refs/heads/main
+
API head_sha
```

A source manual run on another branch or tag produces an explicit non-upload
state:

```text
workflow_dispatch_ref_not_main
```

## Pull-request binding

For `pull_request`, retrieve and verify:

```text
GET /repos/{owner}/{repository}/pulls/{number}
GET /repos/{owner}/{repository}/git/ref/pull/{number}/merge
GET /repos/{owner}/{repository}/git/commits/{merge_sha}
```

Require:

```text
PR number
PR base repository
PR head repository
PR head branch
PR head SHA
workflow-run head repository
workflow-run head branch
workflow-run head SHA
GitHub-generated merge ref
GitHub-generated merge SHA
merge parent 1 = PR base SHA
merge parent 2 = PR head SHA
```

The downloaded metadata must then match:

```text
event_name
=
pull_request

ref
=
refs/pull/<number>/merge

sha
=
verified GitHub-generated merge SHA

pr_number
=
verified pull-request number

is_fork
=
independently derived head-repository/base-repository relation
```

Fork pull requests are skipped only after the fork relation is verified through
the GitHub API identities.

## Strict artifact boundary

Require exactly one metadata file under either accepted layout:

```text
*/meta/sarif_upload.json
*/artifacts/meta/sarif_upload.json
```

Require exactly one SARIF file under either accepted layout:

```text
*/reports/sarif.json
*/artifacts/reports/sarif.json
```

Reject:

```text
multiple metadata files
multiple SARIF files
symlinked artifact roots or members
metadata larger than 64 KiB
SARIF larger than 128 MiB
UTF-8 BOM
duplicate JSON keys
NaN
Infinity
unexpected metadata fields
missing metadata fields
invalid field types
```

Missing metadata and missing SARIF remain explicit non-error skip states.

## API-derived upload output

Only a verified non-skipped relation writes:

```text
skip=false
ref=<API-derived verified ref>
sha=<API-derived verified SHA>
sarif_path=<single bounded SARIF file>
```

The CodeQL step consumes only those verifier outputs:

```yaml
with:
  sarif_file: ${{ steps.target.outputs.sarif_path }}
  ref: ${{ steps.target.outputs.ref }}
  sha: ${{ steps.target.outputs.sha }}
  category: pulse-gates
```

The downloaded artifact cannot directly select the final upload target.

## Privileged workflow source boundary

Remove `workflow_dispatch` from the privileged SARIF upload workflow.

The workflow now runs only through:

```yaml
on:
  workflow_run:
    workflows: ["PULSE CI"]
    types: [completed]
```

Checkout explicitly selects the repository default branch and disables
credential persistence:

```yaml
with:
  ref: ${{ github.event.repository.default_branch }}
  persist-credentials: false
```

This prevents a manually selected feature branch from supplying modified code
to the `security-events: write` workflow.

## Permissions

Use exactly:

```yaml
permissions:
  contents: read
  actions: read
  pull-requests: read
  security-events: write
```

The added `pull-requests: read` permission is used only for independent
pull-request identity verification.

## Immutable Action identities

Preserve:

```text
actions/checkout
→ pinned full commit SHA

actions/download-artifact
→ pinned v8.0.1 full commit SHA

github/codeql-action/upload-sarif
→ pinned v4.37.4 full commit SHA
```

No mutable Action tag or branch is introduced.

## Permanent regression

Add:

```text
tests/test_check_sarif_workflow_run_binding_v0.py
```

Register exactly once in:

```text
ci/tools-tests.list
```

Coverage includes:

```text
main push PASS
version-tag push PASS
push SHA substitution rejection
main workflow_dispatch PASS
feature workflow_dispatch SKIP
same-repository pull request PASS
fork pull request SKIP
pull-request-number substitution rejection
pull-request-head substitution rejection
merge-parent substitution rejection
event substitution rejection
duplicate JSON-key rejection
duplicate metadata-file rejection
exact workflow wiring
immutable Action references
API-derived ref/SHA/category wiring
```

## Validation

Local construction checks:

```text
Python compilation:
PASS

workflow YAML parse:
PASS

registered regression direct execution:
PASS

UTF-8 BOM:
absent

trailing whitespace:
absent

final newline:
present
```

Required repository checks:

```text
workflow-lint
repo-hygiene
Tools smoke tests
PULSE CI
PULSE Core CI
code scanning
git diff --check
```

## Effects

```text
artifact self-asserted upload identity:
removed

GitHub API workflow-run binding:
added

GitHub API pull-request binding:
added

GitHub merge relation verification:
added

fork state authority:
API-derived

final upload ref and SHA:
API-derived and artifact-matched

privileged upload workflow_dispatch:
removed

source PULSE CI workflow_dispatch on main:
supported

source PULSE CI workflow_dispatch outside main:
explicitly skipped

PULSE runtime:
unchanged

schemas:
unchanged

policy:
unchanged

gate registry:
unchanged

active gate sets:
unchanged

release decision:
unchanged

release authority:
unchanged