### PR TITLE
docs(readme): bind Transition Meter identity at repository entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 PULSEmech is the canonical mechanical implementation of PULSE.
 
+**Current systems measure states. PULSEmech Transition Meter measures the evidence-bound transition between states.**
+
+Artifact-bound AI release authority is the first concrete PULSEmech implementation domain of this broader transition-measurement architecture.
+
+[**Open the foundational PULSEmech Transition Meter architecture**](PULSEMECH_TRANSITION_METER.md)
+
 > **Public origin / prior-art notice:** PULSE has a minimum public origin record. For the visible provenance anchors and attribution boundary, see the [Public Origin / Prior Art Notice](docs/quality_ledger.md#10-public-origin--prior-art-notice).
 
 ## Primary PULSEmech technical source


### PR DESCRIPTION
## Summary

Expose the PULSEmech Transition Meter identity directly at the repository
entry point.

The README opening now states:

> Current systems measure states. PULSEmech Transition Meter measures the
> evidence-bound transition between states.

It also makes explicit that artifact-bound AI release authority is the first
concrete PULSEmech implementation domain of the broader
transition-measurement architecture.

## Changes

- add the defining Transition Meter statement immediately after the canonical
  PULSEmech definition;
- bind artifact-bound AI release authority to the broader
  transition-measurement architecture;
- add an early direct link to the foundational
  `PULSEMECH_TRANSITION_METER.md` document;
- preserve the existing README structure and all current technical content.

## Boundary

This documentation-only change does not:

- modify release authority, policy, gates, evidence, or runtime behavior;
- claim completed implementation across every Transition Meter domain;
- create a separate Transition Meter project identity;
- remove or replace any existing README section.

The change makes the existing relationship between PULSEmech, the Transition
Meter, evidence-bound transition measurement, and artifact-bound AI release
authority explicit at the repository entry point.